### PR TITLE
Fix error when HEPMCoutput:file = hepmcremove option is used for pythia8 output

### DIFF
--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -5542,20 +5542,20 @@ tar -czf split_$1.tar.gz split_$1
             if os.path.isfile(file_path):
                 if 'removeHEPMC' in self.to_store:
                     os.remove(file_path)
+                else:
+                    self.update_status('Storing Pythia8 files of previous run', level='pythia', error=True)
+                    if 'compressHEPMC' in self.to_store:
+                        misc.gzip(file_path,stdout=file_path)
+                        hepmc_fileformat = ".gz"
 
-                self.update_status('Storing Pythia8 files of previous run', level='pythia', error=True)
-                if 'compressHEPMC' in self.to_store:
-                    misc.gzip(file_path,stdout=file_path)
-                    hepmc_fileformat = ".gz"
+                    moveHEPMC_in_to_store = None
+                    for to_store in self.to_store:
+                        if "moveHEPMC" in to_store:
+                           moveHEPMC_in_to_store = to_store
 
-                moveHEPMC_in_to_store = None
-                for to_store in self.to_store:
-                    if "moveHEPMC" in to_store:
-                        moveHEPMC_in_to_store = to_store
-
-                if not moveHEPMC_in_to_store == None:
-                    move_hepmc_path = moveHEPMC_in_to_store.split("@")[1]
-                    os.system("mv " + file_path + hepmc_fileformat + " " + move_hepmc_path)
+                    if not moveHEPMC_in_to_store == None:
+                        move_hepmc_path = moveHEPMC_in_to_store.split("@")[1]
+                        os.system("mv " + file_path + hepmc_fileformat + " " + move_hepmc_path)
 
         self.update_status('Done', level='pythia',makehtml=False,error=True)
         self.results.save()        


### PR DESCRIPTION
Fix an error raised when using HEPMCoutput:file = hepmcremove in pythia8 card. 

In the line 5553 the code checks  for the string "moveHEPMC" which is also a substring in "removeHEPMC" so then the error is raised in line 5557 when the string is splitted using '@' separator which is not there. 

Also the message "Storing pythia output..." is no needed with this option. 