### PR TITLE
Fixes for build errors in lo_vect_diagid 

### DIFF
--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -89,6 +89,7 @@ c
 c     local
 c
 	   double precision P1(0:3, nexternal)
+      INTEGER CHANNEL
 C  
 C DATA
 C  
@@ -296,7 +297,7 @@ c     local
 c
 	   double precision P1(0:3, nexternal)
 	   integer ivec
-
+      INTEGER CHANNEL
 C  
 C DATA
 C  
@@ -344,7 +345,9 @@ C     Select a flavor combination (need to do here for right sign)
 	 CALL RANMAR(hel_rand(IVEC))
 	 CALL RANMAR(col_rand(IVEC))
 	 ENDDO
-   call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, ALL_OUT , selected_hel, selected_col)
+
+         channel = %(get_channel)s
+         call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, ALL_OUT , selected_hel, selected_col)
 
 	 DO IVEC=1,NB_PAGE
 	 DSIGUU = ALL_OUT(IVEC)

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -400,18 +400,18 @@ C       Call UNWGT to unweight and store events
      end
 
 ## if(vectorize_code) {
-     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, out , selected_hel, selected_col)
-c cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+     SUBROUTINE SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channel, out, selected_hel, selected_col)
+c    ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 c    input:
-c      p_multi: a list of momenta (nb of momenta nb_page)
-c      hel_rand: a list of random number (will be used to pick helicity)
-c.     col_rand: a list of random number (will be used to pick leading color)
-c      ICONFIG: channel of integration selected
-c      out: list of amplitude square (times multi-channel factor)
-c      selected_hel: list of selected helicity -> not used in practise. 
-c      jamp2_multi: return the list of jamp2 -> need to be changed to follow helicity setup
-c cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-c     USE OMP_LIB comment openmp port for the moment
+c    p_multi: a list of momenta (nb of momenta nb_page)
+c    hel_rand: a list of random numbers (to pick helicity)
+c    col_rand: a list of random numbers (to pick leading color)
+c    channel: channel of integration selected
+c    out: list of amplitude square (times multi-channel factor)
+c    selected_hel: list of selected helicity -> not used in practise 
+c    jamp2_multi: return the list of jamp2 -> need to be changed to follow helicity setup
+c    ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+c    USE OMP_LIB comment openmp port for the moment
      implicit none
 
      include 'nexternal.inc'

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, RCOL, channel, IVEC, ANS, IHEL, ICOL)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, RCOL, iconfig, IVEC, ANS, IHEL, ICOL)
 C 
 %(info_lines)s
 C 
@@ -39,7 +39,7 @@ C
     REAL*8 P(0:3,NEXTERNAL),ANS
     double precision RHEL ! random number for selecting helicity
     double precision RCOL ! random number for selecting helicity
-    integer channel ! channel to keep for the multi-channel
+    integer iconfig ! channel to keep for the multi-channel
     integer ivec ! for using the correct coupling
 c
 c   output argument
@@ -248,7 +248,7 @@ c         Set right sign for ANS, based on sign of chosen helicity
     ENDIF
     ANS=ANS/DBLE(IDEN)
 
-    call select_color(rcol, jamp2, channel,%(proc_id)s,  icol)
+    call select_color(rcol, jamp2, iconfig,%(proc_id)s,  icol)
 
     END
 

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -1,4 +1,4 @@
-SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, RCOL, channel, IVEC, ANS, IHEL, ICOL)
+SUBROUTINE SMATRIX%(proc_id)s(P, RHEL, RCOL, iconfig, IVEC, ANS, IHEL, ICOL)
 C 
 %(info_lines)s
 C 
@@ -8,7 +8,7 @@ C Returns amplitude squared summed/avg over colors
 c and helicities
 c for the point in phase space P(0:3,NEXTERNAL)
 c INPUT:
-C  chanel, channel of integration under consideration
+C  iconfig: channel of integration under consideration
 C        related by symmetry to the G directory (but not always that value)
 c  potentially times multi-channel weight
 C  
@@ -36,7 +36,7 @@ C
     REAL*8 P(0:3,NEXTERNAL)
     double precision RHEL ! random number for selecting helicity
     double precision RCOL ! random number for selecting helicity
-    integer channel ! channel to keep for the multi-channel
+    integer iconfig ! channel to keep for the multi-channel
     integer ivec ! for using the correct coupling
 c
 c   output argument
@@ -158,7 +158,7 @@ c         Set right sign for ANS, based on sign of chosen helicity
     ENDIF
     ANS=ANS/DBLE(IDEN)
 
-    call select_color(rcol, jamp2, channel,%(proc_id)s,  icol)
+    call select_color(rcol, jamp2, iconfig,%(proc_id)s,  icol)
 
     END
  


### PR DESCRIPTION
Hi @oliviermattelaer these are a few fixes for your MR https://github.com/mg5amcnlo/mg5amcnlo/pull/5

Without these fixes, I generated gg to ttgg and it failed to build
```
/cvmfs/sft.cern.ch/lcg/releases/gcc/11.2.0-ad950/x86_64-centos7/bin/gfortran -w -fPIC  -ffixed-line-length-132 -w -c auto_dsig1.f -I../../Source/ -fopenmp
auto_dsig1.f:453:7:

  453 |       C.     COL_RAND: A LIST OF RANDOM NUMBER (WILL BE USED TO PICK
      |       1
Error: Unclassifiable statement at (1)
auto_dsig1.f:155:13:

  155 |       CHANNEL = SUBDIAG(1)
      |             1
Error: Symbol ‘channel’ at (1) has no IMPLICIT type
auto_dsig1.f:388:62:

  388 |       CALL SMATRIX1_MULTI(P_MULTI, HEL_RAND, COL_RAND, CHANNEL,
      |                                                              1
Error: Symbol ‘channel’ at (1) has no IMPLICIT type
``` 
With these fixes, the build succeeds.
Can you please check if they make sense?

That said, this patch fixes the build errors, but there are other issues in lo_vect_diagid
- the main reason why I wanted lo_vect_diagid was to check whether coloramps.inc and coloramps.h produces the same order: even with lo_vect_diagid, the order of colors remains different for gg->ttgg and gg->ttggg (but they are the same for tt and ttg)
- in addition, lo_vect_diagid changes the "AMP2(i)=AMP2(i)+AMP(j)*DCONJG(AMP(j))" lines, and I am now unable to get the same xsection in fortran and cudacpp (this is true whether I use coloramps.h as-is or I force it to hav ethe same order as coloramps.inc... but anyway I think that this file only affects the LHE file, not the xsec)

So I guess there is more work needed before #5 can be merged? However thes three patches I propose (or a variant thereof) are probably needed

Thanks!
Andrea


