### PR TITLE
chore: Remove Python 2 only code blocks as Python 2 support dropped

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,7 +24,7 @@ Dependencies :
 
  * MadGraph5_aMC@NLO *
 
-- Python 3.7 (or higher, python2.7 is also working for the time being)
+- Python 3.7 (or higher)
 
  * MadEvent *
 Package for the LO cross-section computation and generation of events 

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2,7 +2,6 @@
 
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 from madgraph.interface import reweight_interface
 from six.moves import map
 from six.moves import range

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -15,7 +15,6 @@
 """ Command interface for MadSpin """
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import collections
 import logging
 import math

--- a/MadSpin/madspin
+++ b/MadSpin/madspin
@@ -20,9 +20,9 @@ and call immediately the command line interface scripts"""
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
-if  sys.version_info[1] < 6:
-    sys.exit('MadSpin works only with python 2.7 or with python 3.6 (or later).\n\
-               Please upgrate your version of python.')
+if sys.version_info < (3, 7):
+    sys.exit('MadSpin works only with python 3.7 (or later).\n\
+               Please upgrade your version of python.')
 
 import os
 import optparse

--- a/MadSpin/madspin
+++ b/MadSpin/madspin
@@ -18,7 +18,6 @@
 and call immediately the command line interface scripts"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 if sys.version_info < (3, 7):
     sys.exit('MadSpin works only with python 3.7 (or later).\n\

--- a/Template/LO/bin/generate_events
+++ b/Template/LO/bin/generate_events
@@ -27,8 +27,8 @@ import time
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 pjoin = os.path.join
 
-if sys.version_info[1] < 7:
-    sys.exit('MadEvent works with python 2.7/3.7 or higher.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadEvent works with python 3.7 or higher.\n\
                Please upgrade your version of python.')
 
 try:

--- a/Template/LO/bin/internal/Gridpack/gridrun
+++ b/Template/LO/bin/internal/Gridpack/gridrun
@@ -21,8 +21,8 @@ and call immediately the command line interface scripts"""
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
-if sys.version_info[1] < 7:
-    sys.exit('MadGraph/MadEvent 5 works only with python 2.7/3.7 or later.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadGraph/MadEvent 5 works only with python 3.7 or later.\n\
                Please upgrate your version of python.')
 
 try:

--- a/Template/LO/bin/internal/Gridpack/gridrun
+++ b/Template/LO/bin/internal/Gridpack/gridrun
@@ -19,7 +19,6 @@
 and call immediately the command line interface scripts"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 if sys.version_info < (3, 7):
     sys.exit('MadGraph/MadEvent 5 works only with python 3.7 or later.\n\

--- a/Template/LO/bin/internal/addmasses_optional.py
+++ b/Template/LO/bin/internal/addmasses_optional.py
@@ -6,7 +6,6 @@
 # Insert W/Z when missing
 
 from __future__ import absolute_import
-from __future__ import print_function
 import math,sys,re
 from xml.dom import minidom
 from six.moves import range

--- a/Template/LO/bin/madevent
+++ b/Template/LO/bin/madevent
@@ -19,8 +19,8 @@
 and call immediately the command line interface scripts"""
 
 import sys
-if sys.version_info[1] < 7:
-    sys.exit('MadGraph/MadEvent 5 works only with python 2.7/3.7 or later.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadGraph/MadEvent 5 works only with python 3.7 or later.\n\
                Please upgrate your version of python.')
 
 try:

--- a/Template/MadWeight/Python/Info.py
+++ b/Template/MadWeight/Python/Info.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import input
 def giveInfo(class_):
         if type(class_)!=str:

--- a/Template/MadWeight/Python/clean.py
+++ b/Template/MadWeight/Python/clean.py
@@ -34,7 +34,6 @@
 ## BEGIN INCLUDE
 ##
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 
 #1 #########################################################################

--- a/Template/MadWeight/Python/expand_MadWeight.py
+++ b/Template/MadWeight/Python/expand_MadWeight.py
@@ -2,7 +2,6 @@
 
 # Module
 from __future__ import absolute_import
-from __future__ import print_function
 import string
 import os
 import sys

--- a/Template/MadWeight/Python/madweight.py
+++ b/Template/MadWeight/Python/madweight.py
@@ -7,7 +7,6 @@
 
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import string
 import sys
 import os

--- a/Template/MadWeight/Python/put_banner.py
+++ b/Template/MadWeight/Python/put_banner.py
@@ -100,7 +100,6 @@
 
 
 from __future__ import absolute_import
-from __future__ import print_function
 import os,re,sys
 from six.moves import range
 from six.moves import input

--- a/Template/MadWeight/Python/splitbanner.py
+++ b/Template/MadWeight/Python/splitbanner.py
@@ -15,7 +15,6 @@
 ##                                                                      ##
 ##########################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 from six.moves import input
 # patch if symbolic directory replace by real file

--- a/Template/MadWeight/Python/tests.py
+++ b/Template/MadWeight/Python/tests.py
@@ -21,7 +21,6 @@
 #  TEST #################################################################################################
 #########################################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 from six.moves import input
 sys.path.append('./Source/MadWeight/Python')

--- a/Template/MadWeight/bin/madweight.py
+++ b/Template/MadWeight/bin/madweight.py
@@ -16,7 +16,6 @@
 """ This is the main script in order to generate events in MadEvent """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import os
 import subprocess 

--- a/Template/MadWeight/bin/madweight.py
+++ b/Template/MadWeight/bin/madweight.py
@@ -29,10 +29,6 @@ import time
 
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 
-if not sys.version_info[0] == 2 or sys.version_info[1] < 6:
-    sys.exit('MadEvent works with python 2.6 or higher (but not python 3.X).\n\
-               Please upgrade your version of python.')
-
 # Check if optimize mode is (and should be) activated
 if __debug__ and (not os.path.exists(os.path.join(root_path,'../..', 'bin','create_release.py'))):
     print('launch in debug mode')

--- a/Template/MadWeight/bin/mw_options
+++ b/Template/MadWeight/bin/mw_options
@@ -19,10 +19,6 @@
 and call immediately the command line interface scripts"""
 
 import sys
-if not sys.version_info[0] == 2 or sys.version_info[1] < 6:
-    sys.exit('MadWeight 5 works only with python 2.6 or later (but not python 3.X).\n\
-               Please upgrade your version of python.')
-
 import os
 import optparse
 

--- a/Template/MadWeight/mod_file/check_model.py
+++ b/Template/MadWeight/mod_file/check_model.py
@@ -4,7 +4,6 @@
 
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import string
 import os
 import sys

--- a/Template/MadWeight/mod_file/mod_file.py
+++ b/Template/MadWeight/mod_file/mod_file.py
@@ -2,7 +2,6 @@
 
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import string
 import os
 import sys

--- a/Template/NLO/Utilities/NLO_Born3.py
+++ b/Template/NLO/Utilities/NLO_Born3.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 
-from __future__ import print_function
 from __future__ import absolute_import
 from six.moves import range
 inp = open('./MADatNLO.top', 'r')

--- a/Template/NLO/Utilities/collect_plots.py
+++ b/Template/NLO/Utilities/collect_plots.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import pickle
 import subprocess
 import sys

--- a/Template/NLO/bin/aMCatNLO
+++ b/Template/NLO/bin/aMCatNLO
@@ -19,8 +19,8 @@
 and call immediately the command line interface scripts"""
 
 import sys
-if   sys.version_info[1] < 7:
-    sys.exit('MadGraph/aMCatNLO 5 works only with python 2.7/3.7 or later .\n\
+if   sys.version_info < (3, 7):
+    sys.exit('MadGraph/aMCatNLO 5 works only with python 3.7 or later .\n\
                Please upgrate your version of python.')
 
 try:

--- a/Template/NLO/bin/calculate_xsect
+++ b/Template/NLO/bin/calculate_xsect
@@ -28,8 +28,8 @@ pjoin = os.path.join
 sys.path.append(pjoin(root_path,'bin','internal'))
 import amcatnlo_run_interface as run      
 
-if sys.version_info[1] < 7:
-    sys.exit('MadEvent works with python 2.7/3.7 or higher.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadEvent works with python 3.7 or higher.\n\
                Please upgrade your version of python.')
 
 try:

--- a/Template/NLO/bin/generate_events
+++ b/Template/NLO/bin/generate_events
@@ -28,8 +28,8 @@ pjoin = os.path.join
 sys.path.append(pjoin(root_path,'bin','internal'))
 import amcatnlo_run_interface as run      
 
-if sys.version_info[1] < 7:
-    sys.exit('MadEvent works with python 2.7/3.7 or higher.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadEvent works with python 3.7 or higher.\n\
                Please upgrade your version of python.')
 
 try:

--- a/Template/NLO/bin/internal/split_jobs.py
+++ b/Template/NLO/bin/internal/split_jobs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #  MZ, 2012-06-14
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
 import tarfile

--- a/Template/NLO/bin/shower
+++ b/Template/NLO/bin/shower
@@ -28,8 +28,8 @@ pjoin = os.path.join
 sys.path.append(pjoin(root_path,'bin','internal'))
 import amcatnlo_run_interface as run      
 
-if sys.version_info[1] < 7:
-    sys.exit('MadEvent works with python 2.7 or 3.7 and higher.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadEvent works with python 3.7 and higher.\n\
                Please upgrade your version of python.')
 
 try:

--- a/aloha/aloha_fct.py
+++ b/aloha/aloha_fct.py
@@ -11,7 +11,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 from aloha.aloha_object import *
 import aloha.aloha_lib as aloha_lib
 import cmath

--- a/aloha/aloha_lib.py
+++ b/aloha/aloha_lib.py
@@ -44,7 +44,6 @@
 
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 from array import array
 import collections
 from fractions import Fraction

--- a/aloha/aloha_parsers.py
+++ b/aloha/aloha_parsers.py
@@ -20,7 +20,6 @@ Lex + Yacc framework"""
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import numbers
 import os

--- a/aloha/bin/aloha
+++ b/aloha/bin/aloha
@@ -6,10 +6,6 @@ import os
 import optparse
 import logging
 
-if not sys.version_info[0] == 2 or sys.version_info[1] < 6:
-    sys.exit('ALOHA works only with python 2.6 or later (but not python 3.X).\n\
-               Please upgrade your version of python.')
-
 # Get the parent directory (mg root) of the script real path (bin)
 # and add it to the current PYTHONPATH
 

--- a/bin/compile.py
+++ b/bin/compile.py
@@ -14,7 +14,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
 import logging

--- a/bin/create_aloha_release.py
+++ b/bin/create_aloha_release.py
@@ -34,11 +34,6 @@ following actions:
 from __future__ import absolute_import
 import sys
 from six.moves import input
-
-if not sys.version_info[0] == 2 or sys.version_info[1] < 6:
-    sys.exit('MadGraph5_aMC@NLO works only with python 2.6 or later (but not python 3.X).\n\
-               Please upgrate your version of python.')
-
 import glob
 import optparse
 import logging

--- a/bin/create_release.py
+++ b/bin/create_release.py
@@ -30,7 +30,6 @@ following actions:
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 from six.moves import range
 from six.moves import input

--- a/bin/create_release.py
+++ b/bin/create_release.py
@@ -35,8 +35,8 @@ import sys
 from six.moves import range
 from six.moves import input
 
-if sys.version_info[1] < 7:
-    sys.exit('MadGraph5_aMC@NLO works only with python 2.7/3.7 or later.\n\
+if sys.version_info < (3, 7):
+    sys.exit('MadGraph5_aMC@NLO works only with python 3.7 or later.\n\
                Please upgrate your version of python.')
 
 import glob

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -22,17 +22,14 @@ start = time.time()
 and call immediately the command line interface scripts"""
 
 import sys
-if sys.version_info[0] == 2:
-    sys.exit("MadGraph5_aMC@NLO works only with python 3.7 (and later).\n"+\
-             "  You are currently using Python2.%s. Please use a more recent version of Python." % sys.version_info[1])
-elif  sys.version_info[1] < 7:
-    sys.exit("MadGraph5_aMC@NLO works only with python 3.7 (and later).\n"+\
-              "  You are currently using Python 3.%i. So please upgrade your version of Python." % sys.version_info[1]) 
+if sys.version_info < (3, 7):
+   sys.exit('MadGraph5_aMC@NLO works with python 3.7 or higher.\n\
+              Please upgrade your version of python.')
     
 try:
     import six
 except ImportError:
-    message = 'madgraph requires the six module. The easiest way to install it is to run "pip%s install six --user"\n' % (sys.version_info[0] if sys.version_info[0]==3 else '')
+    message = 'madgraph requires the six module. The easiest way to install it is to run "python -m pip install six --user"\n'
     message += 'in case of problem with pip, you can download the file at https://pypi.org/project/six/ . It has a single python file that you just need to put inside a directory of your $PYTHONPATH environment variable.'
     sys.exit(message)
 
@@ -78,10 +75,6 @@ if __debug__ and not options.debug and \
 import logging
 import logging.config
 import madgraph.interface.coloring_logging
-
-if sys.version_info[0] ==2:
-    logging.warning("\033[91mpython2 support will be removed in last quarter 2021. If you use python2 due to issue with Python3, please report them on https://bugs.launchpad.net/mg5amcnlo\033[0m")
-
 
 if ' ' in os.getcwd():
     logging.warning("\033[91mPath does contains spaces. We advise that you change your current path to avoid to have space in the path.\033[0m")

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 from __future__ import absolute_import
-from __future__ import print_function
 import time
 start = time.time()
 

--- a/madgraph/fks/fks_base.py
+++ b/madgraph/fks/fks_base.py
@@ -16,7 +16,6 @@
 """Definitions of the objects needed for the implementation of MadFKS"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import madgraph
 import madgraph.core.base_objects as MG
 import madgraph.core.helas_objects as helas_objects

--- a/madgraph/fks/fks_common.py
+++ b/madgraph/fks/fks_common.py
@@ -17,7 +17,6 @@
 and MadFKS from born"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import madgraph
 import madgraph.core.base_objects as MG
 import madgraph.core.helas_objects as helas_objects

--- a/madgraph/interface/amcatnlo_interface.py
+++ b/madgraph/interface/amcatnlo_interface.py
@@ -17,7 +17,6 @@
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import logging
 import pydoc

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -18,7 +18,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import atexit
 import glob
 import logging

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -5737,8 +5737,8 @@ if '__main__' == __name__:
     # This can ONLY run a single command !!
     import sys
 
-    if sys.version_info[1] < 7:
-        sys.exit('MadGraph5_aMc@NLO works only with python 2.7 or python3.7 and later.\n'+\
+    if sys.version_info < (3, 7):
+        sys.exit('MadGraph5_aMc@NLO works only with python 3.7 and later.\n'+\
                'Please upgrade your version of python or specify a compatible version.')
 
     import os

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -20,7 +20,6 @@ from __future__ import division
 
 
 from __future__ import absolute_import
-from __future__ import print_function
 import ast
 import logging
 import math

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -1889,11 +1889,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             event_per_job = nb_event // nb_submit
             nb_job_with_plus_one = nb_event % nb_submit
             start_event, stop_event = 0,0
-            if sys.version_info[1] == 6 and sys.version_info[0] == 2:
-                if input.endswith('.gz'):
-                    misc.gunzip(input)
-                    input = input[:-3]
-                    
+
             for i in range(nb_submit):
                 #computing start/stop event
                 event_requested = event_per_job

--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -16,7 +16,6 @@
 
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import math
 import os

--- a/madgraph/interface/launch_ext_program.py
+++ b/madgraph/interface/launch_ext_program.py
@@ -15,7 +15,6 @@
 
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import os
 import pydoc

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -18,7 +18,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import collections
 import itertools
 import glob

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -7316,8 +7316,8 @@ if '__main__' == __name__:
     # Launch the interface without any check if one code is already running.
     # This can ONLY run a single command !!
     import sys
-    if not sys.version_info[0] in [2,3] or sys.version_info[1] < 6:
-        sys.exit('MadGraph/MadEvent 5 works only with python 2.6, 2.7 or python 3.7 or later).\n'+\
+    if sys.version_info < (3, 7):
+        sys.exit('MadGraph/MadEvent 5 works only with python 3.7 or later).\n'+\
                'Please upgrate your version of python.')
 
     import os

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -18,7 +18,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import atexit
 import collections
 import cmath

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -1547,17 +1547,6 @@ This will take effect only in a NEW terminal
             except Exception:
                 raise self.InvalidCmd('%s needs argument True or False'%args[0])
 
-        if args[0] in ['low_mem_multicore_nlo_generation']:
-            if args[1]:
-                if sys.version_info[0] == 2:
-                    if  sys.version_info[1] == 6:
-                        raise Exception('python2.6 does not support such functionalities please use python2.7')
-                #else:
-                #    raise Exception('python3.x does not support such functionalities please use python2.7')
-        
-
-
-
         if args[0] in ['gauge']:
             if args[1] not in ['unitary','Feynman', 'axial']:
                 raise self.InvalidCmd('gauge needs argument unitary, axial or Feynman.')

--- a/madgraph/interface/reweight_interface.py
+++ b/madgraph/interface/reweight_interface.py
@@ -15,7 +15,6 @@
 """ Command interface for Re-Weighting """
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import difflib
 import logging
 import math

--- a/madgraph/iolibs/export_fks.py
+++ b/madgraph/iolibs/export_fks.py
@@ -15,7 +15,6 @@
 """Methods and classes to export matrix elements to fks format."""
 
 from __future__ import absolute_import
-from __future__ import print_function
 from __future__ import division
 import glob
 import logging

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -2032,17 +2032,7 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
             f2py_compiler = default_compiler['f2py']
         elif misc.which('f2py'):
             f2py_compiler = 'f2py'
-        elif sys.version_info[1] == 6:
-            if misc.which('f2py-2.6'):
-                f2py_compiler = 'f2py-2.6'
-            elif misc.which('f2py2.6'):
-                f2py_compiler = 'f2py2.6'
-        elif sys.version_info[1] == 7:
-            if misc.which('f2py-2.7'):
-                f2py_compiler = 'f2py-2.7'
-            elif misc.which('f2py2.7'):
-                f2py_compiler = 'f2py2.7'            
-        
+
         to_replace = {'fortran': f77_compiler, 'f2py': f2py_compiler}
         
         

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -2030,8 +2030,13 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
         # Try to find the correct one.
         if default_compiler['f2py'] and misc.which(default_compiler['f2py']):
             f2py_compiler = default_compiler['f2py']
+        elif misc.which('f2py%d.%d' %(sys.version_info.major, sys.version_info.minor)):
+            f2py_compiler = 'f2py%d.%d' %(sys.version_info.major, sys.version_info.minor)
+        elif misc.which('f2py%d' %(sys.version_info.major)):
+            f2py_compiler = 'f2py%d' %(sys.version_info.major)            
         elif misc.which('f2py'):
             f2py_compiler = 'f2py'
+
 
         to_replace = {'fortran': f77_compiler, 'f2py': f2py_compiler}
         

--- a/madgraph/iolibs/save_model.py
+++ b/madgraph/iolibs/save_model.py
@@ -16,7 +16,6 @@
 """Function to save model files."""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import os
 

--- a/madgraph/iolibs/ufo_expression_parsers.py
+++ b/madgraph/iolibs/ufo_expression_parsers.py
@@ -18,7 +18,6 @@ different languages/frameworks (Fortran and Pythia8). Uses the PLY 3.3
 Lex + Yacc framework"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import os
 import re

--- a/madgraph/madweight/Cards.py
+++ b/madgraph/madweight/Cards.py
@@ -33,7 +33,6 @@
 ##                                                                      ##
 ##########################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import re
 import os
 import math

--- a/madgraph/madweight/MW_driver.py
+++ b/madgraph/madweight/MW_driver.py
@@ -14,7 +14,6 @@
 ################################################################################
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import math
 import os 
 import sys

--- a/madgraph/madweight/MW_info.py
+++ b/madgraph/madweight/MW_info.py
@@ -56,7 +56,6 @@
 ## BEGIN INCLUDE
 ##
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import os
 import re

--- a/madgraph/madweight/blob_solution.py
+++ b/madgraph/madweight/blob_solution.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from __future__ import print_function
 import six
 from six.moves import range
 try:

--- a/madgraph/madweight/change_tf.py
+++ b/madgraph/madweight/change_tf.py
@@ -3,7 +3,6 @@
 #Extension
 
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import re
 import string

--- a/madgraph/madweight/create_param.py
+++ b/madgraph/madweight/create_param.py
@@ -43,7 +43,6 @@
 ## BEGIN INCLUDE
 ##
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 try:
     import madgraph.madweight.MW_info as MW_param

--- a/madgraph/madweight/create_run.py
+++ b/madgraph/madweight/create_run.py
@@ -2,7 +2,6 @@
 
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import string,os,sys,re,time,stat,filecmp
 from six.moves import range
 from six.moves import input

--- a/madgraph/madweight/diagram_class.py
+++ b/madgraph/madweight/diagram_class.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import logging
 import os

--- a/madgraph/madweight/mod_file.py
+++ b/madgraph/madweight/mod_file.py
@@ -138,7 +138,6 @@
 
 # Module
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
 import re

--- a/madgraph/madweight/particle_class.py
+++ b/madgraph/madweight/particle_class.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 invisible_list = [12,14,16,18]
 invisible_list += [1000012,1000014,1000016,1000022,1000023,1000024,1000025,1000035]
 

--- a/madgraph/madweight/proc_info.py
+++ b/madgraph/madweight/proc_info.py
@@ -1,7 +1,6 @@
 
 
 from __future__ import absolute_import
-from __future__ import print_function
 import re
 import sys
 import string

--- a/madgraph/madweight/verif_event.py
+++ b/madgraph/madweight/verif_event.py
@@ -33,7 +33,6 @@
 ##########################################################################
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import re
 import sys

--- a/madgraph/madweight/write_MadWeight.py
+++ b/madgraph/madweight/write_MadWeight.py
@@ -3,7 +3,6 @@
 
 #Extension
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import six
 from six.moves import map

--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -12,7 +12,6 @@
 #                                                                               
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import subprocess
 import logging
 import os

--- a/madgraph/various/combine_plots.py
+++ b/madgraph/various/combine_plots.py
@@ -14,7 +14,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import glob
 import os
 import re

--- a/madgraph/various/hepmc_parser.py
+++ b/madgraph/various/hepmc_parser.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import gzip
 from six.moves import range
 import os 

--- a/madgraph/various/histograms.py
+++ b/madgraph/various/histograms.py
@@ -19,7 +19,6 @@ and scale/PDF uncertainties."""
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import array
 import copy
 import fractions

--- a/madgraph/various/lhe_parser.py
+++ b/madgraph/various/lhe_parser.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import collections
 import random
 import re

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -281,6 +281,11 @@ def has_f2py():
     has_f2py = False
     if which('f2py'):
         has_f2py = True
+    elif misc.which('f2py%d.%d' %(sys.version_info.major, sys.version_info.minor)):
+        has_f2py = True
+    elif misc.which('f2py%d' %(sys.version_info.major)):
+        has_f2py = True
+
     return has_f2py       
         
 #===============================================================================

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -15,7 +15,6 @@
 """A set of functions performing routine administrative I/O tasks."""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import collections
 import contextlib
 import itertools

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -282,16 +282,6 @@ def has_f2py():
     has_f2py = False
     if which('f2py'):
         has_f2py = True
-    elif sys.version_info[1] == 6:
-        if which('f2py-2.6'):
-            has_f2py = True
-        elif which('f2py2.6'):
-            has_f2py = True                 
-    else:
-        if which('f2py-2.7'):
-            has_f2py = True 
-        elif which('f2py2.7'):
-            has_f2py = True  
     return has_f2py       
         
 #===============================================================================

--- a/madgraph/various/plot_djrs.py
+++ b/madgraph/various/plot_djrs.py
@@ -15,7 +15,6 @@
 ################################################################################
 """Example code to plot custom curves based on djrs.dat with matplotlib"""
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys 
 import matplotlib.pyplot as plt

--- a/madgraph/various/process_checks.py
+++ b/madgraph/various/process_checks.py
@@ -1267,12 +1267,9 @@ class LoopMatrixElementTimer(LoopMatrixElementEvaluator):
         dir_name=res_timings['dir_path']
 
         def check_disk_usage(path):
-            return subprocess.Popen("du -shc -L "+str(path), \
-                stdout=subprocess.PIPE, shell=True).communicate()[0].decode(errors='ignore').split()[-2]
-            # The above is compatible with python 2.6, not the neater version below
-            # -> need to check if need .decode for python3.7
-            #return subprocess.check_output(["du -shc %s"%path],shell=True).\
-            #                                                         split()[-2]
+            return subprocess.check_output(
+                [f"du -shc {path}"], shell=True, encoding="utf8"
+            ).split()[-2]
 
         res_timings['du_source']=check_disk_usage(pjoin(\
                                                  export_dir,'Source','*','*.f'))

--- a/madgraph/various/progressbar.py
+++ b/madgraph/various/progressbar.py
@@ -40,7 +40,6 @@ automatically supports features like auto-resizing when available.
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import six
 from six.moves import range
 __author__ = "Nilton Volpato"

--- a/madgraph/various/q_polynomial.py
+++ b/madgraph/various/q_polynomial.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import array
 import copy
 import math

--- a/madgraph/various/rambo.py
+++ b/madgraph/various/rambo.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import math
 import random
 from six.moves import range

--- a/madgraph/various/systematics.py
+++ b/madgraph/various/systematics.py
@@ -15,7 +15,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 from six.moves import zip
 if __name__ == "__main__":

--- a/mg5decay/decay_objects.py
+++ b/mg5decay/decay_objects.py
@@ -40,7 +40,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import array
 import cmath
 import collections

--- a/models/check_param_card.py
+++ b/models/check_param_card.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import itertools
 import xml.etree.ElementTree as ET
 import math

--- a/models/hgg_plugin/write_param_card.py
+++ b/models/hgg_plugin/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/models/loop_sm/write_param_card.py
+++ b/models/loop_sm/write_param_card.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 from __future__ import absolute_import
 from six.moves import range
 __date__ = "3 june 2010"

--- a/models/taudecay_UFO/write_param_card.py
+++ b/models/taudecay_UFO/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/models/write_param_card.py
+++ b/models/write_param_card.py
@@ -13,7 +13,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import models.model_reader as model_reader
 import madgraph.core.base_objects as base_objects
 import madgraph.various.misc as misc

--- a/tests/IOTests.py
+++ b/tests/IOTests.py
@@ -14,7 +14,6 @@
 ################################################################################
 
 from __future__ import absolute_import
-from __future__ import print_function
 import copy
 import os
 import sys

--- a/tests/acceptance_tests/test_cmd_amcatnlo.py
+++ b/tests/acceptance_tests/test_cmd_amcatnlo.py
@@ -769,7 +769,6 @@ class MECmdShell(IOTests.IOTestManager):
         #      Total cross-section: 1.249e+03 +- 3.2e+00 pb        
         cross_section = data[i+4]
         cross_section = float(cross_section.split(':')[1].split('+-')[0])
-        # warning, delta may not be compatible with python 2.6 
         try:
             self.assertAlmostEqual(6675.0, cross_section,delta=50)
         except TypeError:

--- a/tests/acceptance_tests/test_cmd_amcatnlo.py
+++ b/tests/acceptance_tests/test_cmd_amcatnlo.py
@@ -14,7 +14,6 @@
 ################################################################################
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import subprocess
 import unittest
 import os

--- a/tests/acceptance_tests/test_cmd_madevent.py
+++ b/tests/acceptance_tests/test_cmd_madevent.py
@@ -14,7 +14,6 @@
 ################################################################################
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import subprocess
 import unittest
 import os

--- a/tests/acceptance_tests/test_model_equivalence.py
+++ b/tests/acceptance_tests/test_model_equivalence.py
@@ -13,7 +13,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 import copy
 import subprocess
 import shutil

--- a/tests/input_files/LoopSMEWTest/write_param_card.py
+++ b/tests/input_files/LoopSMEWTest/write_param_card.py
@@ -1,6 +1,5 @@
 
 
-from __future__ import print_function
 from __future__ import absolute_import
 from six.moves import range
 __date__ = "3 june 2010"

--- a/tests/input_files/LoopSMTest/write_param_card.py
+++ b/tests/input_files/LoopSMTest/write_param_card.py
@@ -1,6 +1,5 @@
 
 
-from __future__ import print_function
 from __future__ import absolute_import
 from six.moves import range
 __date__ = "3 june 2010"

--- a/tests/input_files/SMEFTatNLO_running/write_param_card.py
+++ b/tests/input_files/SMEFTatNLO_running/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "3 june 2010"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/tests/input_files/fourfermion_UFO/write_param_card.py
+++ b/tests/input_files/fourfermion_UFO/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "22 Sept 2011"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/tests/input_files/full_sm_UFO/write_param_card.py
+++ b/tests/input_files/full_sm_UFO/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 __date__ = "3 june 2010"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 

--- a/tests/input_files/loop_MSSM/write_param_card.py
+++ b/tests/input_files/loop_MSSM/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/tests/input_files/loop_smgrav/write_param_card.py
+++ b/tests/input_files/loop_smgrav/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "3 june 2010"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/tests/input_files/sm_with_custom_propa/write_param_card.py
+++ b/tests/input_files/sm_with_custom_propa/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from __future__ import print_function
 from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'

--- a/tests/parallel_tests/compare_with_old_mg5_version.py
+++ b/tests/parallel_tests/compare_with_old_mg5_version.py
@@ -19,7 +19,6 @@ model format.
 The reference version is given here as a argument which can be changed by hand.
 """
 from __future__ import absolute_import
-from __future__ import print_function
 import itertools
 import logging
 import os

--- a/tests/parallel_tests/decay_comparator.py
+++ b/tests/parallel_tests/decay_comparator.py
@@ -18,7 +18,6 @@ by FR in the decays.py files of the model.
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import logging
 import os
 import shutil

--- a/tests/parallel_tests/madevent_comparator.py
+++ b/tests/parallel_tests/madevent_comparator.py
@@ -18,7 +18,6 @@ formats (txt, tex, ...).
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import datetime
 import glob
 import itertools

--- a/tests/parallel_tests/test_ML5.py
+++ b/tests/parallel_tests/test_ML5.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import logging.config
 import logging
 import pydoc

--- a/tests/parallel_tests/test_ML5EW.py
+++ b/tests/parallel_tests/test_ML5EW.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-from __future__ import print_function
 import logging.config
 import logging
 import pydoc

--- a/tests/parallel_tests/test_aloha.py
+++ b/tests/parallel_tests/test_aloha.py
@@ -17,7 +17,6 @@ the output of the Feynman Rules."""
 from __future__ import division
 
 from __future__ import absolute_import
-from __future__ import print_function
 import math
 import os
 import time

--- a/tests/parallel_tests/test_madweight.py
+++ b/tests/parallel_tests/test_madweight.py
@@ -18,7 +18,6 @@ formats (txt, tex, ...).
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import datetime
 import glob
 import itertools

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -28,7 +28,6 @@
 """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import inspect
 import tarfile

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -30,11 +30,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import sys
-
-if not sys.version_info[0] in [2,3] or sys.version_info[1] < 6:
-    sys.exit('MadGraph5_aMC@NLO works only with python 2.6 or later (but not python 3.X).\n\
-               Please upgrate your version of python.')
-
 import inspect
 import tarfile
 import logging

--- a/tests/unit_tests/core/test_helas_objects.py
+++ b/tests/unit_tests/core/test_helas_objects.py
@@ -13,7 +13,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 from madgraph.iolibs import helas_call_writers
 from six.moves import range
 from six.moves import zip

--- a/tests/unit_tests/fks/test_extra_ew.py
+++ b/tests/unit_tests/fks/test_extra_ew.py
@@ -13,7 +13,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 from cmd import Cmd
 from six.moves import zip
 """ Basic test of the command interface """

--- a/tests/unit_tests/fks/test_fks_taggedphotons.py
+++ b/tests/unit_tests/fks/test_fks_taggedphotons.py
@@ -13,7 +13,6 @@
 #
 ################################################################################
 from __future__ import absolute_import
-from __future__ import print_function
 from cmd import Cmd
 from six.moves import zip
 """ Basic test of the command interface """

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -15,7 +15,6 @@
 """ Basic test of the command interface """
 
 from __future__ import absolute_import
-from __future__ import print_function
 import unittest
 import madgraph
 import madgraph.interface.master_interface as cmd

--- a/tests/unit_tests/iolibs/test_drawing_eps.py
+++ b/tests/unit_tests/iolibs/test_drawing_eps.py
@@ -20,7 +20,6 @@ from __future__ import division
 # The following lines are needed to run the
 # diagram generation using __main__
 from __future__ import absolute_import
-from __future__ import print_function
 import os, sys
 from six.moves import range
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]

--- a/tests/unit_tests/iolibs/test_export_cpp.py
+++ b/tests/unit_tests/iolibs/test_export_cpp.py
@@ -15,7 +15,6 @@
 """Unit test library for the export Pythia8 format routines"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import six
 StringIO = six
 import copy

--- a/tests/unit_tests/loop/test_loop_diagram_generation.py
+++ b/tests/unit_tests/loop/test_loop_diagram_generation.py
@@ -17,7 +17,6 @@
    loop_diagram_generaiton"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import copy
 import itertools
 import logging

--- a/tests/unit_tests/loop/test_loop_drawing.py
+++ b/tests/unit_tests/loop/test_loop_drawing.py
@@ -17,7 +17,6 @@
    loop_helas_objects.py"""
 from __future__ import division
 from __future__ import absolute_import
-from __future__ import print_function
 import copy
 import itertools
 import logging

--- a/tests/unit_tests/loop/test_loop_helas_objects.py
+++ b/tests/unit_tests/loop/test_loop_helas_objects.py
@@ -17,7 +17,6 @@
    loop_helas_objects.py"""
 
 from __future__ import absolute_import
-from __future__ import print_function
 import copy
 import itertools
 import logging

--- a/tests/unit_tests/various/test_cmd.py
+++ b/tests/unit_tests/various/test_cmd.py
@@ -14,7 +14,6 @@
 ################################################################################
 
 from __future__ import absolute_import
-from __future__ import print_function
 import os
 
 from madgraph import MG5DIR


### PR DESCRIPTION
Given https://github.com/mg5amcnlo/mg5amcnlo/commit/25a208db24bf9c28f6650f10b86fdfa04a7b1493 all Python 2 support has been dropped, and so code that references or uses Python 2 can be removed. This should also extend to removing all use of `six`, as it is used only for Python 2 to Python 3 support.

Note that **all code under `vendor/`** has been left alone as it is assumed that this is literally ported code and for ease of updating in the future it should be identical to original source code.


To simplify comparisons to the Python version use the pattern of

```python
sys.version_info < (3, 7)
```

as comparison to tuples is supported.

File specific comments:

  - `aloha/bin/aloha`
  - `bin/create_aloha_release.py`
  - `Template/MadWeight/bin/madweight.py`
  - `Template/MadWeight/bin/mw_options`
  - `tests/test_manager.py`
    
    All had `sys.exit` conditions that claimed their code didn't work with Python 3. This is assumed to now be false, as otherwise these pieces of code would no longer work in modern `MadGraph5_aMC@NLO`, and so these `sys.exit` conditions are removed.

  - `bin/mg5_aMC`

    Use standard 'python -m pip' pattern to avoid potential issues with the wrong version of `pip3` being on PATH.

  - `madgraph/iolibs/export_v4.py`
  - `madgraph/various/misc.py`

    In Python 3.x `f2py` has the following names under the virtual environment's `bin/` dir: `f2py`, `f2py3`, `f2py3.x`. As the patterns that exist are for `'f2py2.x'` and `'f2py-2.x'` and these patterns only exist for Python 2 versions of NumPy the relevant code blocks are removed.

* Remove use of `from __future__ import print_function`.