### PR TITLE
Append only ME process definition instead of full ME

### DIFF
--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -5807,13 +5807,12 @@ class HelasMultiProcess(base_objects.PhysicsObject):
                         matrix_element_list.append(matrix_element)
                         if combine_matrix_elements:
                             amplitude_tags.append(amplitude_tag)
-                            identified_matrix_elements.append(matrix_element)
+                            identified_matrix_elements.append(matrix_element.get('processes'))
                             permutations.append(amplitude_tag[-1][0].\
                                                 get_external_numbers())
                     else: # try
                         # Identical matrix element found
-                        other_processes = identified_matrix_elements[me_index].\
-                                          get('processes')
+                        other_processes = identified_matrix_elements[me_index]
                         # Reorder each of the processes
                         # Since decay chain, only reorder legs_with_decays
                         for proc in matrix_element.get('processes'):
@@ -5853,15 +5852,15 @@ class HelasMultiProcess(base_objects.PhysicsObject):
                         # Keep track of amplitude tags
                         if combine_matrix_elements:
                             amplitude_tags.append(amplitude_tag)
-                            identified_matrix_elements.append(me)
+                            identified_matrix_elements.append(me.get('processes'))
                             permutations.append(amplitude_tag[-1][0].\
                                                 get_external_numbers())
                     else:
                         matrix_element_list = []
                 else:
                     # Identical matrix element found
-                    other_processes = identified_matrix_elements[me_index].\
-                                      get('processes')
+                    other_processes = identified_matrix_elements[me_index]
+                                      
                     
                     other_processes.append(cls.reorder_process(\
                         amplitude.get('process'),


### PR DESCRIPTION
When computing a new matrix element in the amplitudes cycle, the full ME object is appended to the `identified_matrix_elements` list. 
If an amplitude tag is repeated in the cycle (meaning `me_index = amplitude_tags.index(amplitude_tag)` does not raise a `ValueError`) then the `identified_matrix_elements` is used to retrieve the processes to combine and to log at screen.

It is not needed to save the full ME in `identified_matrix_elements` but just the process definition related to the ME.


-----
Tested the resident memory consumption before and after the correction for the process

```
import model SMEFTsim_topU3l_MwScheme_UFO_b_massless-cHl3_cll1_massless
define p = g u c d s b  u~ d~ c~ s~ b~
define j = p
generate p p  > mu- vm~ j j QCD=2 NP=1 SMHLOOP=0
``` 

Before fix peak RES consumption : 177308
After fix peak RES consumption : 129712

Which means roughly a 30% reduction of the resource consumption (highly dependent on the process definition)