### PR TITLE
Lo vect diagid

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -2923,9 +2923,9 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
     _install_opts.extend(_advanced_install_opts)
 
     _v4_export_formats = ['madevent', 'standalone', 'standalone_msP','standalone_msF',
-                          'matrix', 'standalone_rw', 'madweight'] 
+                          'matrix', 'standalone_rw'] 
     _export_formats = _v4_export_formats + ['standalone_cpp', 'pythia8', 'aloha',
-                                            'matchbox_cpp', 'matchbox',
+                                            'matchbox_cpp',
                                             'standalone_gpu']
     _set_options = ['group_subprocesses',
                     'ignore_six_quark_processes',

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -6330,10 +6330,10 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
             data = {"num": iproc + 1,
                  "proc": matrix_elements[iproc].get('processes')[0].base_string()}
             call_dsig_proc_lines.append(\
-                "IF(IPROC.EQ.%(num)d) DSIGPROC=DSIG%(num)d(P1,WGT,IMODE) ! %(proc)s" % data
+                "IF(IPROC.EQ.%(num)d) DSIGPROC=DSIG%(num)d(P1,WGT,IMODE, ICONF) ! %(proc)s" % data
                 )
             call_dsig_proc_lines_vec.append(\
-                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK, ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ALL_OUT) ! %(proc)s" % data
+                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK, ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ICONF, ALL_OUT) ! %(proc)s" % data
                 )
 
         replace_dict['call_dsig_proc_lines'] = "\n".join(call_dsig_proc_lines)

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -1280,7 +1280,7 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
             for config in sorted(config_to_diag_dict.keys()):
 
                 line = "AMP2(%(num)d)=AMP2(%(num)d)+" % \
-                       {"num": (config_to_diag_dict[config][0] + 1)}
+                       {"num": (config)}
 
                 amp = "+".join(["AMP(%(num)d)" % {"num": a.get('number')} for a in \
                                   sum([diagrams[idiag].get('amplitudes') for \
@@ -6330,10 +6330,10 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
             data = {"num": iproc + 1,
                  "proc": matrix_elements[iproc].get('processes')[0].base_string()}
             call_dsig_proc_lines.append(\
-                "IF(IPROC.EQ.%(num)d) DSIGPROC=DSIG%(num)d(P1,WGT,IMODE, ICONF) ! %(proc)s" % data
+                "IF(IPROC.EQ.%(num)d) DSIGPROC=DSIG%(num)d(P1,WGT,IMODE) ! %(proc)s" % data
                 )
             call_dsig_proc_lines_vec.append(\
-                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK, ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ICONF, ALL_OUT) ! %(proc)s" % data
+                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK, ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ALL_OUT) ! %(proc)s" % data
                 )
 
         replace_dict['call_dsig_proc_lines'] = "\n".join(call_dsig_proc_lines)

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -1297,13 +1297,15 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
                 #line += " * get_channel_cut(p, %s) " % (config)
                 ret_lines.append(line)
         else:
-            for idiag, diag in enumerate(matrix_element.get('diagrams')):
+            idiag = 0
+            for diag in matrix_element.get('diagrams'):
                 # Ignore any diagrams with 4-particle vertices.
                 if diag.get_vertex_leg_numbers()!=[] and max(diag.get_vertex_leg_numbers()) > minvert:
                     continue
+                idiag += 1
                 # Now write out the expression for AMP2, meaning the sum of
                 # squared amplitudes belonging to the same diagram
-                line = "AMP2(%(num)d)=AMP2(%(num)d)+" % {"num": (idiag + 1)}
+                line = "AMP2(%(num)d)=AMP2(%(num)d)+" % {"num": (idiag)}
                 line += "+".join(["AMP(%(num)d)*dconjg(AMP(%(num)d))" % \
                                   {"num": a.get('number')} for a in \
                                   diag.get('amplitudes')])
@@ -4626,7 +4628,7 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         # The proc prefix is not used for MadEvent output so it can safely be set
         # to an empty string.
         replace_dict = {'proc_prefix':'',
-                        'set_amp2_line': 'ANS=ANS*AMP2(MAPCONFIG(ICONFIG))/XTOT'}
+                        'set_amp2_line': 'ANS=ANS*AMP2(ICONFIG)/XTOT'}
  
  
         # Extract helas calls
@@ -4929,13 +4931,18 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         helicity_lines = self.get_helicity_lines(matrix_element, add_nb_comb=True)
         replace_dict['helicity_lines'] = helicity_lines
         
+        context = {'read_write_good_hel':True, 'vectorize_code': False}
         if not isinstance(self, ProcessExporterFortranMEGroup):            
-            replace_dict['read_write_good_hel'] = self.read_write_good_hel(ncomb)
+            replace_dict['read_write_good_hel'] = self.read_write_good_hel(ncomb)  
+            context['ungroup_mode'] = True            
         else:
             replace_dict['read_write_good_hel'] = ""
-        
-        context = {'read_write_good_hel':True}
-        
+            context['vectorize_code'] =  True
+            context['ungroup_mode'] = True  
+                
+
+
+
         if writer:
             file = open(pjoin(_file_path, \
                           'iolibs/template_files/auto_dsig_v4.inc')).read()

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -1,4 +1,4 @@
-DOUBLE PRECISION FUNCTION DSIG%(proc_id)s(PP,WGT,IMODE, ICONF)
+DOUBLE PRECISION FUNCTION DSIG%(proc_id)s(PP,WGT,IMODE)
 C ************************************************************
 C
 %(info_lines)s
@@ -13,7 +13,8 @@ C             imode 0 run, 1 init, 2 reweight,
 C                   3 finalize, 4 only PDFs,
 C                   5 squared amplitude only (never
 C                     generate events)
-C             iconf: channel of integration under consideration
+C     Important input passed via common
+C             iconfig: channel of integration under consideration
 C                    used for the amp2(multi-channel) / color assignment
 C                    note: not unique for a G directory (due to sym. channel)
 C     Output:
@@ -35,7 +36,7 @@ C
 C ARGUMENTS 
 C  
       DOUBLE PRECISION PP(0:3,NEXTERNAL), WGT
-      INTEGER IMODE, ICONF
+      INTEGER IMODE
 C  
 C LOCAL VARIABLES 
 C  
@@ -44,7 +45,7 @@ C
       DOUBLE PRECISION XPQ(-7:7),PD(0:MAXPROC)
       DOUBLE PRECISION DSIGUU,R,RCONF
 
-      INTEGER LUN,IFACT,NFACT
+      INTEGER LUN,ICONF,IFACT,NFACT
       DATA NFACT/1/
       SAVE NFACT
 C
@@ -131,7 +132,7 @@ C     Continue only if IMODE is 0, 4 or 5
            P1 = PP
          endif
 
-         CALL SMATRIX%(proc_id)s(P1,0,iconf,DSIGUU,JAMP2(0,1),1)
+         CALL SMATRIX%(proc_id)s(P1,0,iconfig,DSIGUU,JAMP2(0,1),1)
 
 		 IF (IMODE.EQ.5) THEN
             IF (DSIGUU.LT.1D199) THEN		 
@@ -179,7 +180,7 @@ C
 
 ## }
 
-DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE,ICONF, ALL_OUT)
+DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE, ALL_OUT)
 C ****************************************************
 C
 %(info_lines)s
@@ -194,7 +195,8 @@ C             imode 0 run, 1 init, 2 reweight,
 C                   3 finalize, 4 only PDFs,
 C                   5 squared amplitude only (never
 C                     generate events)
-C             iconf: channel of integration under consideration
+C     Important input via common block  
+C             iconfig: channel of integration under consideration
 C                    used for the amp2(multi-channel) / color assignment
 C                    note: not unique for a G directory (due to sym. channel)
 C                    note: unique over the current vector 
@@ -222,7 +224,7 @@ C
       DOUBLE PRECISION ALL_XBK(2,NB_PAGE)
       DOUBLE PRECISION ALL_Q2FACT(2,NB_PAGE)
       DOUBLE PRECISION ALL_CM_RAP(NB_PAGE)
-      INTEGER IMODE, ICONF
+      INTEGER IMODE
       DOUBLE PRECISION ALL_OUT(NB_PAGE)
 C ----------
 C BEGIN CODE
@@ -235,7 +237,7 @@ C
       DOUBLE PRECISION XPQ(-7:7),PD(0:MAXPROC)
       DOUBLE PRECISION ALL_PD(0:MAXPROC, NB_PAGE) 
       DOUBLE PRECISION DSIGUU,R,RCONF
-      INTEGER LUN, IFACT,NFACT
+      INTEGER LUN,ICONF,IFACT,NFACT
       DATA NFACT/1/
       SAVE NFACT
       double precision RHEL ! random number
@@ -297,7 +299,7 @@ C BEGIN CODE
 C ----------
       %(cutsdone)s
       IF(IMODE.EQ.1)THEN
-	NFACT = DSIG%(proc_id)s(all_pp(0,1,1), all_wgt(1), IMODE, ICONF)
+	NFACT = DSIG%(proc_id)s(all_pp(0,1,1), all_wgt(1), IMODE)
 	RETURN
       ENDIF	   
 
@@ -325,13 +327,13 @@ c	 CM_RAP = ALL_CM_RAP(IVEC)
            p_multi(:,:,IVEC) = ALL_PP(:,:,IVEC)
          endif
 	 CALL RANMAR(hel_rand(IVEC))
-c         CALL SMATRIX%(proc_id)s(P1, RHEL, channel, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
+c         CALL SMATRIX%(proc_id)s(P1, RHEL, ICONFIG, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
 	 ENDDO
 
 c	 do IVEC=1, NB_PAGE
-c	 	 CALL SMATRIX%(proc_id)s(p_multi(0,1,IVEC), hel_rand(ivec), ICONF, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
+c	 	 CALL SMATRIX%(proc_id)s(p_multi(0,1,IVEC), hel_rand(ivec), ICONFIG, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
 c	 enddo 
-         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONF , ALL_OUT , selected_hel, jamp2)
+         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONFIG , ALL_OUT , selected_hel, jamp2)
 
 
 	 DO IVEC=1,NB_PAGE
@@ -402,16 +404,24 @@ C
      end
 
 
-     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONF, out , selected_hel, jamp2_multi)
-
-     USE OMP_LIB
+     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONFIG, out , selected_hel, jamp2_multi)
+c cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c    input:
+c      p_multi: a list of momenta (nb of momenta nb_page)
+c      hel_rand: a list of random number (will be used to pick helicity)
+c      ICONFIG: channel of integration selected
+c      out: list of amplitude square (times multi-channel factor)
+c      selected_hel: list of selected helicity -> not used in practise. 
+c      jamp2_multi: return the list of jamp2 -> need to be changed to follow helicity setup
+c cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c     USE OMP_LIB comment openmp port for the moment
 
      include 'nexternal.inc'
      include '../../Source/vector.inc'
      include 'maxamps.inc'
      double precision p_multi(0:3, nexternal, NB_PAGE)
      double precision hel_rand(nb_page)
-     integer ICONF
+     integer ICONFIG
      double precision out(nb_page)
      integer selected_hel(nb_page)
      double precision jamp2_multi(0:MAXFLOW, nb_page)
@@ -419,20 +429,20 @@ C
      integer ivec
 
 
-!$OMP PARALLEL
-!$OMP DO
+c !$OMP PARALLEL
+c !$OMP DO
       DO IVEC=1, NB_PAGE
       	 call SMATRIX%(proc_id)s(p_multi(0,1,IVEC),
      &	                         hel_rand(IVEC),
-     &				 ICONF,
+     &				 ICONFIG,
      &				 out(IVEC),
 c     &				 selected_hel(IVEC),
      &				 jamp2_multi(0,IVEC),
      &				 IVEC
      &				 )
       ENDDO
-!$OMP END DO
-!$OMP END PARALLEL
+c !$OMP END DO
+c !$OMP END PARALLEL
      return
      end
 

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -1,5 +1,5 @@
-DOUBLE PRECISION FUNCTION DSIG%(proc_id)s(PP,WGT,IMODE)
-C ****************************************************
+DOUBLE PRECISION FUNCTION DSIG%(proc_id)s(PP,WGT,IMODE, ICONF)
+C ************************************************************
 C
 %(info_lines)s
 C
@@ -13,6 +13,9 @@ C             imode 0 run, 1 init, 2 reweight,
 C                   3 finalize, 4 only PDFs,
 C                   5 squared amplitude only (never
 C                     generate events)
+C             iconf: channel of integration under consideration
+C                    used for the amp2(multi-channel) / color assignment
+C                    note: not unique for a G directory (due to sym. channel)
 C     Output:
 C             Amplitude squared and summed
 C ****************************************************
@@ -32,7 +35,7 @@ C
 C ARGUMENTS 
 C  
       DOUBLE PRECISION PP(0:3,NEXTERNAL), WGT
-      INTEGER IMODE
+      INTEGER IMODE, ICONF
 C  
 C LOCAL VARIABLES 
 C  
@@ -41,7 +44,7 @@ C
       DOUBLE PRECISION XPQ(-7:7),PD(0:MAXPROC)
       DOUBLE PRECISION DSIGUU,R,RCONF
 
-      INTEGER LUN,ICONF,IFACT,NFACT
+      INTEGER LUN,IFACT,NFACT
       DATA NFACT/1/
       SAVE NFACT
 C
@@ -86,7 +89,6 @@ c
 c     local
 c
 	   double precision P1(0:3, nexternal)
-      integer channel
 C  
 C DATA
 C  
@@ -129,8 +131,7 @@ C     Continue only if IMODE is 0, 4 or 5
            P1 = PP
          endif
 
-	 channel = %(get_channel)s
-         CALL SMATRIX%(proc_id)s(P1,0,channel,DSIGUU,JAMP2(0,1),1)
+         CALL SMATRIX%(proc_id)s(P1,0,iconf,DSIGUU,JAMP2(0,1),1)
 
 		 IF (IMODE.EQ.5) THEN
             IF (DSIGUU.LT.1D199) THEN		 
@@ -178,7 +179,7 @@ C
 
 ## }
 
-DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE, ALL_OUT)
+DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE,ICONF, ALL_OUT)
 C ****************************************************
 C
 %(info_lines)s
@@ -193,6 +194,10 @@ C             imode 0 run, 1 init, 2 reweight,
 C                   3 finalize, 4 only PDFs,
 C                   5 squared amplitude only (never
 C                     generate events)
+C             iconf: channel of integration under consideration
+C                    used for the amp2(multi-channel) / color assignment
+C                    note: not unique for a G directory (due to sym. channel)
+C                    note: unique over the current vector 
 C     Output:
 C             Amplitude squared and summed
 C ****************************************************
@@ -217,7 +222,7 @@ C
       DOUBLE PRECISION ALL_XBK(2,NB_PAGE)
       DOUBLE PRECISION ALL_Q2FACT(2,NB_PAGE)
       DOUBLE PRECISION ALL_CM_RAP(NB_PAGE)
-      INTEGER IMODE
+      INTEGER IMODE, ICONF
       DOUBLE PRECISION ALL_OUT(NB_PAGE)
 C ----------
 C BEGIN CODE
@@ -230,11 +235,10 @@ C
       DOUBLE PRECISION XPQ(-7:7),PD(0:MAXPROC)
       DOUBLE PRECISION ALL_PD(0:MAXPROC, NB_PAGE) 
       DOUBLE PRECISION DSIGUU,R,RCONF
-      INTEGER LUN,ICONF,IFACT,NFACT
+      INTEGER LUN, IFACT,NFACT
       DATA NFACT/1/
       SAVE NFACT
       double precision RHEL ! random number
-      integer channel
 C
 C     STUFF FOR DRESSED EE COLLISIONS --even if not supported for now--
 C     
@@ -293,7 +297,7 @@ C BEGIN CODE
 C ----------
       %(cutsdone)s
       IF(IMODE.EQ.1)THEN
-	NFACT = DSIG%(proc_id)s(all_pp(0,1,1), all_wgt(1), IMODE)
+	NFACT = DSIG%(proc_id)s(all_pp(0,1,1), all_wgt(1), IMODE, ICONF)
 	RETURN
       ENDIF	   
 
@@ -323,12 +327,11 @@ c	 CM_RAP = ALL_CM_RAP(IVEC)
 	 CALL RANMAR(hel_rand(IVEC))
 c         CALL SMATRIX%(proc_id)s(P1, RHEL, channel, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
 	 ENDDO
-	 channel = %(get_channel)s
 
 c	 do IVEC=1, NB_PAGE
-c	 	 CALL SMATRIX%(proc_id)s(p_multi(0,1,IVEC), hel_rand(ivec), channel, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
+c	 	 CALL SMATRIX%(proc_id)s(p_multi(0,1,IVEC), hel_rand(ivec), ICONF, ALL_OUT(IVEC), JAMP2(0, IVEC), IVEC)
 c	 enddo 
-         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand,  channel, ALL_OUT , selected_hel, jamp2)
+         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONF , ALL_OUT , selected_hel, jamp2)
 
 
 	 DO IVEC=1,NB_PAGE
@@ -399,7 +402,7 @@ C
      end
 
 
-     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand,  channel, out , selected_hel, jamp2_multi)
+     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONF, out , selected_hel, jamp2_multi)
 
      USE OMP_LIB
 
@@ -408,7 +411,7 @@ C
      include 'maxamps.inc'
      double precision p_multi(0:3, nexternal, NB_PAGE)
      double precision hel_rand(nb_page)
-     integer channel
+     integer ICONF
      double precision out(nb_page)
      integer selected_hel(nb_page)
      double precision jamp2_multi(0:MAXFLOW, nb_page)
@@ -421,7 +424,7 @@ C
       DO IVEC=1, NB_PAGE
       	 call SMATRIX%(proc_id)s(p_multi(0,1,IVEC),
      &	                         hel_rand(IVEC),
-     &				 channel,
+     &				 ICONF,
      &				 out(IVEC),
 c     &				 selected_hel(IVEC),
      &				 jamp2_multi(0,IVEC),

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -121,6 +121,11 @@ C     Continue only if IMODE is 0, 4 or 5
       IF(IMODE.NE.0.AND.IMODE.NE.4.and.IMODE.NE.5) RETURN
 
 %(passcuts_begin)s
+
+## if(ungroup_mode){
+    CALL UPDATE_SCALE_COUPLING(PP, WGT)
+##} 
+
 %(pdf_lines)s
          IF (IMODE.EQ.4)THEN
             DSIG%(proc_id)s = PD(0)
@@ -180,6 +185,7 @@ C
 
 ## }
 
+## if(vectorize_code) {
 DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE, ALL_OUT)
 C ****************************************************
 C
@@ -387,14 +393,7 @@ C       Call UNWGT to unweight and store events
 	ENDDO
 %(passcuts_end)s
       END
-## if(read_write_good_hel) {
-C
-C     Functionality to handling grid
-C
-%(read_write_good_hel)s
-
 ## }
-
 
 
 
@@ -403,7 +402,7 @@ C
      return
      end
 
-
+## if(vectorize_code) {
      SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, ICONFIG, out , selected_hel, jamp2_multi)
 c cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c    input:
@@ -445,6 +444,8 @@ c !$OMP END DO
 c !$OMP END PARALLEL
      return
      end
+
+## }
 
 	integer FUNCTION GET_NHEL%(proc_id)s(hel, ipart)
 c         if hel>0 return the helicity of particule ipart for the selected helicity configuration

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONF, ANS, JAMP2, IVEC)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONFIG, ANS, JAMP2, IVEC)
 C 
 %(info_lines)s
 C 
@@ -9,7 +9,7 @@ c and helicities
 c for the point in phase space P(0:3,NEXTERNAL)
 c  INPUT
 c
-c  ICONF channel of integration under-consideration
+c  ICONFIG channel of integration under-consideration
 c  correspond to the G directory up to symmetry between the channel (so not unique)
 c
 c  IVEC position of that specific event in the vectorization page
@@ -38,7 +38,7 @@ C ARGUMENTS
 C  
     REAL*8 P(0:3,NEXTERNAL),ANS
     double precision RHEL ! random number for selecting helicity
-    integer iconf ! channel to keep for the multi-channel
+    integer iconfig  ! channel to keep for the multi-channel
     integer ivec ! for using the correct coupling
 c
 c global (due to reading writting) 
@@ -104,7 +104,7 @@ c      	      	      	   2 means approximation by the	denominator of the propaga
     INTEGER          ISUM_HEL
     LOGICAL                    MULTI_CHANNEL
     COMMON/TO_MATRIX/ISUM_HEL, MULTI_CHANNEL
-%(define_iconfigs_lines)s
+
     DATA XTRY, XREJ /0,0/
     DATA NGOOD /0,0/
     DATA ISHEL/0,0/
@@ -234,7 +234,7 @@ c         Set right sign for ANS, based on sign of chosen helicity
 	    endif	
         ENDDO
         IF (XTOT.NE.0D0) THEN
-		ANS=ANS*AMP2(ICONF)/XTOT
+		ANS=ANS*AMP2(ICONFIG)/XTOT
         ELSE IF(ANS.ne.0d0) THEN
 	     IF(NB_FAIL.ge.10)then
 			write(*,*) "Problem in the multi-channeling. All amp2 are zero but not the total matrix-element"

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, channel, ANS, JAMP2, IVEC)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONF, ANS, JAMP2, IVEC)
 C 
 %(info_lines)s
 C 
@@ -7,6 +7,12 @@ C
 C Returns amplitude squared -- no average over initial state/symmetry factor
 c and helicities
 c for the point in phase space P(0:3,NEXTERNAL)
+c  INPUT
+c
+c  ICONF channel of integration under-consideration
+c  correspond to the G directory up to symmetry between the channel (so not unique)
+c
+c  IVEC position of that specific event in the vectorization page
 C  
 %(process_lines)s
 C 
@@ -32,7 +38,7 @@ C ARGUMENTS
 C  
     REAL*8 P(0:3,NEXTERNAL),ANS
     double precision RHEL ! random number for selecting helicity
-    integer channel ! channel to keep for the multi-channel
+    integer iconf ! channel to keep for the multi-channel
     integer ivec ! for using the correct coupling
 c
 c global (due to reading writting) 
@@ -73,7 +79,7 @@ C
     logical init_mode
     common /to_determine_zero_hel/init_mode
     include '../../Source/vector.inc'
-    DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
+    DOUBLE PRECISION AMP2(LMAXCONFIGS), JAMP2(0:MAXFLOW)
    
     CHARACTER*101         HEL_BUFF
     COMMON/TO_HELICITY/  HEL_BUFF
@@ -121,7 +127,7 @@ C ----------
     ENDDO
      
     IF (multi_channel) THEN
-        DO I=1,NDIAGS
+        DO I=1,LMAXCONFIGS
             AMP2(I)=0D0
         ENDDO
         JAMP2(0)=%(ncolor)d
@@ -219,19 +225,16 @@ c         Set right sign for ANS, based on sign of chosen helicity
     IF (MULTI_CHANNEL) THEN
         XTOT=0D0
         DO I=1,LMAXCONFIGS
-	    J = CONFSUB(%(proc_id)s, I)
-	    if (J.ne.0) then
 	    if(sde_strat.eq.1) then
-	         AMP2(J) = AMP2(J) * GET_CHANNEL_CUT(P, I)
-                 XTOT=XTOT+AMP2(J)
+	         AMP2(I) = AMP2(I) * GET_CHANNEL_CUT(P, I)
+                 XTOT=XTOT+AMP2(I)
 	    else
-	    	 AMP2(J) = GET_CHANNEL_CUT(P, I)
-                 XTOT=XTOT+AMP2(J)
+	    	 AMP2(I) = GET_CHANNEL_CUT(P, I)
+                 XTOT=XTOT+AMP2(I)
 	    endif	
-            endif	
         ENDDO
         IF (XTOT.NE.0D0) THEN
-		ANS=ANS*AMP2(channel)/XTOT
+		ANS=ANS*AMP2(ICONF)/XTOT
         ELSE IF(ANS.ne.0d0) THEN
 	     IF(NB_FAIL.ge.10)then
 			write(*,*) "Problem in the multi-channeling. All amp2 are zero but not the total matrix-element"
@@ -308,7 +311,7 @@ C
 C GLOBAL VARIABLES
 C
    include '../../Source/vector.inc'
-    Double Precision amp2(maxamps), jamp2(0:maxflow)
+    Double Precision amp2(*), jamp2(0:maxflow)
     include 'coupl.inc'
 
 	double precision small_width_treatment

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, channel, ANS, JAMP2, IVEC)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONF, ANS, JAMP2, IVEC)
 C 
 %(info_lines)s
 C 
@@ -7,6 +7,9 @@ C
 C Returns amplitude squared summed/avg over colors
 c and helicities
 c for the point in phase space P(0:3,NEXTERNAL)
+c INPUT:
+C   ICONF, channel of integration under consideration
+C        related by symmetry to the G directory (but not always that value)
 C  
 %(process_lines)s
 C 
@@ -30,7 +33,7 @@ C
 C ARGUMENTS 
 C  
     REAL*8 P(0:3,NEXTERNAL),ANS
-    INTEGER IVEC
+    INTEGER ICONF, IVEC
 C  
 C LOCAL VARIABLES 
 C  
@@ -44,7 +47,6 @@ C
         REAL*8 XTOT
         INTEGER  J, JJ
 	double precision RHEL
-	integer channel
       double precision get_channel_cut
       external get_channel_cut
 
@@ -52,7 +54,7 @@ C
 C GLOBAL VARIABLES
 C
     include '../../Source/vector.inc'
-    DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
+    DOUBLE PRECISION AMP2(LMAXCONFIGS), JAMP2(0:MAXFLOW)
 
 
 C
@@ -88,7 +90,7 @@ C ----------
     ENDDO
      
     IF (multi_channel) THEN
-        DO I=1,NDIAGS
+        DO I=1,LMAXCONFIGS
             AMP2(I)=0D0
         ENDDO
         JAMP2(0)=%(ncolor)d
@@ -133,19 +135,16 @@ c         Set right sign for ANS, based on sign of chosen helicity
     IF (MULTI_CHANNEL) THEN
         XTOT=0D0
         DO I=1,LMAXCONFIGS
-	    J = CONFSUB(%(proc_id)s, I)
-	    if (J.ne.0)then
 	      if (sde_strat.eq.1)then
-	         AMP2(J) = AMP2(J) * GET_CHANNEL_CUT(P, I)
+	         AMP2(I) = AMP2(I) * GET_CHANNEL_CUT(P, I)
                else
-	     	         AMP2(J) = GET_CHANNEL_CUT(P, I)
+	     	 AMP2(I) = GET_CHANNEL_CUT(P, I)
 	       endif
-             XTOT=XTOT+AMP2(J)
+             XTOT=XTOT+AMP2(I)
 
-             endif
         ENDDO
         IF (XTOT.NE.0D0) THEN
-	   ANS=ANS*AMP2(channel)/XTOT
+	   ANS=ANS*AMP2(ICONF)/XTOT
         ELSE IF(ANS.ne.0d0) THEN
 			write(*,*) "Problem in the multi-channeling. All amp2 are zero but not the total matrix-element"
 	        stop 1
@@ -219,7 +218,7 @@ C
 C GLOBAL VARIABLES
 C
     include '../../Source/vector.inc'
-    Double Precision amp2(maxamps), jamp2(0:maxflow)
+    Double Precision amp2(*), jamp2(0:maxflow)
     include 'coupl.inc'
 
        double precision tmin_for_channel

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONF, ANS, JAMP2, IVEC)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, ICONFIG, ANS, JAMP2, IVEC)
 C 
 %(info_lines)s
 C 
@@ -8,7 +8,7 @@ C Returns amplitude squared summed/avg over colors
 c and helicities
 c for the point in phase space P(0:3,NEXTERNAL)
 c INPUT:
-C   ICONF, channel of integration under consideration
+C   ICONFIG, channel of integration under consideration
 C        related by symmetry to the G directory (but not always that value)
 C  
 %(process_lines)s
@@ -33,7 +33,7 @@ C
 C ARGUMENTS 
 C  
     REAL*8 P(0:3,NEXTERNAL),ANS
-    INTEGER ICONF, IVEC
+    INTEGER ICONFIG, IVEC
 C  
 C LOCAL VARIABLES 
 C  
@@ -77,7 +77,7 @@ c      	      	      	   2 means approximation by the	denominator of the propaga
     INTEGER          ISUM_HEL
     LOGICAL                    MULTI_CHANNEL
     COMMON/TO_MATRIX/ISUM_HEL, MULTI_CHANNEL
-%(define_iconfigs_lines)s
+
 ${helicity_lines}
 %(den_factor_line)s
 
@@ -144,7 +144,7 @@ c         Set right sign for ANS, based on sign of chosen helicity
 
         ENDDO
         IF (XTOT.NE.0D0) THEN
-	   ANS=ANS*AMP2(ICONF)/XTOT
+	   ANS=ANS*AMP2(ICONFIG)/XTOT
         ELSE IF(ANS.ne.0d0) THEN
 			write(*,*) "Problem in the multi-channeling. All amp2 are zero but not the total matrix-element"
 	        stop 1

--- a/madgraph/iolibs/template_files/matrix_madevent_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_v4.inc
@@ -56,7 +56,7 @@ C
 C  
 C GLOBAL VARIABLES
 C  
-    DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
+    DOUBLE PRECISION AMP2(LMAXCONFIGS), JAMP2(0:MAXFLOW)
     COMMON/TO_AMPS/  AMP2,       JAMP2
     
     CHARACTER*101        HEL_BUFF
@@ -84,7 +84,7 @@ C ----------
     ENDDO
      
     IF (multi_channel) THEN
-        DO I=1,NDIAGS
+        DO I=1,LMAXCONFIGS
             AMP2(I)=0D0
         ENDDO
         JAMP2(0)=%(ncolor)d
@@ -169,7 +169,7 @@ c           Include the Jacobian from helicity sampling
     ENDIF
     IF (MULTI_CHANNEL) THEN
         XTOT=0D0
-        DO I=1,NDIAGS
+        DO I=1,LMAXCONFIGS
             XTOT=XTOT+AMP2(I)
         ENDDO
         IF (XTOT.NE.0D0) THEN
@@ -240,7 +240,7 @@ C
 C  
 C GLOBAL VARIABLES
 C  
-    Double Precision amp2(maxamps), jamp2(0:maxflow)
+    Double Precision amp2(LMAXCONFIGS), jamp2(0:maxflow)
     common/to_amps/  amp2,       jamp2
     include 'coupl.inc'
 

--- a/madgraph/iolibs/template_files/matrix_madevent_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_v4.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P,ANS)
+SUBROUTINE SMATRIX%(proc_id)s(P, DUM0, ICONFIG, ANS, JAMP2V, DUM1)
 C  
 %(info_lines)s
 C 
@@ -11,7 +11,7 @@ C
 %(process_lines)s
 C  
     use DiscreteSampler
-    IMPLICIT NONE
+    IMPLICIT NONE    
 C  
 C CONSTANTS
 C  
@@ -31,6 +31,13 @@ C
 C ARGUMENTS 
 C  
     REAL*8 P(0:3,NEXTERNAL),ANS
+    !not used DUM0: (suppose to be random number for selecting helicity)
+    !not used DUM1 (suppose to be event position in vector size)
+    INTEGER DUM0, DUM1
+    ! channel of integration (for selecting the multi-channel weight)
+    INTEGER ICONFIG
+    ! vectorised form for jamp2 -> even if only one member
+    Double precision jamp2v(0:maxflow,1)
 c
 c global (due to reading writting)
 c 
@@ -68,7 +75,6 @@ C
     INTEGER          ISUM_HEL
     LOGICAL                    MULTI_CHANNEL
     COMMON/TO_MATRIX/ISUM_HEL, MULTI_CHANNEL
-%(define_iconfigs_lines)s
     DATA IDUM /-1/
     DATA XTRY, XREJ, NGOOD /0,0,0/
     SAVE YFRAC, IGOOD, JHEL
@@ -180,6 +186,7 @@ c           Include the Jacobian from helicity sampling
         ENDIF
     ENDIF
     ANS=ANS/DBLE(IDEN)
+    JAMP2V(:,1) = JAMP2
     END
  
  
@@ -201,6 +208,7 @@ C
     include 'genps.inc'
     include 'nexternal.inc'
     include 'maxamps.inc'
+    include 'maxconfigs.inc'
     INTEGER    NWAVEFUNCS,     NCOLOR
     PARAMETER (NWAVEFUNCS=%(nwavefuncs)d, NCOLOR=%(ncolor)d) 
     REAL*8     ZERO
@@ -212,6 +220,8 @@ C
 	LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
 	DATA CHOSEN_SO_CONFIGS/%(chosen_so_configs)s/
 	SAVE CHOSEN_SO_CONFIGS
+    INTEGER IVEC	
+    PARAMETER (IVEC=1)
 C  
 C ARGUMENTS 
 C  


### PR DESCRIPTION
Hi Andrea,

You can merge this branch as soon as you are ready for it.
This branch include change to the amp2 numbering as we discussed before.

For completeness, the main goal was to be able to have the same index for the identification of the amp2 index as for the one related to the definition of the allowed color flow for the event.

I will still improve this branch to be sure/upgrade other mode to have consistent code and/or be sure that everything is fine (like loop-induced/....) but this can be done independently within this branch or to the other ones when this is merged.