### PR TITLE
Clear SQUEUE_FORMAT environment variable for job control

### DIFF
--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -1729,6 +1729,10 @@ class SLURMCluster(Cluster):
     def control_one_job(self, id):
         """ control the status of a single job with it's cluster id """
         cmd = 'squeue j'+str(id)
+        # Remove incompatible squeue formats 
+        env = os.environ.copy()
+        if "SQUEUE_FORMAT" in env:
+            del env["SQUEUE_FORMAT"]
         status = misc.Popen([cmd], shell=True, stdout=subprocess.PIPE,
                                   stderr=open(os.devnull,'w'))
         
@@ -1748,7 +1752,11 @@ class SLURMCluster(Cluster):
     def control(self, me_dir):
         """ control the status of a single job with it's cluster id """
         cmd = "squeue"
-        pstatus = misc.Popen([cmd], stdout=subprocess.PIPE)
+        # Remove incompatible squeue formats 
+        env = os.environ.copy()
+        if "SQUEUE_FORMAT" in env:
+            del env["SQUEUE_FORMAT"]
+        pstatus = misc.Popen([cmd], stdout=subprocess.PIPE,env=env)
 
         me_dir = self.get_jobs_identifier(me_dir)
 

--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -1734,7 +1734,7 @@ class SLURMCluster(Cluster):
         if "SQUEUE_FORMAT" in env:
             del env["SQUEUE_FORMAT"]
         status = misc.Popen([cmd], shell=True, stdout=subprocess.PIPE,
-                                  stderr=open(os.devnull,'w'))
+                                  stderr=open(os.devnull,'w'),env=env)
         
         for line in status.stdout:
             line = line.decode(errors='ignore').strip()


### PR DESCRIPTION
I encountered an issue with the slurm cluster mode of MadGraph. 
My jobs got stuck in HOLD and weren't working properly.

A solution to this was to disable the squeue formatting in the environment variable `unset SQUEUE_FORMAT`.
Similarly arguments like `SQUEUE_SORT` exist but should not have an impact.

This PR makes sure that the `SQUEUE_FORMAT` env. var. is unset so that MadGraph can parse the result properly.
Cheers,
Alexander Neuwirth