### PR TITLE
Second set of vector.inc changes for cudacpp integration (make VECSIZE_USED a function argument)

### DIFF
--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -1,16 +1,17 @@
-      subroutine sample_full(ndim,ncall,itmax,itmin,dsig,ninvar,nconfigs)
+      subroutine sample_full(ndim,ncall,itmax,itmin,dsig,ninvar,nconfigs,VECSIZE_USED)
 c**************************************************************************
 c     Driver for sample which does complete integration
 c     This is done in double precision, and should be told the
 c     number of possible phasespace choices.
 c     Arguments:
-c     ndim       Number of dimensions for integral(number or random #'s/point)
-c     ncall      Number of times to evaluate the function/iteration
-c     itmax      Max number of iterations
-c     itmin      Min number of iterations
-c     ninvar     Number of invarients to keep grids on (s,t,u, s',t' etc)
-c     nconfigs   Number of different pole configurations 
-c     dsig       Function to be integrated
+c     ndim           Number of dimensions for integral(number or random #'s/point)
+c     ncall          Number of times to evaluate the function/iteration
+c     itmax          Max number of iterations
+c     itmin          Min number of iterations
+c     dsig           Function to be integrated
+c     ninvar         Number of invarients to keep grids on (s,t,u, s',t' etc)
+c     nconfigs       Number of different pole configurations 
+c     VECSIZE_USED   Number of events in parallel out of VECSIZE_MEMMAX
 c**************************************************************************
       implicit none
       include 'genps.inc'
@@ -19,6 +20,7 @@ c
 c Arguments
 c
       integer ndim,ncall,itmax,itmin,ninvar,nconfigs
+      integer VECSIZE_USED
       external         dsig
       double precision dsig
 c
@@ -141,7 +143,7 @@ c-----
 C     Fix for 2>1 process where ndim is 2 and not 1
       ninvar = max(2,ninvar)
 
-      call sample_init(ndim,ncall,itmax,ninvar,nconfigs)
+      call sample_init(ndim,ncall,itmax,ninvar,nconfigs,VECSIZE_USED)
       call graph_init
       do i=1,itmax
          xmean(i)=0d0
@@ -374,7 +376,7 @@ c
       ncall = ncall*4 ! / 2**(itmax-2)
       write(*,*) "Starting w/ ncall = ", ncall
       itmax = 8
-      call sample_init(ndim,ncall,itmax,ninvar,nconfigs)
+      call sample_init(ndim,ncall,itmax,ninvar,nconfigs,VECSIZE_USED)
       do i=1,itmax
          xmean(i)=0d0
          xsigma(i)=0d0
@@ -652,7 +654,7 @@ c     $     ntot/1000,'</th><th align=right>',teff,'</th></tr>'
 
 
 
-      subroutine sample_init(p1, p2, p3, p4, p5)
+      subroutine sample_init(p1, p2, p3, p4, p5, VECSIZE_USED)
 c************************************************************************
 c     Initialize grid and random number generators
 c************************************************************************
@@ -668,7 +670,7 @@ c
 c     Arguments
 c
       integer p1, p2, p3, p4, p5
-
+      integer VECSIZE_USED
 c
 c     Local
 c

--- a/Template/LO/SubProcesses/cuts.f
+++ b/Template/LO/SubProcesses/cuts.f
@@ -256,11 +256,15 @@ c               fixed_ren_scale=.true.
 c               call set_ren_scale(P,scale)
 c            endif
 c         endif
-         
+
+c     If scale is fixed, update G-dependent couplings for VECSIZE_MEMMAX events
+c     This is called only once in the application (FIRSTTIME=.true.)
+c     Only VECSIZE_USED events are needed, but this variable is unknown here
+c     Using VECSIZE_MEMMAX is correct and has a negligible performance overhead
 
          if(fixed_ren_scale) then
             G = SQRT(4d0*PI*ALPHAS(scale))
-            do i =1, VECSIZE_USED
+            do i =1, VECSIZE_MEMMAX ! no need to use VECSIZE_USED here
                call update_as_param(i)
             enddo
          endif

--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -1805,7 +1805,7 @@ C      include 'maxparticles.inc'
       end
 
       
-      subroutine update_scale_coupling_vec(all_p, all_wgt,all_q2fact, VECSIZE_USED_in)
+      subroutine update_scale_coupling_vec(all_p, all_wgt,all_q2fact, VECSIZE_USED)
       implicit none
 
 C
@@ -1823,7 +1823,7 @@ C      include 'maxparticles.inc'
       
       double precision all_p(4*maxdim/3+14,*), all_wgt(*)
       double precision all_q2fact(2,*)
-      integer i,j,k, VECSIZE_USED_in
+      integer i,j,k, VECSIZE_USED
 
       logical setclscales
       external setclscales
@@ -1837,7 +1837,7 @@ c      save firsttime
       if(.not.fixed_ren_scale) then
          scale = 0d0
       endif
-      do i =1, VECSIZE_USED_in
+      do i =1, VECSIZE_USED
 
          if(.not.fixed_ren_scale) then
             call set_ren_scale(all_p(1,i),scale)

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -6334,7 +6334,7 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
                 "IF(IPROC.EQ.%(num)d) DSIGPROC=DSIG%(num)d(P1,WGT,IMODE) ! %(proc)s" % data
                 )
             call_dsig_proc_lines_vec.append(\
-                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK, ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ALL_OUT) ! %(proc)s" % data
+                "IF(IPROC.EQ.%(num)d) CALL DSIG%(num)d_VEC(ALL_P1,ALL_XBK,ALL_Q2FACT,ALL_CM_RAP,ALL_WGT,IMODE,ALL_OUT,VECSIZE_USED) ! %(proc)s" % data
                 )
 
         replace_dict['call_dsig_proc_lines'] = "\n".join(call_dsig_proc_lines)

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -4976,9 +4976,14 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         vector_size = banner_mod.ConfigFile.format_variable(vector_size, int, name='vector_size')
         vector_size = max(1, vector_size)
         text=["""C
-C Offloading ME to GPUs or vectorized C++ needs a vector API.
-C Fortran arrays in this API can hold up to VECSIZE_MEMMAX events.
-C These arrays are statically allocated at compile time.
+C If VECSIZE_MEMMAX is greater than 1, a vector API is used:
+C this is designed for offloading MEs to GPUs or vectorized C++,
+C but it can also be used for computing MEs in Fortran.
+C If VECSIZE_MEMMAX equals 1, the old scalar API is used:
+C this can only be used for computing MEs in Fortran.
+C
+C Fortran arrays in the vector API can hold up to VECSIZE_MEMMAX
+C events and are statically allocated at compile time.
 C The constant value of VECSIZE_MEMMAX is fixed at codegen time
 C (output madevent ... --vector_size=<VECSIZE_MEMMAX>).
 C

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -4977,7 +4977,6 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         vector_size = max(1, vector_size)
 
         text = [" integer VECSIZE_MEMMAX\n"," parameter (VECSIZE_MEMMAX=%i)\n" % vector_size]
-        text += [" integer VECSIZE_USED\n"," parameter (VECSIZE_USED=VECSIZE_MEMMAX)\n"]
 
         fsock.writelines(text)
         return vector_size

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -179,7 +179,7 @@ C
 
 ## }
 
-DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT,IMODE, ALL_OUT)
+DOUBLE PRECISION FUNCTION DSIG%(proc_id)s_VEC(ALL_PP, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ALL_WGT, IMODE, ALL_OUT, VECSIZE_USED)
 C ****************************************************
 C
 %(info_lines)s
@@ -220,6 +220,7 @@ C
       DOUBLE PRECISION ALL_CM_RAP(VECSIZE_MEMMAX)
       INTEGER IMODE
       DOUBLE PRECISION ALL_OUT(VECSIZE_MEMMAX)
+      INTEGER VECSIZE_USED
 C ----------
 C BEGIN CODE
 C ----------
@@ -332,7 +333,7 @@ C     Select a flavor combination (need to do here for right sign)
 	 ENDDO
 	 channel = %(get_channel)s
 
-         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, ALL_OUT , selected_hel, selected_col)
+         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, ALL_OUT , selected_hel, selected_col, VECSIZE_USED)
 
 
 	 DO IVEC=1,VECSIZE_USED
@@ -396,7 +397,7 @@ C
      end
 
 
-     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, out , selected_hel, selected_col)
+     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, out, selected_hel, selected_col, VECSIZE_USED)
      USE OMP_LIB
      implicit none
 
@@ -410,6 +411,7 @@ C
      double precision out(VECSIZE_MEMMAX)
      integer selected_hel(VECSIZE_MEMMAX)
      integer selected_col(VECSIZE_MEMMAX)
+     INTEGER VECSIZE_USED
 
      integer ivec
 

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -404,6 +404,8 @@ C
      include 'nexternal.inc'
      include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
      include 'maxamps.inc'
+     INTEGER                 NCOMB
+     PARAMETER (             NCOMB=%(ncomb)d)
      double precision p_multi(0:3, nexternal, VECSIZE_MEMMAX)
      double precision hel_rand(VECSIZE_MEMMAX)
      double precision col_rand(VECSIZE_MEMMAX)

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -73,7 +73,8 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
       include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'coupl.inc'
-      integer VECSIZE_USED
+      INTEGER VECSIZE_USED
+      DATA VECSIZE_USED/VECSIZE_MEMMAX/
 
 C-----
 C  BEGIN CODE

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -73,6 +73,7 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
       include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'coupl.inc'
+      integer VECSIZE_USED
 
 C-----
 C  BEGIN CODE
@@ -182,7 +183,7 @@ c         itmin = itmin + 1
       endif
 
       write(*,*) "about to integrate ", ndim,ncall,itmax,itmin,ninvar,nconfigs
-      call sample_full(ndim,ncall,itmax,itmin,dsig,ninvar,nconfigs)
+      call sample_full(ndim,ncall,itmax,itmin,dsig,ninvar,nconfigs,VECSIZE_USED)
 
 c
 c     Now write out events to permanent file

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -74,7 +74,7 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
       include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'coupl.inc'
       INTEGER VECSIZE_USED
-      DATA VECSIZE_USED/VECSIZE_MEMMAX/
+      DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime
 
 C-----
 C  BEGIN CODE

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -219,7 +219,7 @@ C       We are using the grouped_processes grid and it is initialized.
       RETURN
       END
 
-      SUBROUTINE DSIG_VEC(ALL_P,ALL_WGT,all_xbk, all_q2fact, all_cm_rap, ICONF,IPROC,IMIRROR, ALL_OUT,VECSIZE_USED)
+      SUBROUTINE DSIG_VEC(ALL_P,ALL_WGT,all_xbk,all_q2fact,all_cm_rap,ICONF,IPROC,IMIRROR,ALL_OUT,VECSIZE_USED)
 c     ******************************************************
 c
 c     INPUT: ALL_PP(0:3, NEXTERNAL, VECSIZE_USED)
@@ -302,7 +302,7 @@ C       If we were in the initialization phase of the grid for MC over grouped p
       	  ALLOW_HELICITY_GRID_ENTRIES = .False.
       endif
 
-      call DSIGPROC_vec(ALL_P, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ICONF, IPROC,IMIRROR,SYMCONF,CONFSUB,ALL_WGT,0, ALL_OUT)
+      call DSIGPROC_vec(ALL_P,ALL_XBK,ALL_Q2FACT,ALL_CM_RAP,ICONF,IPROC,IMIRROR,SYMCONF,CONFSUB,ALL_WGT,0,ALL_OUT,VECSIZE_USED)
 
       
       Do i =1,VECSIZE_USED
@@ -841,7 +841,7 @@ C     ccccccccccccccccccccccccc
 C      vectorize version
 C     ccccccccccccccccccccccccc
 
-      subroutine DSIGPROC_VEC(ALL_P, ALL_XBK, ALL_Q2FACT, ALL_CM_RAP, ICONF,IPROC,IMIRROR,SYMCONF,CONFSUB,ALL_WGT,IMODE,all_out)
+      subroutine DSIGPROC_VEC(ALL_P,ALL_XBK,ALL_Q2FACT,ALL_CM_RAP,ICONF,IPROC,IMIRROR,SYMCONF,CONFSUB,ALL_WGT,IMODE,all_out,VECSIZE_USED)
 C     ****************************************************
 C     RETURNS DIFFERENTIAL CROSS SECTION 
 C     FOR A PROCESS
@@ -875,6 +875,7 @@ C
       INTEGER ICONF,IPROC,IMIRROR,IMODE
       INTEGER SYMCONF(0:LMAXCONFIGS)
       INTEGER CONFSUB(MAXSPROC,LMAXCONFIGS)
+      INTEGER VECSIZE_USED
 C     
 C     GLOBAL VARIABLES
 C     

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -812,7 +812,7 @@ c    not needed anymore ... can be removed ... set for debugging only
      endif
 c     set the running scale 
 c     and update the couplings accordingly
-      if (VECSIZE_USED.le.1) then
+      IF (VECSIZE_MEMMAX.LE.1) THEN ! no-vector (NB not VECSIZE_USED!)
       call update_scale_coupling(pp, wgt)
       endif
 


### PR DESCRIPTION
Hi @oliviermattelaer @roiser this is a (WIP, for now) second set of vector.inc changes for cudacpp integration.

It is a followup to #23 and it includes it internally (as that has not been merged yet).

It is addressing the part that was still missing in #23, namely it transforms VECSIZE_USED from a global constant parameter into a local variable that is passed through the code as a function argument. This is what OLivier had suggested during our chat on Thursday morning.

More details from the log of https://github.com/mg5amcnlo/mg5amcnlo/commit/fc4dfd92529928afc4d92c21eaf589aa88cd7f23
```
This is how VECSIZE_USED is currently passed throughout a Fortran-only application:
- in driver.f, program DRIVER reads VECSIZE_USED from user inputs
- in driver.f, program DRIVER calls SAMPLE_FULL with argument VECSIZE_USED
 > in dsample.f, subroutine SAMPLE_FULL calls SAMPLE_INIT (in dsample.f) with argument VECSIZE_USED
  == in dsample.f, subroutine SAMPLE_INIT uses argument VECSIZE_USED
 > in dsample.f, subroutine SAMPLE_FULL calls SELECT_GROUPING with argument VECSIZE_USED
  == in auto_dsig.f, subroutine SELECT_GROUPING uses argument VECSIZE_USED
 > in dsample.f, subroutine SAMPLE_FULL calls DSIG_VEC with argument VECSIZE_USED
  > in auto_dsig.f, subroutine DSIG_VEC calls UPDATE_SCALE_COUPLING_VEC with argument VECSIZE_USED
   == in reweight.f, subroutine UPDATE_SCALE_COUPLING_VEC uses argument VECSIZE_USED
  > in auto_dsig.f, subroutine DSIG_VEC calls DSIG_PROC_VEC with argument VECSIZE_USED
   > in auto_dsig.f, subroutine DSIG_PROC_VEC calls DSIG1_VEC with argument VECSIZE_USED
    > in auto_dsig1.f, subroutine DSIG1_VEC calls SMATRIX1_MULTI with argument VECSIZE_USED
     == in auto_dsig1.f, subroutine SMATRIX1_MULTI uses argument VECSIZE_USED
```

This is almost complete, actually the last log says it is complete, but I will change it and amend the log with a force push, so I leave it in WIP for now. The only things that I would like to change are the following
- The comments in vector.inc refer to the case when the code is generated in vector mode. When vector mode is not used (i.e. when VECSIZE_MEMMAX is 1), I think that it would be better to use different comments. Or at least, the case VECSIZE_MEMMAX=1 should be mentioned in the comments.
- The initialization of VECSIZE_USED is now a DATA block in driver.f. This is how I plan to use it when the cudacpp integration is complete (i.e. when my next set of patches is ported upstream). But for the moment, this code without cudacpp would make more sense with a PARAMETER definition in driver.f. This is esepcially the case for VECSIZE_MEMMAX=1 above.
- I will also leave this in WIP until the previous #23 is merged, so it becomes clearer what this one adds.

Anyway, these are almost cosmetic changes. The code now builds (and hopefully runs) also in fortran only mode, both in vector and no vector mode.

I have an upcoming MR of madgraph4gpu that is based on this one, I will add the reference when I create it.