### PR TITLE
Migrate history files (mg5history, me5history, mw5history, decayhistory) to ensure XDG Base Directory compliance

### DIFF
--- a/MadSpin/madspin
+++ b/MadSpin/madspin
@@ -4,11 +4,11 @@
 #
 # Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
@@ -33,7 +33,6 @@ import optparse
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 sys.path.insert(0, root_path)
 
-
 # Write out nice usage message if called with -h or --help
 usage = "usage: %prog [options] [FILE] "
 parser = optparse.OptionParser(usage=usage)
@@ -51,7 +50,6 @@ parser.add_option("","--debug", action="store_true", default=False, dest='debug'
 if len(args) == 0:
     args = ''
 
-
 import subprocess
 
 # Check if optimize mode is (and should be) activated
@@ -64,7 +62,7 @@ import logging
 import logging.config
 import madgraph.interface.coloring_logging
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -76,8 +74,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -86,11 +84,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'decayhistory')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "decayhistory")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -103,12 +109,11 @@ except:
 if __debug__:
         print('Running MG5 in debug mode')
 
-
 # Set logging level according to the logging level given by options
 #logging.basicConfig(level=vars(logging)[options.logging])
 try:
     if __debug__ and options.logging == 'INFO':
-        options.logging = 'DEBUG'    
+        options.logging = 'DEBUG'
     logging.config.fileConfig(os.path.join(root_path, 'madgraph', 'interface', '.mg5_logging.conf'))
     logging.root.setLevel(eval('logging.' + options.logging))
     logging.getLogger('madgraph').setLevel(eval('logging.' + options.logging))
@@ -120,7 +125,7 @@ import MadSpin.interface_madspin as interface
 # Call the cmd interface main loop
 try:
     if options.file or args:
-        # They are an input file 
+        # They are an input file
         if args:
             input_file = os.path.realpath(args[0])
         else:
@@ -157,16 +162,11 @@ try:
         try:
             cmd_line.exec_cmd('quit all', printcmd=False)
             readline.set_history_length(100)
-            if not os.path.exists(os.path.join(os.environ['HOME'], '.mg5')):
-                os.mkdir(os.path.join(os.environ['HOME'], '.mg5'))
+            if not os.path.exists(state_dir):
+                os.mkdir(state_dir)
             readline.write_history_file(history_file)
         except Exception as error:
             pass
 except KeyboardInterrupt:
-    print('writting history and quit on KeyboardInterrupt') 
+    print('writting history and quit on KeyboardInterrupt')
     pass
-
-
-
-
-    

--- a/Template/LO/bin/generate_events
+++ b/Template/LO/bin/generate_events
@@ -3,11 +3,11 @@
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
@@ -37,21 +37,19 @@ except ImportError:
     message = 'madgraph requires the six module. The easiest way to install it is to run "pip install six --user"\n'
     message += 'in case of problem with pip, you can download the file at https://pypi.org/project/six/ . It has a single python file that you just need to put inside a directory of your $PYTHONPATH environment variable.'
     sys.exit(message)
-    
+
 # Check if optimize mode is (and should be) activated
 if __debug__ and (not os.path.exists(pjoin(root_path,'../..', 'bin','create_release.py'))):
     subprocess.call([sys.executable] + ['-O'] + sys.argv)
     sys.exit()
 
-
 sys.path.append(pjoin(root_path,'bin','internal'))
-import madevent_interface as ME        
-
+import madevent_interface as ME
 
 import logging
 import logging.config
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -63,8 +61,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -73,11 +71,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'me5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "me5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -90,15 +96,12 @@ except:
 if __debug__:
         print('Running MG5 in debug mode')
 
-
-
 def set_configuration():
     import coloring_logging
     logging.config.fileConfig(os.path.join(root_path, 'bin', 'internal', 'me5_logging.conf'))
     logging.root.setLevel(logging.INFO)
     logging.getLogger('madevent').setLevel(logging.INFO)
-    logging.getLogger('madgraph').setLevel(logging.INFO)    
-
+    logging.getLogger('madgraph').setLevel(logging.INFO)
 
 def treat_old_argument(argument):
     """Have the MG4 behavior for this script"""
@@ -116,18 +119,17 @@ def treat_old_argument(argument):
         try:
             opt = argument[2]
         except:
-            if mode == 1: 
+            if mode == 1:
                 opt = six.moves.input('Enter name for jobs on pbs queue\n')
             else:
                 opt = int(six.moves.input('Enter number of cores\n'))
-        
+
         try:
             name = argument[3]
         except:
             name = six.moves.input('enter run name\n')
 
 #    launch = ME.MadEventCmd(me_dir=root_path)
-        
 
     if mode == 1:
         argument = ['fake','-f', str(name), '--cluster']
@@ -138,13 +140,7 @@ def treat_old_argument(argument):
 
     return argument
 
-
-
-
-
-
-
-################################################################################  
+################################################################################
 ##   EXECUTABLE
 ################################################################################
 
@@ -152,7 +148,7 @@ if '__main__' == __name__:
     # Check that python version is valid
 
     set_configuration()
-    argument = sys.argv    
+    argument = sys.argv
     try:
         if '-h' in argument or '--help' in argument:
             launch = ME.MadEventCmdShell(me_dir=root_path, force_run=True)
@@ -160,7 +156,7 @@ if '__main__' == __name__:
             sys.exit()
         elif len(argument) > 1 and argument[1] in ['0', '1', '2']:
             argument = treat_old_argument(argument)
-        
+
         with ME.MadEventCmdShell.RunWebHandling(root_path, ):
             launch = ME.MadEventCmdShell(me_dir=root_path, force_run=True)
             launch.run_cmd('generate_events %s' % ' '.join(argument[1:]))
@@ -176,19 +172,7 @@ if '__main__' == __name__:
     except Exception as error:
         logging.error(str(error))
         sys.exit()
-            
-    # reconfigure path for the web 
+
+    # reconfigure path for the web
     #if len(argument) == 5:
     #    ME.pass_in_web_mode()
-
-             
-        
-
-        
-    
-    
-    
-    
-    
-    
-    

--- a/Template/LO/bin/madevent
+++ b/Template/LO/bin/madevent
@@ -4,11 +4,11 @@
 #
 # Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
@@ -30,7 +30,6 @@ except ImportError:
     message += 'in case of problem with pip, you can download the file at https://pypi.org/project/six/ . It has a single python file that you just need to put inside a directory of your $PYTHONPATH environment variable.'
     sys.exit(message)
 
-    
 import os
 import optparse
 
@@ -40,17 +39,12 @@ import optparse
 root_path = os.path.dirname(os.path.realpath( __file__ ))
 sys.path.insert(0, root_path)
 
-
-
 class MyOptParser(optparse.OptionParser):
-    
+
     class InvalidOption(Exception): pass
 
     def error(self, msg=''):
         raise MyOptParser.InvalidOption(msg)
-
-
-
 
 # Write out nice usage message if called with -h or --help
 usage = "usage: %prog [options] [FILE] "
@@ -68,7 +62,7 @@ for i in range(len(sys.argv)-1):
         (options, args) = parser.parse_args(sys.argv[1:len(sys.argv)-i])
         done = True
     except MyOptParser.InvalidOption as error:
-        pass 
+        pass
     else:
         args += sys.argv[len(sys.argv)-i:]
 if not done:
@@ -77,7 +71,7 @@ if not done:
         (options, args) = parser.parse_args()
     except MyOptParser.InvalidOption as error:
         print(error)
-        sys.exit(2)  
+        sys.exit(2)
 
 if len(args) == 0:
     args = ''
@@ -94,7 +88,7 @@ if __debug__ and not options.debug and \
 import logging
 import logging.config
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -106,8 +100,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -116,11 +110,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'me5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "me5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -133,13 +135,12 @@ except:
 if __debug__:
         print( 'Running MG5 in debug mode')
 
-
 # Set logging level according to the logging level given by options
 #logging.basicConfig(level=vars(logging)[options.logging])
 import internal.coloring_logging
 try:
     if __debug__ and options.logging == 'INFO':
-        options.logging = 'DEBUG'    
+        options.logging = 'DEBUG'
     if options.logging.isdigit():
         level = int(options.logging)
     else:
@@ -160,7 +161,7 @@ try:
         sys.exit(0)
     with cmd_interface.MadEventCmdShell.RunWebHandling(os.path.dirname(root_path), ):
         if (args and os.path.isfile(args[0])):
-            # They are an input file 
+            # They are an input file
             input_file = args[0]
             if options.web:
                 cmd_line = cmd_interface.MadEventCmd(force_run=True)
@@ -168,7 +169,7 @@ try:
                 cmd_line.use_rawinput = False
                 cmd_line.haspiping = False
                 cmd_line.run_cmd('import command ' + input_file)
-                cmd_line.run_cmd('quit')      
+                cmd_line.run_cmd('quit')
             else:
                 cmd_line = cmd_interface.MadEventCmdShell(force_run=True)
                 cmd_line.use_rawinput = False
@@ -188,7 +189,7 @@ try:
                 else:
                     print( 'ERROR: %s  not a valid command. Please retry' % args[0])
             else:
-                cmd_line.use_rawinput = False    
+                cmd_line.use_rawinput = False
                 cmd_line.run_cmd(' '.join(args))
                 cmd_line.run_cmd('quit')
         else:
@@ -206,20 +207,19 @@ except cmd_interface.MadEventAlreadyRunning  as  error:
     logging.error(str(error))
     sys.exit(1)
 
-try: 
+try:
     readline.set_history_length(100)
-    if not os.path.exists(os.path.join(os.environ['HOME'], '.mg5')):
-        os.mkdir(os.path.join(os.environ['HOME'], '.mg5'))
+    if not os.path.exists(state_dir):
+        os.mkdir(state_dir)
     readline.write_history_file(history_file)
 except:
     pass
-    
+
 try:
     if cmd_line.history[-1] not in ['EOF','quit','exit']:
         cmd_line.results.store_result()
 except:
     pass
-
 
 #try:
 #    # Remove lock file

--- a/Template/MadWeight/bin/madweight.py
+++ b/Template/MadWeight/bin/madweight.py
@@ -3,11 +3,11 @@
 #
 # Copyright (c) 2011 The MadGraph Development team and Contributors
 #
-# This file is a part of the MadGraph 5 project, an application which 
+# This file is a part of the MadGraph 5 project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph license which should accompany this 
+# It is subject to the MadGraph license which should accompany this
 # distribution.
 #
 # For more information, please visit: http://madgraph.phys.ucl.ac.be
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import sys
 import os
-import subprocess 
+import subprocess
 import logging
 import logging.config
 import re
@@ -39,14 +39,11 @@ if __debug__ and (not os.path.exists(os.path.join(root_path,'../..', 'bin','crea
     subprocess.call([sys.executable] + ['-O'] + sys.argv)
     sys.exit()
 
-
-
-
 pjoin = os.path.join
 sys.path.append(pjoin(root_path,'bin','internal'))
-import madweight_interface as MW        
+import madweight_interface as MW
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -58,8 +55,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -68,11 +65,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'mw5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "mw5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -85,14 +90,12 @@ except:
 if __debug__:
         print('Running MG5 in debug mode')
 
-
 def set_configuration():
     import coloring_logging
     logging.config.fileConfig(os.path.join(root_path, 'bin', 'internal', 'me5_logging.conf'))
     logging.root.setLevel(logging.INFO)
     logging.getLogger('madevent').setLevel(logging.INFO)
-    logging.getLogger('madgraph').setLevel(logging.INFO)    
-
+    logging.getLogger('madgraph').setLevel(logging.INFO)
 
 def treat_old_argument(argument):
     """Have the MW4 behavior for this script"""
@@ -104,7 +107,7 @@ def treat_old_argument(argument):
         MWparam.set_run_opt(sys.argv)
     logger = logging.getLogger('madgraph')
     opt =  MWparam.run_opt
-    cmds = [] 
+    cmds = []
     if opt['param']: #-1
         cmds.append('treatcards')
     if opt['analyzer']: #-2
@@ -120,11 +123,11 @@ def treat_old_argument(argument):
     if opt['control']: # -7
         logger.warning('Option -7/control not supported anymore.')
     if opt['status']: # -7
-        logger.warning('Option "status" not supported anymore.')        
+        logger.warning('Option "status" not supported anymore.')
     if opt['collect']: # -8
-        cmds.append('collect')   
+        cmds.append('collect')
     if opt['plot']: # -9
-        logger.warning('Option -9/plot not supported anymore.')            
+        logger.warning('Option -9/plot not supported anymore.')
     if opt['relaunch']: # relaunch
         cmds.append('refine 1')
     if opt['refine']: # refine
@@ -132,18 +135,13 @@ def treat_old_argument(argument):
     if opt['clean'] == 1: # clean
          cmds.append('clean')
     if opt['clean']: # clean
-         cmds.append('clean %s' % opt['clean'])         
-         
+         cmds.append('clean %s' % opt['clean'])
+
     return cmds
 
-
-
-
-
-
-################################################################################  
+################################################################################
 ##   EXECUTABLE
-################################################################################                                
+################################################################################
 if '__main__' == __name__:
     # Check that python version is valid
 
@@ -157,7 +155,7 @@ if '__main__' == __name__:
             cmds = treat_old_argument(argument)
             for cmd in cmds:
                 launch.run_cmd(cmd)
-        else: 
+        else:
             launch.run_cmd('launch %s' % ' '.join(argument[1:]))
             launch.run_cmd('quit')
     except KeyboardInterrupt:
@@ -169,26 +167,12 @@ if '__main__' == __name__:
         logging.error(str(error))
         sys.exit()
     except Exception as error:
-        if os.path.exists(pjoin(root_path, 'RunWeb')): 
+        if os.path.exists(pjoin(root_path, 'RunWeb')):
             os.remove(pjoin(root_path, 'RunWeb'))
-        raise 
-                        
-    if os.path.exists(pjoin(root_path, 'RunWeb')): 
-        os.remove(pjoin(root_path, 'RunWeb'))      
-    
-    
-    # reconfigure path for the web 
+        raise
+
+    if os.path.exists(pjoin(root_path, 'RunWeb')):
+        os.remove(pjoin(root_path, 'RunWeb'))
+    # reconfigure path for the web
     #if len(argument) == 5:
     #    ME.pass_in_web_mode()
-
-             
-        
-
-        
-    
-    
-    
-    
-    
-    
-    

--- a/Template/MadWeight/bin/mw_options
+++ b/Template/MadWeight/bin/mw_options
@@ -4,11 +4,11 @@
 #
 # Copyright (c) 2009 The MadGraph Development team and Contributors
 #
-# This file is a part of the MadGraph 5 project, an application which 
+# This file is a part of the MadGraph 5 project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph license which should accompany this 
+# It is subject to the MadGraph license which should accompany this
 # distribution.
 #
 # For more information, please visit: http://madgraph.phys.ucl.ac.be
@@ -32,17 +32,12 @@ import optparse
 root_path = os.path.dirname(os.path.realpath( __file__ ))
 sys.path.insert(0, root_path)
 
-
-
 class MyOptParser(optparse.OptionParser):
-    
+
     class InvalidOption(Exception): pass
 
     def error(self, msg=''):
         raise MyOptParser.InvalidOption(msg)
-
-
-
 
 # Write out nice usage message if called with -h or --help
 usage = "usage: %prog [options] [FILE] "
@@ -60,7 +55,7 @@ for i in range(len(sys.argv)-1):
         (options, args) = parser.parse_args(sys.argv[1:len(sys.argv)-i])
         done = True
     except MyOptParser.InvalidOption, error:
-        pass 
+        pass
     else:
         args += sys.argv[len(sys.argv)-i:]
 if not done:
@@ -69,7 +64,7 @@ if not done:
         (options, args) = parser.parse_args()
     except MyOptParser.InvalidOption, error:
         print error
-        sys.exit(2)  
+        sys.exit(2)
 
 if len(args) == 0:
     args = ''
@@ -86,7 +81,7 @@ if __debug__ and not options.debug and \
 import logging
 import logging.config
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -98,8 +93,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -108,11 +103,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'me5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "me5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -125,13 +128,12 @@ except:
 if __debug__:
         print 'Running MG5 in debug mode'
 
-
 # Set logging level according to the logging level given by options
 #logging.basicConfig(level=vars(logging)[options.logging])
 import internal.coloring_logging
 try:
     if __debug__ and options.logging == 'INFO':
-        options.logging = 'DEBUG'    
+        options.logging = 'DEBUG'
     logging.config.fileConfig(os.path.join(root_path, 'internal', 'me5_logging.conf'))
     logging.root.setLevel(eval('logging.' + options.logging))
     logging.getLogger('madgraph').setLevel(eval('logging.' + options.logging))
@@ -143,14 +145,14 @@ import internal.common_run_interface as common_run_interface
 # Call the cmd interface main loop
 try:
     if (args and os.path.exists(args[0])):
-        # They are an input file 
+        # They are an input file
         input_file = args[0]
         if options.web:
             cmd_line = cmd_interface.MadWeightCmd()
             cmd_line.debug_output = os.path.join(os.path.dirname(input_file),'generation.log')
             cmd_line.use_rawinput = False
             cmd_line.run_cmd('import command ' + input_file)
-            cmd_line.run_cmd('quit')      
+            cmd_line.run_cmd('quit')
         else:
             cmd_line = cmd_interface.MadWeightCmdShell()
             cmd_line.use_rawinput = False
@@ -166,7 +168,7 @@ try:
             else:
                 print 'ERROR: %s  not a valid command. Please retry' % args[0]
         else:
-            cmd_line.use_rawinput = False    
+            cmd_line.use_rawinput = False
             cmd_line.run_cmd(' '.join(args))
             cmd_line.run_cmd('quit')
     else:
@@ -177,28 +179,27 @@ try:
         else:
             cmd_line = cmd_interface.MadWeightCmdShell()
             cmd_line.cmdloop()
-            
+
 except KeyboardInterrupt:
-    print 'writting history and directory and quit on KeyboardInterrupt' 
+    print 'writting history and directory and quit on KeyboardInterrupt'
     pass
 except common_run_interface.AlreadyRunning, error:
     logging.error(str(error))
     sys.exit()
-try: 
+try:
     readline.set_history_length(100)
-    if not os.path.exists(os.path.join(os.environ['HOME'], '.mg5')):
-        os.mkdir(os.path.join(os.environ['HOME'], '.mg5'))
+    if not os.path.exists(state_dir):
+        os.mkdir(state_dir)
     readline.write_history_file(history_file)
 except:
     pass
-    
+
 try:
     if cmd_line.history[-1] not in ['EOF','quit','exit']:
         cmd_line.results.store_result()
 except:
     print error
     pass
-
 
 try:
     # Remove lock file

--- a/Template/NLO/bin/aMCatNLO
+++ b/Template/NLO/bin/aMCatNLO
@@ -4,11 +4,11 @@
 #
 # Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
@@ -29,7 +29,7 @@ except ImportError:
     message = 'madgraph requires the six module. The easiest way to install it is to run "pip install six --user"\n'
     message += 'in case of problem with pip, you can download the file at https://pypi.org/project/six/ . It has a single python file that you just need to put inside a directory of your $PYTHONPATH environment variable.'
     sys.exit(message)
-    
+
 import os
 import optparse
 
@@ -39,17 +39,12 @@ import optparse
 root_path = os.path.dirname(os.path.realpath( __file__ ))
 sys.path.insert(0, root_path)
 
-
-
 class MyOptParser(optparse.OptionParser):
-    
+
     class InvalidOption(Exception): pass
 
     def error(self, msg=''):
         raise MyOptParser.InvalidOption(msg)
-
-
-
 
 # Write out nice usage message if called with -h or --help
 usage = "usage: %prog [options] [FILE] "
@@ -67,7 +62,7 @@ for i in range(len(sys.argv)-1):
         (options, args) = parser.parse_args(sys.argv[1:len(sys.argv)-i])
         done = True
     except MyOptParser.InvalidOption as error:
-        pass 
+        pass
     else:
         args += sys.argv[len(sys.argv)-i:]
 if not done:
@@ -76,7 +71,7 @@ if not done:
         (options, args) = parser.parse_args()
     except MyOptParser.InvalidOption as error:
         print(error)
-        sys.exit(2)  
+        sys.exit(2)
 
 if len(args) == 0:
     args = ''
@@ -93,7 +88,7 @@ if __debug__ and not options.debug and \
 import logging
 import logging.config
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -105,8 +100,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -115,11 +110,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'me5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "me5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -132,13 +135,12 @@ except:
 if __debug__:
         print( 'Running MG5 in debug mode')
 
-
 # Set logging level according to the logging level given by options
 #logging.basicConfig(level=vars(logging)[options.logging])
 import internal.coloring_logging
 try:
     if __debug__ and options.logging == 'INFO':
-        options.logging = 'DEBUG'    
+        options.logging = 'DEBUG'
     if options.logging.isdigit():
         level = int(options.logging)
     else:
@@ -154,7 +156,7 @@ import internal.amcatnlo_run_interface as cmd_interface
 # Call the cmd interface main loop
 try:
     if (args and os.path.isfile(args[0])):
-        # They are an input file 
+        # They are an input file
         input_file = args[0]
         if options.web:
             cmd_line = cmd_interface.aMCatNLOCmd()
@@ -162,7 +164,7 @@ try:
             cmd_line.use_rawinput = False
             cmd_line.haspiping = False
             cmd_line.run_cmd('import command ' + input_file)
-            cmd_line.run_cmd('quit')      
+            cmd_line.run_cmd('quit')
         else:
             cmd_line = cmd_interface.aMCatNLOCmdShell()
             cmd_line.use_rawinput = False
@@ -182,7 +184,7 @@ try:
             else:
                 print( 'ERROR: %s  not a valid command. Please retry' % args[0])
         else:
-            cmd_line.use_rawinput = False    
+            cmd_line.use_rawinput = False
             cmd_line.run_cmd(' '.join(args))
             cmd_line.run_cmd('quit')
     else:
@@ -193,28 +195,27 @@ try:
         else:
             cmd_line = cmd_interface.aMCatNLOCmdShell()
             cmd_line.cmdloop()
-            
+
 except KeyboardInterrupt:
     print( 'writting history and directory and quit on KeyboardInterrupt')
     pass
 except cmd_interface.aMCatNLOAlreadyRunning as error:
     logging.error(str(error))
     sys.exit()
-try: 
+try:
     readline.set_history_length(100)
-    if not os.path.exists(os.path.join(os.environ['HOME'], '.mg5')):
-        os.mkdir(os.path.join(os.environ['HOME'], '.mg5'))
+    if not os.path.exists(state_dir):
+        os.mkdir(state_dir)
     readline.write_history_file(history_file)
 except:
     pass
-    
+
 try:
     if cmd_line.history[-1] not in ['EOF','quit','exit']:
         cmd_line.results.store_result()
 except:
     print( error)
     pass
-
 
 try:
     # Remove lock file

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -8,11 +8,11 @@ start = time.time()
 #
 # Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
@@ -27,8 +27,8 @@ if sys.version_info[0] == 2:
              "  You are currently using Python2.%s. Please use a more recent version of Python." % sys.version_info[1])
 elif  sys.version_info[1] < 7:
     sys.exit("MadGraph5_aMC@NLO works only with python 3.7 (and later).\n"+\
-              "  You are currently using Python 3.%i. So please upgrade your version of Python." % sys.version_info[1]) 
-    
+              "  You are currently using Python 3.%i. So please upgrade your version of Python." % sys.version_info[1])
+
 try:
     import six
 except ImportError:
@@ -44,7 +44,6 @@ import optparse
 
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 sys.path.insert(0, root_path)
-
 
 # Write out nice usage message if called with -h or --help
 usage = "usage: %prog [options] [FILE] "
@@ -62,7 +61,7 @@ parser.add_option("","--debug", action="store_true", default=False, dest='debug'
 parser.add_option("-m", "--mode", dest="plugin",
                   help="Define some additional command provide by a PLUGIN")
 parser.add_option("-s", "--nocaffeinate", action="store_false", default=True, dest='nosleep',
-                  help='For mac user, forbids to use caffeinate when running with a script')                               
+                  help='For mac user, forbids to use caffeinate when running with a script')
 (options, args) = parser.parse_args()
 if len(args) == 0:
     args = ''
@@ -82,11 +81,10 @@ import madgraph.interface.coloring_logging
 if sys.version_info[0] ==2:
     logging.warning("\033[91mpython2 support will be removed in last quarter 2021. If you use python2 due to issue with Python3, please report them on https://bugs.launchpad.net/mg5amcnlo\033[0m")
 
-
 if ' ' in os.getcwd():
     logging.warning("\033[91mPath does contains spaces. We advise that you change your current path to avoid to have space in the path.\033[0m")
 
-try: 
+try:
     import readline
 except ImportError:
     try:
@@ -98,8 +96,8 @@ else:
 
     if 'r261:67515' in sys.version and  'GCC 4.2.1 (Apple Inc. build 5646)' in sys.version:
         readline.parse_and_bind("bind ^I rl_complete")
-        readline.__doc__ = 'libedit'  
-    
+        readline.__doc__ = 'libedit'
+
     elif hasattr(readline, '__doc__'):
         if 'libedit' not in readline.__doc__:
             readline.parse_and_bind("tab: complete")
@@ -108,11 +106,19 @@ else:
     else:
         readline.__doc__ = 'GNU'
         readline.parse_and_bind("tab: complete")
-        
+
     # charge history file
     try:
-        history_file = os.path.join(os.environ['HOME'], '.mg5', 'mg5history')
+        legacy_state_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_state_dir):
+            state_dir = legacy_state_dir
+        else:
+            state_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+        history_file = os.path.join(state_dir, "mg5history")
         readline.read_history_file(history_file)
+
     except:
         pass
 
@@ -129,7 +135,7 @@ if __debug__:
 #logging.basicConfig(level=vars(logging)[options.logging])
 try:
     if __debug__ and options.logging == 'INFO':
-        options.logging = 'DEBUG'    
+        options.logging = 'DEBUG'
     if options.logging.isdigit():
         level = int(options.logging)
     else:
@@ -153,7 +159,6 @@ try:
 except:
     pass
 
-
 if options.plugin:
     if not os.path.exists(os.path.join(root_path, 'PLUGIN', options.plugin)):
         print( "ERROR: %s is not present in the PLUGIN directory. Please install it first")
@@ -169,10 +174,8 @@ if options.plugin:
     cmd_line.plugin=options.plugin
 elif options.web:
     cmd_line = interface.MasterCmdWeb()
-else: 
+else:
     cmd_line = interface.MasterCmd(mgme_dir = options.mgme_dir)
-
-
 
 # Call the cmd interface main loop
 try:
@@ -181,7 +184,7 @@ try:
             logging.getLogger('madgraph').warning("launching caffeinate to prevent idle sleep when MG5aMC is running. Run './bin/mg5_aMC -s' to prevent this.")
             pid = os.getpid()
             subprocess.Popen(['caffeinate', '-i', '-w', str(pid)])
-        # They are an input file 
+        # They are an input file
         if args:
             input_file = os.path.realpath(args[0])
         else:
@@ -208,17 +211,14 @@ try:
         else:
             cmd_line.cmdloop()
 except KeyboardInterrupt:
-    print('writting history and quit on KeyboardInterrupt') 
+    print('writting history and quit on KeyboardInterrupt')
     pass
 
 try:
     cmd_line.exec_cmd('quit all', printcmd=False)
     readline.set_history_length(100)
-    if not os.path.exists(os.path.join(os.environ['HOME'], '.mg5')):
-        os.mkdir(os.path.join(os.environ['HOME'], '.mg5'))
+    if not os.path.exists(state_dir):
+        os.mkdir(state_dir)
     readline.write_history_file(history_file)
 except Exception as error:
     pass
-
-
-    

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -17,8 +17,6 @@
 """
 from __future__ import division
 
-
-
 from __future__ import absolute_import
 from __future__ import print_function
 import ast
@@ -44,7 +42,7 @@ try:
     GNU_SPLITTING = ('GNU' in readline.__doc__)
 except:
     GNU_SPLITTING = True
-     
+
 root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 root_path = os.path.split(root_path)[0]
 sys.path.insert(0, os.path.join(root_path,'bin'))
@@ -70,11 +68,11 @@ except ImportError:
     import internal.save_load_object as save_load_object
     import internal.gen_crossxhtml as gen_crossxhtml
     import internal.lhe_parser as lhe_parser
-    import internal.FO_analyse_card as FO_analyse_card 
+    import internal.FO_analyse_card as FO_analyse_card
     import internal.sum_html as sum_html
     from internal import InvalidCmd, MadGraph5Error
-    
-    MADEVENT=True    
+
+    MADEVENT=True
 else:
     # import from madgraph directory
     import madgraph.interface.extended_cmd as cmd
@@ -84,13 +82,13 @@ else:
     import madgraph.iolibs.files as files
     import madgraph.various.cluster as cluster
     import madgraph.various.lhe_parser as lhe_parser
-    import madgraph.various.FO_analyse_card as FO_analyse_card 
+    import madgraph.various.FO_analyse_card as FO_analyse_card
     import madgraph.iolibs.save_load_object as save_load_object
     import madgraph.madevent.gen_crossxhtml as gen_crossxhtml
     import models.check_param_card as param_card_mod
     import madgraph.madevent.sum_html as sum_html
 #    import madgraph.various.histograms as histograms # imported later to not slow down the loading of the code
-    
+
     from madgraph import InvalidCmd, MadGraph5Error, MG5DIR
     MADEVENT=False
 
@@ -129,7 +127,7 @@ class HelpToCmd(object):
     def help_compute_widths(self):
         logger.info("syntax: compute_widths Particle [Particles] [OPTIONS]")
         logger.info("-- Compute the widths for the particles specified.")
-        logger.info("   By default, this takes the current param_card and overwrites it.") 
+        logger.info("   By default, this takes the current param_card and overwrites it.")
         logger.info("   Precision allows to define when to include three/four/... body decays (LO).")
         logger.info("   If this number is an integer then all N-body decay will be included.")
         logger.info("  Various options:\n")
@@ -182,15 +180,12 @@ class HelpToCmd(object):
         logger.info('   threshold option allows to change the minimal value required to')
         logger.info('   a non zero value for the particle (default:1e-12s)')
 
-
-
 class CheckValidForCmd(object):
     """ The Series of check routines in common between amcatnlo_run and
     madevent interface"""
 
     def check_set(self, args):
         """ check the validity of the line"""
-
 
         if len(args) < 2:
             if len(args)==1 and "=" in args[0]:
@@ -219,7 +214,7 @@ class CheckValidForCmd(object):
         type: PART PATH --output=PATH -f --precision=N
         return the model.
         """
-        
+
         # Check that MG5 directory is present .
         if MADEVENT and not self.options['mg5_path']:
             raise self.InvalidCmd('''The automatic computations of widths requires that MG5 is installed on the system.
@@ -232,7 +227,6 @@ class CheckValidForCmd(object):
         except ImportError:
             raise self.ConfigurationError('''Can\'t load MG5.
             The variable mg5_path should not be correctly configure.''')
-        
 
         ufo_path = pjoin(self.me_dir,'bin','internal', 'ufomodel')
         # Import model
@@ -241,28 +235,28 @@ class CheckValidForCmd(object):
             #restrict_file = None
             #if os.path.exists(pjoin(ufo_path, 'restrict_default.dat')):
             #    restrict_file = pjoin(ufo_path, 'restrict_default.dat')
-            
+
             force_CMS = self.mother and self.mother.options['complex_mass_scheme']
-            model = import_ufo.import_model(modelname, decay=True, 
+            model = import_ufo.import_model(modelname, decay=True,
                                    restrict=True, complex_mass_scheme=force_CMS)
         else:
             force_CMS = self.proc_characteristics['complex_mass_scheme']
             model = import_ufo.import_model(pjoin(self.me_dir,'bin','internal',
                          'ufomodel'), decay=True, complex_mass_scheme=force_CMS)
-            
+
 #        if not hasattr(model.get('particles')[0], 'partial_widths'):
 #            raise self.InvalidCmd, 'The UFO model does not include partial widths information. Impossible to compute widths automatically'
-            
+
         # check if the name are passed to default MG5
         if '-modelname' not in open(pjoin(self.me_dir,'Cards','proc_card_mg5.dat')).read():
-            model.pass_particles_name_in_mg_default()        
+            model.pass_particles_name_in_mg_default()
         model = model_reader.ModelReader(model)
         particles_name = dict([(p.get('name'), p.get('pdg_code'))
                                                for p in model.get('particles')])
         particles_name.update(dict([(p.get('antiname'), p.get('pdg_code'))
-                                               for p in model.get('particles')]))        
-        
-        output = {'model': model, 'force': False, 'output': None, 
+                                               for p in model.get('particles')]))
+
+        output = {'model': model, 'force': False, 'output': None,
                   'path':None, 'particles': set(), 'body_decay':4.0025,
                   'min_br':None, 'precision_channel':0.01}
         for arg in args:
@@ -272,7 +266,7 @@ class CheckValidForCmd(object):
                     raise self.InvalidCmd('Invalid Path for the output. Please retry.')
                 if not os.path.isfile(output_path):
                     output_path = pjoin(output_path, 'param_card.dat')
-                output['output'] = output_path       
+                output['output'] = output_path
             elif arg == '-f':
                 output['force'] = True
             elif os.path.isfile(arg):
@@ -312,7 +306,7 @@ class CheckValidForCmd(object):
         if not output['particles']:
             raise self.InvalidCmd('''This routines requires at least one particle in order to compute
             the related width''')
-            
+
         if output['output'] is None:
             output['output'] = output['path']
 
@@ -320,37 +314,36 @@ class CheckValidForCmd(object):
 
     def check_delphes(self, arg, nodefault=False):
         """Check the argument for pythia command
-        syntax: delphes [NAME] 
+        syntax: delphes [NAME]
         Note that other option are already remove at this point
         """
-        
+
         # If not pythia-pgs path
         if not self.options['delphes_path']:
             logger.info('Retry to read configuration file to find delphes path')
             self.set_configuration()
-      
+
         if not self.options['delphes_path']:
             error_msg = 'No valid Delphes path set.\n'
             error_msg += 'Please use the set command to define the path and retry.\n'
             error_msg += 'You can also define it in the configuration file.\n'
-            raise self.InvalidCmd(error_msg)  
+            raise self.InvalidCmd(error_msg)
 
         tag = [a for a in arg if a.startswith('--tag=')]
-        if tag: 
+        if tag:
             arg.remove(tag[0])
             tag = tag[0][6:]
-            
-                  
+
         if len(arg) == 0 and not self.run_name:
             if self.results.lastrun:
                 arg.insert(0, self.results.lastrun)
             else:
-                raise self.InvalidCmd('No run name currently define. Please add this information.')             
-        
+                raise self.InvalidCmd('No run name currently define. Please add this information.')
+
         if len(arg) == 1 and self.run_name == arg[0]:
             arg.pop(0)
 
-        filepath = None        
+        filepath = None
         if not len(arg):
             prev_tag = self.set_run_name(self.run_name, tag, 'delphes')
             paths = [pjoin(self.me_dir,'Events',self.run_name, '%(tag)s_pythia_events.hep.gz'),
@@ -367,44 +360,42 @@ class CheckValidForCmd(object):
                     filepath = p % {'tag': prev_tag}
                     break
             else:
-                a = input("NO INPUT")          
+                a = input("NO INPUT")
                 if nodefault:
                     return False
                 else:
                     self.help_pgs()
                     raise self.InvalidCmd('''No file file pythia_events.* currently available
             Please specify a valid run_name''')
-        
+
         if len(arg) == 1:
             prev_tag = self.set_run_name(arg[0], tag, 'delphes')
-            if os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)):            
+            if os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)
             elif os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc.gz' % prev_tag)):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc.gz' % prev_tag)
-            elif os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep' % prev_tag)):            
+            elif os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep' % prev_tag)):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)
             elif os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc' % prev_tag)):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc.gz' % prev_tag)
-            else:                
+            else:
                 raise self.InvalidCmd('No events file corresponding to %s run with tag %s.:%s '\
-                    % (self.run_name, prev_tag, 
+                    % (self.run_name, prev_tag,
                        pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)))
         else:
             if tag:
                 self.run_card['run_tag'] = tag
             self.set_run_name(self.run_name, tag, 'delphes')
-            
-        return filepath               
 
+        return filepath
 
     def check_add_time_of_flight(self, args):
         """check that the argument are correct"""
-        
-        
+
         if len(args) >2:
             self.help_time_of_flight()
             raise self.InvalidCmd('Too many arguments')
-        
+
         # check if the threshold is define. and keep it's value
         if args and args[-1].startswith('--threshold='):
             try:
@@ -414,31 +405,26 @@ class CheckValidForCmd(object):
             args.remove(args[-1])
         else:
             threshold = 1e-12
-            
-        if len(args) == 1 and  os.path.exists(args[0]): 
+
+        if len(args) == 1 and  os.path.exists(args[0]):
                 event_path = args[0]
         else:
             if len(args) and self.run_name != args[0]:
                 self.set_run_name(args.pop(0))
-            elif not self.run_name:            
+            elif not self.run_name:
                 self.help_add_time_of_flight()
-                raise self.InvalidCmd('Need a run_name to process')  
-            if self.LO:          
+                raise self.InvalidCmd('Need a run_name to process')
+            if self.LO:
                 event_path = pjoin(self.me_dir, 'Events', self.run_name, 'unweighted_events.lhe.gz')
             else:
                 event_path = pjoin(self.me_dir, 'Events', self.run_name, 'events.lhe.gz')
             if not os.path.exists(event_path):
                 event_path = event_path[:-3]
-                if not os.path.exists(event_path):    
+                if not os.path.exists(event_path):
                     raise self.InvalidCmd('No unweighted events associate to this run.')
 
-
-        
         #reformat the data
-        args[:] = [event_path, threshold]    
-    
-
-
+        args[:] = [event_path, threshold]
 
     def check_open(self, args):
         """ check the validity of the line """
@@ -539,7 +525,6 @@ class CheckValidForCmd(object):
             plugin = [t  for t in args if t.startswith('--plugin')][0]
             args.remove(plugin)
             opts.append(plugin)
-            
 
         if len(args) == 0:
             if self.run_name:
@@ -557,7 +542,6 @@ class CheckValidForCmd(object):
 
         args += opts
 
-
     def check_check_events(self,args):
         """Check the argument for decay_events command
         syntax is "decay_events [NAME]"
@@ -572,15 +556,14 @@ class CheckValidForCmd(object):
             else:
                 raise self.InvalidCmd('No run name currently defined. Please add this information.')
                 return
-        
+
         if args[0] and os.path.isfile(args[0]):
             pass
         else:
             if args[0] != self.run_name:
                 self.set_run_name(args[0], allow_new_tag=False)
-    
-            args[0] = self.get_events_path(args[0])
 
+            args[0] = self.get_events_path(args[0])
 
     def get_events_path(self, run_name):
         """return the path to the output events
@@ -606,8 +589,6 @@ class CheckValidForCmd(object):
                 raise self.InvalidCmd('No events file corresponding to %s run. ' % run_name)
         return correct_path
 
-
-
 class MadEventAlreadyRunning(InvalidCmd):
     pass
 class AlreadyRunning(MadEventAlreadyRunning):
@@ -619,7 +600,6 @@ class ZeroResult(Exception): pass
 # CommonRunCmd
 #===============================================================================
 class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
-
 
     debug_output = 'ME5_debug'
     helporder = ['Main Commands', 'Documented commands', 'Require MG5 directory',
@@ -672,12 +652,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                          'nb_core': None,
                          'cluster_temp_path':None}
 
-
     def __init__(self, me_dir, options, *args, **opts):
         """common"""
 
         self.force_run = False # this flag force the run even if RunWeb is present
-        self.stop_for_runweb = False # this flag indicates if we stop this run because of RunWeb. 
+        self.stop_for_runweb = False # this flag indicates if we stop this run because of RunWeb.
         if 'force_run' in opts and opts['force_run']:
             self.force_run = True
             del opts['force_run']
@@ -686,14 +665,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # Define current MadEvent directory
         if me_dir is None and MADEVENT:
             me_dir = root_path
-        
+
         if os.path.isabs(me_dir):
             self.me_dir = me_dir
         else:
             self.me_dir = pjoin(os.getcwd(),me_dir)
-            
+
         self.options = options
-        
+
         self.param_card_iterator = [] #an placeholder containing a generator of paramcard for scanning
 
         # usefull shortcut
@@ -703,9 +682,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         # Check that the directory is not currently running_in_idle
         if not self.force_run:
-            if os.path.exists(pjoin(me_dir,'RunWeb')): 
+            if os.path.exists(pjoin(me_dir,'RunWeb')):
                 message = '''Another instance of the program is currently running.
-                (for this exact same directory) Please wait that this is instance is 
+                (for this exact same directory) Please wait that this is instance is
                 closed. If no instance is running, you can delete the file
                 %s and try again.''' % pjoin(me_dir,'RunWeb')
                 self.stop_for_runweb = True
@@ -720,11 +699,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # Load the configuration file
         self.set_configuration()
 
-
         # Define self.proc_characteristics
         self.get_characteristics()
         self.postprocessing_dirs = []
-        
+
         if not  self.proc_characteristics['ninitial']:
             # Get number of initial states
             nexternal = open(pjoin(self.me_dir,'Source','nexternal.inc')).read()
@@ -736,7 +714,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     def make_make_all_html_results(self, folder_names = [], jobs=[]):
         return sum_html.make_all_html_results(self, folder_names, jobs)
 
-
     def write_RunWeb(self, me_dir):
         self.writeRunWeb(me_dir)
         self.gen_card_html()
@@ -746,17 +723,17 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         pid = os.getpid()
         fsock = open(pjoin(me_dir,'RunWeb'),'w')
         fsock.write(repr(pid))
-        fsock.close()        
-        
+        fsock.close()
+
     class RunWebHandling(object):
-        
+
         def __init__(self, me_dir, crashifpresent=True, warnifpresent=True):
             """raise error if RunWeb already exists
             me_dir is the directory where the write RunWeb"""
-            
+
             self.remove_run_web = True
             self.me_dir = me_dir
-            
+
             if crashifpresent or warnifpresent:
                 if os.path.exists(pjoin(me_dir, 'RunWeb')):
                     pid = open(pjoin(me_dir, 'RunWeb')).read()
@@ -764,15 +741,15 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         pid = int(pid)
                     except Exception:
                         pid = "unknown"
-                    
+
                     if pid == 'unknown' or misc.pid_exists(pid):
-                        # bad situation 
+                        # bad situation
                         if crashifpresent:
                             if isinstance(crashifpresent, Exception):
                                 raise crashifpresent
                             else:
                                 message = '''Another instance of the program is currently running (pid = %s).
-                (for this exact same directory). Please wait that this is instance is 
+                (for this exact same directory). Please wait that this is instance is
                 closed. If no instance is running, you can delete the file
                 %s and try again.''' % (pid, pjoin(me_dir, 'RunWeb'))
                                 raise AlreadyRunning(message)
@@ -785,16 +762,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     else:
                         logger.debug('RunWeb exists but no associated process. Will Ignore it!')
                     return
-            
+
             # write RunWeb
-            
+
             CommonRunCmd.writeRunWeb(me_dir)
-            
+
         def __enter__(self):
             return
-        
+
         def __exit__(self,exc_type, exc_value, traceback):
-            
+
             if self.remove_run_web:
                 try:
                     os.remove(pjoin(self.me_dir,'RunWeb'))
@@ -808,12 +785,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             def wrapper(*args, **kw):
                 with self:
                     return f(*args, **kw)
-            return wrapper        
+            return wrapper
 
-        
-            
-            
-            
     ############################################################################
     def split_arg(self, line, error=False):
         """split argument and remove run_options"""
@@ -849,11 +822,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         return args
 
-
     @misc.multiple_try(nb_try=5, sleep=2)
     def load_results_db(self):
         """load the current results status"""
-        
+
         # load the current status of the directory
         if os.path.exists(pjoin(self.me_dir,'HTML','results.pkl')):
             try:
@@ -865,7 +837,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 self.results = gen_crossxhtml.AllResults(model, process, self.me_dir)
                 self.results.resetall(self.me_dir)
             else:
-                try:                                
+                try:
                     self.results.resetall(self.me_dir)
                 except Exception as error:
                     logger.debug(error)
@@ -894,16 +866,15 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     def do_treatcards(self, line, amcatnlo=False):
         """Advanced commands: create .inc files from param_card.dat/run_card.dat"""
 
-
         #ensure that the cluster/card are consistent
         if hasattr(self, 'run_card'):
             self.cluster.modify_interface(self)
-        else:   
+        else:
             try:
                 self.cluster.modify_interface(self)
             except Exception as error:
                 misc.sprint(str(error))
-                
+
         keepwidth = False
         if '--keepwidth' in line:
             keepwidth = True
@@ -931,8 +902,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             run_card.write_include_file(opt['output_dir'])
 
         if mode in ['MadLoop', 'all']:
-            if os.path.exists(pjoin(self.me_dir, 'Cards', 'MadLoopParams.dat')):          
-                self.MadLoopparam = banner_mod.MadLoopParam(pjoin(self.me_dir, 
+            if os.path.exists(pjoin(self.me_dir, 'Cards', 'MadLoopParams.dat')):
+                self.MadLoopparam = banner_mod.MadLoopParam(pjoin(self.me_dir,
                                                   'Cards', 'MadLoopParams.dat'))
                 # write the output file
                 self.MadLoopparam.write(pjoin(self.me_dir,"SubProcesses",
@@ -955,23 +926,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 fsock.close()
                 return
             else:
-                devnull = open(os.devnull, 'w')  
+                devnull = open(os.devnull, 'w')
                 subprocess.call([sys.executable, 'write_param_card.py'],
                              cwd=pjoin(self.me_dir,'bin','internal','ufomodel'), stdout=devnull, stderr=devnull)
                 default = pjoin(self.me_dir,'bin','internal','ufomodel','param_card.dat')
                 if not os.path.exists(default):
                     files.cp(pjoin(self.me_dir, 'Cards','param_card_default.dat'), default)
 
-
             if amcatnlo and not keepwidth:
                 # force particle in final states to have zero width
                 pids = self.get_pid_final_initial_states()
                 # check those which are charged under qcd
                 if pjoin(self.me_dir,'bin','internal','ufomodel') not in sys.path:
-                    sys.path.insert(0,pjoin(self.me_dir,'bin','internal', 'ufomodel'))     
-                if pjoin(self.me_dir,'bin','internal') not in sys.path:    
+                    sys.path.insert(0,pjoin(self.me_dir,'bin','internal', 'ufomodel'))
+                if pjoin(self.me_dir,'bin','internal') not in sys.path:
                     sys.path.insert(0,pjoin(self.me_dir,'bin','internal'))
-                
+
                 #Ensure that the model that we are going to load is the current
                 #one.
                 to_del = [name  for name in sys.modules.keys()
@@ -983,8 +953,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         del sys.modules[name]
                     except Exception:
                         continue
-                        
-                #raise Exception( sys.path, self.me_dir)              
+
+                #raise Exception( sys.path, self.me_dir)
                 #raise Exception, "%s %s %s" % (sys.path, os.path.exists(pjoin(self.me_dir,'bin','internal', 'ufomodel')), os.listdir(pjoin(self.me_dir,'bin','internal', 'ufomodel')))
                 import ufomodel as ufomodel
                 zero = ufomodel.parameters.ZERO
@@ -1040,16 +1010,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         self.ask_edit_card_static(cards, mode, plot, self.options['timeout'],
                                   self.ask, first_cmd=first_cmd, from_banner=from_banner,
                                   banner=banner, lhapdf=self.options['lhapdf'])
-        
+
         for c in cards:
             if not os.path.isabs(c):
-                c = pjoin(self.me_dir, c) 
+                c = pjoin(self.me_dir, c)
             if not os.path.exists(c):
                 default = c.replace('dat', '_default.dat')
                 if os.path.exists(default):
                     files.cp(default, c)
-            
-                
 
     @staticmethod
     def ask_edit_card_static(cards, mode='fixed', plot=True,
@@ -1074,7 +1042,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         question = """Do you want to edit a card (press enter to bypass editing)?\n"""
         possible_answer = ['0', 'done']
         card = {0:'done'}
-        
+
         indent = max(len(path2name(card_name)) for card_name in cards)
         question += '/'+'-'*60+'\\\n'
         for i, card_name in enumerate(cards):
@@ -1083,7 +1051,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             possible_answer.append(imode)
             question += '| %-77s|\n'%((' \x1b[31m%%s\x1b[0m. %%-%ds : \x1b[32m%%s\x1b[0m'%indent)%(i+1, imode, card_name))
             card[i+1] = imode
-            
+
         if plot and not 'plot_card.dat' in cards:
             question += '| %-77s|\n'%((' \x1b[31m9\x1b[0m. %%-%ds : \x1b[32mplot_card.dat\x1b[0m'%indent) % 'plot')
             possible_answer.append(9)
@@ -1111,7 +1079,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         while out not in ['0', 'done']:
             out = ask(question, '0', possible_answer, timeout=int(1.5*timeout),
                               path_msg='enter path', ask_class = AskforEditCard,
-                              cards=cards, mode=mode, 
+                              cards=cards, mode=mode,
                               lhapdf=lhapdf,
                               **opt)
             if 'return_instance' in opt and opt['return_instance']:
@@ -1140,7 +1108,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
            madanalysis5_hadron_card.dat
            madanalysis5_parton_card.dat
            rivet_card.dat
-           
+
            Please update the unit-test: test_card_type_recognition when adding
            cards.
         """
@@ -1149,12 +1117,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if fulltext == '':
             logger.warning('File %s is empty' % path)
             return 'unknown'
-        
+
         to_search = ['<MGVersion>',           # banner
-                     '<mg5proccard>' 
+                     '<mg5proccard>'
                      'ParticlePropagator',    # Delphes
-                     'ExecutionPath', 
-                     'Treewriter', 
+                     'ExecutionPath',
+                     'Treewriter',
                      'CEN_max_tracker',
                      '#TRIGGER CARD',         # delphes_trigger.dat
                      'parameter set name',    # pgs_card
@@ -1181,8 +1149,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     '@MG5aMC', # MA5 hadronique
                     'run_rivet_later', # Rivet
                     ]
-        
-        
+
         text = re.findall('(%s)' % '|'.join(to_search), fulltext, re.I)
         text = [t.lower() for t in text]
         if '<mgversion>' in text or '<mg5proccard>' in text:
@@ -1199,7 +1166,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if any(f.startswith('lhe') for f in ma5_flag):
                 return 'madanalysis5_parton_card.dat'
             if any(f.startswith(('hepmc','hep','stdhep','lhco')) for f in ma5_flag):
-                return 'madanalysis5_hadron_card.dat'            
+                return 'madanalysis5_hadron_card.dat'
             else:
                 return 'unknown'
         elif '#trigger card' in text:
@@ -1219,7 +1186,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             return 'madweight_card.dat'
         elif 'transfer_card.dat' in text:
             return 'transfer_card.dat'
-        elif 'block' in text and 'decay' in text: 
+        elif 'block' in text and 'decay' in text:
             return 'param_card.dat'
         elif 'b_stable' in text:
             return 'shower_card.dat'
@@ -1245,7 +1212,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         else:
             return 'unknown'
 
-
     ############################################################################
     def get_available_tag(self):
         """create automatically a tag"""
@@ -1257,23 +1223,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if 'tag_%s' %i not in used_tags:
                 return 'tag_%s' % i
 
-
     ############################################################################
     @misc.mute_logger(names=['madgraph.various.histograms',
                                           'internal.histograms'],levels=[20,20])
     def generate_Pythia8_HwU_plots(self, plot_root_path,
-                                   merging_scale_name, observable_name, 
+                                   merging_scale_name, observable_name,
                                    data_path):
         """Generated the HwU plots from Pythia8 driver output for a specific
         observable."""
-        
+
         try:
             import madgraph
-        except ImportError:  
+        except ImportError:
             import internal.histograms as histograms
         else:
             import madgraph.various.histograms as histograms
-        
+
         # Make sure that the file is present
         if not os.path.isfile(data_path):
             return False
@@ -1285,7 +1250,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         # Now also plot the max vs min merging scale
         merging_scales_available = [label[1] for label in \
-                  histos[0].bins.weight_labels if 
+                  histos[0].bins.weight_labels if
                   histograms.HwU.get_HwU_wgt_label_type(label)=='merging_scale']
         if len(merging_scales_available)>=2:
             min_merging_scale = min(merging_scales_available)
@@ -1296,11 +1261,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         # jet_samples_to_keep = None means that all jet_samples are kept
         histo_output_options = {
-          'format':'gnuplot', 
+          'format':'gnuplot',
           'uncertainties':['scale','pdf','statistical',
-                           'merging_scale','alpsfact'], 
+                           'merging_scale','alpsfact'],
           'ratio_correlations':True,
-          'arg_string':'Automatic plotting from MG5aMC', 
+          'arg_string':'Automatic plotting from MG5aMC',
           'jet_samples_to_keep':None,
           'use_band':['merging_scale','alpsfact'],
           'auto_open':False
@@ -1315,7 +1280,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         histos.output(pjoin(plot_root_path,
             'central_%s_%s_plots'%(merging_scale_name,observable_name)),
             **histo_output_options)
-        
+
         for scale in merging_scales_available:
             that_scale_histos = histograms.HwUList(
                                data_path,  run_id=0, merging_scale=scale)
@@ -1327,11 +1292,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # to compare the summed jet samples for the maximum and minimum
         # merging scale available.
         if not min_merging_scale is None:
-            min_scale_histos = histograms.HwUList(data_path, 
-                               consider_reweights=[], run_id=0, 
+            min_scale_histos = histograms.HwUList(data_path,
+                               consider_reweights=[], run_id=0,
                                         merging_scale=min_merging_scale)
-            max_scale_histos = histograms.HwUList(data_path, 
-                               consider_reweights=[], run_id=0, 
+            max_scale_histos = histograms.HwUList(data_path,
+                               consider_reweights=[], run_id=0,
                                         merging_scale=max_merging_scale)
 
             # Give the histos types so that the plot labels look good
@@ -1345,31 +1310,30 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     histo.type = '%s=%.4g'%(merging_scale_name, max_merging_scale)
                 else:
                     histo.type += '|%s=%.4g'%(merging_scale_name, max_merging_scale)
-            
+
             # Now plot and compare against oneanother the shape for the the two scales
             histograms.HwUList(min_scale_histos+max_scale_histos).output(
                 pjoin(plot_root_path,'min_max_%s_%s_comparison'
                                          %(merging_scale_name,observable_name)),
-                format='gnuplot', 
-                uncertainties=[], 
+                format='gnuplot',
+                uncertainties=[],
                 ratio_correlations=True,
-                arg_string='Automatic plotting from MG5aMC', 
+                arg_string='Automatic plotting from MG5aMC',
                 jet_samples_to_keep=None,
                 use_band=[],
                 auto_open=False)
         return True
-    
+
     def gen_card_html(self):
         """ """
-        devnull = open(os.devnull, 'w')        
+        devnull = open(os.devnull, 'w')
         try:
             misc.call(['./bin/internal/gen_cardhtml-pl'], cwd=self.me_dir,
                         stdout=devnull, stderr=devnull)
         except Exception:
             pass
         devnull.close()
-            
-    
+
     def create_plot(self, mode='parton', event_path=None, output=None, tag=None):
         """create the plot"""
 
@@ -1379,14 +1343,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if mode != 'Pythia8':
             madir = self.options['madanalysis_path']
             td = self.options['td_path']
-    
+
             if not madir or not td or \
                 not os.path.exists(pjoin(self.me_dir, 'Cards', 'plot_card.dat')):
                 return False
         else:
             PY8_plots_root_path = pjoin(self.me_dir,'HTML',
                                                self.run_name,'%s_PY8_plots'%tag)
-        
+
         if 'ickkw' in self.run_card:
             if int(self.run_card['ickkw']) and mode == 'Pythia':
                 self.update_status('Create matching plots for Pythia', level='pythia')
@@ -1397,22 +1361,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                stdout=pjoin(self.me_dir,'Events','events.tree'))
                     files.mv(pjoin(self.me_dir,'Events',self.run_name, tag+'_pythia_xsecs.tree'),
                          pjoin(self.me_dir,'Events','xsecs.tree'))
-    
+
                 # Generate the matching plots
                 misc.call([self.dirbin+'/create_matching_plots.sh',
                            self.run_name, tag, madir],
                                 stdout = os.open(os.devnull, os.O_RDWR),
                                 cwd=pjoin(self.me_dir,'Events'))
-    
+
                 #Clean output
                 misc.gzip(pjoin(self.me_dir,"Events","events.tree"),
                           stdout=pjoin(self.me_dir,'Events',self.run_name, tag + '_pythia_events.tree.gz'))
                 files.mv(pjoin(self.me_dir,'Events','xsecs.tree'),
                          pjoin(self.me_dir,'Events',self.run_name, tag+'_pythia_xsecs.tree'))
-            
+
             elif mode == 'Pythia8' and (int(self.run_card['ickkw'])==1  or \
                   self.run_card['ktdurham']>0.0 or self.run_card['ptlund']>0.0):
-                
+
                 self.update_status('Create matching plots for Pythia8',
                                                                 level='pythia8')
 
@@ -1477,7 +1441,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 pt_plot_files = sorted(
                             (('Pt',p) for p in plot_files if '_pt_' in p),
                             key = sorted_plots)
-                last_obs = None            
+                last_obs = None
                 for obs, one_plot in djr_plot_files+pt_plot_files:
                     if obs!=last_obs:
                         # Add a line between observables
@@ -1487,7 +1451,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     short_name = name
                     for dummy in ['_plots','_djr','_pt']:
                         short_name = short_name.replace(dummy,'')
-                    short_name = short_name.replace('_',' ')                        
+                    short_name = short_name.replace('_',' ')
                     if 'min max' in short_name:
                         short_name = "%s comparison with min/max merging scale"%obs
                     if 'central' in short_name:
@@ -1547,7 +1511,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             misc.gunzip(event_path, keep=True)
             event_path = event_path[:-3]
 
-        
         self.update_status('Creating Plots for %s level' % mode, level = mode.lower())
 
         mode = mode.lower()
@@ -1594,7 +1557,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         self.update_status('End Plots for %s level' % mode, level = mode.lower(),
                                                                  makehtml=False)
-        
 
         return True
 
@@ -1651,7 +1613,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         logger.info("syntax: systematics RUN_NAME [OUTPUT] [options]",'$MG:BOLD')
         logger.info("-- Run the systematics run on the RUN_NAME run.")
         logger.info("   RUN_NAME can be a path to a lhef file.")
-        logger.info("   OUTPUT can be the path to the output lhe file, otherwise the input file will be overwritten") 
+        logger.info("   OUTPUT can be the path to the output lhe file, otherwise the input file will be overwritten")
         logger.info("")
         logger.info("options: (values written are the default)", '$MG:BOLD')
         logger.info("")
@@ -1693,17 +1655,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         logger.info("")
         logger.info("   Input for weight format")
         logger.info("     The parameter will be interpreted by python using: https://docs.python.org/2/library/stdtypes.html#string-formatting")
-        logger.info("     The allowed parameters are 'muf','mur','pdf','dyn','alps','id'") 
+        logger.info("     The allowed parameters are 'muf','mur','pdf','dyn','alps','id'")
 
-        
     def complete_systematics(self, text, line, begidx, endidx):
         """auto completion for the systematics command"""
- 
+
         args = self.split_arg(line[0:begidx], error=False)
         options = ['--mur=', '--muf=', '--pdf=', '--dyn=','--alps=',
                    '--together=','--from_card ','--remove_wgts=',
                    '--keep_wgts=','--start_id=']
-        
+
         if len(args) == 1 and os.path.sep not in text:
             #return valid run_name
             data = misc.glob(pjoin('*','*events.lhe*'), pjoin(self.me_dir, 'Events'))
@@ -1717,11 +1678,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         elif len(args)==2 and os.path.sep in args[1]:
             #logger.warning('2args %s', args[1])
             return self.path_completion(text, '.')
-              
+
         elif not line.endswith(tuple(options)):
             return self.list_completion(text, options)
-        
-         
+
     ############################################################################
     def do_systematics(self, line):
         """ syntax is 'systematics [INPUT [OUTPUT]] OPTIONS'
@@ -1730,7 +1690,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             --alps=1
             --dyn=-1
             --together=mur,muf #can be repeated
-            
+
             #special options
             --from_card=
         """
@@ -1743,21 +1703,18 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         else:
             if lhapdf_version.startswith('5'):
                 logger.info('can not run systematics with lhapdf 5')
-                return              
-        
+                return
+
         lhapdf = misc.import_python_lhapdf(self.options['lhapdf'])
         if not lhapdf:
             logger.info('can not run systematics since can not link python to lhapdf')
             return
-        
- 
 
-    
         self.update_status('Running Systematics computation', level='parton')
         args = self.split_arg(line)
         #split arguments and option
         opts= []
-        args = [a for a in args if not a.startswith('-') or opts.append(a)] 
+        args = [a for a in args if not a.startswith('-') or opts.append(a)]
 
         #check sanity of options
         if any(not o.startswith(('--mur=', '--muf=', '--alps=','--dyn=','--together=','--from_card','--pdf=',
@@ -1765,17 +1722,17 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                  '--weight_info='))
                 for o in opts):
             raise self.InvalidCmd("command systematics called with invalid option syntax. Please retry.")
-        
+
         # check that we have define the input
         if len(args) == 0:
             if self.run_name:
                 args[0] = self.run_name
             else:
                 raise self.InvalidCmd('no default run. Please specify the run_name')
-        
+
         if args[0] != self.run_name:
             self.set_run_name(args[0])
-          
+
         # always pass to a path + get the event size
         result_file= sys.stdout
         if not os.path.isfile(args[0]) and not os.path.sep in args[0]:
@@ -1783,12 +1740,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     pjoin(self.me_dir, 'Events', args[0], 'unweighted_events.lhe'),
                     pjoin(self.me_dir, 'Events', args[0], 'events.lhe.gz'),
                     pjoin(self.me_dir, 'Events', args[0], 'events.lhe')]
-            
+
             for p in path:
                 if os.path.exists(p):
                     nb_event = self.results[args[0]].get_current_info()['nb_event']
-                    
-                    
+
                     if self.run_name != args[0]:
                         tag = self.results[args[0]].tags[0]
                         self.set_run_name(args[0], tag,'parton', False)
@@ -1807,7 +1763,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             output = pjoin(os.getcwd(),args[1])
         else:
             output = input
-    
+
         lhaid = [self.run_card.get_lhapdf_id()]
         if 'store_rwgt_info' in self.run_card and not self.run_card['store_rwgt_info']:
             raise self.InvalidCmd("The events was not generated with store_rwgt_info=True. Can not evaluate systematics error on this event file.")
@@ -1820,7 +1776,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     return
                 else:
                     raise self.InvalidCmd('systematics not available for decay processes.')
-        
+
         try:
             pdfsets_dir = self.get_lhapdf_pdfsetsdir()
         except Exception as error:
@@ -1831,13 +1787,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if '--from_card' in opts:
             opts.remove('--from_card')
             opts.append('--from_card=internal')
-            
+
             # Check that all pdfset are correctly installed
             if 'systematics_arguments' in self.run_card.user_set:
                 pdf = [a[6:] for a in self.run_card['systematics_arguments']
                          if a.startswith('--pdf=')]
-                lhaid += [t.split('@')[0] for p in pdf for t in p.split(',') 
-                                            if t not in ['errorset', 'central']]                
+                lhaid += [t.split('@')[0] for p in pdf for t in p.split(',')
+                                            if t not in ['errorset', 'central']]
             elif 'sys_pdf' in self.run_card.user_set:
                 if '&&' in self.run_card['sys_pdf']:
                     if isinstance(self.run_card['sys_pdf'], list):
@@ -1848,13 +1804,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     lhaid += [l.split()[0] for l in sys_pdf]
                 else:
                     lhaid += [l for l in self.run_card['sys_pdf'].split() if not l.isdigit() or int(l) > 500]
-                    
+
         else:
             #check that all p
             pdf = [a[6:] for a in opts if a.startswith('--pdf=')]
-            lhaid += [t.split('@')[0] for p in pdf for t in p.split(',') 
+            lhaid += [t.split('@')[0] for p in pdf for t in p.split(',')
                                             if t not in ['errorset', 'central']]
-        
+
         # Copy all the relevant PDF sets
         try:
             [self.copy_lhapdf_set([onelha], pdfsets_dir, require_local=False) for onelha in lhaid if onelha != 0]
@@ -1862,7 +1818,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             logger.debug(str(error))
             logger.warning('impossible to download all the pdfsets. Bypass systematics')
             return
-        
+
         if self.options['run_mode'] ==2 and self.options['nb_core'] != 1:
             nb_submit = min(int(self.options['nb_core']), nb_event//2500)
         elif self.options['run_mode'] ==1:
@@ -1871,7 +1827,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             except Exception:
                 nb_submit =1
         else:
-            nb_submit =1 
+            nb_submit =1
 
         if MADEVENT:
             import internal.systematics as systematics
@@ -1880,11 +1836,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         #one core:
         if nb_submit in [0,1]:
-            systematics.call_systematics([input, output] + opts, 
+            systematics.call_systematics([input, output] + opts,
                                          log=lambda x: logger.info(str(x)),
                                          result=result_file
                                          )
-            
+
         elif self.options['run_mode'] in [1,2]:
             event_per_job = nb_event // nb_submit
             nb_job_with_plus_one = nb_event % nb_submit
@@ -1893,7 +1849,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 if input.endswith('.gz'):
                     misc.gunzip(input)
                     input = input[:-3]
-                    
+
             for i in range(nb_submit):
                 #computing start/stop event
                 event_requested = event_per_job
@@ -1901,7 +1857,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     event_requested += 1
                 start_event = stop_event
                 stop_event = start_event + event_requested
-                    
+
                 prog = sys.executable
                 input_files = [os.path.basename(input)]
                 output_files = ['./tmp_%s_%s' % (i, os.path.basename(output)),
@@ -1915,8 +1871,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                               '--stop_event=%i' %stop_event,
                               '--result=./log_sys_%s.txt' %i,
                               '--lhapdf_config=%s' % self.options['lhapdf']]
-                required_output = output_files            
-                self.cluster.cluster_submit(prog, argument, 
+                required_output = output_files
+                self.cluster.cluster_submit(prog, argument,
                                             input_files=input_files,
                                             output_files=output_files,
                                             cwd=os.path.dirname(output),
@@ -1958,18 +1914,18 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     else:
                         all_cross.append(cross)
                     pos+=1
-                        
+
             if 'event_norm' in self.run_card and \
                                        self.run_card['event_norm'] in ['unity']:
                 all_cross= [cross/nb_event for cross in all_cross]
-                
-            sys_obj = systematics.call_systematics([input, None] + opts, 
+
+            sys_obj = systematics.call_systematics([input, None] + opts,
                                          log=lambda x: logger.info(str(x)),
                                          result=result_file,
                                          running=False
-                                         )                    
+                                         )
             sys_obj.print_cross_sections(all_cross, nb_event, result_file)
-            
+
             #concatenate the output file
             subprocess.call(['cat']+\
                             ['./tmp_%s_%s' % (i, os.path.basename(output)) for i in range(nb_submit)],
@@ -1978,14 +1934,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             for i in range(nb_submit):
                 os.remove('%s/tmp_%s_%s' %(os.path.dirname(output),i,os.path.basename(output)))
             #    os.remove('%s/log_sys_%s.txt' % (os.path.dirname(output),i))
-                                                  
-
-            
-            
 
         self.update_status('End of systematics computation', level='parton', makehtml=False)
-        
-        
+
     ############################################################################
     def do_reweight(self, line):
         """ syntax is "reweight RUN_NAME"
@@ -1993,7 +1944,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             parameter. Description of the methods are available here
             cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Reweight
         """
-        
 
         #### Utility function
         def check_multicore(self):
@@ -2012,9 +1962,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     return False
                 if line.startswith('change') and line[6:].strip().startswith('multicore'):
                     split_line = line.split()
-                    if len(split_line) > 2: 
+                    if len(split_line) > 2:
                         multicore = bool(split_line[2])
-            # we have reached the first launch in the card ensure that no output change 
+            # we have reached the first launch in the card ensure that no output change
             #are done after that point.
             lines = [line[6:].strip() for line in lines if line.startswith('change')]
             for line in lines:
@@ -2022,13 +1972,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     return False
                 elif line.startswith('multicore'):
                     split_line = line.split()
-                    if len(split_line) > 1: 
+                    if len(split_line) > 1:
                         multicore = bool(split_line[1])
 
             return multicore
-            
-        
-        
+
         if '-from_cards' in line and not os.path.exists(pjoin(self.me_dir, 'Cards', 'reweight_card.dat')):
             return
         # option for multicore to avoid that all of them create the same directory
@@ -2038,16 +1986,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             multicore='wait'
         else:
             multicore=False
-            
+
         # plugin option
         plugin = False
         if '--plugin=' in line:
             plugin = [l.split('=',1)[1] for l in line.split() if '--plugin=' in l][0]
         elif hasattr(self, 'switch') and self.switch['reweight'] not in ['ON','OFF']:
             plugin=self.switch['reweight']
-            
 
-            
         # Check that MG5 directory is present .
         if MADEVENT and not self.options['mg5_path']:
             raise self.InvalidCmd('''The module reweight requires that MG5 is installed on the system.
@@ -2059,16 +2005,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         except ImportError:
             raise self.ConfigurationError('''Can\'t load Reweight module.
             The variable mg5_path might not be correctly configured.''')
-        
+
         if not '-from_cards' in line:
             self.keep_cards(['reweight_card.dat'], ignore=['*'])
-            self.ask_edit_cards(['reweight_card.dat'], 'fixed', plot=False)        
+            self.ask_edit_cards(['reweight_card.dat'], 'fixed', plot=False)
 
         # load the name of the event file
-        args = self.split_arg(line) 
+        args = self.split_arg(line)
         if plugin and '--plugin=' not in line:
             args.append('--plugin=%s' % plugin)
-        
+
         if not self.force_run:
             # forbid this function to create an empty item in results.
             if self.run_name and self.results.current and  self.results.current['cross'] == 0:
@@ -2077,7 +2023,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             # ensure that the run_card is present
             if not hasattr(self, 'run_card'):
                 self.run_card = banner_mod.RunCard(pjoin(self.me_dir, 'Cards', 'run_card.dat'))
-            
+
             # we want to run this in a separate shell to avoid hard f2py crash
             command =  [sys.executable]
             if os.path.exists(pjoin(self.me_dir, 'bin', 'madevent')):
@@ -2087,7 +2033,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if not isinstance(self, cmd.CmdShell):
                 command.append('--web')
             command.append('reweight')
-            
+
             #########   START SINGLE CORE MODE ############
             if self.options['nb_core']==1 or self.run_card['nevents'] < 101 or not check_multicore(self):
                 if self.run_name:
@@ -2118,8 +2064,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     if self.results.current['cross'] == 0 and self.run_name:
                         self.results.delete_run(self.run_name, self.run_tag)
                 except:
-                    pass                    
-                # re-define current run     
+                    pass
+                # re-define current run
                 try:
                     self.results.def_current(self.run_name, self.run_tag)
                 except Exception:
@@ -2132,9 +2078,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     mycluster = cluster.MultiCore(nb_core=self.options['nb_core'])
                 else:
                     mycluster = self.cluster
-                
+
                 new_args=list(args)
-                self.check_decay_events(new_args) 
+                self.check_decay_events(new_args)
                 try:
                     os.remove(pjoin(self.me_dir,'rw_me','rwgt.pkl'))
                 except Exception as error:
@@ -2161,14 +2107,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     to_zip = False
                 devnull= open(os.devnull)
                 for i in range(nb_file):
-                    new_command = list(command) 
+                    new_command = list(command)
                     if to_zip:
                         new_command.append('%s_%s.lhe' % (new_args[0],i))
                         all_lhe.append('%s_%s.lhe' % (new_args[0],i))
                     else:
                         new_command.append('%s_%s.lhe' % (new_args[0][:-3],i))
                         all_lhe.append('%s_%s.lhe' % (new_args[0][:-3],i))
-                    
+
                     if '-from_cards' not in command:
                         new_command.append('-from_cards')
                     if plugin:
@@ -2195,9 +2141,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 if any(os.path.exists('%s_%s_debug.log' % (f, self.run_tag)) for f in all_lhe):
                     for f in all_lhe:
                         if os.path.exists('%s_%s_debug.log' % (f, self.run_tag)):
-                            raise Exception("Some of the run failed: Please read %s_%s_debug.log" % (f, self.run_tag)) 
-                
-                
+                            raise Exception("Some of the run failed: Please read %s_%s_debug.log" % (f, self.run_tag))
+
                 if 'event_norm' in self.run_card and self.run_card['event_norm'] in ['average','bias']:
                     for key, value in cross_sections.items():
                         cross_sections[key] = value / (nb_event+1)
@@ -2208,20 +2153,20 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     logger.info('%s : %s pb' % (key, cross_sections[key]))
                 return
             ##########    END MULTI-CORE HANDLING #############
-                              
+
         self.to_store.append('event')
         # forbid this function to create an empty item in results.
         if not self.force_run and self.results.current['cross'] == 0 and self.run_name:
             self.results.delete_run(self.run_name, self.run_tag)
 
-        self.check_decay_events(args) 
+        self.check_decay_events(args)
         # args now alway content the path to the valid files
-        rwgt_interface = reweight_interface.ReweightInterface 
+        rwgt_interface = reweight_interface.ReweightInterface
         if plugin:
-            rwgt_interface = misc.from_plugin_import(self.plugin_path, 'new_reweight', 
-                                        plugin, warning=False, 
-                                        info="Will use re-weighting from pluging %(plug)s")    
-        
+            rwgt_interface = misc.from_plugin_import(self.plugin_path, 'new_reweight',
+                                        plugin, warning=False,
+                                        info="Will use re-weighting from pluging %(plug)s")
+
         reweight_cmd = rwgt_interface(args[0], mother=self)
         #reweight_cmd.use_rawinput = False
         #reweight_cmd.mother = self
@@ -2230,7 +2175,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             self.update_status('Running Reweighting (LO approximate)', level='madspin')
         else:
             self.update_status('Running Reweighting', level='madspin')
-        
+
         path = pjoin(self.me_dir, 'Cards', 'reweight_card.dat')
         reweight_cmd.raw_input=False # probably useless ...
         reweight_cmd.me_dir = self.me_dir
@@ -2239,9 +2184,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         reweight_cmd.do_quit('')
 
         logger.info("quit rwgt")
-        
-        
-        
+
         # re-define current run
         try:
             self.results.def_current(self.run_name, self.run_tag)
@@ -2251,7 +2194,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     ############################################################################
     def do_pgs(self, line):
         """launch pgs"""
-        
+
         args = self.split_arg(line)
         # Check argument's validity
         if '--no_default' in args:
@@ -2358,9 +2301,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         self.update_status('finish', level='pgs', makehtml=False)
 
-    ############################################################################                                                                                                           
+    ############################################################################
     def do_compute_widths(self, line):
-        """Require MG5 directory: Compute automatically the widths of a set 
+        """Require MG5 directory: Compute automatically the widths of a set
         of particles"""
 
         args = self.split_arg(line)
@@ -2375,23 +2318,21 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             opts['path'] = pjoin(self.me_dir, 'Cards', 'param_card.dat')
             if not opts['force'] :
                 self.ask_edit_cards(['param_card.dat'],[], plot=False)
-        
-        
+
         line = 'compute_widths %s %s' % \
                 (' '.join([str(i) for i in opts['particles']]),
                  ' '.join('--%s=%s' % (key,value) for (key,value) in opts.items()
                         if key not in ['model', 'force', 'particles'] and value))
         out = cmd.exec_cmd(line, model=opts['model'])
-        
-    
+
         self.child = None
         del cmd
         return out
-        
+
     ############################################################################
     def complete_add_time_of_flight(self, text, line, begidx, endidx):
         "Complete command"
-       
+
         args = self.split_arg(line[0:begidx], error=False)
 
         if len(args) == 1:
@@ -2412,7 +2353,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         args = self.split_arg(line)
         #check the validity of the arguments and reformat args
         self.check_add_time_of_flight(args)
-        
+
         event_path, threshold = args
         #gunzip the file
         if event_path.endswith('.gz'):
@@ -2421,13 +2362,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             event_path = event_path[:-3]
         else:
             need_zip = False
-            
+
         import random
         try:
             import madgraph.various.lhe_parser as lhe_parser
         except:
-            import internal.lhe_parser as lhe_parser 
-            
+            import internal.lhe_parser as lhe_parser
+
         logger.info('Add time of flight information on file %s' % event_path)
         lhe = lhe_parser.EventFile(event_path)
         output = open('%s_2vertex.lhe' % event_path, 'w')
@@ -2455,17 +2396,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             output.write(str(event))
         output.write('</LesHouchesEvents>\n')
         output.close()
-        
+
         files.mv('%s_2vertex.lhe' % event_path, event_path)
-        
+
         if need_zip:
             misc.gzip(event_path)
-                
 
-    ############################################################################ 
+    ############################################################################
     def do_print_results(self, line):
         """Not in help:Print the cross-section/ number of events for a given run"""
-        
+
         args = self.split_arg(line)
         options={'path':None, 'mode':'w', 'format':'full'}
         for arg in list(args):
@@ -2474,8 +2414,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 name = name [2:]
                 options[name] = value
                 args.remove(arg)
-        
-        
+
         if len(args) > 0:
             run_name = args[0]
         else:
@@ -2493,7 +2432,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             raise self.InvalidCmd('%s is not a valid run_name or it doesn\'t have any information' \
                                   % run_name)
 
-            
         if len(args) == 2:
             tag = args[1]
             if tag.isdigit():
@@ -2506,7 +2444,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 data = self.results[run_name].return_tag(tag)
         else:
             data = self.results[run_name].return_tag(None) # return the last
-        
+
         if options['path']:
             self.print_results_in_file(data, options['path'], options['mode'], options['format'])
         else:
@@ -2516,7 +2454,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         """ All action require before any type of run. Typically overloaded by
         daughters if need be."""
         pass
-
 
     def copy_lep_densities(self, name, sourcedir):
         """copies the leptonic densities so that they are correctly compiled
@@ -2541,7 +2478,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     def runMA5(MA5_interpreter, MA5_cmds, MA5_runtag, logfile_path, advertise_log=True):
         """ Run MA5 in a controlled environnment."""
         successfull_MA5_run = True
-                
+
         try:
             # Predefine MA5_logger as None in case we don't manage to retrieve it.
             MA5_logger = None
@@ -2575,25 +2512,25 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     MA5_logger.removeHandler(handler)
                 for handler in BackUp_MA5_handlers:
                     MA5_logger.addHandler(handler)
-        
+
         return successfull_MA5_run
 
     #===============================================================================
     # Return a Main instance of MadAnlysis5, provided its path
     #===============================================================================
     @staticmethod
-    def get_MadAnalysis5_interpreter(mg5_path, ma5_path, mg5_interface=None, 
+    def get_MadAnalysis5_interpreter(mg5_path, ma5_path, mg5_interface=None,
                     logstream = sys.stdout, loglevel =logging.INFO, forced = True,
                     compilation=False):
         """ Makes sure to correctly setup paths and constructs and return an MA5 path"""
-        
-        MA5path = os.path.normpath(pjoin(mg5_path,ma5_path)) 
-        
+
+        MA5path = os.path.normpath(pjoin(mg5_path,ma5_path))
+
         if MA5path is None or not os.path.isfile(pjoin(MA5path,'bin','ma5')):
             return None
         if MA5path not in sys.path:
             sys.path.insert(0, MA5path)
-    
+
         try:
             # We must backup the readline module attributes because they get modified
             # when MA5 imports root and that supersedes MG5 autocompletion
@@ -2608,7 +2545,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             with misc.stdchannel_redirected(sys.stdout, os.devnull):
                 with misc.stdchannel_redirected(sys.stderr, os.devnull):
                     MA5_interpreter = MA5Interpreter(MA5path, LoggerLevel=loglevel,
-                                                     LoggerStream=logstream,forced=forced, 
+                                                     LoggerStream=logstream,forced=forced,
                                                      no_compilation=not compilation)
         except Exception as e:
             if six.PY3 and not __debug__:
@@ -2620,7 +2557,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             logger.debug('MadAnalysis5 error was:')
             logger.debug('-'*60)
             logger.debug(error.getvalue()[:-1])
-            logger.debug('-'*60)          
+            logger.debug('-'*60)
             MA5_interpreter = None
         finally:
             # Now restore the readline MG5 state
@@ -2638,14 +2575,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 mg5_interface.set_readline_completion_display_matches_hook()
 
         return MA5_interpreter
-    
+
     def check_madanalysis5(self, args, mode='parton'):
         """Check the argument for the madanalysis5 command
         syntax: madanalysis5_parton [NAME]
         """
 
         MA5_options = {'MA5_stdout_lvl':'default'}
-        
+
         stdout_level_tags = [a for a in args if a.startswith('--MA5_stdout_lvl=')]
         for slt in stdout_level_tags:
             lvl = slt.split('=')[1].strip()
@@ -2659,7 +2596,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     MA5_options['MA5_stdout_lvl'] = getattr(logging, lvl)
                 except:
                         raise InvalidCmd("MA5 output level specification"+\
-                                                 " '%s' is incorrect." % str(lvl))                    
+                                                 " '%s' is incorrect." % str(lvl))
             args.remove(slt)
 
         if mode=='parton':
@@ -2679,7 +2616,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             logger.info('Now trying to read the configuration file again'+
                                                    ' to find MadAnalysis5 path')
             self.set_configuration()
-            
+
         if not self.options['madanalysis5_path'] or not \
             os.path.exists(pjoin(self.options['madanalysis5_path'],'bin','ma5')):
             error_msg = 'No valid MadAnalysis5 path set.\n'
@@ -2695,9 +2632,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             raise self.InvalidCmd('Your installed version of MadAnalysis5 and/or'+\
                     ' MadGraph5_aMCatNLO does not seem to support analysis at'+
                                                             '%s level.'%mode)
-        
+
         tag = [a for a in args if a.startswith('--tag=')]
-        if tag: 
+        if tag:
             args.remove(tag[0])
             tag = tag[0][6:]
 
@@ -2707,19 +2644,19 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             else:
                 raise self.InvalidCmd('No run name currently defined. '+
                                                  'Please add this information.')
-        
+
         if len(args) >= 1:
             if mode=='parton' and args[0] != self.run_name and \
-             not os.path.exists(pjoin(self.me_dir,'Events',args[0], 
+             not os.path.exists(pjoin(self.me_dir,'Events',args[0],
              'unweighted_events.lhe.gz')) and not os.path.exists(
                                            pjoin(self.me_dir,'Events',args[0])):
                 raise self.InvalidCmd('No events file in the %s run.'%args[0])
-            self.set_run_name(args[0], tag, level='madanalysis5_%s'%mode)            
+            self.set_run_name(args[0], tag, level='madanalysis5_%s'%mode)
         else:
             if tag:
                 self.run_card['run_tag'] = args[0]
-            self.set_run_name(self.run_name, tag, level='madanalysis5_%s'%mode)  
-        
+            self.set_run_name(self.run_name, tag, level='madanalysis5_%s'%mode)
+
         if mode=='parton':
             if any(t for t in args if t.startswith('--input=')):
                 raise InvalidCmd('The option --input=<input_file> is not'+
@@ -2742,17 +2679,17 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         MA5_options['inputs'].append('%s.gz'%input_file)
                     elif os.path.exists(input_file):
                         misc.gzip(input_file, stdout='%s.gz' % input_file)
-                        MA5_options['inputs'].append('%s.gz'%input_file)  
-    
+                        MA5_options['inputs'].append('%s.gz'%input_file)
+
         if mode=='hadron':
             # Make sure to store current results (like Pythia8 hep files)
             # so that can be found here
             self.store_result()
-            
+
             hadron_tag = [t for t in args if t.startswith('--input=')]
             if hadron_tag and hadron_tag[0][8:]:
                 hadron_inputs = hadron_tag[0][8:].split(',')
-            
+
             # If not set above, then we must read it from the card
             elif MA5_options['inputs'] == ['fromCard']:
                 hadron_inputs = banner_mod.MadAnalysis5Card(pjoin(self.me_dir,
@@ -2768,16 +2705,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     # Special check/actions
                     continue
                 # Check if the specified file exists and is not a wildcard
-                if os.path.isfile(htag) or (os.path.exists(htag) and 
+                if os.path.isfile(htag) or (os.path.exists(htag) and
                                           stat.S_ISFIFO(os.stat(htag).st_mode)):
                     MA5_options['inputs'].append(htag)
                     continue
 
-                # Now select one source per tag, giving priority to unzipped 
+                # Now select one source per tag, giving priority to unzipped
                 # files with 'events' in their name (case-insensitive).
                 file_candidates = misc.glob(htag, pjoin(self.me_dir,'Events',self.run_name))+\
                                   misc.glob('%s.gz'%htag, pjoin(self.me_dir,'Events',self.run_name))
-                priority_files = [f for f in file_candidates if 
+                priority_files = [f for f in file_candidates if
                                 self.run_card['run_tag'] in os.path.basename(f)]
                 priority_files = [f for f in priority_files if
                                         'EVENTS' in os.path.basename(f).upper()]
@@ -2789,11 +2726,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     MA5_options['inputs'].append(priority_files[-1])
                     continue
                 if file_candidates:
-                    MA5_options['inputs'] += file_candidates 
+                    MA5_options['inputs'] += file_candidates
                     continue
 
         return MA5_options
-    
+
     def ask_madanalysis5_run_configuration(self, runtype='parton',mode=None):
         """Ask the question when launching madanalysis5.
         In the future we can ask here further question about the MA5 run, but
@@ -2801,10 +2738,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         cards = ['madanalysis5_%s_card.dat'%runtype]
         self.keep_cards(cards)
-        
+
         if self.force:
             return runtype
-        
+
         # This heavy-looking structure of auto is just to mimick what is done
         # for ask_pythia_configuration
         auto=False
@@ -2817,7 +2754,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         # For now, we don't pass any further information and simply return the
         # input mode asked for
-        mode = runtype 
+        mode = runtype
         return mode
 
     def complete_madanalysis5_hadron(self,text, line, begidx, endidx):
@@ -2837,11 +2774,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 tmp2 = self.list_completion(text, ['-f',
                 '--MA5_stdout_lvl=','--input=','--no_default', '--tag='], line)
                 return tmp1 + tmp2
-            
+
         elif '--MA5_stdout_lvl=' in line and not any(arg.startswith(
                                           '--MA5_stdout_lvl=') for arg in args):
-            return self.list_completion(text, 
-                ['--MA5_stdout_lvl=%s'%opt for opt in 
+            return self.list_completion(text,
+                ['--MA5_stdout_lvl=%s'%opt for opt in
                 ['logging.INFO','logging.DEBUG','logging.WARNING',
                                                 'logging.CRITICAL','90']], line)
         elif '--input=' in line and not any(arg.startswith(
@@ -2849,9 +2786,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             return self.list_completion(text, ['--input=%s'%opt for opt in
          (banner_mod.MadAnalysis5Card._default_hadron_inputs +['path'])], line)
         else:
-            return self.list_completion(text, ['-f', 
+            return self.list_completion(text, ['-f',
                 '--MA5_stdout_lvl=','--input=','--no_default', '--tag='], line)
-
 
     def do_rivet(self, line, postprocess=False):
         """launch rivet on the HepMC output"""
@@ -2869,13 +2805,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 args.insert(0, self.results.lastrun)
             else:
                 raise self.InvalidCmd('No run name currently define. '+
-                                                 'Please add this information.')          
+                                                 'Please add this information.')
 
         if not hasattr(self, 'run_card'):
             name = args[0]
             self.set_run_name(name, tag=None, level='rivet', reload_card=True,
                         allow_new_tag=True)
-
 
             self.configure_directory(html_opening =False)
 
@@ -2890,7 +2825,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
             self.keep_cards(['rivet_card.dat'], ignore=['*'])
             self.ask_edit_cards(['rivet_card.dat'], 'fixed', plot=False)
-
 
         #1 Get Rivet configurations from rivet_card.dat
         if not os.path.exists(pjoin(self.me_dir, 'Cards', 'rivet_card.dat')):
@@ -2925,7 +2859,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # # Get weight name (merging scale)
         py8_card = banner_mod.PY8Card(pjoin(self.me_dir, 'Cards', 'pythia8_card.dat'))
         if rivet_config["weight_name"] == "default":
-            rivet_config.setWeightName(runcard=self.run_card, py8card=py8_card) 
+            rivet_config.setWeightName(runcard=self.run_card, py8card=py8_card)
 
         rivet_add = ""
         if not (rivet_config["rivet_add"] == "default" or rivet_config["rivet_add"]  == None):
@@ -2943,7 +2877,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                                                            pjoin(rivet_path, 'lib64', 'python%s.%s' %(major,minor), 'site-packages'))
         set_env = set_env + "export PYTHONPATH={0}:{1}:$PYTHONPATH\n".format(pjoin(yoda_path, 'lib', 'python%s.%s' %(major,minor), 'site-packages'),\
                                                                            pjoin(yoda_path, 'lib64', 'python%s.%s' %(major,minor), 'site-packages'))
-
 
         #3 Fetch HepMC files
         py8_output = py8_card["HEPMCoutput:file"]
@@ -3010,16 +2943,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 self.update_status('rivet done', level='rivet')
                 return
 
-
     def do_madanalysis5_hadron(self, line):
         """launch MadAnalysis5 at the hadron level."""
         return self.run_madanalysis5(line,mode='hadron')
 
-
-
     def run_madanalysis5(self, line, mode='parton'):
         """launch MadAnalysis5 at the parton level or at the hadron level with
-        a specific command line."""  
+        a specific command line."""
 
         # Check argument's validity
         args = self.split_arg(line)
@@ -3040,7 +2970,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         else:
             # Called issued by the user itself and only MA5 will be run.
             # we must therefore ask wheter the user wants to edit the card
-            self.ask_madanalysis5_run_configuration(runtype=mode) 
+            self.ask_madanalysis5_run_configuration(runtype=mode)
 
         if not self.options['madanalysis5_path'] or \
             all(not os.path.exists(pjoin(self.me_dir, 'Cards',card)) for card in
@@ -3055,7 +2985,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             MA5_opts = self.check_madanalysis5(args, mode=mode)
             self.configure_directory(html_opening =False)
         else:
-            # initialize / remove lhapdf mode        
+            # initialize / remove lhapdf mode
             self.configure_directory(html_opening =False)
             MA5_opts = self.check_madanalysis5(args, mode=mode)
 
@@ -3094,8 +3024,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         #    misc.sprint('* Commands for MA5 runtag %s:'%MA5_runtag)
         #    misc.sprint('\n'+('\n'.join('* %s'%cmd for cmd in MA5_cmds)))
         #    misc.sprint('****************************************')
-        
-        self.update_status('\033[92mRunning MadAnalysis5 [arXiv:1206.1599]\033[0m', 
+
+        self.update_status('\033[92mRunning MadAnalysis5 [arXiv:1206.1599]\033[0m',
                            level='madanalysis5_%s'%mode)
         if mode=='hadron':
             logger.info('Hadron input files considered:')
@@ -3112,19 +3042,18 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if MA5_card['stdout_lvl'] is None:
                 MA5_lvl = self.options['stdout_level']
             else:
-                MA5_lvl = MA5_card['stdout_lvl']                
+                MA5_lvl = MA5_card['stdout_lvl']
         else:
             MA5_lvl = MA5_opts['MA5_stdout_lvl']
 
         # Bypass initialization information
         MA5_interpreter = CommonRunCmd.get_MadAnalysis5_interpreter(
-                self.options['mg5_path'], 
+                self.options['mg5_path'],
                 self.options['madanalysis5_path'],
                 logstream=sys.stdout,
                 loglevel=100,
                 forced=True,
                 compilation=True)
-
 
         # If failed to start MA5, then just leave
         if MA5_interpreter is None:
@@ -3134,7 +3063,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         used_up_fifos = []
         # Now loop over the different MA5_runs
         for MA5_run_number, (MA5_runtag, MA5_cmds) in enumerate(MA5_cmds_list):
-            
+
             # Since we place every MA5 run in a fresh new folder, the MA5_run_number
             # is always zero.
             MA5_run_number = 0
@@ -3146,20 +3075,19 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             else:
                 MA5_interpreter.init_parton()
             MA5_interpreter.setLogLevel(MA5_lvl)
-            
+
             if MA5_runtag!='default':
                 if MA5_runtag.startswith('_reco_'):
                     logger.info("MadAnalysis5 now running the reconstruction '%s'..."%
                                                      MA5_runtag[6:],'$MG:color:GREEN')
                 elif MA5_runtag=='Recasting':
                     logger.info("MadAnalysis5 now running the recasting...",
-                                                              '$MG:color:GREEN') 
+                                                              '$MG:color:GREEN')
                 else:
                     logger.info("MadAnalysis5 now running the '%s' analysis..."%
                                                    MA5_runtag,'$MG:color:GREEN')
-                    
 
-            # Now the magic, let's call MA5            
+            # Now the magic, let's call MA5
             if not CommonRunCmd.runMA5(MA5_interpreter, MA5_cmds, MA5_runtag,
                 pjoin(self.me_dir,'Events',self.run_name,'%s_MA5_%s.log'%(self.run_tag,MA5_runtag))):
                 # Unsuccessful MA5 run, we therefore stop here.
@@ -3168,7 +3096,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if MA5_runtag.startswith('_reco_'):
                 # When doing a reconstruction we must first link the event file
                 # created with MA5 reconstruction and then directly proceed to the
-                # next batch of instructions. There can be several output directory 
+                # next batch of instructions. There can be several output directory
                 # if there were several input files.
                 links_created=[]
                 for i, input in enumerate(MA5_opts['inputs']):
@@ -3176,7 +3104,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     # undergo any reconstruction of course.
                     if not banner_mod.MadAnalysis5Card.events_can_be_reconstructed(input):
                         continue
-                    
+
                     if input.endswith('.fifo'):
                         if input in used_up_fifos:
                             # Only run once on each fifo
@@ -3197,7 +3125,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     shutil.move(reco_output,pjoin(self.me_dir,'HTML',
                                  self.run_name,'%s_MA5_%s_ANALYSIS%s_%d'%
                                     (self.run_tag,mode.upper(),MA5_runtag,i+1)))
-                    
+
                     # link the reconstructed event file to the run directory
                     links_created.append(os.path.basename(reco_event_file))
                     parent_dir_name = os.path.basename(os.path.dirname(reco_event_file))
@@ -3234,13 +3162,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 logger.error('MadAnalysis5 failed to create PDF output')
             if MA5_runtag!='default':
                 logger.info("MadAnalysis5 successfully completed the "+
-                  "%s. Reported results are placed in:"%("analysis '%s'"%MA5_runtag 
+                  "%s. Reported results are placed in:"%("analysis '%s'"%MA5_runtag
                            if MA5_runtag.upper()!='RECASTING' else "recasting"))
             else:
                 logger.info("MadAnalysis5 successfully completed the analysis."+
                                             " Reported results are placed in:")
             logger.info('  --> %s'%pjoin(self.me_dir,'Events',self.run_name,carboncopy_name))
-            
+
             anal_dir = pjoin(self.me_dir,'MA5_%s_ANALYSIS_%s'  %(mode.upper(),MA5_runtag))
             if not os.path.exists(anal_dir):
                 logger.error('MadAnalysis5 failed to completed succesfully')
@@ -3249,7 +3177,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             shutil.move(anal_dir, pjoin(self.me_dir,'HTML',self.run_name,
                 '%s_MA5_%s_ANALYSIS_%s'%(self.run_tag,mode.upper(),MA5_runtag)))
 
-        # Set the number of events and cross-section to the last one 
+        # Set the number of events and cross-section to the last one
         # (maybe do something smarter later)
         new_details={}
         for detail in ['nb_event','cross','error']:
@@ -3260,22 +3188,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         self.update_status('Finished MA5 analyses.', level='madanalysis5_%s'%mode,
                                                                  makehtml=False)
- 
+
         #Update the banner
         self.banner.add(pjoin(self.me_dir, 'Cards',
                                                'madanalysis5_%s_card.dat'%mode))
         banner_path = pjoin(self.me_dir,'Events', self.run_name,
                                '%s_%s_banner.txt'%(self.run_name, self.run_tag))
         self.banner.write(banner_path)
- 
+
         if not no_default:
             logger.info('Find more information about this run on the HTML local page')
             logger.info('  --> %s'%pjoin(self.me_dir,'index.html'))
-    
+
     ############################################################################
     # End of MadAnalysis5 related function
     ############################################################################
-    
+
     def do_delphes(self, line):
         """ run delphes and make associate root file/plot """
 
@@ -3286,16 +3214,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             args.remove('--no_default')
         else:
             no_default = False
-            
+
         if no_default and  not os.path.exists(pjoin(self.me_dir, 'Cards', 'delphes_card.dat')):
             logger.info('No delphes_card detected, so not run Delphes')
             return
-            
+
         # Check all arguments
         filepath = self.check_delphes(args, nodefault=no_default)
         if no_default and not filepath:
             return # no output file but nothing to do either.
-        
+
         self.update_status('prepare delphes run', level=None)
 
         if os.path.exists(pjoin(self.options['delphes_path'], 'data')):
@@ -3354,7 +3282,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             logger.info('If you are interested in lhco output. please run root2lhco converter.')
             logger.info(' or edit bin/internal/run_delphes3 to run the converter automatically.')
 
-
         #eradir = self.options['exrootanalysis_path']
         madir = self.options['madanalysis_path']
         td = self.options['td_path']
@@ -3368,7 +3295,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             misc.gzip(pjoin(self.me_dir, 'Events', self.run_name, '%s_delphes_events.lhco' % tag))
 
         self.update_status('delphes done', level='delphes', makehtml=False)
-
 
     ############################################################################
     def get_pid_final_initial_states(self):
@@ -3396,7 +3322,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                self.options['run_mode'] ==1:
             # no need to transfer the pdf.
             return ''
-        
+
         def check_cluster(path):
             if not self.options["cluster_local_path"] or \
                         os.path.exists(self.options["cluster_local_path"]) or\
@@ -3412,7 +3338,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 return " "
             else:
                 return path
-                             
 
         if hasattr(self, 'pdffile') and self.pdffile:
             return self.pdffile
@@ -3432,7 +3357,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 else:
                     self.pdffile = " "
                 return self.pdffile
-                      
+
     ############################################################################
     def do_open(self, line):
         """Open a text file/ eps file / html file"""
@@ -3449,7 +3374,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         """Set an option, which will be default for coming generations/outputs
         """
         # cmd calls automaticaly post_set after this command.
-
 
         args = self.split_arg(line)
         # Check the validity of the arguments
@@ -3530,7 +3454,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     tmp = args[1].lower()
                 else:
                     raise
-            self.options[args[0]] = tmp 
+            self.options[args[0]] = tmp
         elif args[0].startswith('f2py_compiler'):
             to_do = True
             if args[0].endswith('_py2') and six.PY3:
@@ -3571,7 +3495,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if 'cluster' in args[0] or args[0] == 'run_mode':
                 self.configure_run_mode(self.options['run_mode'])
 
-
             # Check the validity of the arguments
             self.check_set(args)
 
@@ -3598,11 +3521,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         elif run_mode == 0:
             nb_core = 1
 
-
-
         if run_mode in [0, 2]:
             if not( hasattr(self, 'cluster')
-                    and isinstance(self.cluster, cluster.MultiCore) 
+                    and isinstance(self.cluster, cluster.MultiCore)
                     and self.cluster.nb_core == nb_core):
                 self.cluster = cluster.MultiCore(**self.options)
                 self.cluster.nb_core = nb_core
@@ -3619,27 +3540,27 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 print(self.plugin_path)
                 # Check if a plugin define this type of cluster
                 # check for PLUGIN format
-                cluster_class = misc.from_plugin_import(self.plugin_path, 
+                cluster_class = misc.from_plugin_import(self.plugin_path,
                                             'new_cluster', cluster_name,
                                             info = 'cluster handling will be done with PLUGIN: %(plug)s' )
                 print(type(cluster_class))
                 if cluster_class:
                     self.cluster = cluster_class(**self.options)
                 else:
-                    raise self.InvalidCmd("%s is not recognized as a supported cluster format." % cluster_name)     
-                         
+                    raise self.InvalidCmd("%s is not recognized as a supported cluster format." % cluster_name)
+
     def check_param_card(self, path, run=True, dependent=False):
         """
         1) Check that no scan parameter are present
         2) Check that all the width are define in the param_card.
-        - If a scan parameter is define. create the iterator and recall this fonction 
+        - If a scan parameter is define. create the iterator and recall this fonction
           on the first element.
         - If some width are set on 'Auto', call the computation tools.
         - Check that no width are too small (raise a warning if this is the case)
         3) if dependent is on True check for dependent parameter (automatic for scan)"""
-        
+
         self.static_check_param_card(path, self, run=run, dependent=dependent)
-        
+
         card = param_card_mod.ParamCard(path)
         for param in card['decay']:
             width = param.value
@@ -3649,16 +3570,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 mass = card['mass'].get(param.lhacode).value
             except Exception:
                 continue
-        
-        
-        
+
     @staticmethod
-    def static_check_param_card(path, interface, run=True, dependent=False, 
+    def static_check_param_card(path, interface, run=True, dependent=False,
                                 iterator_class=param_card_mod.ParamCardIterator):
-        pattern_scan = re.compile(r'''^(decay)?[\s\d]*scan''', re.I+re.M)  
+        pattern_scan = re.compile(r'''^(decay)?[\s\d]*scan''', re.I+re.M)
         pattern_width = re.compile(r'''decay\s+(\+?\-?\d+)\s+auto(@NLO|)''',re.I)
         text = open(path).read()
-               
+
         if pattern_scan.search(text):
             if not isinstance(interface, cmd.CmdShell):
                 # we are in web mode => forbid scan due to security risk
@@ -3669,7 +3588,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             first_card = main_card.next(autostart=True)
             first_card.write(path)
             return CommonRunCmd.static_check_param_card(path, interface, run, dependent=True)
-        
+
         pdg_info = pattern_width.findall(text)
         if pdg_info:
             if run:
@@ -3682,16 +3601,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     line = '%s --nlo' % (' '.join(pdg))
                 CommonRunCmd.static_compute_widths(line, interface, path)
             else:
-                logger.info('''Some width are on Auto in the card. 
+                logger.info('''Some width are on Auto in the card.
     Those will be computed as soon as you have finish the edition of the cards.
     If you want to force the computation right now and being able to re-edit
     the cards afterwards, you can type \"compute_wdiths\".''')
-                
+
         card = param_card_mod.ParamCard(path)
-        if dependent: 
-              
+        if dependent:
+
             AskforEditCard.update_dependent(interface, interface.me_dir, card, path, timer=20)
-        
+
         for param in card['decay']:
             width = param.value
             if width == 0:
@@ -3720,15 +3639,15 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     @staticmethod
     def static_compute_widths(line, interface, path=None):
         """ factory to try to find a way to call the static method"""
-        
+
         handled = True
         if isinstance(interface, CommonRunCmd):
             if path:
-                line = '%s %s' % (line, path) 
+                line = '%s %s' % (line, path)
             interface.do_compute_widths(line)
         else:
             handled = False
-            
+
         if handled:
             return
 
@@ -3746,27 +3665,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 cmd.exec_cmd('set automatic_html_opening False --no_save')
             except Exception:
                 pass
-            
+
             model = interface.get_model()
-            
-            
+
             line = 'compute_widths %s --path=%s' % (line, path)
             cmd.exec_cmd(line, model=model)
             interface.child = None
             del cmd
-            return 
-            
-            
-            
+            return
+
         raise Exception('fail to find a way to handle Auto width')
-        
-        
+
     def store_scan_result(self):
         """return the information that need to be kept for the scan summary.
         Auto-width are automatically added."""
-        
-        return {'cross': self.results.current['cross']}
 
+        return {'cross': self.results.current['cross']}
 
     def add_error_log_in_html(self, errortype=None):
         """If a ME run is currently running add a link in the html output"""
@@ -3794,7 +3708,6 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 pass
         if not 'ME5_debug' in self.debug_output:
             os.system('ln -s %s ME5_debug &> /dev/null' % self.debug_output)
-
 
     def do_quit(self, line):
         """Not in help: exit """
@@ -3825,13 +3738,12 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
     def __del__(self):
         """try to remove RunWeb?"""
-        
+
         if not self.stop_for_runweb and not self.force_run:
             try:
                 os.remove(pjoin(self.me_dir,'RunWeb'))
             except Exception:
                 pass
-            
 
     def update_status(self, status, level, makehtml=True, force=True,
                       error=False, starttime = None, update_results=True,
@@ -3907,8 +3819,15 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 config_path = pjoin(os.environ['MADGRAPH_BASE'],'mg5_configuration.txt')
                 self.set_configuration(config_path=config_path, final=False)
             if 'HOME' in os.environ:
-                config_path = pjoin(os.environ['HOME'],'.mg5',
-                                                        'mg5_configuration.txt')
+                legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+                if os.path.exists(legacy_config_dir):
+                    config_dir = legacy_config_dir
+                else:
+                    config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
+
+                config_path = os.path.join(config_dir, 'mg5_configuration.txt')
+
                 if os.path.exists(config_path):
                     self.set_configuration(config_path=config_path,  final=False)
             if amcatnlo:
@@ -3930,7 +3849,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # read the file and extract information
         logger.info('load configuration from %s ' % config_file.name)
         for line in config_file:
-            
+
             if '#' in line:
                 line = line.split('#',1)[0]
             line = line.replace('\n','').replace('\r\n','')
@@ -3983,7 +3902,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 self.options[key] = None
             elif key.startswith('cluster') and key != 'cluster_status_update':
                 if key in ('cluster_nb_retry','cluster_wait_retry'):
-                    self.options[key] = int(self.options[key]) 
+                    self.options[key] = int(self.options[key])
                 if hasattr(self,'cluster'):
                     del self.cluster
                 pass
@@ -4022,11 +3941,10 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         """ find a valid run_name for the current job """
 
         name = 'run_%02d'
-        data = [int(s[4:j]) for s in os.listdir(pjoin(me_dir,'Events')) for 
+        data = [int(s[4:j]) for s in os.listdir(pjoin(me_dir,'Events')) for
                 j in range(4,len(s)+1) if \
                 s.startswith('run_') and s[4:j].isdigit()]
         return name % (max(data+[0])+1)
-
 
     ############################################################################
     def do_decay_events(self,line):
@@ -4071,15 +3989,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 madspin_cmd.mg5cmd.exec_cmd( 'set %s %s --no_save' %(key,value), errorhandling=False, printcmd=False, precmd=False, postcmd=True)
         madspin_cmd.cluster = self.cluster
         madspin_cmd.mother = self
-        
+
         madspin_cmd.update_status = lambda *x,**opt: self.update_status(*x, level='madspin',**opt)
 
         path = pjoin(self.me_dir, 'Cards', 'madspin_card.dat')
 
         madspin_cmd.import_command_file(path)
 
-
-        if not madspin_cmd.me_run_name: 
+        if not madspin_cmd.me_run_name:
             # create a new run_name directory for this output
             i = 1
             while os.path.exists(pjoin(self.me_dir,'Events', '%s_decayed_%i' % (self.run_name,i))):
@@ -4147,22 +4064,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
     def complete_print_results(self,text, line, begidx, endidx):
         "Complete the print results command"
-        args = self.split_arg(line[0:begidx], error=False) 
+        args = self.split_arg(line[0:begidx], error=False)
         if len(args) == 1:
             #return valid run_name
             data = misc.glob(pjoin('*','unweighted_events.lhe.gz'),
-                             pjoin(self.me_dir, 'Events')) 
+                             pjoin(self.me_dir, 'Events'))
 
             data = [n.rsplit('/',2)[1] for n in data]
             tmp1 =  self.list_completion(text, data)
-            return tmp1        
+            return tmp1
         else:
             data = misc.glob('*_pythia_events.hep.gz', pjoin(self.me_dir, 'Events', args[0]))
             data = [os.path.basename(p).rsplit('_',1)[0] for p in data]
             data += ["--mode=a", "--mode=w", "--path=", "--format=short"]
             tmp1 =  self.list_completion(text, data)
             return tmp1
-            
+
     def help_print_result(self):
         logger.info("syntax: print_result [RUN] [TAG] [options]")
         logger.info("-- show in text format the status of the run (cross-section/nb-event/...)")
@@ -4171,22 +4088,19 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         logger.info("--format=short (only if --path is define)")
         logger.info("        allows to have a multi-column output easy to parse")
 
-
     ############################################################################
     def find_model_name(self):
         """ return the model name """
         if hasattr(self, 'model_name'):
             return self.model_name
-        
+
         def join_line(old, to_add):
             if old.endswith('\\'):
                 newline = old[:-1] + to_add
             else:
                 newline = old + line
             return newline
-            
-        
-        
+
         model = 'sm'
         proc = []
         continuation_line = None
@@ -4203,7 +4117,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 continue
             #line = line.split('=')[0]
             if line.startswith('import') and 'model' in line:
-                model = line.split()[2]   
+                model = line.split()[2]
                 proc = []
                 if model.endswith('\\'):
                     continuation_line = 'model'
@@ -4216,14 +4130,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 if proc[-1].endswith('\\'):
                     continuation_line = 'proc'
         self.model = model
-        self.process = proc 
+        self.process = proc
         return model
-
 
     ############################################################################
     def do_check_events(self, line):
         """ Run some sanity check on the generated events."""
-                
+
         # Check that MG5 directory is present .
         if MADEVENT and not self.options['mg5_path']:
             raise self.InvalidCmd('''The module reweight requires that MG5 is installed on the system.
@@ -4235,18 +4148,17 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         except ImportError:
             raise self.ConfigurationError('''Can\'t load Reweight module.
             The variable mg5_path might not be correctly configured.''')
-              
 
         # load the name of the event file
-        args = self.split_arg(line) 
-        self.check_check_events(args) 
+        args = self.split_arg(line)
+        self.check_check_events(args)
         # args now alway content the path to the valid files
         reweight_cmd = reweight_interface.ReweightInterface(args[0], allow_madspin=True)
         reweight_cmd.mother = self
         self.update_status('Running check on events', level='check')
-        
+
         reweight_cmd.check_events()
-        
+
     ############################################################################
     def complete_check_events(self, text, line, begidx, endidx):
         args = self.split_arg(line[0:begidx], error=False)
@@ -4271,15 +4183,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if not '-f' in args:
             data.append('-f')
         tmp1 =  self.list_completion(text, data)
-        return tmp1 
-
-
+        return tmp1
 
     def complete_compute_widths(self, text, line, begidx, endidx, formatting=True):
         "Complete the compute_widths command"
 
         args = self.split_arg(line[0:begidx])
-        
+
         if args[-1] in  ['--path=', '--output=']:
             completion = {'path': self.path_completion(text)}
         elif line[begidx-1] == os.path.sep:
@@ -4287,22 +4197,21 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if current_dir.startswith('--path='):
                 current_dir = current_dir[7:]
             if current_dir.startswith('--output='):
-                current_dir = current_dir[9:]                
+                current_dir = current_dir[9:]
             completion = {'path': self.path_completion(text, current_dir)}
         else:
-            completion = {}            
-            completion['options'] = self.list_completion(text, 
+            completion = {}
+            completion['options'] = self.list_completion(text,
                             ['--path=', '--output=', '--min_br=0.\$', '--nlo',
-                             '--precision_channel=0.\$', '--body_decay='])            
-        
+                             '--precision_channel=0.\$', '--body_decay='])
+
         return self.deal_multiple_categories(completion, formatting)
-        
 
     def update_make_opts(self, run_card=None):
         """update the make_opts file writing the environmental variables
         stored in make_opts_var"""
         make_opts = os.path.join(self.me_dir, 'Source', 'make_opts')
-        
+
         # Set some environment variables common to all interfaces
         if not hasattr(self,'options') or not 'pythia8_path' in self.options or \
            not self.options['pythia8_path'] or \
@@ -4317,8 +4226,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if __debug__ and 'global_flag' not in run_card.user_set:
                 self.make_opts_var['GLOBAL_FLAG'] = "-O -fbounds-check"
             else:
-                self.make_opts_var['GLOBAL_FLAG'] = run_card['global_flag']     
-            self.make_opts_var['ALOHA_FLAG'] = run_card['aloha_flag']     
+                self.make_opts_var['GLOBAL_FLAG'] = run_card['global_flag']
+            self.make_opts_var['ALOHA_FLAG'] = run_card['aloha_flag']
             self.make_opts_var['MATRIX_FLAG'] = run_card['matrix_flag']
 
         return self.update_make_opts_full(make_opts, self.make_opts_var)
@@ -4331,9 +4240,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         """
         make_opts = path
         pattern = re.compile(r'^(\w+)\s*=\s*(.*)$',re.DOTALL)
-        diff = False # set to True if one varible need to be updated 
+        diff = False # set to True if one varible need to be updated
                      #if on False the file is not modify
-        
+
         tag = '#end_of_make_opts_variables\n'
         make_opts_variable = True # flag to say if we are in edition area or not
         content = []
@@ -4341,7 +4250,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         need_keys = list(variables.keys())
         for line in open(make_opts):
             line = line.strip()
-            if make_opts_variable: 
+            if make_opts_variable:
                 if line.startswith('#') or not line:
                     if line.startswith('#end_of_make_opts_variables'):
                         make_opts_variable = False
@@ -4354,24 +4263,22 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         diff=True
                     else:
                         need_keys.remove(key)
-                else: 
+                else:
                     make_opts_variable = False
                     content.append(line)
-            else:                  
+            else:
                 content.append(line)
-                     
+
         if need_keys:
-            diff=True #This means that new definition are added to the file. 
+            diff=True #This means that new definition are added to the file.
 
         content_variables = '\n'.join('%s=%s' % (k,v) for k, v in variables.items() if v is not None)
         content_variables += '\n%s' % tag
 
         if diff:
-            with open(make_opts, 'w') as fsock: 
+            with open(make_opts, 'w') as fsock:
                 fsock.write(content_variables + '\n'.join(content))
-        return       
-
-
+        return
 
 # lhapdf-related functions
     def link_lhapdf(self, libdir, extra_dirs = []):
@@ -4388,7 +4295,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         else:
             pdfsetsdir = subprocess.Popen([self.options['lhapdf'], '--datadir'],
                  stdout = subprocess.PIPE).stdout.read().decode(errors='ignore').strip()
-        
+
         self.lhapdf_pdfsets = self.get_lhapdf_pdfsets_list(pdfsetsdir)
         # link the static library in lib
         lhalib = 'libLHAPDF.a'
@@ -4404,22 +4311,20 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         self.make_opts_var['lhapdfsubversion'] = lhapdf_version.split('.',2)[1]
         self.make_opts_var['lhapdf_config'] = self.options['lhapdf']
 
-
     def get_characteristics(self, path=None):
         """reads the proc_characteristics file and initialises the correspondant
         dictionary"""
-        
+
         if not path:
             path = os.path.join(self.me_dir, 'SubProcesses', 'proc_characteristics')
-        
+
         self.proc_characteristics = banner_mod.ProcCharacteristic(path)
         return self.proc_characteristics
 
-
     def copy_lhapdf_set(self, lhaid_list, pdfsets_dir, require_local=True):
-        """copy (if needed) the lhapdf set corresponding to the lhaid in lhaid_list 
+        """copy (if needed) the lhapdf set corresponding to the lhaid in lhaid_list
         into lib/PDFsets.
-        if require_local is False, just ensure that the pdf is in pdfsets_dir 
+        if require_local is False, just ensure that the pdf is in pdfsets_dir
         """
 
         if not hasattr(self, 'lhapdf_pdfsets'):
@@ -4464,7 +4369,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                             os.remove(pjoin(self.me_dir, 'lib', 'PDFsets', name))
                     except Exception as error:
                         logger.debug('%s', error)
-        
+
         if self.options["cluster_local_path"]:
             lhapdf_cluster_possibilities = [self.options["cluster_local_path"],
                                       pjoin(self.options["cluster_local_path"], "lhapdf"),
@@ -4480,7 +4385,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         # Check if we need to copy the pdf
             if self.options["cluster_local_path"] and self.options["run_mode"] == 1 and \
                 any((os.path.exists(pjoin(d, pdfset)) for d in lhapdf_cluster_possibilities)):
-    
+
                 os.environ["LHAPATH"] = [d for d in lhapdf_cluster_possibilities if os.path.exists(pjoin(d, pdfset))][0]
                 os.environ["CLUSTER_LHAPATH"] = os.environ["LHAPATH"]
                 # no need to copy it
@@ -4505,20 +4410,19 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                             break
                     if found:
                         continue
-                    
-                    
+
             #check that the pdfset is not already there
             elif not os.path.exists(pjoin(self.me_dir, 'lib', 'PDFsets', pdfset)) and \
                not os.path.isdir(pjoin(self.me_dir, 'lib', 'PDFsets', pdfset)):
-    
+
                 if pdfset and not os.path.exists(pjoin(pdfsets_dir, pdfset)):
                     self.install_lhapdf_pdfset(pdfsets_dir, pdfset)
-    
+
                 if os.path.exists(pjoin(pdfsets_dir, pdfset)):
                     files.cp(pjoin(pdfsets_dir, pdfset), pjoin(self.me_dir, 'lib', 'PDFsets'))
                 elif os.path.exists(pjoin(os.path.dirname(pdfsets_dir), pdfset)):
                     files.cp(pjoin(os.path.dirname(pdfsets_dir), pdfset), pjoin(self.me_dir, 'lib', 'PDFsets'))
-            
+
     def install_lhapdf_pdfset(self, pdfsets_dir, filename):
         """idownloads and install the pdfset filename in the pdfsets_dir"""
         lhapdf_version = self.get_lhapdf_version()
@@ -4527,10 +4431,9 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                              pdfsets_dir, filename,
                                              lhapdf_version=lhapdf_version,
                                              alternate_path=local_path)
-                                                 
 
     @staticmethod
-    def install_lhapdf_pdfset_static(lhapdf_config, pdfsets_dir, filename, 
+    def install_lhapdf_pdfset_static(lhapdf_config, pdfsets_dir, filename,
                                         lhapdf_version=None, alternate_path=None):
         """idownloads and install the pdfset filename in the pdfsets_dir.
         Version which can be used independently of the class.
@@ -4546,14 +4449,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if isinstance(filename, int):
             pdf_info = CommonRunCmd.get_lhapdf_pdfsets_list_static(pdfsets_dir, lhapdf_version)
             filename = pdf_info[filename]['filename']
-        
+
         if os.path.exists(pjoin(pdfsets_dir, filename)):
             logger.debug('%s is already present in %s', filename, pdfsets_dir)
             return
-             
+
         logger.info('Trying to download %s' % filename)
 
-            
         if lhapdf_version.startswith('5.'):
 
             # use the lhapdf-getdata command, which is in the same path as
@@ -4566,7 +4468,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             # lhapdf-config
             getdata = lhapdf_config.replace('lhapdf-config', ('lhapdf'))
 
-            if lhapdf_version.startswith('6.1'): 
+            if lhapdf_version.startswith('6.1'):
                 misc.call([getdata, 'install', filename], cwd = pdfsets_dir)
             else:
                 #for python 6.2.1, import lhapdf should be working to download pdf
@@ -4582,13 +4484,13 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         else:
             raise MadGraph5Error('Not valid LHAPDF version: %s' % lhapdf_version)
-        
+
         # check taht the file has been installed in the global dir
         if os.path.exists(pjoin(pdfsets_dir, filename)) or \
            os.path.isdir(pjoin(pdfsets_dir, filename)):
             logger.info('%s successfully downloaded and stored in %s' \
                     % (filename, pdfsets_dir))
-            
+
         #otherwise (if v5) save it locally
         elif lhapdf_version.startswith('5.'):
             logger.warning('Could not download %s into %s. Trying to save it locally' \
@@ -4597,8 +4499,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                                       lhapdf_version=lhapdf_version)
         elif lhapdf_version.startswith('6.') and '.LHgrid' in filename:
             logger.info('Could not download %s: Try %s', filename, filename.replace('.LHgrid',''))
-            return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, pdfsets_dir, 
-                                                              filename.replace('.LHgrid',''), 
+            return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, pdfsets_dir,
+                                                              filename.replace('.LHgrid',''),
                                         lhapdf_version, alternate_path)
         elif lhapdf_version.startswith('6.'):
             # try to do a simple wget
@@ -4610,29 +4512,29 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
             if os.path.exists(pjoin(pdfsets_dir, filename)) or \
                os.path.isdir(pjoin(pdfsets_dir, filename)):
                 logger.info('%s successfully downloaded and stored in %s' \
-                        % (filename, pdfsets_dir))  
+                        % (filename, pdfsets_dir))
             elif 'LHAPDF_DATA_PATH' in os.environ and os.environ['LHAPDF_DATA_PATH']:
-                
+
                 if pdfsets_dir in os.environ['LHAPDF_DATA_PATH'].split(':'):
                     lhapath = os.environ['LHAPDF_DATA_PATH'].split(':')
                     lhapath = [p for p in lhapath if os.path.exists(p)]
                     lhapath.remove(pdfsets_dir)
                     os.environ['LHAPDF_DATA_PATH'] = ':'.join(lhapath)
                     if lhapath:
-                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None, 
-                                                              filename, 
+                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None,
+                                                              filename,
                                         lhapdf_version, alternate_path)
                     elif 'LHAPATH' in os.environ and os.environ['LHAPATH']:
-                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None, 
-                                                              filename, 
+                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None,
+                                                              filename,
                                         lhapdf_version, alternate_path)
                     else:
                         raise MadGraph5Error( \
                 'Could not download %s into %s. Please try to install it manually.' \
-                    % (filename, pdfsets_dir)) 
+                    % (filename, pdfsets_dir))
                 else:
-                    return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None, 
-                                                              filename, 
+                    return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None,
+                                                              filename,
                                         lhapdf_version, alternate_path)
             elif 'LHAPATH' in os.environ and os.environ['LHAPATH']:
                 if pdfsets_dir in os.environ['LHAPATH'].split(':'):
@@ -4641,25 +4543,23 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                     lhapath.remove(pdfsets_dir)
                     os.environ['LHAPATH'] = ':'.join(lhapath)
                     if lhapath:
-                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None, 
-                                                              filename, 
+                        return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None,
+                                                              filename,
                                         lhapdf_version, alternate_path)
                     else:
                         raise MadGraph5Error('Could not download %s into %s. Please try to install it manually.' \
-                    % (filename, pdfsets_dir)) 
+                    % (filename, pdfsets_dir))
                 else:
-                    return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None, 
-                                                              filename, 
+                    return CommonRunCmd.install_lhapdf_pdfset_static(lhapdf_config, None,
+                                                              filename,
                                         lhapdf_version, alternate_path)
-            else:  
+            else:
                 raise MadGraph5Error('Could not download %s into %s. Please try to install it manually.' \
-                    % (filename, pdfsets_dir))                          
-            
-        else:                    
-            raise MadGraph5Error('Could not download %s into %s. Please try to install it manually.' \
                     % (filename, pdfsets_dir))
 
-
+        else:
+            raise MadGraph5Error('Could not download %s into %s. Please try to install it manually.' \
+                    % (filename, pdfsets_dir))
 
     def get_lhapdf_pdfsets_list(self, pdfsets_dir):
         """read the PDFsets.index file, which should be located in the same
@@ -4695,7 +4595,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         elif lhapdf_version.startswith('6.'):
             pdfsets_lines = \
                     [l for l in open(pjoin(pdfsets_dir, 'pdfsets.index'),'r').read().split('\n') if l.strip()]
-            lhapdf_pdfsets = dict( (int(l.split()[0]), 
+            lhapdf_pdfsets = dict( (int(l.split()[0]),
                         {'lhaid': int(l.split()[0]),
                           'filename': l.split()[1]}) \
                          for l in pdfsets_lines)
@@ -4711,19 +4611,18 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 
         try:
             lhapdf_version = \
-                    subprocess.Popen([lhapdf_config, '--version'], 
+                    subprocess.Popen([lhapdf_config, '--version'],
                         stdout = subprocess.PIPE).stdout.read().decode(errors='ignore').strip()
         except OSError as error:
             if error.errno == 2:
                 raise Exception( 'lhapdf executable (%s) is not found on your system. Please install it and/or indicate the path to the correct executable in input/mg5_configuration.txt' % lhapdf_config)
             else:
                 raise
-                
+
         # this will be removed once some issues in lhapdf6 will be fixed
         if lhapdf_version.startswith('6.0'):
             raise MadGraph5Error('LHAPDF 6.0.x not supported. Please use v6.1 or later')
         return lhapdf_version
-
 
     def get_lhapdf_version(self):
         """returns the lhapdf version number"""
@@ -4747,40 +4646,39 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         elif lhapdf_version.startswith('6.'):
             datadir = subprocess.Popen([lhapdf_config, '--datadir'],
                          stdout = subprocess.PIPE).stdout.read().decode(errors='ignore').strip()
-        
+
         if ':' in datadir:
             for totry in datadir.split(':'):
                 if os.path.exists(pjoin(totry, 'pdfsets.index')):
                     return totry
             else:
                 return None
-        
+
         return datadir
 
     def get_lhapdf_pdfsetsdir(self):
-        
+
         lhapdf_version = self.get_lhapdf_version()
         return self.get_lhapdf_pdfsetsdir_static(self.options['lhapdf'], lhapdf_version)
 
     ############################################################################
     def get_Pdir(self):
         """get the list of Pdirectory if not yet saved."""
-        
+
         if hasattr(self, "Pdirs"):
             if self.me_dir in self.Pdirs[0]:
                 return self.Pdirs
-        self.Pdirs = [pjoin(self.me_dir, 'SubProcesses', l.strip()) 
+        self.Pdirs = [pjoin(self.me_dir, 'SubProcesses', l.strip())
                      for l in open(pjoin(self.me_dir,'SubProcesses', 'subproc.mg'))]
         return self.Pdirs
 
     def get_lhapdf_libdir(self):
-        
+
         if 'LHAPATH' in os.environ:
             for d in os.environ['LHAPATH'].split(':'):
                 if os.path.isdir(d):
                     return d
-        
-        
+
         lhapdf_version = self.get_lhapdf_version()
 
         if lhapdf_version.startswith('5.'):
@@ -4796,28 +4694,28 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
 class AskforEditCard(cmd.OneLinePathCompletion):
     """A class for asking a question where in addition you can have the
     set command define and modifying the param_card/run_card correctly
-    
+
     special action can be trigger via trigger_XXXX when the user start a line
     with XXXX. the output of such function should be new line that can be handle.
     (return False to repeat the question)
     """
 
-    all_card_name = ['param_card', 'run_card', 'pythia_card', 'pythia8_card', 
+    all_card_name = ['param_card', 'run_card', 'pythia_card', 'pythia8_card',
                      'madweight_card', 'MadLoopParams', 'shower_card', 'rivet_card']
-    to_init_card = ['param', 'run', 'madweight', 'madloop', 
+    to_init_card = ['param', 'run', 'madweight', 'madloop',
                     'shower', 'pythia8','delphes','madspin', 'rivet']
     special_shortcut = {}
     special_shortcut_help = {}
-    
+
     integer_bias = 1 # integer corresponding to the first entry in self.cards
-    
+
     PY8Card_class = banner_mod.PY8Card
 
     def load_default(self):
         """ define all default variable. No load of card here.
             This allow to subclass this class and just change init and still have
             all variables defined."""
-    
+
         if not hasattr(self, 'me_dir'):
             self.me_dir = None
         self.param_card = None
@@ -4826,10 +4724,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.conflict = []
         self.restricted_value = {}
         self.mode = ''
-        self.cards = [] 
+        self.cards = []
         self.run_set = []
         self.has_mw = False
-        self.has_ml = False   
+        self.has_ml = False
         self.has_shower = False
         self.has_PY8 = False
         self.has_delphes = False
@@ -4837,16 +4735,15 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.paths = {}
         self.update_block = []
 
-    
     def define_paths(self, **opt):
         # Initiation
         if 'pwd' in opt:
             self.me_dir = opt['pwd']
         elif 'mother_interface' in opt:
-            self.mother_interface = opt['mother_interface']     
+            self.mother_interface = opt['mother_interface']
         if not hasattr(self, 'me_dir') or not self.me_dir:
             self.me_dir = self.mother_interface.me_dir
-        
+
         #define paths
         self.paths['param'] = pjoin(self.me_dir,'Cards','param_card.dat')
         self.paths['param_default'] = pjoin(self.me_dir,'Cards','param_card_default.dat')
@@ -4877,14 +4774,11 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.paths['madanalysis5_hadron_default'] = pjoin(self.me_dir,'Cards','madanalysis5_hadron_card_default.dat')
         self.paths['FO_analyse'] = pjoin(self.me_dir,'Cards', 'FO_analyse_card.dat')
 
-
-     
-    
     def __init__(self, question, cards=[], from_banner=None, banner=None, mode='auto',
                      lhapdf=None, *args, **opt):
 
         self.lhapdf = lhapdf
-        self.load_default()        
+        self.load_default()
         self.define_paths(**opt)
         self.last_editline_pos = 0
 
@@ -4910,24 +4804,23 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if not opt['write_file']:
                 self.writting_card = False
                 self.param_consistency = False
-                        
+
         #update default path by custom one if specify in cards
         for card in cards:
             if os.path.exists(card) and os.path.sep in cards:
                 card_name = CommonRunCmd.detect_card_type(card)
-                card_name = card_name.split('_',1)[0] 
+                card_name = card_name.split('_',1)[0]
                 self.paths[card_name] = card
-                
+
         # go trough the initialisation of each card and detect conflict
         for name in self.to_init_card:
             new_vars = set(getattr(self, 'init_%s' % name)(cards))
             new_conflict = self.all_vars.intersection(new_vars)
             self.conflict.union(new_conflict)
             self.all_vars.union(new_vars)
-            
 
     def init_from_banner(self, from_banner, banner):
-        """ defined card that need to be initialized from the banner file 
+        """ defined card that need to be initialized from the banner file
             from_banner should be a list of card to load from the banner object
         """
 
@@ -4943,7 +4836,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if from_banner == ['param', 'run'] and list(banner.keys()) == ['mgversion']:
                 if self.mother_interface:
                     results = self.mother_interface.results
-                    run_name = self.mother_interface.run_name 
+                    run_name = self.mother_interface.run_name
                     run_tag = self.mother_interface.run_tag
                     banner = banner_mod.recover_banner(results, 'parton', run_name, run_tag)
                     self.mother_interface.banner = banner
@@ -4952,16 +4845,15 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     raise
 
         return self.from_banner
-    
 
     def get_path(self, name, cards):
         """initialise the path if requested"""
 
         defname = '%s_default' % name
-        
+
         if name in self.from_banner:
             return self.from_banner[name]
-        
+
         if isinstance(cards, list):
             if name in cards:
                 return True
@@ -4973,29 +4865,29 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 cardnames = [os.path.basename(p) for p in cards]
                 if '%s_card.dat' % name in cardnames:
                     return True
-                else:       
+                else:
                     return False
-            
+
         elif isinstance(cards, dict) and name in cards:
             self.paths[name]= cards[name]
             if defname in cards:
                 self.paths[defname] = cards[defname]
             elif os.path.isfile(cards[name].replace('.dat', '_default.dat')):
-                    self.paths[defname] = cards[name].replace('.dat', '_default.dat')            
+                    self.paths[defname] = cards[name].replace('.dat', '_default.dat')
             else:
                 self.paths[defname] = self.paths[name]
-                
+
             return True
         else:
             return False
 
     def init_param(self, cards):
         """check if we need to load the param_card"""
-        
+
         self.pname2block = {}
         self.restricted_value = {}
         self.param_card = {}
-        
+
         is_valid_path = self.get_path('param', cards)
         if not is_valid_path:
             self.param_consistency = False
@@ -5011,11 +4903,11 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             logger.error('Current param_card is not valid. We are going to use the default one.')
             logger.error('problem detected: %s' % e)
             files.cp(self.paths['param_default'], self.paths['param'])
-            self.param_card = param_card_mod.ParamCard(self.paths['param'])   
-         
+            self.param_card = param_card_mod.ParamCard(self.paths['param'])
+
         # Read the comment of the param_card_default to find name variable for
         # the param_card also check which value seems to be constrained in the
-        # model.   
+        # model.
         if os.path.exists(self.paths['param_default']):
             default_param = param_card_mod.ParamCard(self.paths['param_default'])
         else:
@@ -5023,9 +4915,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.pname2block, self.restricted_value = default_param.analyze_param_card()
         self.param_card_default = default_param
         return list(self.pname2block.keys())
-        
+
     def init_run(self, cards):
-      
+
         self.run_set = []
         is_valid_path = self.get_path('run', cards)
         if not is_valid_path:
@@ -5033,8 +4925,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         if isinstance(is_valid_path, banner_mod.RunCard):
             self.run_card = is_valid_path
             return []
-        
-        
+
         try:
             self.run_card = banner_mod.RunCard(self.paths['run'], consistency='warning')
         except IOError:
@@ -5043,7 +4934,6 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             run_card_def = banner_mod.RunCard(self.paths['run_default'], consistency=False)
         except IOError:
             run_card_def = {}
-
 
         if run_card_def:
             if self.run_card:
@@ -5054,7 +4944,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.run_set = list(self.run_card.keys())
         else:
             self.run_set = []
-        
+
         if self.run_set:
             self.special_shortcut.update(
                 {'ebeam':([float],['run_card ebeam1 %(0)s', 'run_card ebeam2 %(0)s']),
@@ -5070,8 +4960,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 'pbpb':([],['run_card lpp1 1', 'run_card lpp2 1','run_card nb_proton1 82', 'run_card nb_neutron1 126', 'run_card mass_ion1 195.0820996698', 'run_card nb_proton2 82', 'run_card nb_neutron2 126', 'run_card mass_ion2 195.0820996698' ]),
                 'pp': ([],['run_card lpp1 1', 'run_card lpp2 1','run_card nb_proton1 1', 'run_card nb_neutron1 0', 'run_card mass_ion1 -1', 'run_card nb_proton2 1', 'run_card nb_neutron2 0', 'run_card mass_ion2 -1']),
                 })
-            
-            self.special_shortcut_help.update({              
+
+            self.special_shortcut_help.update({
     'ebeam' : 'syntax: set ebeam VALUE:\n      This parameter sets the energy to both beam to the value in GeV',
     'lpp'   : 'syntax: set ebeam  VALUE:\n'+\
               '   Set the type of beam to a given value for both beam\n'+\
@@ -5084,29 +4974,29 @@ class AskforEditCard(cmd.OneLinePathCompletion):
     'lep'   : 'syntax: set lep VALUE:\n      Set for a electron-positron collision with that given center of mass energy (in GeV)',
     'fixed_scale' : 'syntax: set fixed_scale VALUE:\n      Set all scales to the give value (in GeV)',
     'no_parton_cut': 'remove all cut (but BW_cutoff)',
-    'cm_velocity': 'set sqrts to have the above velocity for the incoming particles', 
+    'cm_velocity': 'set sqrts to have the above velocity for the incoming particles',
     'pbpb': 'setup heavy ion configuration for lead-lead collision',
     'pbp': 'setup heavy ion configuration for lead-proton collision',
     'pp': 'remove setup of heavy ion configuration to set proton-proton collision',
     })
-            
+
         self.update_block += [b.name for b in self.run_card.blocks]
-        
+
         return self.run_set
-    
+
     def init_madweight(self, cards):
-        
+
         self.has_mw = False
         if not self.get_path('madweight', cards):
             return []
-        
+
         #add special function associated to MW
         self.do_change_tf = self.mother_interface.do_define_transfer_fct
         self.complete_change_tf = self.mother_interface.complete_define_transfer_fct
         self.help_change_tf = self.mother_interface.help_define_transfer_fct
         if not os.path.exists(self.paths['transfer']):
             logger.warning('No transfer function currently define. Please use the change_tf command to define one.')
-        
+
         self.has_mw = True
         try:
             import madgraph.madweight.Cards as mwcards
@@ -5116,7 +5006,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.mw_card = self.mw_card.info
         self.mw_vars = []
         for key in self.mw_card:
-            if key == 'comment': 
+            if key == 'comment':
                 continue
             for key2 in self.mw_card.info[key]:
                 if isinstance(key2, str) and not key2.isdigit():
@@ -5124,12 +5014,12 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         return self.mw_vars
 
     def init_madloop(self, cards):
-        
+
         if isinstance(cards, dict):
             for key in ['ML', 'madloop','MadLoop']:
                 if key in cards:
                     self.paths['ML'] = cards[key]
-        
+
         self.has_ml = False
         if os.path.isfile(self.paths['ML']):
             self.has_ml = True
@@ -5138,9 +5028,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.ml_vars = [k.lower() for k in self.MLcard.keys()]
             return self.ml_vars
         return []
-        
+
     def init_shower(self, cards):
-        
+
         self.has_shower = False
         if not self.get_path('shower', cards):
             return []
@@ -5148,20 +5038,20 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         self.shower_card = shower_card_mod.ShowerCard(self.paths['shower'])
         self.shower_vars = list(self.shower_card.keys())
         return self.shower_vars
-    
+
     def init_pythia8(self, cards):
-        
+
         self.has_PY8 = False
         if not self.get_path('pythia8', cards):
             return []
-            
+
         self.has_PY8 = True
         self.PY8Card = self.PY8Card_class(self.paths['pythia8'])
         self.PY8CardDefault = self.PY8Card_class()
-            
-        self.py8_vars = [k.lower() for k in self.PY8Card.keys()] 
-        
-        self.special_shortcut.update({                       
+
+        self.py8_vars = [k.lower() for k in self.PY8Card.keys()]
+
+        self.special_shortcut.update({
             'simplepy8':([],['pythia8_card hadronlevel:all False',
                              'pythia8_card partonlevel:mpi False',
                              'pythia8_card BeamRemnants:primordialKT False',
@@ -5204,10 +5094,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         return []
 
     def init_madspin(self, cards):
-        
+
         if not self.get_path('madspin', cards):
             return []
-        
+
         self.special_shortcut.update({
             'spinmode':([str], ['add madspin_card --before_line="launch" set spinmode %(0)s']),
             'nodecay':([], ['edit madspin_card --comment_line="decay"'])
@@ -5217,29 +5107,28 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             'nodecay': 'remove all decay previously defined in madspin',
              })
         return []
-    
+
     def init_delphes(self, cards):
-        
-        self.has_delphes = False  
+
+        self.has_delphes = False
         if not self.get_path('pythia8', cards):
             return []
         self.has_delphes = True
         return []
 
-
     def set_CM_velocity(self, line):
         """compute sqrts from the velocity in the center of mass frame"""
-        
+
         v = banner_mod.ConfigFile.format_variable(line, float, 'velocity')
                 # Define self.proc_characteristics
         self.mother_interface.get_characteristics()
         proc_info = self.mother_interface.proc_characteristics
         if 'pdg_initial1' not in proc_info:
             logger.warning('command not supported')
-            
+
         if len(proc_info['pdg_initial1']) == 1 == len(proc_info['pdg_initial2']) and\
            abs(proc_info['pdg_initial1'][0]) == abs(proc_info['pdg_initial2'][0]):
-        
+
             m = self.param_card.get_value('mass', abs(proc_info['pdg_initial1'][0]))
             sqrts = 2*m/ math.sqrt(1-v**2)
             self.do_set('run_card ebeam1 %s' % (sqrts/2.0))
@@ -5247,16 +5136,14 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.do_set('run_card lpp 0')
         else:
             logger.warning('This is only possible for a single particle in the initial state')
-             
 
-
-    def do_help(self, line, conflict_raise=False, banner=True):  
+    def do_help(self, line, conflict_raise=False, banner=True):
         # TODO nicer factorization !
-          
-#     try:                
-        if banner:                      
+
+#     try:
+        if banner:
             logger.info('*** HELP MESSAGE ***', '$MG:BOLD')
-         
+
         args = self.split_arg(line)
         # handle comand related help
         if len(args)==0 or (len(args) == 1 and hasattr(self, 'do_%s' % args[0])):
@@ -5265,24 +5152,24 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 print('Allowed Argument')
                 print('================')
                 print('\t'.join(self.allow_arg))
-                print() 
+                print()
                 print('Special shortcut: (type help <name>)')
                 print('====================================')
-                print('    syntax: set <name> <value>') 
+                print('    syntax: set <name> <value>')
                 print('\t'.join(self.special_shortcut))
                 print()
             if banner:
-                logger.info('*** END HELP ***', '$MG:BOLD')  
-            return out      
+                logger.info('*** END HELP ***', '$MG:BOLD')
+            return out
         # check for special shortcut.
         # special shortcut:
-        if args[0] in self.special_shortcut:    
+        if args[0] in self.special_shortcut:
             if args[0] in self.special_shortcut_help:
                 print(self.special_shortcut_help[args[0]])
             if banner:
-                logger.info('*** END HELP ***', '$MG:BOLD')  
-            return       
-        
+                logger.info('*** END HELP ***', '$MG:BOLD')
+            return
+
         start = 0
         card = ''
         if  args[0]+'_card' in self.all_card_name+ self.cards:
@@ -5296,7 +5183,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             card = args[0]
             if len(args) == 1:
                 if args[0] == 'pythia8_card':
-                    args[0] = 'PY8Card'              
+                    args[0] = 'PY8Card'
                 if args[0] == 'param_card':
                     logger.info("Param_card information: ", '$MG:color:BLUE')
                     print("File to define the various model parameter")
@@ -5308,18 +5195,18 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     print('syntax please refer to: https://madanalysis.irmp.ucl.ac.be/')
                     print('or to the user manual [arXiv:1206.1599]')
                     if args[0].startswith('madanalysis5_hadron'):
-                        print() 
+                        print()
                         print('This card also allow to make recasting analysis')
-                        print('For more detail, see: arXiv:1407.3278')                   
+                        print('For more detail, see: arXiv:1407.3278')
                 elif hasattr(self, args[0]):
                     logger.info("%s information: " % args[0], '$MG:color:BLUE')
                     print((eval('self.%s' % args[0]).__doc__))
                     logger.info("List of parameter associated", '$MG:color:BLUE')
                     print("\t".join(list(eval('self.%s' % args[0]).keys())))
                 if banner:
-                    logger.info('*** END HELP ***', '$MG:BOLD')  
+                    logger.info('*** END HELP ***', '$MG:BOLD')
                 return card
-                    
+
         #### RUN CARD
         if args[start] in [l.lower() for l in self.run_card.keys()] and card in ['', 'run_card']:
             if args[start] not in self.run_set:
@@ -5340,10 +5227,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 logger.info('**   AMBIGUOUS NAME: %s **', args[start], '$MG:BOLD')
                 if card == '':
                     logger.info('**   If not explicitely speficy this parameter  will modif the param_card file', '$MG:BOLD')
-                 
+
             if args[start] == 'width':
                 args[start] = 'decay'
-                
+
             if len(args) == start+1:
                 self.param_card.do_help(args[start], tuple())
                 key = None
@@ -5362,36 +5249,36 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     key = tuple([int(i) for i in args[start+1:]])
                 except ValueError:
                     logger.warning('Failed to identify LHA information')
-                    return card           
-            
+                    return card
+
             if key in self.param_card[args[start]].param_dict:
                 self.param_card.do_help(args[start], key, default=self.param_card_default)
             elif key:
                 logger.warning('invalid information: %s not defined in the param_card' % (key,))
         # PARAM_CARD NO BLOCK NAME ---------------------------------------------
-        elif args[start] in self.pname2block and card in ['','param_card']: 
+        elif args[start] in self.pname2block and card in ['','param_card']:
             if args[start] in self.conflict and not conflict_raise:
                 conflict_raise = True
                 logger.info('**   AMBIGUOUS NAME: %s **', args[start], '$MG:BOLD')
                 if card == '':
                     logger.info('**   If not explicitely speficy this parameter  will modif the param_card file', '$MG:BOLD')
-                 
+
             all_var = self.pname2block[args[start]]
             for bname, lhaid in all_var:
                 new_line = 'param_card %s %s %s' % (bname,
                    ' '.join([ str(i) for i in lhaid]), ' '.join(args[start+1:]))
-                self.do_help(new_line, conflict_raise=True, banner=False) 
-                
+                self.do_help(new_line, conflict_raise=True, banner=False)
+
         # MadLoop Parameter  ---------------------------------------------------
         elif self.has_ml and args[start] in self.ml_vars \
                                                and card in ['', 'MadLoop_card']:
-        
+
             if args[start] in self.conflict and not conflict_raise:
                 conflict_raise = True
                 logger.info('**   AMBIGUOUS NAME: %s **', args[start], '$MG:BOLD')
                 if card == '':
-                    logger.info('**   If not explicitely speficy this parameter  will modif the madloop_card file', '$MG:BOLD')                
-                
+                    logger.info('**   If not explicitely speficy this parameter  will modif the madloop_card file', '$MG:BOLD')
+
             self.MLcard.do_help(args[start])
 
         # Pythia8 Parameter  ---------------------------------------------------
@@ -5400,25 +5287,24 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 conflict_raise = True
                 logger.info('**   AMBIGUOUS NAME: %s **', args[start], '$MG:BOLD')
                 if card == '':
-                    logger.info('**   If not explicitely speficy this parameter  will modif the pythia8_card file', '$MG:BOLD')  
+                    logger.info('**   If not explicitely speficy this parameter  will modif the pythia8_card file', '$MG:BOLD')
 
             self.PY8Card.do_help(args[start])
         elif card.startswith('madanalysis5'):
             print('MA5')
-            
-            
+
         elif banner:
-            print("no help available") 
-          
-        if banner:                      
-            logger.info('*** END HELP ***', '$MG:BOLD')    
+            print("no help available")
+
+        if banner:
+            logger.info('*** END HELP ***', '$MG:BOLD')
         #six.moves.input('press enter to quit the help')
-        return card       
+        return card
 #     except Exception, error:
 #         if __debug__:
 #             import traceback
 #             traceback.print_exc()
-#             print error    
+#             print error
 
     def complete_help(self, text, line, begidx, endidx):
         prev_timer = signal.alarm(0) # avoid timer if any
@@ -5486,7 +5372,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 allowed['delphes_card'] = ''
             if self.has_rivet:
                 allowed['rivet_card'] = ''
-        
+
         elif len(args) == 2:
             if args[1] == 'run_card':
                 allowed = {'run_card':'default'}
@@ -5501,7 +5387,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             elif args[1] == 'MadLoop_card':
                 allowed = {'madloop_card':'default'}
             elif args[1] == 'pythia8_card':
-                allowed = {'pythia8_card':'default'}                
+                allowed = {'pythia8_card':'default'}
             elif self.has_mw and args[1] in list(self.mw_card.keys()):
                 allowed = {'mw_block':args[1]}
             elif args[1] == 'shower_card':
@@ -5515,7 +5401,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
         else:
             start = 1
-            if args[1] in  ['run_card', 'param_card', 'MadWeight_card', 'shower_card', 
+            if args[1] in  ['run_card', 'param_card', 'MadWeight_card', 'shower_card',
                             'MadLoop_card','pythia8_card','delphes_card','plot_card',
                             'madanalysis5_parton_card','madanalysis5_hadron_card', 'rivet_card']:
                 start = 2
@@ -5525,7 +5411,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             elif args[start] in list(self.param_card.keys()) or args[start] == 'width':
                 if args[start] == 'width':
                     args[start] = 'decay'
-                    
+
                 if args[start+1:]:
                     allowed = {'block':(args[start], args[start+1:])}
                 else:
@@ -5534,10 +5420,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if args[start+1:]:
                     allowed = {'mw_block':(args[start], args[start+1:])}
                 else:
-                    allowed = {'mw_block':args[start]}     
+                    allowed = {'mw_block':args[start]}
             #elif len(args) == start +1:
             #        allowed['value'] = ''
-            else: 
+            else:
                 allowed['value'] = ''
 
         if 'category' in list(allowed.keys()):
@@ -5557,7 +5443,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
             possibilities['category of parameter (optional)'] = \
                           self.list_completion(text, categories)
-        
+
         if 'shortcut' in list(allowed.keys()):
             possibilities['special values'] = self.list_completion(text, list(self.special_shortcut.keys())+['qcut', 'showerkt'])
 
@@ -5566,7 +5452,6 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if allowed['run_card'] == 'default':
                 opts.append('default')
 
-
             possibilities['Run Card'] = self.list_completion(text, opts)
 
         if 'param_card' in list(allowed.keys()):
@@ -5574,25 +5459,25 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if allowed['param_card'] == 'default':
                 opts.append('default')
             possibilities['Param Card'] = self.list_completion(text, opts)
-            
+
         if 'madweight_card' in list(allowed.keys()):
             opts = self.mw_vars + [k for k in self.mw_card.keys() if k !='comment']
             if allowed['madweight_card'] == 'default':
                 opts.append('default')
-            possibilities['MadWeight Card'] = self.list_completion(text, opts)            
+            possibilities['MadWeight Card'] = self.list_completion(text, opts)
 
         if 'madloop_card' in list(allowed.keys()):
             opts = self.ml_vars
             if allowed['madloop_card'] == 'default':
                 opts.append('default')
             possibilities['MadLoop Parameter'] = self.list_completion(text, opts)
-                                
+
         if 'pythia8_card' in list(allowed.keys()):
             opts = self.py8_vars
             if allowed['pythia8_card'] == 'default':
                 opts.append('default')
             possibilities['Pythia8 Parameter'] = self.list_completion(text, opts)
-                                
+
         if 'rivet_card' in list(allowed.keys()):
             opts = self.rivet_vars
             if allowed['rivet_card'] == 'default':
@@ -5603,12 +5488,12 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             opts = self.shower_vars + [k for k in self.shower_card.keys() if k !='comment']
             if allowed['shower_card'] == 'default':
                 opts.append('default')
-            possibilities['Shower Card'] = self.list_completion(text, opts)            
+            possibilities['Shower Card'] = self.list_completion(text, opts)
 
         if 'delphes_card' in allowed:
             if allowed['delphes_card'] == 'default':
                 opts = ['default', 'atlas', 'cms']
-            possibilities['Delphes Card'] = self.list_completion(text, opts)              
+            possibilities['Delphes Card'] = self.list_completion(text, opts)
 
         if 'value' in list(allowed.keys()):
             opts = ['default', 'scale']
@@ -5622,12 +5507,11 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 allowed_for_run = []
                 if args[-1].lower() in self.run_card.allowed_value:
                     allowed_for_run = self.run_card.allowed_value[args[-1].lower()]
-                    if '*' in allowed_for_run: 
+                    if '*' in allowed_for_run:
                         allowed_for_run.remove('*')
                 elif isinstance(self.run_card[args[-1]], bool):
                     allowed_for_run = ['True', 'False']
                 opts += [str(i) for i in  allowed_for_run]
-                
 
             possibilities['Special Value'] = self.list_completion(text, opts)
 
@@ -5637,7 +5521,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 allowed_block.append('width')
                 possibilities['Param Card Block' ] = \
                                        self.list_completion(text, allowed_block)
-                
+
             elif isinstance(allowed['block'], six.string_types):
                 block = self.param_card[allowed['block']].param_dict
                 ids = [str(i[0]) for i in block
@@ -5678,23 +5562,21 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 ids = [str(i[nb]) for i in block if isinstance(i, tuple) and\
                            len(i) > nb and \
                            [str(a) for a in i[:nb]] == allowed['mw_block'][1]]
-                
+
                 if not ids:
                     if tuple([i for i in allowed['mw_block'][1]]) in block or \
                                       allowed['mw_block'][1][0] in list(block.keys()):
                         opts = ['default']
                         possibilities['Special value'] = self.list_completion(text, opts)
-                possibilities['MadWeight Card id' ] = self.list_completion(text, ids) 
+                possibilities['MadWeight Card id' ] = self.list_completion(text, ids)
 
         return self.deal_multiple_categories(possibilities, formatting)
-         
+
     def do_set(self, line):
         """ edit the value of one parameter in the card"""
-        
 
         args = self.split_arg(line)
-        
-        
+
         if len(args) == 0:
             logger.warning("No argument. For help type 'help set'.")
         # fix some formatting problem
@@ -5703,7 +5585,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             args += [arg1, arg2]
         if '=' in args:
             args.remove('=')
-        
+
         args[:-1] = [ a.lower() for a in args[:-1]]
         if len(args) == 1: #special shortcut without argument -> lowercase
             args = [args[0].lower()]
@@ -5717,8 +5599,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 else:
                     logger.warning('additional argument will be ignored')
             values ={}
-            for i, argtype in enumerate(targettypes):           
-                try:  
+            for i, argtype in enumerate(targettypes):
+                try:
                     values = {str(i): banner_mod.ConfigFile.format_variable(args[i+1], argtype, args[0])}
                 except ValueError as e:
                     logger.warning("Wrong argument: The entry #%s should be of type %s.", i+1, argtype)
@@ -5757,7 +5639,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         start = 0
         if len(args) < 2:
             logger.warning('Invalid set command %s (need two arguments)' % line)
-            return            
+            return
 
         # Special case for the qcut value
         if args[0].lower() == 'qcut':
@@ -5770,7 +5652,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                                     p_card, flags=(re.M+re.I))
                 if n==0:
                     p_card = '%s \n QCUT= %s' % (p_card, args[1])
-                with open(pythia_path, 'w') as fsock: 
+                with open(pythia_path, 'w') as fsock:
                     fsock.write(p_card)
                 return
         # Special case for the showerkt value
@@ -5787,14 +5669,14 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 with open(pythia_path, 'w') as fsock:
                     fsock.write(p_card)
                 return
-            
+
         card = '' #store which card need to be modify (for name conflict)
         if args[0] == 'madweight_card':
             if not self.mw_card:
                 logger.warning('Invalid Command: No MadWeight card defined.')
                 return
             args[0] = 'MadWeight_card'
-        
+
         if args[0] == 'shower_card':
             if not self.shower_card:
                 logger.warning('Invalid Command: No Shower card defined.')
@@ -5853,7 +5735,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if len(args) < 3:
                 logger.warning('Invalid set command: %s (not enough arguments)' % line)
                 return
-            
+
         elif args[0] in ['MadLoop_card']:
             if args[1] == 'default':
                 logger.info('replace MadLoopParams.dat by the default card','$MG:BOLD')
@@ -5888,7 +5770,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 files.cp(self.paths['MS_default'], self.paths['madspin'])
                 return
             else:
-                logger.warning("""Command set not allowed for modifying the madspin_card. 
+                logger.warning("""Command set not allowed for modifying the madspin_card.
                     Check the command \"decay\" instead.""")
                 return
 
@@ -5936,13 +5818,13 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if any(t.startswith('scan') for t in args):
                 index = [i for i,t in enumerate(args) if t.startswith('scan')][0]
                 args = args[:index] + [' '.join(args[index:])]
-                
+
             if args[start] in self.conflict and card == '':
                 text  = 'ambiguous name (present in more than one card). Please specify which card to edit'
                 text += ' in the format < set card parameter value>'
                 logger.warning(text)
                 return
-            
+
             if args[start] == 'width':
                 args[start] = 'decay'
 
@@ -5998,7 +5880,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 logger.warning('invalid set command %s' % line)
                 return
             self.modified_card.add('param')
-        
+
         # PARAM_CARD NO BLOCK NAME ---------------------------------------------
         elif args[start] in self.pname2block and card in ['','param_card']:
             if args[start] in self.conflict and card == '':
@@ -6006,7 +5888,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 text += ' in the format < set card parameter value>'
                 logger.warning(text)
                 return
-            
+
             all_var = self.pname2block[args[start]]
             for bname, lhaid in all_var:
                 new_line = 'param_card %s %s %s' % (bname,
@@ -6017,27 +5899,27 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 for bname, lhaid in all_var:
                     logger.warning('   %s %s' % (bname, ' '.join([str(i) for i in lhaid])))
                 logger.warning('all listed variables have been modified')
-                
+
         # MadWeight_card with block name ---------------------------------------
         elif self.has_mw and (args[start] in self.mw_card and args[start] != 'comment') \
                                               and card in ['','MadWeight_card']:
-            
+
             if args[start] in self.conflict and card == '':
                 text  = 'ambiguous name (present in more than one card). Please specify which card to edit'
                 text += ' in the format < set card parameter value>'
                 logger.warning(text)
                 return
-                       
+
             block = args[start]
             name = args[start+1]
             value = args[start+2:]
             self.setM(block, name, value)
-            self.mw_card.write(self.paths['MadWeight'])        
-        
+            self.mw_card.write(self.paths['MadWeight'])
+
         # MadWeight_card NO Block name -----------------------------------------
         elif self.has_mw and args[start] in self.mw_vars \
                                              and card in ['', 'MadWeight_card']:
-            
+
             if args[start] in self.conflict and card == '':
                 text  = 'ambiguous name (present in more than one card). Please specify which card to edit'
                 text += ' in the format < set card parameter value>'
@@ -6049,13 +5931,13 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 logger.warning('%s is define in more than one block: %s.Please specify.'
                                % (args[start], ','.join(block)))
                 return
-           
+
             block = block[0]
             name = args[start]
             value = args[start+1:]
             self.setM(block, name, value)
             self.mw_card.write(self.paths['MadWeight'])
-             
+
         # MadWeight_card New Block ---------------------------------------------
         elif self.has_mw and args[start].startswith('mw_') and len(args[start:]) == 3\
                                                     and card == 'MadWeight_card':
@@ -6063,7 +5945,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             name = args[start+1]
             value = args[start+2]
             self.setM(block, name, value)
-            self.mw_card.write(self.paths['MadWeight'])    
+            self.mw_card.write(self.paths['MadWeight'])
 
         #### SHOWER CARD
         elif self.has_shower and args[start].lower() in [l.lower() for l in \
@@ -6101,7 +5983,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         # MadLoop Parameter  ---------------------------------------------------
         elif self.has_ml and args[start] in self.ml_vars \
                                                and card in ['', 'MadLoop_card']:
-        
+
             if args[start] in self.conflict and card == '':
                 text = 'ambiguous name (present in more than one card). Please specify which card to edit'
                 logger.warning(text)
@@ -6140,7 +6022,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         # Rivet Parameter -----------------------------------------------------
         elif self.has_rivet and (card in ['', 'rivet_card'])\
              and args[start].lower() in [k.lower() for k in self.rivet_card.keys()]:
-      
+
             if args[start] in self.conflict and card == '':
                 text = 'ambiguous name (present in more than one card). Please specify which card to edit'
                 logger.warning(text)
@@ -6155,10 +6037,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.rivet_card.write(self.paths['rivet'], self.paths['rivet_default'])
 
         #INVALID --------------------------------------------------------------
-        else:      
+        else:
             logger.warning('invalid set command %s ' % line)
             arg = args[start].lower()
-            if self.has_PY8:   
+            if self.has_PY8:
                 close_opts = [name for name in self.PY8Card if name.lower().startswith(arg[:3]) or arg in name.lower()]
                 if close_opts:
                     logger.info('Did you mean one of the following PY8 options:\n%s' % '\t'.join(close_opts))
@@ -6166,14 +6048,14 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 close_opts = [name for name in self.run_card if name.lower().startswith(arg[:3]) or arg in name.lower()]
                 if close_opts:
                     logger.info('Did you mean one of the following run_card options:\n%s' % '\t'.join(close_opts))
-                
+
             return
 
     def setM(self, block, name, value):
-        
+
         if isinstance(value, list) and len(value) == 1:
             value = value[0]
-            
+
         if block not in self.mw_card:
             logger.warning('block %s was not present in the current MadWeight card. We are adding it' % block)
             self.mw_card[block] = {}
@@ -6195,9 +6077,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         else:
             logger.warning("Invalid command: No value. To set default value. Use \"default\" as value")
             return
-        
+
         self.mw_card[block][name] = value
-    
+
     def setR(self, name, value):
 
         if self.mother_interface.inputfile:
@@ -6205,11 +6087,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         else:
             self.run_card.set(name, value, user=True)
         new_value = self.run_card.get(name)
-        logger.info('modify parameter %s of the run_card.dat to %s' % (name, new_value),'$MG:BOLD')        
-
+        logger.info('modify parameter %s of the run_card.dat to %s' % (name, new_value),'$MG:BOLD')
 
     def setML(self, name, value, default=False):
-        
+
         try:
             self.MLcard.set(name, value, user=True)
         except Exception as error:
@@ -6263,8 +6144,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if tag and not tag.isdigit():
                     logger.warning('Invalid input: scan tag need to be integer and not "%s"' % tag)
                     return
-                
-                
+
                 pass
             else:
                 try:
@@ -6279,8 +6159,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         else:
             logger.info('modify param_card information scale of BLOCK %s set to %s' %\
                         (block, value), '$MG:BOLD')
-            self.param_card[block].scale = value            
-    
+            self.param_card[block].scale = value
+
     def check_card_consistency(self):
         """This is run on quitting the class. Apply here all the self-consistency
         rule that you want. Do the modification via the set command."""
@@ -6289,7 +6169,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         #       LO specific check
         ########################################################################
         if self.run_card and isinstance(self.run_card,banner_mod.RunCardLO):
-            
+
             proc_charac = self.mother_interface.proc_characteristics
             if proc_charac['grouped_matrix'] and \
                   abs(self.run_card['lpp1']) == 1 == abs(self.run_card['lpp2']) and \
@@ -6297,7 +6177,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                  self.run_card['nb_neutron1'] != self.run_card['nb_neutron2'] or
                  self.run_card['mass_ion1'] != self.run_card['mass_ion2']):
                 raise Exception("Heavy ion profile for both beam are different but the symmetry used forbids it. \n Please generate your process with \"set group_subprocesses False\".")
-            
+
             # check for nhel if using eva
             if  self.run_card['pdlabel']  == 'eva' or \
                 self.run_card['pdlabel1'] == 'eva' or \
@@ -6319,7 +6199,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     continue
                 if isinstance(mass,str):
                     continue
-                
+
                 if mass:
                     to_sleep = True
                     if abs(width/mass) < self.run_card['small_width_treatment']:
@@ -6332,28 +6212,28 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     if CommonRunCmd.sleep_for_error and to_sleep:
                         time.sleep(5)
                         CommonRunCmd.sleep_for_error = False
-                        
+
             # @LO if PY6 shower => event_norm on sum
             if 'pythia_card.dat' in self.cards and 'run' in self.allow_arg:
                 if self.run_card['event_norm'] != 'sum':
                     logger.info('Pythia6 needs a specific normalisation of the events. We will change it accordingly.', '$MG:BOLD' )
-                    self.do_set('run_card event_norm sum') 
+                    self.do_set('run_card event_norm sum')
             # @LO if PY6 shower => event_norm on sum
             elif 'pythia8_card.dat' in self.cards:
                 if self.run_card['event_norm'] == 'sum':
                     logger.info('Pythia8 needs a specific normalisation of the events. We will change it accordingly.', '$MG:BOLD' )
-                    self.do_set('run_card event_norm average')  
-                
+                    self.do_set('run_card event_norm average')
+
             if 'MLM' in proc_charac['limitations']:
                 if self.run_card['dynamical_scale_choice'] == -1:
                     raise InvalidCmd("Your model is identified as not fully supported within MG5aMC.\n" +\
                         "As your process seems to be impacted by the issue,\n"+\
-                      "You can NOT run with CKKW dynamical scale for this model. Please choose another one.") 
+                      "You can NOT run with CKKW dynamical scale for this model. Please choose another one.")
                 if self.run_card['ickkw']:
                     raise InvalidCmd("Your model is identified as not fully supported within MG5aMC.\n" +\
                         "As your process seems to be impacted by the issue,\n" +\
-                      "You can NOT run with MLM matching/merging. Please check if merging outside MG5aMC are suitable or refrain to use merging with this model") 
-            
+                      "You can NOT run with MLM matching/merging. Please check if merging outside MG5aMC are suitable or refrain to use merging with this model")
+
             if 'fix_scale' in proc_charac['limitations']:
                 if not self.run_card['fixed_fac_scale'] or not self.run_card['fixed_ren_scale']:
                     raise InvalidCmd("Your model is identified as having not SM running of the strong coupling.\n"+\
@@ -6361,7 +6241,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if self.run_card['ickkw']:
                     raise InvalidCmd("Your model is identified as having not SM running of the strong coupling.\n"+\
                                      "Therefore you can not perform MLM merging with this model.")
-                    
+
                 if self.run_card['lpp1'] !=0 or self.run_card['lpp2'] !=0:
                     logger.critical("Your model is identified as having not SM running of the strong coupling.\n"+\
                                     "PLEASE check carefully the value use for alphas in the internal log.")
@@ -6389,14 +6269,13 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                         self.cards.remove('pythia8_card.dat')
                 else:
                     logger.info('Remember that Parton-Shower are not yet ready for such proton component definition (HW implementation in progress).', '$MG:BOLD' )
- 
-                 
+
         ########################################################################
         #       NLO specific check
         ########################################################################
         # For NLO run forbid any pdg specific cut on massless particle
         if self.run_card and isinstance(self.run_card,banner_mod.RunCardNLO):
-            
+
             try:
                 proc_charac = self.mother_interface.proc_characteristics
             except:
@@ -6406,19 +6285,19 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if self.run_card['ickkw']:
                     raise Exception( "Your model is identified as not fully supported within MG5aMC.\n" +\
                       "You can NOT run with FxFx/UnLOPS matching/merging. Please check if merging outside MG5aMC are suitable or refrain to use merging with this model")
-            
+
             if 'fix_scale' in proc_charac['limitations']:
                 raise Exception( "Your model is identified as not fully supported within MG5aMC.\n" +\
                                  "Your model does not have a SM like running of the strong coupling.")
-                        
+
             for pdg in set(list(self.run_card['pt_min_pdg'].keys())+list(self.run_card['pt_max_pdg'].keys())+
-                           list(self.run_card['mxx_min_pdg'].keys())): 
-                   
+                           list(self.run_card['mxx_min_pdg'].keys())):
+
                 if int(pdg)<0:
                     raise Exception("For PDG specific cuts, always use positive PDG codes: the cuts are applied to both particles and anti-particles")
                 if self.param_card.get_value('mass', int(pdg), default=0) ==0:
                     raise Exception("For NLO runs, you can use PDG specific cuts only for massive particles: (failed for %s)" % pdg)
-        
+
             # if NLO reweighting is ON: ensure that we keep the rwgt information
             if 'reweight' in self.allow_arg and 'run' in self.allow_arg and \
             not self.run_card['store_rwgt_info']:
@@ -6429,32 +6308,31 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if any(o in ['NLO', 'LO+NLO'] for o in options):
                     logger.info('NLO reweighting is on ON. Automatically set store_rwgt_info to True', '$MG:BOLD' )
                     self.do_set('run_card store_rwgt_info True')
-        
-            # if external computation for the systematics are asked then switch 
+
+            # if external computation for the systematics are asked then switch
             #automatically the book-keeping of the weight for NLO
             if 'run' in self.allow_arg and \
                         self.run_card['systematics_program'] == 'systematics'  and \
                         not self.run_card['store_rwgt_info']:
                 logger.warning('To be able to run systematics program, we set store_rwgt_info to True')
                 self.do_set('run_card store_rwgt_info True')
-        
+
             #check relation between ickkw and shower_card
             if 'run' in self.allow_arg and self.run_card['ickkw'] == 3 :
                 if 'shower' in self.allow_arg:
                     if self.shower_card['qcut'] == -1:
-                        self.do_set('shower_card qcut %f' % (2*self.run_card['ptj'])) 
+                        self.do_set('shower_card qcut %f' % (2*self.run_card['ptj']))
                     elif self.shower_card['qcut'] < self.run_card['ptj']*2:
                         logger.error("ptj cut [in run_card: %s] is more than half the value of QCUT [shower_card: %s] This is not recommended:\n see http://amcatnlo.web.cern.ch/amcatnlo/FxFx_merging.htm ",
                                      self.run_card['ptj'], self.shower_card['qcut'])
-                        
+
                     if self.shower_card['njmax'] == -1:
-                        if not proc_charac: #shoud not happen in principle 
+                        if not proc_charac: #shoud not happen in principle
                             raise Exception( "Impossible to setup njmax automatically. Please setup that value manually.")
                         njmax = proc_charac['max_n_matched_jets']
-                        self.do_set('shower_card njmax %i' % njmax) 
+                        self.do_set('shower_card njmax %i' % njmax)
                     if self.shower_card['njmax'] == 0:
                         raise Exception("Invalid njmax parameter. Can not be set to 0")
-
 
             #check relation between lepton PDF // dressed lepton collisions // ...
             if abs(self.run_card['lpp1']) != 1  or  abs(self.run_card['lpp2']) != 1:
@@ -6467,11 +6345,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     # this can be dressed lepton or photon-flux
                     if proc_charac['pdg_initial1'] in [[13],[-13]] and  proc_charac['pdg_initial2'] in [[13],[-13]]:
                         if self['pdlabel'] not in self.allowed_lep_densities[(-13,13)]:
-                            raise banner_mod.InvalidRunCard('pdlabel %s not allowed for dressed-lepton collisions' % self['pdlabel'])   
-                        
-                    
-       
-        
+                            raise banner_mod.InvalidRunCard('pdlabel %s not allowed for dressed-lepton collisions' % self['pdlabel'])
+
         # Check the extralibs flag.
         if self.has_shower and isinstance(self.run_card, banner_mod.RunCardNLO):
             modify_extralibs, modify_extrapaths = False,False
@@ -6483,33 +6358,33 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     extralibs.remove('stdhep')
                     modify_extralibs = True
                 if 'Fmcfio' in self.shower_card['extralibs']:
-                    extralibs.remove('Fmcfio')     
-                    modify_extralibs = True               
+                    extralibs.remove('Fmcfio')
+                    modify_extralibs = True
             if self.run_card['parton_shower'] == 'PYTHIA8':
                 # First check sanity of PY8
                 if not self.mother_interface.options['pythia8_path']:
                     raise self.mother_interface.InvalidCmd('Pythia8 is not correctly specified  to MadGraph5_aMC@NLO')
                 executable = pjoin(self.mother_interface.options['pythia8_path'], 'bin', 'pythia8-config')
                 if not os.path.exists(executable):
-                    raise self.mother.InvalidCmd('Pythia8 is not correctly specified to MadGraph5_aMC@NLO')                
-                
+                    raise self.mother.InvalidCmd('Pythia8 is not correctly specified to MadGraph5_aMC@NLO')
+
                 # 2. take the compilation flag of PY8 from pythia8-config
                 libs , paths = [], []
                 p = misc.subprocess.Popen([executable, '--libs'], stdout=subprocess.PIPE)
                 stdout, _ = p. communicate()
                 libs = [x[2:] for x in stdout.decode(errors='ignore').split() if x.startswith('-l') or paths.append(x[2:])]
-                
+
                 # Add additional user-defined compilation flags
                 p = misc.subprocess.Popen([executable, '--config'], stdout=subprocess.PIPE)
                 stdout, _ = p. communicate()
                 for lib in ['-ldl','-lstdc++','-lc++']:
                     if lib in stdout.decode(errors='ignore'):
-                        libs.append(lib[2:])                    
+                        libs.append(lib[2:])
 
                 # This precompiler flag is in principle useful for the analysis if it writes HEPMC
                 # events, but there is unfortunately no way for now to specify it in the shower_card.
                 supports_HEPMCHACK = '-DHEPMC2HACK' in stdout.decode(errors='ignore')
-                
+
                 #3. ensure that those flag are in the shower card
                 for L in paths:
                     if L not in extrapaths:
@@ -6525,7 +6400,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                             continue
                     if l not in extralibs:
                         modify_extralibs = True
-                        extralibs.append(l)                        
+                        extralibs.append(l)
             # Apply the required modification
             if modify_extralibs:
                 if extralibs:
@@ -6536,20 +6411,19 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 if extrapaths:
                     self.do_set('shower_card extrapaths %s ' % ' '.join(extrapaths))
                 else:
-                    self.do_set('shower_card extrapaths None ') 
-                    
+                    self.do_set('shower_card extrapaths None ')
+
         # ensure that all cards are in sync
         if self.writting_card:
             for key in list(self.modified_card):
                 self.write_card(key)
 
-
     def reask(self, *args, **opt):
-        
+
         cmd.OneLinePathCompletion.reask(self,*args, **opt)
         if self.has_mw and not os.path.exists(pjoin(self.me_dir,'Cards','transfer_card.dat')):
             logger.warning('No transfer function currently define. Please use the change_tf command to define one.')
-    
+
     fail_due_to_format = 0 #parameter to avoid infinite loop
     def postcmd(self, stop, line):
 
@@ -6557,7 +6431,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             ending_question = cmd.OneLinePathCompletion.postcmd(self,stop,line)
         else:
             ending_question = True
-        
+
         if ending_question:
             self.check_card_consistency()
             if self.param_consistency:
@@ -6574,13 +6448,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                             return self.reask(True)
                         else:
                             raise
-            
+
             return ending_question
-    
-    
-    
-    
-    
+
     def do_update(self, line, timer=0):
         """ syntax: update dependent: Change the mass/width of particles which are not free parameter for the model.
                     update missing:   add to the current param_card missing blocks/parameters.
@@ -6593,15 +6463,15 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         if len(args)==0:
             logger.warning('miss an argument (dependent or missing). Please retry')
             return
-        
+
         if args[0] == 'dependent':
             if not self.mother_interface:
                 logger.warning('Failed to update dependent parameter. This might create trouble for external program (like MadSpin/shower/...)')
-            
+
             pattern_width = re.compile(r'''decay\s+(\+?\-?\d+)\s+auto(@NLO|)''',re.I)
             pattern_scan = re.compile(r'''^(decay)?[\s\d]*scan''', re.I+re.M)
             param_text= open(self.paths['param']).read()
-            
+
             if pattern_scan.search(param_text):
                 #for block, key in self.restricted_value:
                 #    self.param_card[block].get(key).value = -9.999e-99
@@ -6610,8 +6480,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             elif pattern_width.search(param_text):
                 self.do_compute_widths('')
                 self.param_card = param_card_mod.ParamCard(self.paths['param'])
-                
-            # calling the routine doing the work    
+
+            # calling the routine doing the work
             self.update_dependent(self.mother_interface, self.me_dir, self.param_card,
                                    self.paths['param'], timer, run_card=self.run_card,
                                    lhapdfconfig=self.lhapdf)
@@ -6633,7 +6503,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 logger.info('card updated')
             except Exception as error:
                 logger.warning('failed to update to slha1 due to %s' % error)
-            self.param_card = param_card_mod.ParamCard(self.paths['param'])            
+            self.param_card = param_card_mod.ParamCard(self.paths['param'])
         elif args[0] == 'to_full':
             return self.update_to_full(args[1:])
         elif args[0] in self.update_block:
@@ -6644,34 +6514,33 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.help_update()
             logger.warning('unvalid options for update command. Please retry')
 
-
     def update_to_full(self, line):
         """ trigger via update to_full LINE"""
-        
+
         logger.info("update the run_card by including all the hidden parameter")
         self.run_card.write(self.paths['run'], self.paths['run_default'], write_hidden=True)
         if 'run' in self.modified_card:
             self.modified_card.remove('run')
-            
+
     def write_card(self, name):
         """proxy on how to write any card"""
-        
+
         if hasattr(self, 'write_card_%s' % name):
             getattr(self, 'write_card_%s' % name)()
             if name in self.modified_card:
                 self.modified_card.remove(name)
         else:
             raise Exception("Need to add the associate writter proxy for %s" % name)
-        
+
     def write_card_run(self):
         """ write the run_card """
         self.run_card.write(self.paths['run'], self.paths['run_default'])
-        
+
     def write_card_param(self):
-        """ write the param_card """    
-    
+        """ write the param_card """
+
         self.param_card.write(self.paths['param'])
-        
+
     @staticmethod
     def update_dependent(mecmd, me_dir, param_card, path ,timer=0, run_card=None,
                     lhapdfconfig=None):
@@ -6679,19 +6548,16 @@ class AskforEditCard(cmd.OneLinePathCompletion):
            usefull in presence of scan.
            return if the param_card was updated or not
         """
-        
+
         if not param_card:
             return False
 
-
         logger.info('Update the dependent parameter of the param_card.dat')
 
-
-
         modify = False
-        class TimeOutError(Exception): 
+        class TimeOutError(Exception):
             pass
-        def handle_alarm(signum, frame): 
+        def handle_alarm(signum, frame):
             raise TimeOutError
         signal.signal(signal.SIGALRM, handle_alarm)
         if timer:
@@ -6702,11 +6568,11 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
         if run_card:
             as_for_pdf = {'cteq6_m': 0.118,
-                          'cteq6_d': 0.118, 
-                          'cteq6_l': 0.118, 
+                          'cteq6_d': 0.118,
+                          'cteq6_l': 0.118,
                           'cteq6l1': 0.129783,
                           'nn23lo':  0.119,
-                          'nn23lo1': 0.130, 
+                          'nn23lo1': 0.130,
                           'nn23nlo': 0.119,
                           'ct14q00': 0.118,
                           'ct14q07': 0.118,
@@ -6779,18 +6645,16 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     modify = True
             else:
                 logger.warning('missing MG5aMC code. Fail to update dependent parameter. This might create trouble for program like MadSpin/shower/...')
-            
+
         if modify and path:
             param_card.write(path)
         if log_level==20:
             logger.info('param_card up to date.')
-            
+
         return modify
-    
-    
-    
+
     def update_missing(self):
-        
+
         def check_block(self, blockname):
             add_entry = 0
             if blockname.lower() not in self.param_card_default:
@@ -6802,7 +6666,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     param = block.get(key)
                     if blockname != 'decay':
                         text.append('\t%s\t%s # %s\n' % (' \t'.join([repr(i) for i in param.lhacode]), param.value, param.comment))
-                    else: 
+                    else:
                         text.append('DECAY \t%s\t%s # %s\n' % (' \t'.join([repr(i) for i in param.lhacode]), param.value, param.comment))
                     add_entry += 1
             if add_entry:
@@ -6810,7 +6674,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if add_entry:
                 logger.info("Adding %s parameter(s) to block %s", add_entry, blockname)
             return add_entry
-        
+
         # Add to the current param_card all the missing input at default value
         current_block = ''
         input_in_block = set()
@@ -6819,9 +6683,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         text = []
         add_entry = 0
         for line in open(self.paths['param']):
-            
-            new_block = re.findall(r'^\s*(block|decay)\s*(\w*)', line, re.I)               
-            if new_block:                       
+
+            new_block = re.findall(r'^\s*(block|decay)\s*(\w*)', line, re.I)
+            if new_block:
                 new_block = new_block[0]
                 defined_blocks.add(new_block[1].lower())
                 if current_block:
@@ -6834,12 +6698,12 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                     current_block = ''
                 if new_block[1].lower() == 'qnumbers':
                     current_block = ''
-    
-            text.append(line) 
+
+            text.append(line)
             if not current_block:
                 continue
-            
-            #normal line. 
+
+            #normal line.
             #strip comment
             line = line.split('#',1)[0]
             split  = line.split()
@@ -6851,10 +6715,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 except:
                     continue
                 input_in_block.add(tuple(lhacode))
-                    
+
         if current_block:
             add_entry += check_block(self, current_block)
-        
+
         # special check for missing block
         for block in self.param_card_default:
 
@@ -6865,25 +6729,24 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 nb_entry = len(self.param_card_default[block])
                 logger.info("Block %s was missing. Adding the %s associated parameter(s)", block,nb_entry)
                 add_entry += nb_entry
-                text.append(str(self.param_card_default[block])) 
-            
+                text.append(str(self.param_card_default[block]))
+
         # special check for the decay
         input_in_block = decay
         add_entry += check_block(self, 'decay')
-        
+
         if add_entry:
             logger.info('write new param_card with %s new parameter(s).', add_entry, '$MG:BOLD')
             open(self.paths['param'],'w').write(''.join(text))
             self.reload_card(self.paths['param'])
         else:
             logger.info('No missing parameter detected.', '$MG:BOLD')
-    
-    
+
     def check_answer_consistency(self):
         """function called if the code reads a file"""
         self.check_card_consistency()
-        self.do_update('dependent', timer=20) 
-      
+        self.do_update('dependent', timer=20)
+
     def help_set(self):
         '''help message for set'''
 
@@ -6913,7 +6776,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         logger.info('********************* HELP SET ***************************')
 
     def trigger(self, line):
-        
+
         line = line.strip()
         args = line.split()
 
@@ -6923,7 +6786,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             return line
 
         triggerfct = getattr(self, 'trigger_%s' % args[0])
-        
+
         # run the trigger function
         outline = triggerfct(' '.join(args[1:]))
         if not outline:
@@ -6935,7 +6798,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
         # check if the line need to be modified by a trigger
         line = self.trigger(line)
-        
+
         # splitting the line
         line = line.strip()
         args = line.split()
@@ -6945,7 +6808,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         elif hasattr(self, 'do_%s' % args[0]):
             self.do_set(' '.join(args[1:]))
         elif line.strip() != '0' and line.strip() != 'done' and \
-            str(line) != 'EOF' and line.strip() in self.allow_arg:  
+            str(line) != 'EOF' and line.strip() in self.allow_arg:
             self.open_file(line)
             self.value = 'repeat'
         elif os.path.isfile(line):
@@ -6953,7 +6816,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.value = 'repeat'
         elif self.me_dir and os.path.exists(pjoin(self.me_dir, line)):
             self.copy_file(pjoin(self.me_dir,line))
-            self.value = 'repeat'            
+            self.value = 'repeat'
         elif line.strip().startswith(('http:','www', 'https')):
             self.value = 'repeat'
             import tempfile
@@ -6969,27 +6832,25 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 os.close(fsock)
                 self.copy_file(path, pathname=url)
                 os.remove(path)
-                
-                
+
         else:
             self.value = line
 
         return line
 
-
     def do_decay(self, line):
         """edit the madspin_card to define the decay of the associate particle"""
         signal.alarm(0) # avoid timer if any
         path = self.paths['madspin']
-        
+
         if 'madspin_card.dat' not in self.cards or not os.path.exists(path):
             logger.warning("Command decay not valid. Since MadSpin is not available.")
             return
-        
+
         if ">" not in line:
             logger.warning("invalid command for decay. Line ignored")
             return
-        
+
         if "-add" in line:
             # just to have to add the line to the end of the file
             particle = line.split('>')[0].strip()
@@ -6998,7 +6859,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             logger.info("change madspin_card to add one decay to %s: %s" %(particle, line.strip()), '$MG:BOLD')
             if 'launch' in text:
                 text = text.replace('launch', "\ndecay %s\nlaunch\n" % line,1)
-            else: 
+            else:
                 text += '\ndecay %s\n launch \n' % line
         else:
             # Here we have to remove all the previous definition of the decay
@@ -7011,31 +6872,28 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             text = decay_pattern.sub('', text)
             if 'launch' in text:
                 text = text.replace('launch', "\ndecay %s\nlaunch\n" % line,1)
-            else: 
+            else:
                 text += '\ndecay %s\n launch \n' % line
-                
-        with open(path,'w') as fsock:
-            fsock.write(text) 
-        self.reload_card(path)
 
-    
+        with open(path,'w') as fsock:
+            fsock.write(text)
+        self.reload_card(path)
 
     def do_compute_widths(self, line):
         signal.alarm(0) # avoid timer if any
-        
+
         # ensure that the card is in sync
         if 'param' in self.modified_card:
             self.write_card('param')
             self.modified_card.discard('param')
-            
+
         path = self.paths['param']
         pattern = re.compile(r'''decay\s+(\+?\-?\d+)\s+auto(@NLO|)''',re.I)
         text = open(path).read()
         pdg_info = pattern.findall(text)
         has_nlo = any("@nlo"==nlo.lower() for _, nlo in pdg_info)
         pdg = [p for p,_ in pdg_info]
-        
-        
+
         line = '%s %s' % (line, ' '.join(pdg))
         if not '--path' in line:
             line += ' --path=%s' % path
@@ -7058,17 +6916,15 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                         small_width_treatment = self.run_card['small_width_treatment']
                     except Exception: #NLO
                         small_width_treatment = 0
-                    
+
                     if total and total/mass < small_width_treatment:
                         text = "Particle %s with very small width (%g): Learn about special handling here: https://answers.launchpad.net/mg5amcnlo/+faq/3053"
                         logger.warning(text,pid,total)
                     elif total and total/mass < 1e-11:
                         text = "Particle %s with very small width (%g): Numerical inaccuracies can occur if that particle is in a s-channel"
-                        logger.critical(text,pid,total)                        
+                        logger.critical(text,pid,total)
 
-
-            return out      
-            
+            return out
 
     def help_compute_widths(self):
         signal.alarm(0) # avoid timer if any
@@ -7076,14 +6932,14 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
     def help_decay(self):
         """help for command decay which modifies MadSpin_card"""
-        
+
         signal.alarm(0) # avoid timer if any
         print('--syntax: decay PROC [--add]')
         print(' ')
         print('  modify the madspin_card to modify the decay of the associate particle.')
         print('  and define it to PROC.')
         print('  if --add is present, just add a new decay for the associate particle.')
-        
+
     def complete_compute_widths(self, text, line, begidx, endidx, **opts):
         prev_timer = signal.alarm(0) # avoid timer if any
         if prev_timer:
@@ -7092,7 +6948,6 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.stdout.write(line)
             self.stdout.flush()
         return self.mother_interface.complete_compute_widths(text, line, begidx, endidx,**opts)
-
 
     def help_add(self):
         """help for add command"""
@@ -7103,10 +6958,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         logger.info( "   Do not work for the param_card"        )
         logger.info('')
         return self.help_edit(prefix=False)
-        
+
     def help_edit(self, prefix=True):
-        """help for edit command"""      
-        
+        """help for edit command"""
+
         if prefix: logger.info('********************* HELP ADD|EDIT ***************************')
         logger.info( '-- syntax: add filename [OPTION] LINE')
         logger.info( '-- syntax: edit filename [OPTION] LINE')
@@ -7115,7 +6970,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         logger.info( '   OPTION parameter allows to change the position where to write in the file')
         logger.info( '     --after_line=banner : write the line at the end of the banner')
         logger.info( '     --line_position=X : insert the line before line X (starts at 0)')
-        logger.info( '     --line_position=afterlast : insert the line after the latest inserted/modified line.')        
+        logger.info( '     --line_position=afterlast : insert the line after the latest inserted/modified line.')
         logger.info( '     --after_line="<regular-expression>" write the line after the first line matching the regular expression')
         logger.info( '     --before_line="<regular-expression>" write the line before the first line matching the regular expression')
         logger.info( '     --replace_line="<regular-expression>" replace the line matching the regular expression')
@@ -7126,8 +6981,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         logger.info('')
         logger.info( '   example: edit reweight --after_line="change mode\b" change model heft')
         logger.info( '            edit madspin  --after_line="banner" change model XXXX')
-        logger.info('********************* HELP ADD|EDIT ***************************') 
-
+        logger.info('********************* HELP ADD|EDIT ***************************')
 
     def complete_add(self, text, line, begidx, endidx, formatting=True):
         """ auto-completion for add command"""
@@ -7138,20 +6992,20 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             self.stdout.write('\b'*nb_back + '[timer stopped]\n')
             self.stdout.write(line)
             self.stdout.flush()
-        
+
         split = line[:begidx].split()
         if len(split)==1:
-            possibilities = {} 
-            cards = [c.rsplit('.',1)[0] for c in self.cards]   
+            possibilities = {}
+            cards = [c.rsplit('.',1)[0] for c in self.cards]
             possibilities['category of parameter (optional)'] = \
                           self.list_completion(text, cards)
         elif len(split) == 2:
-            possibilities = {} 
-            options = ['--line_position=','--line_position=afterlast','--after_line=banner', '--after_line="','--before_line="']   
+            possibilities = {}
+            options = ['--line_position=','--line_position=afterlast','--after_line=banner', '--after_line="','--before_line="']
             possibilities['category of parameter (optional)'] = \
                           self.list_completion(text, options, line)
         else:
-            return                          
+            return
         return self.deal_multiple_categories(possibilities, formatting)
 
     def do_add(self, line):
@@ -7169,10 +7023,10 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             logger.info("add in the pythia8_card the parameter \"%s\" with value \"%s\"" % (name, value), '$MG:BOLD')
         elif len(args) > 0:
             if args[0] in self.cards:
-                card = args[0]                
+                card = args[0]
             elif "%s.dat" % args[0] in self.cards:
                 card = "%s.dat" % args[0]
-            elif "%s_card.dat" % args[0] in self.cards: 
+            elif "%s_card.dat" % args[0] in self.cards:
                 card = "%s_card.dat" % args[0]
             elif self.has_ml and args[0].lower() == "madloop":
                 card = "MadLoopParams.dat"
@@ -7183,7 +7037,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             if card in self.modified_card:
                 self.write_card(card)
                 self.modified_card.discard(card)
-                
+
             if card in self.paths:
                 path = self.paths[card]
             elif os.path.exists(card):
@@ -7192,8 +7046,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 path = pjoin(self.me_dir,'Cards',card)
             else:
                 raise Exception('unknow path')
-            
-            # handling the various option on where to write the line            
+
+            # handling the various option on where to write the line
             if args[1] == '--clean':
                 ff = open(path,'w')
                 ff.write("# %s \n" % card)
@@ -7223,7 +7077,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 ff.write('\n'.join(split))
                 logger.info("writting at line %d of the file %s the line: \"%s\"" %(pos, card, line.split(None,2)[2] ),'$MG:BOLD')
                 self.last_editline_pos = pos
-                
+
             elif args[1].startswith(('--after_line=banner','--after_line=\'banner\'','--after_line=\"banner\"')):
                 # write the line at the first not commented line
                 text = open(path).read()
@@ -7236,7 +7090,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 ff.write('\n'.join(split))
                 logger.info("writting at line %d of the file %s the line: \"%s\"" %(posline, card, line.split(None,2)[2] ),'$MG:BOLD')
                 self.last_editline_pos = posline
-                
+
             elif args[1].startswith('--replace_line='):
                 # catch the line/regular expression and replace the associate line
                 # if no line match go to check if args[2] has other instruction starting with --
@@ -7250,7 +7104,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 else:
                     new_line = re.split(search_pattern,line)[-1].strip()
                     if new_line.startswith(('--before_line=','--after_line')):
-                        return self.do_add('%s %s' % (args[0], new_line))   
+                        return self.do_add('%s %s' % (args[0], new_line))
                     raise Exception('invalid regular expression: not found in file')
                 # found the line position "posline"
                 # need to check if the a fail savety is present
@@ -7264,8 +7118,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 ff = open(path,'w')
                 ff.write('\n'.join(split))
                 logger.info("Replacing the line \"%s\" [line %d of %s] by \"%s\"" %
-                         (old_line, posline, card, new_line ),'$MG:BOLD') 
-                self.last_editline_pos = posline               
+                         (old_line, posline, card, new_line ),'$MG:BOLD')
+                self.last_editline_pos = posline
 
             elif args[1].startswith('--comment_line='):
                 # catch the line/regular expression and replace the associate line
@@ -7280,16 +7134,15 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                         split[posline] = '#%s' % l
                         nb_mod +=1
                         logger.info("Commenting line \"%s\" [line %d of %s]" %
-                         (l, posline, card ),'$MG:BOLD') 
+                         (l, posline, card ),'$MG:BOLD')
                         # overwrite the previous line
                 if not nb_mod:
                     logger.warning('no line commented (no line matching)')
                 ff = open(path,'w')
                 ff.write('\n'.join(split))
 
-                self.last_editline_pos = posline               
+                self.last_editline_pos = posline
 
-            
             elif args[1].startswith('--before_line='):
                 # catch the line/regular expression and write before that line
                 text = open(path).read()
@@ -7304,9 +7157,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 split.insert(posline, re.split(search_pattern,line)[-1])
                 ff = open(path,'w')
                 ff.write('\n'.join(split))
-                logger.info("writting at line %d of the file %s the line: \"%s\"" %(posline, card, line.split(None,2)[2] ),'$MG:BOLD')                
+                logger.info("writting at line %d of the file %s the line: \"%s\"" %(posline, card, line.split(None,2)[2] ),'$MG:BOLD')
                 self.last_editline_pos = posline
-                                
+
             elif args[1].startswith('--after_line='):
                 # catch the line/regular expression and write after that line
                 text = open(path).read()
@@ -7322,9 +7175,9 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 ff = open(path,'w')
                 ff.write('\n'.join(split))
 
-                logger.info("writting at line %d of the file %s the line: \"%s\"" %(posline+1, card, line.split(None,2)[2] ),'$MG:BOLD')                                 
+                logger.info("writting at line %d of the file %s the line: \"%s\"" %(posline+1, card, line.split(None,2)[2] ),'$MG:BOLD')
                 self.last_editline_pos = posline+1
-                                                 
+
             else:
                 ff = open(path,'a')
                 ff.write("%s \n" % line.split(None,1)[1])
@@ -7333,7 +7186,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
                 self.last_editline_pos = -1
 
             self.reload_card(path)
-            
+
     do_edit = do_add
     complete_edit = complete_add
 
@@ -7364,7 +7217,6 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
         return self.deal_multiple_categories(output, formatting)
 
-
     def do_asperge(self, line):
         """Running ASperGe"""
         signal.alarm(0) # avoid timer if any
@@ -7373,7 +7225,6 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         if 'param' in self.modified_card:
             self.write_card('param')
             self.modified_card.discard('param')
-
 
         path = pjoin(self.me_dir,'bin','internal','ufomodel','ASperGE')
         if not os.path.exists(path):
@@ -7403,14 +7254,12 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         files.mv('%s.new' % card, card)
         self.reload_card(card)
 
-
-
     def copy_file(self, path, pathname=None):
         """detect the type of the file and overwritte the current file"""
-        
+
         if not pathname:
             pathname = path
-        
+
         if path.endswith('.lhco'):
             #logger.info('copy %s as Events/input.lhco' % (path))
             #files.cp(path, pjoin(self.mother_interface.me_dir, 'Events', 'input.lhco' ))
@@ -7419,8 +7268,8 @@ class AskforEditCard(cmd.OneLinePathCompletion):
         elif path.endswith('.lhco.gz'):
             #logger.info('copy %s as Events/input.lhco.gz' % (path))
             #files.cp(path, pjoin(self.mother_interface.me_dir, 'Events', 'input.lhco.gz' ))
-            self.do_set('mw_run inputfile %s' % os.path.relpath(path, self.mother_interface.me_dir))     
-            return             
+            self.do_set('mw_run inputfile %s' % os.path.relpath(path, self.mother_interface.me_dir))
+            return
         else:
             card_name = self.detect_card_type(path)
 
@@ -7440,7 +7289,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
 
     def detect_card_type(self, path):
         """detect card type"""
-        
+
         return CommonRunCmd.detect_card_type(path)
 
     def open_file(self, answer):
@@ -7450,7 +7299,7 @@ class AskforEditCard(cmd.OneLinePathCompletion):
             me_dir = self.mother_interface.me_dir
         except:
             me_dir = None
-            
+
         if answer.isdigit():
             if answer == '9':
                 answer = 'plot'
@@ -7507,13 +7356,13 @@ You can also copy/paste, your event file here.''')
             else:
                 raise
         self.reload_card(path)
-        
-    def reload_card(self, path): 
+
+    def reload_card(self, path):
         """reload object to have it in sync"""
 
-        if path == self.paths['param']:        
+        if path == self.paths['param']:
             try:
-                self.param_card = param_card_mod.ParamCard(path) 
+                self.param_card = param_card_mod.ParamCard(path)
             except (param_card_mod.InvalidParamCard, ValueError) as e:
                 logger.error('Current param_card is not valid. We are going to use the default one.')
                 logger.error('problem detected: %s' % e)
@@ -7543,7 +7392,6 @@ You can also copy/paste, your event file here.''')
             logger.debug('not keep in sync: %s', path)
         return path
 
-
 # A decorator function to handle in a nice way scan/auto width
 def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'param_card.dat'),
                       store_for_scan=lambda obj: obj.store_scan_result,
@@ -7557,7 +7405,7 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                       ):
     """ This is a decorator for customizing/using scan over the param_card (or technically other)
     This should be use like this:
-    
+
     @scanparamcardhandling(arguments)
     def run_launch(self, *args, **opts)
 
@@ -7571,48 +7419,48 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
     ignoreerror -> one class of error which are not for the error
     IteratorClass -> class to use for the iterator
     summaryorder -> function that return the function to call to get the order
-    
+
     advanced:
     check_card -> function that return the function to read the card and init stuff (compute auto-width/init self.iterator/...)
                   This function should define the self.param_card_iterator if a scan exists
                   and the one calling the auto-width functionalities/...
-                  
+
     All the function are taking a single argument (an instance of the class on which the decorator is used)
     and they can either return themself a function or a string.
-    
+
     Note:
     1. the link to auto-width is not fully trivial due to the model handling
-       a. If you inherit from CommonRunCmd (or if the self.mother is). Then 
+       a. If you inherit from CommonRunCmd (or if the self.mother is). Then
        everything should be automatic.
-      
-       b. If you do not you can/should create the funtion self.get_model(). 
-          Which returns the appropriate MG model (like the one from import_ufo.import_model) 
-    
+
+       b. If you do not you can/should create the funtion self.get_model().
+          Which returns the appropriate MG model (like the one from import_ufo.import_model)
+
        c. You can also have full control by defining your own do_compute_widths(self, line)
           functions.
     """
     class restore_iterator(object):
-        """ensure that the original card is always restore even for crash"""  
+        """ensure that the original card is always restore even for crash"""
         def __init__(self, iterator, path):
             self.iterator = iterator
             self.path = path
 
         def __enter__(self):
             return self.iterator
-        
+
         def __exit__(self, ctype, value, traceback ):
             self.iterator.write(self.path)
-    
+
     def decorator(original_fct):
         def new_fct(obj, *args, **opts):
-            
+
             if isinstance(input_path, str):
                 card_path = input_path
             else:
                 card_path = input_path(obj)
-            
+
             #
-            # This is the function that 
+            # This is the function that
             #     1. compute the widths
             #     2. define the scan iterator
             #     3. raise some warning
@@ -7624,16 +7472,16 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
             if obj.param_card_iterator:
                 param_card_iterator = obj.param_card_iterator
                 obj.param_card_iterator = [] # ensure that the code does not re-trigger a scan
-            
+
             if not param_card_iterator:
                 #first run of the function
                 original_fct(obj, *args, **opts)
                 return
-            
+
             with restore_iterator(param_card_iterator, card_path):
                 # this with statement ensure that the original card is restore
                 # whatever happens inside those block
-    
+
                 if not hasattr(obj, 'allow_notification_center'):
                     obj.allow_notification_center = False
                 with misc.TMP_variable(obj, 'allow_notification_center', False):
@@ -7647,7 +7495,7 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                     for card in param_card_iterator:
                         card.write(card_path)
                         # still have to check for the auto-wdith
-                        check_card(obj)(card_path, obj, dependent=True) 
+                        check_card(obj)(card_path, obj, dependent=True)
                         next_name = param_card_iterator.get_next_name(next_name)
                         set_run_name(obj)(next_name)
                         try:
@@ -7656,16 +7504,14 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                             param_card_iterator.store_entry(next_name, {'exception': error})
                         else:
                             param_card_iterator.store_entry(next_name, store_for_scan(obj)(), param_card_path=card_path)
-                            
+
                 #param_card_iterator.write(card_path) #-> this is done by the with statement
                 name = misc.get_scan_name(orig_name, next_name)
-                path = result_path(obj) % name 
+                path = result_path(obj) % name
                 logger.info("write scan results in %s" % path ,'$MG:BOLD')
                 order = summaryorder(obj)()
                 param_card_iterator.write_summary(path, order=order)
 
         return new_fct
-    return decorator    
-
-
+    return decorator
 

--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -2,18 +2,17 @@
 #
 # Copyright (c) 2011 The MadGraph5_aMC@NLO Development team and Contributors
 #
-# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# This file is a part of the MadGraph5_aMC@NLO project, an application which
 # automatically generates Feynman diagrams and matrix elements for arbitrary
 # high-energy processes in the Standard Model and beyond.
 #
-# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this
 # distribution.
 #
 # For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
 #
 ################################################################################
 """  A file containing different extension of the cmd basic python library"""
-
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -40,7 +39,6 @@ except:
     readline = None
     GNU_SPLITTING = True
 
-
 logger = logging.getLogger('cmdprint') # for stdout
 logger_stderr = logging.getLogger('fatalerror') # for stderr
 logger_tuto = logging.getLogger('tutorial') # for stdout
@@ -55,9 +53,8 @@ except ImportError as error:
         import internal.misc as misc
     except:
         raise error
-    
-    MADEVENT = True
 
+    MADEVENT = True
 
 pjoin = os.path.join
 
@@ -67,10 +64,10 @@ class TimeOutError(Exception):
 def debug(debug_only=True):
 
     def deco_debug(f):
-        
+
         if debug_only and not __debug__:
             return f
-        
+
         def deco_f(*args, **opt):
             try:
                 return f(*args, **opt)
@@ -86,7 +83,7 @@ import string
 # The following is copy from the standard cmd routine but pass in new class type
 __all__ = ["Cmd"]
 PROMPT = '(Cmd) '
-IDENTCHARS = string.ascii_letters + string.digits + '_'            
+IDENTCHARS = string.ascii_letters + string.digits + '_'
 class OriginalCmd(object):
     """A simple framework for writing line-oriented command interpreters.
 
@@ -186,7 +183,6 @@ class OriginalCmd(object):
                 except ImportError:
                     pass
 
-
     def precmd(self, line):
         """Hook method executed just before the command line is
         interpreted, but after the input prompt is generated and issued.
@@ -284,20 +280,20 @@ class OriginalCmd(object):
 
     def completenames(self, text, *ignored):
         dotext = 'do_'+text
-        
+
         done = set() # store the command already handle
         out = []
         #misc.sprint([a for a in self.get_names() if a.startswith(dotext)])
         for a in self.get_names():
             if a.startswith(dotext) and a not in done and not done.add(a):
-                # to allow practical shortcut of type do_arg1_arg2 
+                # to allow practical shortcut of type do_arg1_arg2
                 # do not include such here
                 if ('_' not in a[3:] or '%s%s' %(dotext,a[3:].split('_',1)[0]) not in done):
                     done.add(a)
                     out.append(a[3:])
         return out
-        
-        return [a[3:] for a in self.get_names() 
+
+        return [a[3:] for a in self.get_names()
                 if a.startswith(dotext) and a not in done and not done.add(a)
                 and ('_' not in a[3:] or '%s%s' %(dotext,a[3:].split('_',1)[0]) not in done)
                 ]
@@ -454,10 +450,7 @@ class OriginalCmd(object):
                 del texts[-1]
             for col in range(len(texts)):
                 texts[col] = texts[col].ljust(colwidths[col])
-            self.stdout.write("%s\n"%str("  ".join(texts)))    
-    
-    
-
+            self.stdout.write("%s\n"%str("  ".join(texts)))
 
 #===============================================================================
 # CmdExtended
@@ -497,7 +490,7 @@ class BasicCmd(OriginalCmd):
             values = set((s[0] for s in dico.values() if len(s)==1))
             if len(values) == 1:
                 return values
-                
+
         # That's the real work
         out = []
         valid=0
@@ -511,16 +504,16 @@ class BasicCmd(OriginalCmd):
             # Remove duplicate
             d = {}
             for x in opt:
-                d[x] = 1    
+                d[x] = 1
             opt = list(d.keys())
             opt.sort()
             out += opt
 
         if not forceCategory and valid == 1:
             out = out[1:]
-            
+
         return out
-    
+
     @debug()
     def print_suggestions(self, substitution, matches, longest_match_length) :
         """print auto-completions by category"""
@@ -559,13 +552,13 @@ class BasicCmd(OriginalCmd):
                     self.stdout.write(self.completion_prefix + val + \
                                      ' ' * (longest_match_length +1 -len(val)))
                 self.stdout.write('\n')
-    
+
             self.stdout.write(self.prompt+readline.get_line_buffer())
             self.stdout.flush()
         except Exception as error:
             if __debug__:
                 logger.error(error)
-            
+
     def getTerminalSize(self):
         def ioctl_GWINSZ(fd):
             try:
@@ -589,7 +582,7 @@ class BasicCmd(OriginalCmd):
             except Exception:
                 cr = (25, 80)
         return int(cr[1])
-    
+
     def complete(self, text, state):
         """Return the next possible completion for 'text'.
          If a command has not been entered, then complete against command list.
@@ -602,7 +595,7 @@ class BasicCmd(OriginalCmd):
             stripped = len(origline) - len(line)
             begidx = readline.get_begidx() - stripped
             endidx = readline.get_endidx() - stripped
-            
+
             if ';' in line:
                 begin, line = line.rsplit(';',1)
                 begidx = begidx - len(begin) - 1
@@ -631,43 +624,43 @@ class BasicCmd(OriginalCmd):
                 to_rm = len(self.completion_prefix) - 1
                 Nbegidx = len(line.rsplit(os.path.sep, 1)[0]) + 1
                 data = compfunc(Ntext.replace('\ ', ' '), line, Nbegidx, endidx)
-                self.completion_matches = [p[to_rm:] for p in data 
-                                              if len(p)>to_rm]                
+                self.completion_matches = [p[to_rm:] for p in data
+                                              if len(p)>to_rm]
             # correct wrong splitting with '-'/"="
             elif line and line[begidx-1] in ['-',"=",':']:
-             try:    
+             try:
                 sep = line[begidx-1]
                 Ntext = line.split()[-1]
                 self.completion_prefix = Ntext.rsplit(sep,1)[0] + sep
                 to_rm = len(self.completion_prefix)
                 Nbegidx = len(line.rsplit(None, 1)[0])
                 data = compfunc(Ntext, line, Nbegidx, endidx)
-                self.completion_matches = [p[to_rm:] for p in data 
+                self.completion_matches = [p[to_rm:] for p in data
                                               if len(p)>to_rm]
              except Exception as error:
-                 print(error)                
+                 print(error)
             else:
                 self.completion_prefix = ''
                 self.completion_matches = compfunc(text, line, begidx, endidx)
 
         self.completion_matches = [ l if l[-1] in [' ','@','=',os.path.sep]
                                     else ((l + ' ') if not l.endswith('\\$') else l[:-2])
-                                  for l in self.completion_matches if l] 
-        
+                                  for l in self.completion_matches if l]
+
         try:
             return self.completion_matches[state]
         except IndexError as error:
             # if __debug__:
             #    logger.error('\n Completion ERROR:')
             #    logger.error( error)
-            return None    
-        
+            return None
+
     @staticmethod
     def split_arg(line):
         """Split a line of arguments"""
-        
+
         split = re.findall(r"(?:[^\s'\"]|(?:'|\")(?:\\.|[^\"'])*(?:\"|'))+",line)
-        
+
         out=[]
         tmp=''
         for data in split:
@@ -683,7 +676,7 @@ class BasicCmd(OriginalCmd):
             else:
                 out.append(data)
         return out
-    
+
     @staticmethod
     def list_completion(text, list, line=''):
         """Propose completions of text in list"""
@@ -695,19 +688,18 @@ class BasicCmd(OriginalCmd):
                             for f in list
                             if f.startswith(text)
                             ]
-            
+
         return completions
-            
 
     @staticmethod
-    def path_completion(text, base_dir = None, only_dirs = False, 
+    def path_completion(text, base_dir = None, only_dirs = False,
                                                                  relative=True):
         """Propose completions of text to compose a valid path"""
 
         if base_dir is None:
             base_dir = os.getcwd()
         base_dir = os.path.expanduser(os.path.expandvars(base_dir))
-        
+
         if text == '~':
             text = '~/'
         prefix, text = os.path.split(text)
@@ -742,26 +734,23 @@ class BasicCmd(OriginalCmd):
         if relative:
             completion += [prefix + f for f in ['.'+os.path.sep, '..'+os.path.sep] if \
                        f.startswith(text) and not prefix.startswith('.')]
-        
+
         completion = [a.replace(' ','\ ') for a in completion]
         return completion
-
-
-
 
 class CheckCmd(object):
     """Extension of the cmd object for only the check command"""
 
     def check_history(self, args):
         """check the validity of line"""
-        
+
         if len(args) > 1:
             self.help_history()
             raise self.InvalidCmd('\"history\" command takes at most one argument')
-        
+
         if not len(args):
             return
-        
+
         if args[0] =='.':
             if not self._export_dir:
                 raise self.InvalidCmd("No default directory is defined for \'.\' option")
@@ -770,21 +759,21 @@ class CheckCmd(object):
                 if dirpath and not os.path.exists(dirpath) or \
                        os.path.isdir(args[0]):
                     raise self.InvalidCmd("invalid path %s " % dirpath)
-    
+
     def check_save(self, args):
         """check that the line is compatible with save options"""
-        
+
         if len(args) > 2:
             self.help_save()
             raise self.InvalidCmd('too many arguments for save command.')
-        
+
         if len(args) == 2:
             if args[0] != 'options':
                 self.help_save()
                 raise self.InvalidCmd('\'%s\' is not recognized as first argument.' % \
                                                 args[0])
             else:
-                args.pop(0)           
+                args.pop(0)
 
 class HelpCmd(object):
     """Extension of the cmd object for only the help command"""
@@ -792,7 +781,7 @@ class HelpCmd(object):
     def help_quit(self):
         logger.info("-- terminates the application",'$MG:color:BLUE')
         logger.info("syntax: quit",'$MG:BOLD')
-    
+
     help_EOF = help_quit
 
     def help_history(self):
@@ -802,7 +791,7 @@ class HelpCmd(object):
         logger.info("   Cards/proc_card_mg5.dat will be used.")
         logger.info(" > If FILEPATH is omitted, the history will be output to stdout.")
         logger.info("   \"clean\" will remove all entries from the history.")
-        
+
     def help_help(self):
         logger.info("-- access to the in-line help",'$MG:color:BLUE')
         logger.info("syntax: help",'$MG:BOLD')
@@ -810,22 +799,22 @@ class HelpCmd(object):
     def help_save(self):
         """help text for save"""
         logger.info("-- save options configuration to filepath.",'$MG:color:BLUE')
-        logger.info("syntax: save [options]  [FILEPATH]",'$MG:BOLD') 
-        
+        logger.info("syntax: save [options]  [FILEPATH]",'$MG:BOLD')
+
     def help_display(self):
         """help for display command"""
-        logger.info("-- display a the status of various internal state variables",'$MG:color:BLUE')          
+        logger.info("-- display a the status of various internal state variables",'$MG:color:BLUE')
         logger.info("syntax: display " + "|".join(self._display_opts),'$MG:BOLD')
-        
+
 class CompleteCmd(object):
     """Extension of the cmd object for only the complete command"""
 
-    def complete_display(self,text, line, begidx, endidx):        
+    def complete_display(self,text, line, begidx, endidx):
         args = self.split_arg(line[0:begidx])
         # Format
         if len(args) == 1:
             return self.list_completion(text, self._display_opts)
-        
+
     def complete_history(self, text, line, begidx, endidx):
         "Complete the history command"
 
@@ -868,14 +857,14 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
     #suggested list of command
     next_possibility = {} # command : [list of suggested command]
     history_header = ""
-    
+
     _display_opts = ['options','variable']
     allow_notification_center = True
-    
+
     class InvalidCmd(Exception):
         """expected error for wrong command"""
-        pass    
-    
+        pass
+
     ConfigurationError = InvalidCmd
 
     debug_output = 'debug'
@@ -883,7 +872,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
            More information is found in '%(debug)s'.\n
            Please attach this file to your report."""
     config_debug = error_debug
-           
+
     keyboard_stop_msg = """stopping all current operation
             in order to quit the program please enter exit"""
 
@@ -904,10 +893,10 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             else:
                 continue
             break
-    
+
     def __init__(self, *arg, **opt):
         """Init history and line continuation"""
-        
+
         self.log = True
         self.history = []
         self.save_line = '' # for line splitting
@@ -916,8 +905,8 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         self.child = None # sub CMD interface call from this one
         self.mother = None #This CMD interface was called from another one
         self.inputfile = None # input file (in non interactive mode)
-        self.haspiping = not sys.stdin.isatty() # check if mg5 is piped 
-        self.stored_line = '' # for be able to treat answer to question in input file 
+        self.haspiping = not sys.stdin.isatty() # check if mg5 is piped
+        self.stored_line = '' # for be able to treat answer to question in input file
                               # answer which are not required.
         if not hasattr(self, 'helporder'):
             self.helporder = ['Documented commands']
@@ -936,9 +925,8 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if readline and not 'libedit' in readline.__doc__:
             readline.set_completion_display_matches_hook(self.print_suggestions)
 
-    
     def cmdloop(self, intro=None):
-        
+
         self.preloop()
         if intro is not None:
             self.intro = intro
@@ -973,54 +961,53 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             finally:
                 stop = self.postcmd(stop, line)
         self.postloop()
-            
+
     def no_notification(self):
         """avoid to have html opening / notification"""
         self.allow_notification_center = False
         try:
             self.options['automatic_html_opening'] = False
             self.options['notification_center'] = False
-            
+
         except:
             pass
-    
-      
+
     def precmd(self, line):
         """ A suite of additional function needed for in the cmd
         this implement history, line breaking, comment treatment,...
         """
-        
+
         if not line:
             return line
 
         # Check if we are continuing a line:
         if self.save_line:
-            line = self.save_line + line 
+            line = self.save_line + line
             self.save_line = ''
-            
-        line = line.lstrip()        
+
+        line = line.lstrip()
         # Check if the line is complete
         if line.endswith('\\'):
-            self.save_line = line[:-1] 
-            return '' # do nothing   
-                
+            self.save_line = line[:-1]
+            return '' # do nothing
+
         # Remove comment
         if '#' in line:
             line = line.split('#')[0]
 
         # Deal with line splitting
-        if ';' in line: 
+        if ';' in line:
             lines = line.split(';')
             for subline in lines:
                 if not (subline.startswith("history") or subline.startswith('help') \
-                        or subline.startswith('#*')): 
-                    self.history.append(subline)           
+                        or subline.startswith('#*')):
+                    self.history.append(subline)
                 stop = self.onecmd_orig(subline)
                 stop = self.postcmd(stop, subline)
             return ''
-            
+
         # execute the line command
-        self.history.append(line) 
+        self.history.append(line)
         return line
 
     def postcmd(self,stop, line):
@@ -1043,8 +1030,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         # We are in a file reading mode. So we need to redirect the cmd
         self.child = obj_instance
         self.child.mother = self
-        
-        
+
         #ensure that notification are sync:
         self.child.allow_notification_center = self.allow_notification_center
 
@@ -1056,28 +1042,28 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if self.inputfile:
             # we are in non interactive mode -> so pass the line information
             obj_instance.inputfile = self.inputfile
-        
+
         obj_instance.haspiping = self.haspiping
-        
+
         if not interface:
             return self.child
- 
+
     #===============================================================================
     # Ask a question with nice options handling
-    #===============================================================================    
-    def ask(self, question, default, choices=[], path_msg=None, 
+    #===============================================================================
+    def ask(self, question, default, choices=[], path_msg=None,
             timeout = True, fct_timeout=None, ask_class=None, alias={},
-            first_cmd=None, text_format='4', force=False, 
+            first_cmd=None, text_format='4', force=False,
             return_instance=False, **opt):
         """ ask a question with some pre-define possibility
             path info is
         """
-        
+
         if path_msg:
             path_msg = [path_msg]
         else:
             path_msg = []
-            
+
         if timeout is True:
             try:
                 timeout = self.options['timeout']
@@ -1087,20 +1073,20 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         # add choice info to the question
         if choices + path_msg:
             question += ' ['
-            question += "\033[%sm%s\033[0m, " % (text_format, default)    
+            question += "\033[%sm%s\033[0m, " % (text_format, default)
             for data in choices[:9] + path_msg:
                 if default == data:
                     continue
                 else:
                     question += "%s, " % data
-                    
+
             if len(choices) > 9:
-                question += '... , ' 
+                question += '... , '
             question = question[:-2]+']'
         else:
-            question += "[\033[%sm%s\033[0m] " % (text_format, default)    
+            question += "[\033[%sm%s\033[0m] " % (text_format, default)
         if ask_class:
-            obj = ask_class  
+            obj = ask_class
         elif path_msg:
             obj = OneLinePathCompletion
         else:
@@ -1108,10 +1094,10 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
 
         if alias:
             choices += list(alias.keys())
-        
-        question_instance = obj(question, allow_arg=choices, default=default, 
+
+        question_instance = obj(question, allow_arg=choices, default=default,
                                                    mother_interface=self, **opt)
-        
+
         if first_cmd:
             if isinstance(first_cmd, str):
                 question_instance.onecmd(first_cmd)
@@ -1121,7 +1107,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if not self.haspiping:
             if hasattr(obj, "haspiping"):
                 obj.haspiping = self.haspiping
-        
+
         if force:
             answer = default
         else:
@@ -1134,7 +1120,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                     answer = question_instance.default(line)
                     question_instance.postcmd(answer, line)
                     if not return_instance:
-                        return question_instance.answer 
+                        return question_instance.answer
                     else:
                         return question_instance.answer , question_instance
                 if hasattr(question_instance, 'check_answer_consistency'):
@@ -1143,7 +1129,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                     return answer
                 else:
                     return answer, question_instance
-        
+
         question = question_instance.question
         if not force:
             value =   Cmd.timed_input(question, default, timeout=timeout,
@@ -1161,27 +1147,25 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             value = question_instance.default(default)
             if hasattr(question_instance, 'answer'):
                 value = question_instance.answer
-           
 
         if not return_instance:
             return value
         else:
             return value, question_instance
- 
+
     def do_import(self, line):
         """Advanced commands: Import command files"""
 
         args = self.split_arg(line)
         # Check argument's validity
         self.check_import(args)
-        
+
         # Execute the card
         self.import_command_file(args[1])
-    
-        
+
     def check_import(self, args):
         """check import command"""
-        
+
         if '-f' in args:
             self.force = True
             args.remove('-f')
@@ -1191,18 +1175,16 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             raise self.InvalidCmd('import command requires one filepath argument')
         if not os.path.exists(args[1]):
             raise 'No such file or directory %s' % args[1]
-        
-    
+
     def check_answer_in_input_file(self, question_instance, default, path=False, line=None):
         """Questions can have answer in output file (or not)"""
-
 
         if not self.inputfile:
             return None# interactive mode
 
         if line is None:
             line = self.get_stored_line()
-            # line define if a previous answer was not answer correctly 
+            # line define if a previous answer was not answer correctly
 
         if not line:
             try:
@@ -1216,9 +1198,9 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 logger.info('The answer to the previous question is not set in your input file', '$MG:BOLD')
                 logger.info('Use %s value' % default, '$MG:BOLD')
                 return str(default)
-            
+
         line = line.replace('\n','').strip()
-        if '#' in line: 
+        if '#' in line:
             line = line.split('#')[0]
         if not line:
             # Comment or empty line, pass to the next one
@@ -1245,7 +1227,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             for entry in question_instance.allow_arg:
                 if line.lower() == entry.lower():
                     return entry
-        elif any(line.lower()==opt.lower() for opt in options): 
+        elif any(line.lower()==opt.lower() for opt in options):
             possibility = [opt for opt in options if line.lower()==opt.lower()]
             if len (possibility)==1:
                 return possibility[0]
@@ -1254,18 +1236,16 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             line,n = re.subn('\s*=\s*','=', line)
             if n and len(line) != leninit:
                 return self.check_answer_in_input_file(question_instance, default, path=path, line=line)
-            
 
         if hasattr(question_instance, 'special_check_answer_in_input_file'):
             out = question_instance.special_check_answer_in_input_file(line, default)
-            
+
             if out is not None:
                 return out
-            
+
         #else:
         #    misc.sprint('No special check', type(question_instance))
-        
-            
+
         # No valid answer provides
         if self.haspiping:
             self.store_line(line)
@@ -1273,13 +1253,13 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         else:
             logger.info(question_instance.question)
             logger.warning('found line : %s' % line)
-            logger.warning('This answer is not valid for current question. Keep it for next question and use here default: %s', default) 
+            logger.warning('This answer is not valid for current question. Keep it for next question and use here default: %s', default)
             self.store_line(line)
             return str(default)
 
     def store_line(self, line):
         """store a line of the input file which should be executed by the higher mother"""
-        
+
         if self.mother:
             self.mother.store_line(line)
         else:
@@ -1292,17 +1272,15 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             self.mother.stored_line = None
         else:
             value = self.stored_line
-            self.stored_line = None    
+            self.stored_line = None
         return value
 
-
-
     def nice_error_handling(self, error, line):
-        """ """ 
+        """ """
         # Make sure that we are at the initial position
         if self.child:
             return self.child.nice_error_handling(error, line)
-        
+
         os.chdir(self.__initpos)
         # Create the debug files
         self.log = False
@@ -1325,18 +1303,17 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             error_text += '\"%s\" with error:\n' % self.history[-1]
         else:
             error_text = ''
-        error_text += '%s : %s\n' % (error.__class__.__name__, 
+        error_text += '%s : %s\n' % (error.__class__.__name__,
                                             str(error).replace('\n','\n\t'))
         error_text += self.error_debug % {'debug':self.debug_output}
         logger_stderr.critical(error_text)
-        
-                
+
         # Add options status to the debug file
         try:
             self.do_display('options', debug_file)
         except Exception as error:
             debug_file.write('Fail to write options with error %s' % error)
-        
+
         #add the cards:
         for card in ['proc_card_mg5.dat','param_card.dat', 'run_card.dat']:
             try:
@@ -1345,29 +1322,27 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 ff.close()
             except Exception:
                 pass
-            
+
         if hasattr(self, 'options') and 'crash_on_error' in self.options:
             if self.options['crash_on_error'] is True:
                 logger.info('stop computation due to crash_on_error=True')
-                raise 
+                raise
                 sys.exit(str(error))
             elif self.options['crash_on_error'] == 'never':
                 return False
-            
+
         #stop the execution if on a non interactive mode
         if self.use_rawinput == False or self.inputfile:
             return True
         elif self.mother:
             if self.mother.use_rawinput is False:
                 return True
-                
+
             elif self.mother.mother:
                 if self.mother.mother.use_rawinput is False:
-                    return True 
-        
+                    return True
+
         return False
-
-
 
     def nice_user_error(self, error, line):
         if self.child:
@@ -1379,11 +1354,11 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             error_text = 'Command \"%s\" interrupted with error:\n' % line
         else:
             error_text = 'Command \"%s\" interrupted in sub-command:\n' %line
-            error_text += '\"%s\" with error:\n' % self.history[-1] 
-        error_text += '%s : %s' % (error.__class__.__name__, 
+            error_text += '\"%s\" with error:\n' % self.history[-1]
+        error_text += '%s : %s' % (error.__class__.__name__,
                                                 str(error).replace('\n','\n\t'))
         logger_stderr.error(error_text)
-        
+
         if hasattr(self, 'options') and 'crash_on_error' in self.options:
             if self.options['crash_on_error'] is True:
                 logger.info('stop computation due to crash_on_error=True')
@@ -1400,17 +1375,17 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 return True
             elif self.mother.mother:
                 if self.mother.mother.use_rawinput is False:
-                    return True                
-            
+                    return True
+
         # Remove failed command from history
         self.history.pop()
         return False
-    
+
     def nice_config_error(self, error, line):
         if self.child:
             return self.child.nice_user_error(error, line)
 
-        # Make sure that we are at the initial position                                 
+        # Make sure that we are at the initial position
         os.chdir(self.__initpos)
         if not self.history or line == self.history[-1]:
             error_text = 'Error detected in \"%s\"\n' % line
@@ -1429,13 +1404,13 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         error_text += '%s : %s' % (error.__class__.__name__,
                                                 str(error).replace('\n','\n\t'))
         logger_stderr.error(error_text)
-        
+
         # Add options status to the debug file
         try:
             self.do_display('options', debug_file)
         except Exception as error:
             debug_file.write('Fail to write options with error %s' % error)
-            
+
         if hasattr(self, 'options') and 'crash_on_error' in self.options:
             if self.options['crash_on_error'] is True:
                 logger.info('stop computation due to crash_on_error=True')
@@ -1444,9 +1419,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 if self.history:
                     self.history.pop()
                 return False
-            
 
-        
         #stop the execution if on a non interactive mode
         if self.use_rawinput == False or self.inputfile:
             return True
@@ -1455,27 +1428,27 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 return True
             elif self.mother.mother:
                 if self.mother.mother.use_rawinput is False:
-                    return True                             
+                    return True
 
-        # Remove failed command from history                                            
+        # Remove failed command from history
         if self.history:
             self.history.pop()
         return False
-    
+
     def onecmd_orig(self, line, **opt):
         """Interpret the argument as though it had been typed in response
         to the prompt.
 
         The return value is a flag indicating whether interpretation of
         commands by the interpreter should stop.
-        
+
         This allow to pass extra argument for internal call.
         """
         if '~/' in line and 'HOME' in os.environ:
             line = line.replace('~/', '%s/' % os.environ['HOME'])
         if '#' in line:
             line = line.split('#')[0]
-             
+
         line = os.path.expandvars(line)
         cmd, arg, line = self.parseline(line)
         if not line:
@@ -1493,15 +1466,15 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             return func(arg, **opt)
 
     def error_handling(self, error, line):
-        
+
         me_dir = ''
         if hasattr(self, 'me_dir'):
             me_dir = os.path.basename(me_dir) + ' '
-        
+
         misc.EasterEgg('error')
         stop=False
         try:
-            raise 
+            raise
         except self.InvalidCmd as error:
             if __debug__:
                 stop = self.nice_error_handling(error, line)
@@ -1534,28 +1507,24 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if stop:
             self.do_quit('all')
         return stop
-        
-
 
     def onecmd(self, line, **opt):
         """catch all error and stop properly command accordingly"""
-           
+
         try:
             return self.onecmd_orig(line, **opt)
-        except BaseException as error: 
+        except BaseException as error:
             return self.error_handling(error, line)
-            
-    
+
     def stop_on_keyboard_stop(self):
         """action to perform to close nicely on a keyboard interupt"""
         pass # dummy function
-            
-    def exec_cmd(self, line, errorhandling=False, printcmd=True, 
+
+    def exec_cmd(self, line, errorhandling=False, printcmd=True,
                                      precmd=False, postcmd=True,
                                      child=True, **opt):
         """for third party call, call the line with pre and postfix treatment
         without global error handling """
-
 
         if printcmd and not line.startswith('#'):
             logger.info(line)
@@ -1566,25 +1535,25 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if precmd:
             line = current_interface.precmd(line)
         if errorhandling or \
-            (hasattr(self, 'options') and 'crash_on_error' in self.options and 
+            (hasattr(self, 'options') and 'crash_on_error' in self.options and
              self.options['crash_on_error']=='never'):
             stop = current_interface.onecmd(line, **opt)
         else:
             stop = Cmd.onecmd_orig(current_interface, line, **opt)
         if postcmd:
             stop = current_interface.postcmd(stop, line)
-        return stop      
+        return stop
 
     def run_cmd(self, line):
         """for third party call, call the line with pre and postfix treatment
         with global error handling"""
-        
+
         return self.exec_cmd(line, errorhandling=True, precmd=True)
-    
+
     def emptyline(self):
         """If empty line, do nothing. Default is repeat previous command."""
         pass
-    
+
     def default(self, line, log=True):
         """Default action if line is not recognized"""
 
@@ -1595,13 +1564,13 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         if line.strip() in ['q', '.q', 'stop']:
             logger.info("If you want to quit mg5 please type \"exit\".")
 
-        if self.history and self.history[-1] == line:        
+        if self.history and self.history[-1] == line:
             self.history.pop()
-             
+
     # Write the list of command line use in this session
     def do_history(self, line):
         """write in a file the suite of command that was used"""
-        
+
         args = self.split_arg(line)
         # Check arguments validity
         self.check_history(args)
@@ -1619,11 +1588,11 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             output_file = open(output_file, 'w')
         else:
             output_file = open(args[0], 'w')
-            
+
         # Create the command file
         text = self.get_history_header()
-        text += ('\n'.join(self.history) + '\n') 
-        
+        text += ('\n'.join(self.history) + '\n')
+
         #write this information in a file
         output_file.write(text)
         output_file.close()
@@ -1642,7 +1611,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         """remove all line in history (but the last) starting with line.
         up to the point when a line didn't start by something in no_break.
         (reading in reverse order)"""
-        
+
         new_history = []
         for i in range(1, len(self.history)+1):
             cur_line = self.history[-i]
@@ -1657,20 +1626,18 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 continue
             else:
                 new_history.append(cur_line)
-            
+
         new_history.reverse()
         self.history[:] = new_history
-        
-                        
+
     def import_command_file(self, filepath):
         # remove this call from history
         if self.history:
             self.history.pop()
-        
 
         #avoid that command of other file interfere with this one.
         previous_store_line = self.get_stored_line()
-        
+
         # Read the lines of the file and execute them
         if isinstance(filepath, str):
             commandline = open(filepath).readlines()
@@ -1684,7 +1651,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         # filepath can be overwritten during the run (leading to weird results)
         # Note also that we need a generator and not a list.
         for line in self.inputfile:
-            
+
             #remove pointless spaces and \n
             line = line.replace('\n', '').strip()
             # execute the line
@@ -1698,25 +1665,25 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
 
         # If a child was open close it
         if self.child:
-            self.child.exec_cmd('quit')        
+            self.child.exec_cmd('quit')
         self.inputfile = oldinputfile
-        self.use_rawinput = oldraw   
-        
+        self.use_rawinput = oldraw
+
         # restore original store line
         cmd = self
         while hasattr(cmd, 'mother') and cmd.mother:
             cmd = cmd.mother
         cmd.stored_line = previous_store_line
         return
-    
+
     def get_history_header(self):
         """Default history header"""
-        
+
         return self.history_header
-    
+
     def postloop(self):
         """ """
-        
+
         if self.use_rawinput and self.completekey:
             try:
                 import readline
@@ -1726,7 +1693,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 pass
             except AttributeError:
                 pass
-        
+
         args = self.split_arg(self.lastcmd)
         if args and args[0] in ['quit','exit']:
             if 'all' in args:
@@ -1734,28 +1701,28 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             if len(args) >1 and args[1].isdigit():
                 if args[1] not in  ['0', '1']:
                     return True
-                                
+
         return False
-        
+
     #===============================================================================
     # Ask a question with a maximum amount of time to answer
-    #===============================================================================    
+    #===============================================================================
     @staticmethod
     def timed_input(question, default, timeout=None, noerror=True, fct=None,
                     fct_timeout=None):
         """ a question with a maximal time to answer take default otherwise"""
-    
-        def handle_alarm(signum, frame): 
+
+        def handle_alarm(signum, frame):
             raise TimeOutError
-        
+
         signal.signal(signal.SIGALRM, handle_alarm)
-    
+
         if fct is None:
             fct = six.moves.input
-        
+
         if timeout:
             signal.alarm(timeout)
-            question += '[%ss to answer] ' % (timeout)    
+            question += '[%ss to answer] ' % (timeout)
         try:
             result = fct(question)
         except TimeOutError:
@@ -1773,15 +1740,10 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             fct_timeout(False)
         return result
 
-
-
-        
-
-
     # Quit
     def do_quit(self, line):
         """Not in help: exit the mainloop() """
-        
+
         if self.child:
             self.child.exec_cmd('quit ' + line, printcmd=False)
             return
@@ -1796,7 +1758,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                     self.mother.lastcmd = 'quit %s' % level
         elif self.inputfile:
             for line in self.inputfile:
-                logger.warning('command not executed: %s' % line.replace('\n','')) 
+                logger.warning('command not executed: %s' % line.replace('\n',''))
 
         return True
 
@@ -1806,12 +1768,11 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
 
     def do_help(self, line):
         """Not in help: propose some usefull possible action """
-                
+
         # if they are an argument use the default help
         if line:
             return super(Cmd, self).do_help(line)
-        
-        
+
         names = self.get_names()
         cmds = {}
         names.sort()
@@ -1838,8 +1799,8 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 if tag in cmds:
                     cmds[tag].append(cmdname)
                 else:
-                    cmds[tag] = [cmdname] 
-                    
+                    cmds[tag] = [cmdname]
+
         self.stdout.write("%s\n"%str(self.doc_leader))
         for tag in self.helporder:
             if tag not in cmds:
@@ -1854,28 +1815,27 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             header = "%s (type help <topic>):" % name
             self.print_topics(header, item,   15,80)
 
-
         ## Add contextual help
         if len(self.history) == 0:
             last_action_2 = last_action = 'start'
         else:
             last_action_2 = last_action = 'none'
-        
+
         pos = 0
-        authorize = list(self.next_possibility.keys()) 
+        authorize = list(self.next_possibility.keys())
         while last_action_2  not in authorize and last_action not in authorize:
             pos += 1
             if pos > len(self.history):
                 last_action_2 = last_action = 'start'
                 break
-            
+
             args = self.history[-1 * pos].split()
             last_action = args[0]
-            if len(args)>1: 
+            if len(args)>1:
                 last_action_2 = '%s %s' % (last_action, args[1])
-            else: 
+            else:
                 last_action_2 = 'none'
-        
+
         logger.info('Contextual Help')
         logger.info('===============')
         if last_action_2 in authorize:
@@ -1886,25 +1846,25 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             return
         text = 'The following command(s) may be useful in order to continue.\n'
         for option in options:
-            text+='\t %s \n' % option      
+            text+='\t %s \n' % option
         logger.info(text)
 
     def do_display(self, line, output=sys.stdout):
         """Advanced commands: basic display"""
-        
+
         args = self.split_arg(line)
         #check the validity of the arguments
-        
+
         if len(args) == 0:
             self.help_display()
             raise self.InvalidCmd('display require at least one argument')
-        
+
         if args[0] == "options":
-            outstr = "Value of current Options:\n" 
+            outstr = "Value of current Options:\n"
             for key, value in self.options.items():
                 outstr += '%25s \t:\t%s\n' %(key,value)
             output.write(outstr)
-            
+
         elif args[0] == "variable":
             outstr = "Value of Internal Variable:\n"
             try:
@@ -1912,9 +1872,9 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             except Exception:
                 outstr += 'GLOBAL:\nVariable %s is not a global variable\n' % args[1]
             else:
-                outstr += 'GLOBAL:\n' 
+                outstr += 'GLOBAL:\n'
                 outstr += misc.nice_representation(var, nb_space=4)
-               
+
             try:
                 var = eval('self.%s' % args[1])
             except Exception:
@@ -1925,7 +1885,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
             split =  args[1].split('.')
             for i, name in enumerate(split):
                 try:
-                    __import__('.'.join(split[:i+1]))                    
+                    __import__('.'.join(split[:i+1]))
                     exec('%s=sys.modules[\'%s\']' % (split[i], '.'.join(split[:i+1])))
                 except ImportError:
                     try:
@@ -1935,27 +1895,34 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                         break
                     else:
                         outstr += 'EXTERNAL:\n'
-                        outstr += misc.nice_representation(var, nb_space=4)                        
+                        outstr += misc.nice_representation(var, nb_space=4)
                 else:
                     var = eval(args[1])
                     outstr += 'EXTERNAL:\n'
-                    outstr += misc.nice_representation(var, nb_space=4)                        
-            
+                    outstr += misc.nice_representation(var, nb_space=4)
+
             pydoc.pager(outstr)
-    
-    
+
     def do_save(self, line, check=True):
         """Save the configuration file"""
-        
+
         args = self.split_arg(line)
         # Check argument validity
         if check:
             Cmd.check_save(self, args)
-            
+
         # find base file for the configuration
-        if 'HOME' in os.environ and os.environ['HOME']  and \
-        os.path.exists(pjoin(os.environ['HOME'], '.mg5', 'mg5_configuration.txt')):
-            base = pjoin(os.environ['HOME'], '.mg5', 'mg5_configuration.txt')
+        legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+        if os.path.exists(legacy_config_dir):
+            config_dir = legacy_config_dir
+        else:
+            config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
+
+        config_file = os.path.join(config_dir, 'mg5_configuration.txt')
+
+        if 'HOME' in os.environ and os.environ['HOME'] and os.path.exists(config_file):
+            base = config_file
             if hasattr(self, 'me_dir'):
                 basedir = self.me_dir
             elif not MADEVENT:
@@ -1965,7 +1932,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         elif MADEVENT:
             # launch via ./bin/madevent
             for config_file in ['me5_configuration.txt', 'amcatnlo_configuration.txt']:
-                if os.path.exists(pjoin(self.me_dir, 'Cards', config_file)): 
+                if os.path.exists(pjoin(self.me_dir, 'Cards', config_file)):
                     base = pjoin(self.me_dir, 'Cards', config_file)
             basedir = self.me_dir
         else:
@@ -1975,15 +1942,15 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                     self.write_configuration(base, base, self.me_dir)
             base = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
             basedir = MG5DIR
-            
+
         if len(args) == 0:
             args.append(base)
         self.write_configuration(args[0], base, basedir, self.options)
-        
+
     def write_configuration(self, filepath, basefile, basedir, to_keep):
         """Write the configuration file"""
         # We use the default configuration file as a template.
-        # to ensure that all configuration information are written we 
+        # to ensure that all configuration information are written we
         # keep track of all key that we need to write.
 
         logger.info('save configuration file to %s' % filepath)
@@ -1994,18 +1961,18 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         for line in open(basefile):
             if '=' in line:
                 data, value = line.split('=',1)
-            else: 
+            else:
                 text += line
                 continue
             data = data.strip()
             if data.startswith('#'):
                 key = data[1:].strip()
-            else: 
-                key = data 
+            else:
+                key = data
             if '#' in value:
                 value, comment = value.split('#',1)
             else:
-                comment = ''    
+                comment = ''
             if key in to_keep:
                 value = str(to_keep[key])
             else:
@@ -2017,7 +1984,7 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 to_write.remove(key)
             except Exception:
                 pass
-            if '_path' in key:       
+            if '_path' in key:
                 # special case need to update path
                 # check if absolute path
                 if not os.path.isabs(value):
@@ -2026,17 +1993,14 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
         for key in to_write:
             if key in to_keep:
                 text += '%s = %s \n' % (key, to_keep[key])
-        
+
         if not MADEVENT and not has_mg5_path:
             text += """\n# MG5 MAIN DIRECTORY\n"""
-            text += "mg5_path = %s\n" % MG5DIR         
-        
+            text += "mg5_path = %s\n" % MG5DIR
+
         writer = open(filepath,'w')
         writer.write(text)
         writer.close()
-                       
-
-    
 
 class CmdShell(Cmd):
     """CMD command with shell activate"""
@@ -2050,7 +2014,7 @@ class CmdShell(Cmd):
         else:
             logging.info("running shell command: " + line)
             subprocess.call(line, shell=True)
-    
+
     def complete_shell(self, text, line, begidx, endidx):
         """ add path for shell """
 
@@ -2068,10 +2032,8 @@ class CmdShell(Cmd):
 
     def help_shell(self):
         """help for the shell"""
-        logger.info("-- run the shell command CMD and catch output",'$MG:color:BLUE')        
+        logger.info("-- run the shell command CMD and catch output",'$MG:color:BLUE')
         logger.info("syntax: shell CMD (or ! CMD)",'$MG:BOLD')
-
-
 
 class NotValidInput(Exception): pass
 #===============================================================================
@@ -2086,12 +2048,12 @@ class SmartQuestion(BasicCmd):
         self.prompt = '>'
         self.value = None
         BasicCmd.preloop(self)
-        
+
     @property
     def answer(self):
         return self.value
 
-    def __init__(self, question, allow_arg=[], default=None, 
+    def __init__(self, question, allow_arg=[], default=None,
                                             mother_interface=None, *arg, **opt):
 
         self.question = question
@@ -2106,13 +2068,13 @@ class SmartQuestion(BasicCmd):
             del opt['case']
         elif 'casesensitive' in opt:
             self.casesensitive = opt['casesensitive']
-            del opt['casesensitive']            
+            del opt['casesensitive']
         else:
             self.casesensistive = True
         super(SmartQuestion, self).__init__(*arg, **opt)
 
     def __call__(self, question, reprint_opt=True, **opts):
-        
+
         self.question = question
         for key,value in opts:
             setattr(self, key, value)
@@ -2121,7 +2083,6 @@ class SmartQuestion(BasicCmd):
             logger_tuto.info("Need help here? type 'help'", '$MG:BOLD')
             logger_plugin.info("Need help here? type 'help'" , '$MG:BOLD')
         return self.cmdloop()
-        
 
     def completenames(self, text, line, *ignored):
         prev_timer = signal.alarm(0) # avoid timer if any
@@ -2134,18 +2095,18 @@ class SmartQuestion(BasicCmd):
             out = {}
             out[' Options'] = Cmd.list_completion(text, self.allow_arg)
             out[' Recognized command'] = super(SmartQuestion, self).completenames(text,line, *ignored)
-            
+
             return self.deal_multiple_categories(out)
         except Exception as error:
             print(error)
-    
+
     completedefault = completenames
 
     def get_names(self):
         # This method used to pull in base class attributes
         # at a time dir() didn't do it yet.
-        return dir(self)  
-    
+        return dir(self)
+
     def onecmd(self, line, **opt):
         """catch all error and stop properly command accordingly
         Interpret the argument as though it had been typed in response
@@ -2153,7 +2114,7 @@ class SmartQuestion(BasicCmd):
 
         The return value is a flag indicating whether interpretation of
         commands by the interpreter should stop.
-        
+
         This allow to pass extra argument for internal call.
         """
         try:
@@ -2173,17 +2134,17 @@ class SmartQuestion(BasicCmd):
                     func = getattr(self, 'do_' + cmd)
                 except AttributeError:
                     return self.default(line)
-                return func(arg, **opt)        
+                return func(arg, **opt)
         except Exception as error:
-            logger.warning(error)  
+            logger.warning(error)
             if __debug__:
                 raise
-            
+
     def reask(self, reprint_opt=True):
         pat = re.compile('\[(\d*)s to answer\]')
         prev_timer = signal.alarm(0) # avoid timer if any
-        
-        if prev_timer:     
+
+        if prev_timer:
             if pat.search(self.question):
                 timeout = int(pat.search(self.question).groups()[0])
                 signal.alarm(timeout)
@@ -2193,43 +2154,43 @@ class SmartQuestion(BasicCmd):
             print(self.question)
 
         if self.mother_interface:
-            answer = self.mother_interface.check_answer_in_input_file(self, 'EOF', 
+            answer = self.mother_interface.check_answer_in_input_file(self, 'EOF',
                                                                 path=self.allowpath)
             if answer:
                 stop = self.default(answer)
                 self.postcmd(stop, answer)
                 return False
-            
+
         return False
-    
+
     def do_help(self, line):
-        
+
         text=line
         out ={}
         out['Options'] = Cmd.list_completion(text, self.allow_arg)
         out['command'] = BasicCmd.completenames(self, text)
-        
+
         if not text:
             if out['Options']:
                 logger.info( "Here is the list of all valid options:", '$MG:BOLD')
                 logger.info( "  "+  "\n  ".join(out['Options']))
-            if out['command']: 
+            if out['command']:
                 logger.info( "Here is the list of command available:", '$MG:BOLD')
                 logger.info( "  "+  "\n  ".join(out['command']))
         else:
             if out['Options']:
                 logger.info( "Here is the list of all valid options starting with \'%s\'" % text, '$MG:BOLD')
                 logger.info( "  "+  "\n  ".join(out['Options']))
-            if out['command']: 
+            if out['command']:
                 logger.info( "Here is the list of command available starting with \'%s\':" % text, '$MG:BOLD')
                 logger.info( "  "+  "\n  ".join(out['command']))
             elif not  out['Options']:
-                logger.info( "No possibility starting with \'%s\'" % text, '$MG:BOLD')           
+                logger.info( "No possibility starting with \'%s\'" % text, '$MG:BOLD')
         logger.info( "You can type help XXX, to see all command starting with XXX", '$MG:BOLD')
     def complete_help(self, text, line, begidx, endidx):
         """ """
         return self.completenames(text, line)
-        
+
     def default(self, line):
         """Default action if line is not recognized"""
 
@@ -2240,14 +2201,13 @@ class SmartQuestion(BasicCmd):
 
     def emptyline(self):
         """If empty line, return default"""
-        
+
         if self.default_value is not None:
             self.value = self.default_value
 
-
     def postcmd(self, stop, line):
 
-        try:    
+        try:
             if self.value in self.allow_arg:
                 return True
             elif str(self.value) == 'EOF':
@@ -2273,8 +2233,7 @@ class SmartQuestion(BasicCmd):
                 else:
                     raise Exception
 
-                
-            else: 
+            else:
                 raise Exception
         except Exception as error:
             if self.wrong_answer < 100:
@@ -2286,11 +2245,11 @@ class SmartQuestion(BasicCmd):
             else:
                 self.value = self.default_value
                 return True
-                
+
     def cmdloop(self, intro=None):
         super(SmartQuestion,self).cmdloop(intro)
         return self.answer
-    
+
 # a function helper
 def smart_input(input_text, allow_arg=[], default=None):
     print(input_text)
@@ -2302,7 +2261,7 @@ def smart_input(input_text, allow_arg=[], default=None):
 #===============================================================================
 class OneLinePathCompletion(SmartQuestion):
     """ a class for answering a question with the path autocompletion"""
-    
+
     completion_prefix=''
     allowpath=True
 
@@ -2313,23 +2272,23 @@ class OneLinePathCompletion(SmartQuestion):
             self.stdout.write('\b'*nb_back + '[timer stopped]\n')
             self.stdout.write(line)
             self.stdout.flush()
-        
+
         try:
             out = {}
             out[' Options'] = Cmd.list_completion(text, self.allow_arg)
             out[' Path from ./'] = Cmd.path_completion(text, only_dirs = False)
             out[' Recognized command'] = BasicCmd.completenames(self, text, line, begidx, endidx)
-            
+
             return self.deal_multiple_categories(out, formatting)
         except Exception as error:
             print(error)
-            
+
     def precmd(self, *args):
         """ """
-        
+
         signal.alarm(0)
         return SmartQuestion.precmd(self, *args)
-        
+
     def completedefault(self,text, line, begidx, endidx):
         prev_timer = signal.alarm(0) # avoid timer if any
         if prev_timer:
@@ -2342,7 +2301,7 @@ class OneLinePathCompletion(SmartQuestion):
         except Exception as error:
             print(error)
 
-        # Directory continuation                 
+        # Directory continuation
         if args[-1].endswith(os.path.sep):
 
             return Cmd.path_completion(text,
@@ -2351,10 +2310,9 @@ class OneLinePathCompletion(SmartQuestion):
                                        begidx, endidx)
         return self.completenames(text, line, begidx, endidx)
 
-
     def postcmd(self, stop, line):
-        try:    
-            if self.value in self.allow_arg: 
+        try:
+            if self.value in self.allow_arg:
                 return True
             elif self.value and os.path.isfile(self.value):
                 return os.path.relpath(self.value)
@@ -2363,33 +2321,30 @@ class OneLinePathCompletion(SmartQuestion):
                 return True
             elif line and hasattr(self, 'do_%s' % line.split()[0]):
                 # go to retry
-                reprint_opt = True 
+                reprint_opt = True
             elif self.value in ['repeat', 'reask']:
-                reprint_opt = True         
+                reprint_opt = True
             else:
                 raise Exception
-        except Exception as error:  
+        except Exception as error:
             print("""not valid argument. Valid argument are file path or value in (%s).""" \
                           % ','.join(self.allow_arg))
             print('please retry')
-            reprint_opt = False 
+            reprint_opt = False
 
         if line != 'EOF':
             return self.reask(reprint_opt)
 
-            
 # a function helper
 def raw_path_input(input_text, allow_arg=[], default=None):
     print(input_text)
     obj = OneLinePathCompletion(allow_arg=allow_arg, default=default )
     return obj.cmdloop()
 
-
-
 class ControlSwitch(SmartQuestion):
     """A class for asking a question on which program to run.
        This is the abstract class
-       
+
        Behavior for each switch can be customize via:
        set_default_XXXX() -> set default value
            This is super-seeded by self.default_switch if that attribute is defined (and has a key for XXXX)
@@ -2397,7 +2352,7 @@ class ControlSwitch(SmartQuestion):
        check_value_XXXX(value) -> return True/False if the user can set such value
        switch_off_XXXXX()      -> set it off (called for special mode)
        color_for_XXXX(value)   -> return the representation on the screen for value
-       get_cardcmd_for_XXXX(value)> return the command to run to customize the cards to 
+       get_cardcmd_for_XXXX(value)> return the command to run to customize the cards to
                                   match the status
        print_options_XXXX()    -> return the text to disply below "other options"
                                   default is other possible value (ordered correctly)
@@ -2405,32 +2360,32 @@ class ControlSwitch(SmartQuestion):
        consistency_XX_YY(val_XX, val_YY)
            -> XX is the new key set by the user to a new value val_XX
            -> YY is another key set by the user.
-           -> return value should be None or "replace_YY" 
-       
+           -> return value should be None or "replace_YY"
+
        consistency_XX(val_XX):
-            check the consistency of the other switch given the new status of this one. 
+            check the consistency of the other switch given the new status of this one.
             return a dict {key:replaced_value} or {} if nothing to do
-            
+
        user typing "NAME" will result to a call to self.ans_NAME(None)
-       user typing "NAME=XX" will result to a call to self.ans_NAME('XX')    
-       
+       user typing "NAME=XX" will result to a call to self.ans_NAME('XX')
+
        Note on case sensitivity:
        -------------------------
        the XXX is displayed with the case in self.to_control
            but ALL functions should use the lower case version.
-       for key associated to get_allowed_keys(), 
+       for key associated to get_allowed_keys(),
            if (user) value not in that list.
               -> try to find the first entry matching up to the case
-       for ans_XXX, set the value to lower case, but if case_XXX is set to True 
+       for ans_XXX, set the value to lower case, but if case_XXX is set to True
        """
-       
+
     case_sensitive = False
     quit_on = ['0','done', 'EOF','','auto']
 
     def __init__(self, to_control, motherinstance, *args, **opts):
         """to_control is a list of ('KEY': 'Choose the shower/hadronization program')
         """
-    
+
         self.to_control = to_control
         if 'hide_line' in opts:
             self.hide_line = opts['hide_line']
@@ -2440,20 +2395,20 @@ class ControlSwitch(SmartQuestion):
         self.mother_interface = motherinstance
         self.inconsistent_keys = {} #flag parameter which are currently not consistent
                                     # and the value by witch they will be replaced if the
-                                    # inconsistency remains.  
-        self.inconsistent_details = {} # flag to list 
-        self.last_changed = []         # keep the order in which the flag have been modified 
+                                    # inconsistency remains.
+        self.inconsistent_details = {} # flag to list
+        self.last_changed = []         # keep the order in which the flag have been modified
                                        # to choose the resolution order of conflict
         #initialise the main return value
         self.switch = {}
         for key, _ in to_control:
             self.switch[key.lower()] = 'temporary'
-            
+
         self.set_default_switch()
         question = self.create_question()
-        
+
         #check all default for auto-completion
-        allowed_args = [ repr(i)+';' for i in range(1, 1+len(self.to_control))] 
+        allowed_args = [ repr(i)+';' for i in range(1, 1+len(self.to_control))]
         for key in self.switch:
             allowed_args += ['%s=%s;' % (key,s) for s in self.get_allowed(key)]
         # adding special mode
@@ -2480,7 +2435,7 @@ class ControlSwitch(SmartQuestion):
         if '=' not in line:
             if line.strip().startswith('set'):
                 self.mother_interface.store_line(line)
-                return str(default) 
+                return str(default)
             return None
         key, value = line.split('=',1)
         if key.lower() in self.switch:
@@ -2493,13 +2448,9 @@ class ControlSwitch(SmartQuestion):
             return line
 
         return None
-        
-        
-        
-
 
     def set_default_switch(self):
-        
+
         for key,_ in self.to_control:
             key = key.lower()
             if hasattr(self, 'default_switch') and key in self.default_switch:
@@ -2509,19 +2460,19 @@ class ControlSwitch(SmartQuestion):
                 getattr(self, 'set_default_%s' % key)()
             else:
                 self.default_switch_for(key)
-        
+
     def default_switch_for(self, key):
         """use this if they are no dedicated function for such key"""
-        
+
         if hasattr(self, 'get_allowed_%s' % key):
             return getattr(self, 'get_allowed_%s' % key)()[0]
         else:
             self.switch[key] = 'OFF'
-    
+
     def set_all_off(self):
         """set all valid parameter to OFF --call before special keyword--
         """
-        
+
         for key in self.switch:
             if hasattr(self, 'switch_off_%s' % key):
                 getattr(self, 'switch_off_%s' % key)()
@@ -2529,52 +2480,49 @@ class ControlSwitch(SmartQuestion):
                 self.switch[key] = 'OFF'
         self.inconsistent_details = {}
         self.inconsistent_keys = {}
-    
-        
+
     def check_value(self, key, value):
         """return True/False if the value is a correct value to be set by the USER.
            other value than those can be set by the system --like-- Not available.
            This does not check the full consistency of the switch
            """
-           
+
         if hasattr(self, 'check_value_%s' % key):
             return getattr(self, 'check_value_%s' % key)(value)
         elif value in self.get_allowed(key):
             return True
         else:
             return False
-        
-        
+
     def get_cardcmd(self):
-        """ return the list of command that need to be run to have a consistent 
+        """ return the list of command that need to be run to have a consistent
             set of cards with the switch value choosen """
-        
+
         switch = self.answer
         cmd= []
         for key in self.switch:
             if hasattr(self, 'get_cardcmd_for_%s' % key):
                 cmd += getattr(self, 'get_cardcmd_for_%s' % key)(switch[key])
         return cmd
-        
-        
+
     def get_allowed(self, key):
         """return the list of possible value for key"""
 
         if hasattr(self, 'get_allowed_%s' % key):
             return getattr(self, 'get_allowed_%s' % key)()
         else:
-            return ['ON', 'OFF']    
-            
+            return ['ON', 'OFF']
+
     def default(self, line, raise_error=False):
         """Default action if line is not recognized"""
-        
+
         line=line.strip().replace('@', '__at__')
         if ';' in line:
             for l in line.split(';'):
                 if l:
                     out = self.default(l)
             return out
-        
+
         if '=' in line:
             base, value = line.split('=',1)
             base = base.strip()
@@ -2601,7 +2549,7 @@ class ControlSwitch(SmartQuestion):
             except:
                 if self.get_allowed(base):
                     value = self.get_allowed(base)[0]
-                else:                      
+                else:
                     logger.warning('Can not switch "%s" to another value via number', base)
                     self.value='reask'
                     return
@@ -2610,12 +2558,11 @@ class ControlSwitch(SmartQuestion):
                     value = self.get_allowed(base)[cur+1]
                 except IndexError:
                     value = self.get_allowed(base)[0]
-                    if value == "OFF" and  cur == 0:
+                    if value == "OFF" and cur == 0:
                         logger.warning("Invalid action: %s" % self.print_options(base))
-                    elif cur == 0: 
+                    elif cur == 0:
                         logger.warning("Can not change value for this parameter")
-                        
-                        
+
         elif line in ['', 'done', 'EOF', 'eof','0']:
             super(ControlSwitch, self).default(line)
             return self.answer
@@ -2630,9 +2577,9 @@ class ControlSwitch(SmartQuestion):
             logger.warning('unknow command: %s' % line)
             self.value = 'reask'
             return
-        
-        self.value = 'reask'   
-        base = base.lower()               
+
+        self.value = 'reask'
+        base = base.lower()
         if hasattr(self, 'ans_%s' % base):
             if value and not self.is_case_sensitive(base):
                 value = value.lower()
@@ -2642,18 +2589,18 @@ class ControlSwitch(SmartQuestion):
         elif line.startswith('set ') and not hasattr(self.__class__, 'do_set'):
             raise NotValidInput('Not valid command: %s. Did you mean \"%s\"' % (line, line[4:]))
         elif raise_error:
-            raise NotValidInput('Not valid command: %s' % line)                
+            raise NotValidInput('Not valid command: %s' % line)
         else:
             logger.warning('Not valid command: %s' % line)
-   
+
     def is_case_sensitive(self, key):
         """check if a key is case sensitive"""
-        
-        case = self.case_sensitive 
+
+        case = self.case_sensitive
         if hasattr(self, 'case_%s' % key):
             case = getattr(self, 'case_%s' % key)
         return case
-    
+
     def onecmd(self, line, **opt):
         """ensure to rewrite the function if a call is done directly"""
         out = super(ControlSwitch, self).onecmd(line, **opt)
@@ -2662,7 +2609,7 @@ class ControlSwitch(SmartQuestion):
 
     @property
     def answer(self):
-        
+
         #avoid key to Not Avail in the output
         for key,_ in self.to_control:
             if not self.check_value(key, self.switch[key]):
@@ -2676,7 +2623,7 @@ class ControlSwitch(SmartQuestion):
             return out
 
     def postcmd(self, stop, line):
-        
+
         # for diamond class arch where both branch defines the postcmd
         # set it up to be in coop mode
         try:
@@ -2688,7 +2635,7 @@ class ControlSwitch(SmartQuestion):
 
         line = line.strip()
         if ';' in line:
-            line= [l for l in line.split(';') if l][-1] 
+            line= [l for l in line.split(';') if l][-1]
         if line in self.quit_on or self.value in self.quit_on:
             return True
         if self.value != 'reask':
@@ -2700,12 +2647,12 @@ class ControlSwitch(SmartQuestion):
         """change a switch to a given value"""
 
         assert key in self.switch
-        
+
         if hasattr(self, 'ans_%s' % key):
             if not self.is_case_sensitive(key):
                 value = value.lower()
             return getattr(self, 'ans_%s' % key)(value)
-        
+
         if not self.is_case_sensitive(key) and value not in self.get_allowed(key):
             lower = [t.lower() for t in self.get_allowed(key)]
             try:
@@ -2714,52 +2661,50 @@ class ControlSwitch(SmartQuestion):
                 pass # keep the current case, in case check_value accepts it anyway.
             else:
                 value = self.get_allowed(key)[ind]
-        
-        check = self.check_value(key, value) 
+
+        check = self.check_value(key, value)
         if not check:
             logger.warning('"%s" not valid option for "%s"', value, key)
             return
         if isinstance(check, str):
             value = check
-        
+
         self.switch[key] = value
-        
+
         if user:
             self.check_consistency(key, value)
-        
+
     def remove_inconsistency(self, keys=[]):
-        
+
         if not keys:
-            self.inconsistent_keys = {} 
-            self.inconsistent_details = {} 
+            self.inconsistent_keys = {}
+            self.inconsistent_details = {}
         elif isinstance(keys, list):
             for key in keys:
                 if key in self.inconsistent_keys:
                     del self.inconsistent_keys[keys]
-                    del self.inconsistent_details[keys]                
+                    del self.inconsistent_details[keys]
         else:
             if keys in self.inconsistent_keys:
                 del self.inconsistent_keys[keys]
                 del self.inconsistent_details[keys]
-        
+
     def check_consistency(self, key, value):
         """check the consistency of the new flag with the old ones"""
-        
-        
+
         if key in self.last_changed:
             self.last_changed.remove(key)
         self.last_changed.append(key)
-        
+
         # this is used to update self.consistency_keys which contains:
         #  {key: replacement value with solved conflict}
         # it is based on self.consistency_details which is a dict
-        # key:  {'orig_value': 
+        # key:  {'orig_value':
         #                'changed_key':
         #                'new_changed_key_val':
-        #                'replacement': 
+        #                'replacement':
         # which keeps track of all conflict and of their origin.
-        
-        
+
         # rules is a dict: {keys:None} if the value for that key is consistent.
         #                  {keys:value_to_replace} if that key is inconsistent
         if hasattr(self, 'consistency_%s' % key):
@@ -2770,7 +2715,7 @@ class ControlSwitch(SmartQuestion):
             for key2,value2 in self.switch.items():
                 if hasattr(self, 'consistency_%s_%s' % (key,key2)):
                     rules[key2] = getattr(self, 'consistency_%s_%s' % (key,key2))(value, value2)
-                    # check that the suggested value is allowed. 
+                    # check that the suggested value is allowed.
                     # can happen that it is not if some program are not installed
                     if rules[key2] is not None and not self.check_value(key2, rules[key2]):
                         if rules[key2] != 'OFF':
@@ -2778,9 +2723,9 @@ class ControlSwitch(SmartQuestion):
                         rules[key2] = None
                 else:
                     rules[key2] = None
-                    
+
         #
-        
+
         #update the self.inconsisten_details adding new conflict
         # start by removing the inconsistency for the newly set parameter
         self.remove_inconsistency(key)
@@ -2795,10 +2740,10 @@ class ControlSwitch(SmartQuestion):
                     self.inconsistent_details[key2].append(info)
                 else:
                     self.inconsistent_details[key2] = [info]
-        
+
         if not self.inconsistent_details:
             return
-          
+
         # review the status of all conflict
         for key2 in dict(self.inconsistent_details):
             for conflict in list(self.inconsistent_details[key2]):
@@ -2814,15 +2759,14 @@ class ControlSwitch(SmartQuestion):
             if not self.inconsistent_details[key2]:
                 del self.inconsistent_details[key2]
 
-
         # create the valid set of replacement for this current conflict
         # start by current status to avoid to keep irrelevant conflict
         tmp_switch = dict(self.switch)
-        
+
         # build the order in which we have to check the various conflict reported
         to_check = [(c['changed_key'], c['new_changed_key_val']) \
                          for k in self.inconsistent_details.values() for c in k
-                         if c['changed_key'] != key] 
+                         if c['changed_key'] != key]
 
         to_check.sort(key=lambda x: self.last_changed.index(x[0]))
 
@@ -2839,7 +2783,7 @@ class ControlSwitch(SmartQuestion):
                 rules.update(getattr(self, 'consistency_%s' % key2)(value, tmp_switch))
             else:
                 rules = self.check_consistency_with_all(key2, value2)
-                        
+
             for key, replacement in rules.items():
                 if replacement:
                     tmp_switch[key] = replacement
@@ -2857,7 +2801,7 @@ class ControlSwitch(SmartQuestion):
             to_check = to_check_new
         if nstep >=50:
             logger.critical('Failed to find a consistent set of switch values.')
-            
+
         # Now tmp_switch is to a fully consistent setup for sure.
         # fill self.inconsistent_key
         self.inconsistent_keys = {}
@@ -2867,8 +2811,7 @@ class ControlSwitch(SmartQuestion):
                 if value2 == 'OFF' and not self.check_value(key2, 'OFF'):
                     continue
                 self.inconsistent_keys[key2] = value2
-            
-            
+
     def check_consistency_with_all(self, key, value):
         rules = {}
         for key2,value2 in self.switch.items():
@@ -2877,22 +2820,22 @@ class ControlSwitch(SmartQuestion):
             else:
                 rules[key2] = None
         return rules
-    #    
-    # Helper routine for putting questions with correct color 
     #
-    green = '\x1b[32m%s\x1b[0m' 
+    # Helper routine for putting questions with correct color
+    #
+    green = '\x1b[32m%s\x1b[0m'
     yellow = '\x1b[33m%s\x1b[0m'
     red   = '\x1b[31m%s\x1b[0m'
     bold = '\x1b[01m%s\x1b[0m'
     def color_for_value(self, key, switch_value, consistency=True):
-        
+
         if consistency and key in self.inconsistent_keys:
             return self.color_for_value(key, self.inconsistent_keys[key], consistency=False) +\
                                 u' \u21d0 '+ self.yellow % switch_value
-        
+
         if self.check_value(key, switch_value):
             if  hasattr(self, 'color_for_%s' % key):
-                return getattr(self, 'color_for_%s' % key)(switch_value)            
+                return getattr(self, 'color_for_%s' % key)(switch_value)
             if switch_value in ['OFF']:
                 # inconsistent key are the list of key which are inconsistent with the last change
                 return self.red % switch_value
@@ -2900,7 +2843,7 @@ class ControlSwitch(SmartQuestion):
                 return self.green % switch_value
         else:
             if ' ' in switch_value:
-                return self.bold % switch_value 
+                return self.bold % switch_value
             else:
                 return self.red % switch_value
 
@@ -2909,25 +2852,25 @@ class ControlSwitch(SmartQuestion):
         if hasattr(self, 'print_options_%s' % key) and not keep_default:
             return getattr(self, 'print_options_%s' % key)()
 
-        #re-order the options in order to have those in cycling order    
+        #re-order the options in order to have those in cycling order
         try:
             ind =  self.get_allowed(key).index(self.switch[key])
         except Exception as err:
             options = self.get_allowed(key)
         else:
-            options = self.get_allowed(key)[ind:]+ self.get_allowed(key)[:ind] 
+            options = self.get_allowed(key)[ind:]+ self.get_allowed(key)[:ind]
 
         info = '|'.join([v for v in options if v != self.switch[key]])
         if info == '':
             info = 'Please install module'
         return info
-    
+
     def do_help(self, line, list_command=False):
         """dedicated help for the control switch"""
-        
+
         if line:
             return self.print_help_for_switch(line)
-        
+
         # here for simple "help"
         logger.info(" ")
         logger.info("  In order to change a switch you can:")
@@ -2944,18 +2887,17 @@ class ControlSwitch(SmartQuestion):
         if list_command:
             super(ControlSwitch, self).do_help(line)
 
-        
     def print_help_for_switch(self, line):
         """ """
-        
+
         arg = line.split()[0]
-        
+
         if hasattr(self, 'help_%s' % arg):
             return getattr(self, 'help_%s' % arg)('')
-        
+
         if hasattr(self, 'ans_%s' % arg):
             return getattr(self, 'help_%s' % arg).__doc__
-        
+
         if arg in self.switch:
             logger.info("   information for switch %s: ", arg, '$MG:BOLD')
             logger.info("   allowed value:")
@@ -2964,9 +2906,6 @@ class ControlSwitch(SmartQuestion):
                 logger.info("")
                 for line in getattr(self, 'help_text_%s' % arg):
                     logger.info(line)
-                      
-        
-    
 
     def question_formatting(self, nb_col = 80,
                                   ldescription=0,
@@ -2977,13 +2916,13 @@ class ControlSwitch(SmartQuestion):
                                   lnb_key=0,
                                   key=None):
         """should return four lines:
-        1. The upper band (typically /========\ 
+        1. The upper band (typically /========\
         2. The lower band (typically \========/
         3. The line without conflict | %(nb)2d. %(descrip)-20s %(name)5s = %(switch)-10s |
         4. The line with    conflict | %(nb)2d. %(descrip)-20s %(name)5s = %(switch)-10s |
         # Be carefull to include the size of the color flag for the switch
-        green/red/yellow are  adding 9 in length 
-        
+        green/red/yellow are  adding 9 in length
+
         line should be like '| %(nb)2d. %(descrip)-20s %(name)5s = %(switch)-10s |'
 
            the total lenght of the line (for defining the upper/lower line)
@@ -2996,7 +2935,7 @@ class ControlSwitch(SmartQuestion):
                            conflict_switch_nc # self.inconsistent_keys without color formatting
                            add_info
         """
-        
+
         if key:
             # key is only provided for conflict
             len_switch = len(self.switch[key])
@@ -3005,9 +2944,9 @@ class ControlSwitch(SmartQuestion):
             else:
                 len_cswitch = 0
         else:
-            len_switch = 0 
-            len_cswitch = 0 
-            
+            len_switch = 0
+            len_cswitch = 0
+
         list_length = []
         # | 1. KEY = VALUE |
         list_length.append(lnb_key + lname + lswitch + 9)
@@ -3024,22 +2963,21 @@ class ControlSwitch(SmartQuestion):
         #| 1. DESCRIP | KEY = VALUE_MAXSIZE |   INFO   |
         list_length.append(list_length[-1] +3+ max(15,6+ladd_info))
         #| 1. DESCRIP    |   KEY = VALUE_MAXSIZE |     INFO     |
-        list_length.append(list_length[-2] +13+ max(15,10+ladd_info))        
-        
+        list_length.append(list_length[-2] +13+ max(15,10+ladd_info))
+
         selected = [0] + [i+1 for i,s in enumerate(list_length) if s < nb_col]
         selected = selected[-1]
-        
+
         # upper and lower band
         if selected !=0:
             size = list_length[selected-1]
         else:
             size = nb_col
-        
-        
+
         # default for upper/lower:
         upper = "/%s\\" % ("=" * (size-2))
-        lower = "\\%s/" % ("=" * (size-2))        
-        
+        lower = "\\%s/" % ("=" * (size-2))
+
         if selected==0:
             f1= '%(nb){0}d \x1b[1m%(name){1}s\x1b[0m=%(switch)-{2}s'.format(lnb_key,
                                                                   lname,lswitch)
@@ -3051,7 +2989,7 @@ class ControlSwitch(SmartQuestion):
             to_add = nb_col -size
             f1 = '| %(nb){0}d. \x1b[1m%(name){1}s\x1b[0m = %(switch)-{2}s |'.format(lnb_key,
                                                                   lname,lswitch+9+to_add)
-            
+
             f = u'| %(nb){0}d. \x1b[1m%(name){1}s\x1b[0m = %(conflict_switch)-{2}s \u21d0 %(strike_switch)-{3}s |'
             f2 =f.format(lnb_key, lname, len_cswitch+9, lswitch-len_cswitch+len_switch+to_add-1)
         #1. DESCRIP KEY = VALUE
@@ -3091,12 +3029,12 @@ class ControlSwitch(SmartQuestion):
             elif l_conflict_line -3 <= nb_col:
                 f=u'| %(nb){0}d. %(descrip)-{1}s \x1b[1m%(name){2}s\x1b[0m=%(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s'
                 f2 = f.format(lnb_key,ldescription,lname, len_cswitch+9, max(lswitch,lpotential_switch)-len_cswitch+len_switch+to_add-3+3)
-                        
+
             else:
                 ldescription -= (l_conflict_line - nb_col)
                 f=u'| %(nb){0}d. %(descrip)-{1}.{1}s. \x1b[1m%(name){2}s\x1b[0m = %(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s'
                 f2 = f.format(lnb_key,ldescription,lname, len_cswitch+9, max(lswitch,lpotential_switch)-len_cswitch+len_switch+to_add-3+3)
-                
+
         # 1. DESCRIP KEY = VALUE_MAXSIZE
         elif selected == 5:
             f = '%(nb){0}d. %(descrip)-{1}s \x1b[1m%(name){2}s\x1b[0m = %(switch)-{3}s'
@@ -3104,7 +3042,7 @@ class ControlSwitch(SmartQuestion):
             f = u'%(nb){0}d. %(descrip)-{1}s \x1b[1m%(name){2}s\x1b[0m = %(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s'
             f2 = f.format(lnb_key,ldescription,lname,lpotential_switch+9, max(2*lpotential_switch+3, lswitch)-lpotential_switch+len_switch)
         #| 1. DESCRIP KEY = VALUE_MAXSIZE |
-        elif selected == 6: 
+        elif selected == 6:
             f= '| %(nb){0}d. %(descrip)-{1}s \x1b[1m%(name){2}s\x1b[0m = %(switch)-{3}s |'
             f1 = f.format(lnb_key,ldescription,lname,max(2*lpotential_switch+3,lswitch)+9)
             f= u'| %(nb){0}d. %(descrip)-{1}s \x1b[1m%(name){2}s\x1b[0m = %(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s|'
@@ -3115,8 +3053,8 @@ class ControlSwitch(SmartQuestion):
             upper = "/{0:=^%s}|{1:=^%s}|{2:=^%s}\\" % (lnb_key+ldescription+4,
                                                     lname+max(2*lpotential_switch+3, lswitch)+5,
                                                     ladd_info)
-            upper = upper.format(' Description ', ' values ', ' other options ') 
-            
+            upper = upper.format(' Description ', ' values ', ' other options ')
+
             f='| %(nb){0}d. %(descrip)-{1}s | \x1b[1m%(name){2}s\x1b[0m = %(switch)-{3}s |   %(add_info)-{4}s |'
             f1 = f.format(lnb_key,ldescription,lname,max(2*lpotential_switch+3,lswitch)+9, ladd_info-4)
             f= u'| %(nb){0}d. %(descrip)-{1}s | \x1b[1m%(name){2}s\x1b[0m = %(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s|   %(add_info)-{5}s |'
@@ -3127,38 +3065,37 @@ class ControlSwitch(SmartQuestion):
             upper = "/{0:=^%s}|{1:=^%s}|{2:=^%s}\\" % (lnb_key+ldescription+4+5,
                                                     lname+max(3+2*lpotential_switch,lswitch)+10,
                                                     ladd_info)
-            upper = upper.format(' Description ', ' values ', ' other options ') 
-            lower = "\\%s/" % ("=" * (size-2)) 
-            
+            upper = upper.format(' Description ', ' values ', ' other options ')
+            lower = "\\%s/" % ("=" * (size-2))
+
             f='| %(nb){0}d. %(descrip)-{1}s | \x1b[1m%(name){2}s\x1b[0m = %(switch)-{3}s |     %(add_info)-{4}s|'
             f1 = f.format(lnb_key,ldescription+5,5+lname,max(2*lpotential_switch+3,lswitch)+9, ladd_info-5)
             f=u'| %(nb){0}d. %(descrip)-{1}s | \x1b[1m%(name){2}s\x1b[0m = %(conflict_switch)-{3}s \u21d0 %(strike_switch)-{4}s|     %(add_info)-{5}s|'
             f2 = f.format(lnb_key,ldescription+5,5+lname,
                           lpotential_switch+9,
                           max(2*lpotential_switch+3,lswitch)-lpotential_switch+len_switch, ladd_info-5)
-        
+
         return upper, lower, f1, f2
-                
+
     def create_question(self, help_text=True):
         """ create the question  with correct formatting"""
-        
+
         # geth the number of line and column of the shell to adapt the printing
-        # accordingly  
+        # accordingly
         try:
             nb_rows, nb_col = os.popen('stty size', 'r').read().split()
             nb_rows, nb_col = int(nb_rows), int(nb_col)
         except Exception as error:
             nb_rows, nb_col = 20, 80
-        
+
         #compute information on the length of element to display
-        max_len_description = 0 
+        max_len_description = 0
         max_len_switch = 0
         max_len_name = 0
         max_len_add_info = 0
         max_len_potential_switch = 0
         max_nb_key = 1 + int(math.log10(len(self.to_control)))
-        
-        
+
         for key, descrip in self.to_control:
             if key in self.hide_line:
                 continue
@@ -3170,7 +3107,7 @@ class ControlSwitch(SmartQuestion):
             else:
                 to_display = self.switch[key]
             if len(to_display) > max_len_switch: max_len_switch=len(to_display)
-            
+
             info = self.print_options(key)
             if len(info)> max_len_add_info: max_len_add_info = len(info)
 
@@ -3180,23 +3117,21 @@ class ControlSwitch(SmartQuestion):
                 max_k = 0
             if max_k > max_len_potential_switch: max_len_potential_switch = max_k
 
-        upper_line, lower_line, f1, f2 = self.question_formatting(nb_col, max_len_description, max_len_switch, 
-                                         max_len_name, max_len_add_info, 
+        upper_line, lower_line, f1, f2 = self.question_formatting(nb_col, max_len_description, max_len_switch,
+                                         max_len_name, max_len_add_info,
                                          max_len_potential_switch, max_nb_key)
         f3 = 0 #formatting for hidden line
-        
+
         text = \
         ["The following switches determine which programs are run:",
          upper_line
-        ]                     
+        ]
 
-
-        
         for i,(key, descrip) in enumerate(self.to_control):
 
             if key in self.hide_line and not __debug__:
                 continue
-            
+
             data_to_format = {'nb': i+1,
                            'descrip': descrip,
                            'name': key,
@@ -3205,41 +3140,40 @@ class ControlSwitch(SmartQuestion):
                            'switch_nc': self.switch[key],
                            'strike_switch': u'\u0336'.join(' %s ' %self.switch[key].upper()) + u'\u0336',
                            }
-            
+
             hidden_line = False
             if __debug__ and key in self.hide_line:
                 data_to_format['descrip'] = '\x1b[32m%s\x1b[0m' % data_to_format['descrip']
                 data_to_format['add_info'] = '\x1b[32m%s\x1b[0m' % data_to_format['add_info']
                 data_to_format['name'] = '\x1b[32m%s\x1b[0m' % data_to_format['name']
                 hidden_line=True
-                
+
             if key in self.inconsistent_keys:
                 # redefine the formatting here, due to the need to know the conflict size
-                _,_,_, f2 = self.question_formatting(nb_col, max_len_description, max_len_switch, 
-                                         max_len_name, max_len_add_info, 
+                _,_,_, f2 = self.question_formatting(nb_col, max_len_description, max_len_switch,
+                                         max_len_name, max_len_add_info,
                                          max_len_potential_switch, max_nb_key,
                                          key=key)
-                
+
                 data_to_format['conflict_switch_nc'] = self.inconsistent_keys[key]
                 data_to_format['conflict_switch'] = self.color_for_value(key,self.inconsistent_keys[key], consistency=False)
-                
-                if hidden_line: 
-                    f2 = re.sub('%(\((?:name|descrip|add_info)\)-?)(\d+)s', 
+
+                if hidden_line:
+                    f2 = re.sub('%(\((?:name|descrip|add_info)\)-?)(\d+)s',
                                 lambda x: '%%%s%ds' % (x.group(1),int(x.group(2))+9),
                                  f2)
                 text.append(f2 % data_to_format)
             elif hidden_line:
                 if not f3:
-                    f3 = re.sub('%(\((?:name|descrip|add_info)\)-?)(\d+)s', 
+                    f3 = re.sub('%(\((?:name|descrip|add_info)\)-?)(\d+)s',
                                 lambda x: '%%%s%ds' % (x.group(1),int(x.group(2))+9),
                                  f1)
                 text.append(f3 % data_to_format)
             else:
                 text.append(f1 % data_to_format)
 
-                                
         text.append(lower_line)
-        
+
         # find a good example of switch to set for the lower part of the description
         example = None
         for key in self.switch:
@@ -3251,17 +3185,17 @@ class ControlSwitch(SmartQuestion):
                     else:
                         continue
                     break
-                
+
         if not example:
             example = ('KEY', 'VALUE')
-        
+
         if help_text:
             text += \
               ["Either type the switch number (1 to %s) to change its setting," % len(self.to_control),
                "Set any switch explicitly (e.g. type '%s=%s' at the prompt)" % example,
                "Type 'help' for the list of all valid option",
                "Type '0', 'auto', 'done' or just press enter when you are done."]
-            
+
             # check on the number of row:
             if len(text) > nb_rows:
                 # too many lines. Remove some
@@ -3270,27 +3204,26 @@ class ControlSwitch(SmartQuestion):
                               -4, #Either type the switch number (1 to %s) to change its setting,
                               -3, # Set any switch explicitly
                               -1, # Type '0', 'auto', 'done' or just press enter when you are done.
-                             ] 
+                             ]
                 to_remove = to_remove[:min(len(to_remove), len(text)-nb_rows)]
                 text = [t for i,t in enumerate(text) if i-len(text) not in to_remove]
-            
-        self.question =    "\n".join(text)                                                              
+
+        self.question =    "\n".join(text)
         return self.question
-    
 
 #===============================================================================
-# 
+#
 #===============================================================================
 class CmdFile(file):
     """ a class for command input file -in order to debug cmd \n problem"""
-    
+
     def __init__(self, name, opt='rU'):
-        
+
         file.__init__(self, name, opt)
         self.text = file.read(self)
         self.close()
         self.lines = self.text.split('\n')
-    
+
     def readline(self, *arg, **opt):
         """readline method treating correctly a line whithout \n at the end
            (add it)
@@ -3299,18 +3232,15 @@ class CmdFile(file):
             line = self.lines.pop(0)
         else:
             return ''
-        
+
         if line.endswith('\n'):
             return line
         else:
             return line + '\n'
-    
+
     def __next__(self):
-        return self.lines.__next__()    
+        return self.lines.__next__()
 
     def __iter__(self):
         return self.lines.__iter__()
-
-
-
 

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -58,15 +58,12 @@ import aloha
 import madgraph
 from madgraph import MG4DIR, MG5DIR, MadGraph5Error
 
-
 import madgraph.core.base_objects as base_objects
 import madgraph.core.diagram_generation as diagram_generation
 import madgraph.loop.loop_diagram_generation as loop_diagram_generation
 import madgraph.loop.loop_base_objects as loop_base_objects
 import madgraph.core.drawing as draw_lib
 import madgraph.core.helas_objects as helas_objects
-
-
 
 import madgraph.iolibs.drawing_eps as draw
 import madgraph.iolibs.export_cpp as export_cpp
@@ -107,7 +104,6 @@ import aloha.create_aloha as create_aloha
 import aloha.aloha_lib as aloha_lib
 
 import mg5decay.decay_objects as decay_objects
-
 
 # Special logger for the Cmd Interface
 logger = logging.getLogger('cmdprint') # -> stdout
@@ -157,7 +153,7 @@ class CmdExtended(cmd.Cmd):
     # Define the Error Class # Define how error are handle
     InvalidCmd = madgraph.InvalidCmd
     ConfigurationError = MadGraph5Error
-    
+
     intro_banner = "************************************************************\n" + \
         "*                                                          *\n" + \
         "*                     W E L C O M E to                     *\n" + \
@@ -183,7 +179,6 @@ class CmdExtended(cmd.Cmd):
         "*    Type 'tutorial MadLoop' to learn how MadLoop works    *\n" + \
         "*                                                          *\n" + \
         "************************************************************"
-    
 
     def __init__(self, *arg, **opt):
         """Init history and line continuation"""
@@ -203,7 +198,7 @@ class CmdExtended(cmd.Cmd):
                             info['date'])
 
         if os.path.exists(pjoin(MG5DIR, '.bzr')):
-            try: 
+            try:
                 proc = subprocess.Popen(['bzr', 'nick'], stdout=subprocess.PIPE,cwd=MG5DIR)
             except OSError:
                 logger_stderr.critical("Note that this is a development version.\nThis version is intended for development/beta testing and NOT for production.\nThis version has not been fully tested (if at all) and might have limited user support (if at all)")
@@ -211,10 +206,10 @@ class CmdExtended(cmd.Cmd):
             else:
                 bzrname,_ = proc.communicate()
                 proc = subprocess.Popen(['bzr', 'revno'], stdout=subprocess.PIPE,cwd=MG5DIR)
-                bzrversion,_ = proc.communicate() 
-                bzrname, bzrversion = bzrname.decode(errors='ignore').strip(), bzrversion.decode(errors='ignore').strip() 
+                bzrversion,_ = proc.communicate()
+                bzrname, bzrversion = bzrname.decode(errors='ignore').strip(), bzrversion.decode(errors='ignore').strip()
                 len_name = len(bzrname)
-                len_version = len(bzrversion)            
+                len_version = len(bzrversion)
                 info_line += "#*         BZR %s %s %s         *\n" % \
                                 (bzrname,
                                 (34 - len_name - len_version) * ' ',
@@ -233,14 +228,12 @@ class CmdExtended(cmd.Cmd):
 
         if info_line:
             info_line = info_line.replace("#*","*")
-            
 
         logger.info(self.intro_banner % info_line)
 
         cmd.Cmd.__init__(self, *arg, **opt)
 
         self.history = banner_module.ProcCard()
-
 
     def default(self, line):
         """Default action if line is not recognized"""
@@ -302,7 +295,6 @@ class CmdExtended(cmd.Cmd):
 
         return stop
 
-
     def get_history_header(self):
         """return the history header"""
         return self.history_header % misc.get_time_info()
@@ -318,7 +310,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("-- save information as file FILENAME",'$MG:BOLD')
         logger.info("   FILENAME is optional for saving 'options'.")
         logger.info('   By default it uses ./input/mg5_configuration.txt')
-        logger.info('   If you put "global" for FILENAME it will use ~/.mg5/mg5_configuration.txt')
+        logger.info('   If you put "global" for FILENAME it will use the global configuration')
         logger.info('   If this files exists, it is uses by all MG5 on the system but continues')
         logger.info('   to read the local options files.')
         logger.info('   if additional argument are defined for save options, only those arguments will be saved to the configuration file.')
@@ -371,7 +363,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("     %s"%(', '.join(self._advanced_install_opts)))
         logger.info("   The following options are available:")
         logger.info("     --force        Overwrite without asking any existing installation.")
-        logger.info("     --keep_source  Keep a local copy of the sources of the tools MG5_aMC installed from.")         
+        logger.info("     --keep_source  Keep a local copy of the sources of the tools MG5_aMC installed from.")
         logger.info(" ")
         logger.info("   \"install update\"",'$MG:BOLD')
         logger.info("   check if your MG5 installation is the latest one.")
@@ -389,7 +381,6 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info(" > For \"checks\", can specify only to see failed checks.")
         logger.info(" > For \"diagrams\", you can specify where the file will be written.")
         logger.info("   Example: display diagrams ./",'$MG:color:GREEN')
-
 
     def help_launch(self):
         """help for launch command"""
@@ -584,7 +575,6 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("   keyword just after the specification of the type of check desired.")
         logger.info("Example: check profile g g > t t~ [virt=QCD]",'$MG:color:GREEN')
 
-
     def help_generate(self):
 
         logger.info("-- generate diagrams for a given process",'$MG:color:BLUE')
@@ -674,11 +664,11 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("   --output=  : Specify the name of the directory where the merge is done.")
         logger.info("                This allow to do \"import NAME\" to load that merge.")
         logger.info("   --recreate : Force to recreated the merge model even if the merge model directory already exists.")
-        
+
     def help_convert(self):
         logger.info("syntax: convert model FULLPATH")
         logger.info("modify (in place) the UFO model to make it compatible with both python2 and python3")
-        
+
     def help_compute_widths(self):
         logger.info("syntax: calculate_width PART [other particles] [OPTIONS]")
         logger.info("  Computes the width and partial width for a set of particles")
@@ -774,7 +764,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("   for a fixed color flow or color configuration.")
         logger.info(" > This option can considerably slow down the loop ME")
         logger.info("   computation time, especially when summing over all color")
-        logger.info("   and helicity configuration, hence turned off by default.")        
+        logger.info("   and helicity configuration, hence turned off by default.")
         logger.info("gauge unitary|Feynman|axial",'$MG:color:GREEN')
         logger.info(" > (default unitary) choose the gauge of the non QCD part.")
         logger.info(" > For loop processes, only Feynman gauge is employable.")
@@ -793,7 +783,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info(" > This is not used by condor cluster (since condor has")
         logger.info("   its own way to prevent it).")
         logger.info("mg5amc_py8_interface_path PATH",'$MG:color:GREEN')
-        logger.info(" > Necessary when showering events with Pythia8 from Madevent.")        
+        logger.info(" > Necessary when showering events with Pythia8 from Madevent.")
         logger.info("OLP ProgramName",'$MG:color:GREEN')
         logger.info(" > (default 'MadLoop') [Used for virtual generation]")
         logger.info(" > Chooses what One-Loop Program to use for the virtual")
@@ -807,11 +797,11 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("     o internal: All libraries the output depends on are")
         logger.info("       copied and compiled locally in the output directory.")
         logger.info("     o environment_paths: The location of all libraries the ")
-        logger.info("       output depends on should be found in your env. paths.")        
+        logger.info("       output depends on should be found in your env. paths.")
         logger.info("max_npoint_for_channel <value>",'$MG:color:GREEN')
         logger.info(" > (default '0') [Used ONLY for loop-induced outputs with madevent]")
         logger.info(" > Sets the maximum 'n' of n-points loops to be used for")
-        logger.info(" > setting up the integration multichannels.") 
+        logger.info(" > setting up the integration multichannels.")
         logger.info(" > The default value of zero automatically picks the apparent")
         logger.info(" > appropriate choice which is to sometimes pick box loops")
         logger.info(" > but never higher n-points ones.")
@@ -822,13 +812,13 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("zerowidth_tchannel <value>",'$MG:color:GREEN')
         logger.info(" > (default: True) [Used ONLY for tree-level output with madevent]")
         logger.info(" > set the width to zero for all T-channel propagator --no impact on complex-mass scheme mode")
-        logger.info("auto_convert_model <value>",'$MG:color:GREEN')   
-        logger.info(" > (default: False) If set on True any python2 UFO model will be automatically converted to pyton3 format")   
-        logger.info("nlo_mixed_expansion <value>",'$MG:color:GREEN') 
+        logger.info("auto_convert_model <value>",'$MG:color:GREEN')
+        logger.info(" > (default: False) If set on True any python2 UFO model will be automatically converted to pyton3 format")
+        logger.info("nlo_mixed_expansion <value>",'$MG:color:GREEN')
         logger.info("deactivates mixed expansion support at NLO, goes back to MG5aMCv2 behavior")
-        logger.info("acknowledged_v3.1_syntax <value>",'$MG:color:GREEN') 
+        logger.info("acknowledged_v3.1_syntax <value>",'$MG:color:GREEN')
         logger.info("if set to True allows to use syntax which have change meaning between 3.0 and 3.1 version")
-          
+
 #===============================================================================
 # CheckValidForCmd
 #===============================================================================
@@ -846,16 +836,15 @@ class CheckValidForCmd(cmd.CheckCmd):
         if len(args) < 2:
             self.help_add()
             raise self.InvalidCmd('\"add\" requires at least two arguments')
-        
+
         if args[0] not in  ['model', 'process']:
-            raise self.InvalidCmd('\"add\" requires the argument \"process\" or \"model\"')    
-    
+            raise self.InvalidCmd('\"add\" requires the argument \"process\" or \"model\"')
+
         if args[0] == 'process':
             return self.check_generate(args)
-    
+
         if args[0] == 'model':
             pass
-            
 
     def check_define(self, args):
         """check the validity of line
@@ -907,7 +896,6 @@ class CheckValidForCmd(cmd.CheckCmd):
 
         if args[0] == 'variable' and len(args) !=2:
             raise self.InvalidCmd('variable need a variable name')
-
 
     def check_draw(self, args):
         """check the validity of line
@@ -967,7 +955,7 @@ class CheckValidForCmd(cmd.CheckCmd):
             param_card = args.pop(3)
         if any([',' in elem for elem in args if not elem.startswith('--')]):
             raise self.InvalidCmd('Decay chains not allowed in check')
-        
+
         user_options = {'--energy':'1000','--split_orders':'-1',
                    '--reduction':'1|3|5|6','--CTModeRun':'-1',
                    '--helicity':'-1','--seed':'-1','--collier_cache':'-1',
@@ -975,13 +963,13 @@ class CheckValidForCmd(cmd.CheckCmd):
                    '--collier_internal_stability_test':'False',
                    '--collier_mode':'1',
                    '--events': None,
-                   '--skip_evt':0}  
+                   '--skip_evt':0}
 
         if args[0] in ['cms'] or args[0].lower()=='cmsoptions':
             # increase the default energy to 5000
             user_options['--energy']='5000'
             # The first argument gives the name of the coupling order in which
-            # the cms expansion is carried, and the expression following the 
+            # the cms expansion is carried, and the expression following the
             # comma gives the relation of an external parameter with the
             # CMS expansions parameter called 'lambdaCMS'.
             parameters = ['aewm1->10.0/lambdaCMS','as->0.1*lambdaCMS']
@@ -1004,7 +992,7 @@ class CheckValidForCmd(cmd.CheckCmd):
             user_options['--analyze']='None'
             # Decides whether to show plot or not during the analysis
             user_options['--show_plot']='True'
-            # Decides what kind of report 
+            # Decides what kind of report
             user_options['--report']='concise'
             # 'secret' option to chose by which lambda power one should divide
             # the nwa-cms difference. Useful to set to 2 when doing the Born check
@@ -1013,18 +1001,18 @@ class CheckValidForCmd(cmd.CheckCmd):
             user_options['--diff_lambda_power']='1'
             # Sets the range of lambda values to plot
             user_options['--lambda_plot_range']='[-1.0,-1.0]'
-            # Sets a filter to apply at generation. See name of available 
-            # filters in loop_diagram_generations.py, function user_filter 
+            # Sets a filter to apply at generation. See name of available
+            # filters in loop_diagram_generations.py, function user_filter
             user_options['--loop_filter']='None'
             # Apply tweaks to the check like multiplying a certain width by a
-            # certain parameters or changing the analytical continuation of the 
+            # certain parameters or changing the analytical continuation of the
             # logarithms of the UV counterterms
             user_options['--tweak']='default()'
             # Give a name to the run for the files to be saved
             user_options['--name']='auto'
             # Select what resonances must be run
             user_options['--resonances']='1'
-        
+
         for arg in args[:]:
             if arg.startswith('--') and '=' in arg:
                 parsed = arg.split('=')
@@ -1034,12 +1022,12 @@ class CheckValidForCmd(cmd.CheckCmd):
                 user_options[key] = value
                 args.remove(arg)
 
-        # If we are just re-analyzing saved data or displaying options then we 
+        # If we are just re-analyzing saved data or displaying options then we
         # shouldn't check the process format.
         if not (args[0]=='cms' and '--analyze' in user_options and \
                               user_options['--analyze']!='None') and not \
                                             args[0].lower().endswith('options'):
-            
+
             self.check_process_format(" ".join(args[1:]))
 
         for option, value in user_options.items():
@@ -1053,7 +1041,7 @@ class CheckValidForCmd(cmd.CheckCmd):
         if not self._curr_model:
             logger.info("No model currently active, so we import the Standard Model")
             self.do_import('model sm')
-        
+
         argproc_noopt = [a for a in args[1:] if not (a.startswith('--') and "=" in a)]
 
         if args[-1].startswith('--optimize'):
@@ -1070,10 +1058,8 @@ class CheckValidForCmd(cmd.CheckCmd):
             if not isinstance(self._curr_model, model_reader.ModelReader):
                 self._curr_model = model_reader.ModelReader(self._curr_model)
             self._curr_model.set_parameters_and_couplings(path)
-        
-        self.check_process_format(' '.join(argproc_noopt))            
-        
-    
+
+        self.check_process_format(' '.join(argproc_noopt))
 
     def check_process_format(self, process):
         """ check the validity of the string given to describe a format """
@@ -1113,7 +1099,7 @@ class CheckValidForCmd(cmd.CheckCmd):
             if re.search('\D\$', particles):
                 raise self.InvalidCmd(
                 'wrong process format: restriction should be place after the final states')
-                
+
         # '{}' should only be used for onshell particle (including initial/final state)
         # check first that polarization are not include between > >
         if nbsep == 2:
@@ -1123,7 +1109,7 @@ class CheckValidForCmd(cmd.CheckCmd):
         if len(split)==2:
             if '{' in split[1]:
                 raise self.InvalidCmd('Polarization restriction can not be used in forbidding particles')
-            
+
         if '[' in process and '{' in process:
             valid = False
             if 'noborn' in process or 'sqrvirt' in process:
@@ -1131,13 +1117,12 @@ class CheckValidForCmd(cmd.CheckCmd):
             else:
                 raise self.InvalidCmd('Polarization restriction can not be used for NLO processes')
 
-            # below are the check when [QCD] will be valid for computation            
+            # below are the check when [QCD] will be valid for computation
             order = process.split('[')[1].split(']')[0]
             if '=' in order:
                 order = order.split('=')[1]
             if order.strip().lower() != 'qcd':
                 raise self.InvalidCmd('Polarization restriction can not be used for generic NLO computations')
-
 
             for p in particles_parts[1].split():
                 if '{' in p:
@@ -1155,8 +1140,6 @@ class CheckValidForCmd(cmd.CheckCmd):
                         continue
                     if p.get('color') != 1:
                         raise self.InvalidCmd('Polarization restriction can not be used for color charged particles')
-        
-
 
     def check_tutorial(self, args):
         """check the validity of the line"""
@@ -1171,11 +1154,9 @@ class CheckValidForCmd(cmd.CheckCmd):
             self.help_tutorial()
             raise self.InvalidCmd('Too many arguments for tutorial')
 
-
-
     def check_import(self, args):
         """check the validity of line"""
-        
+
         modelname = False
         prefix = True
         if '-modelname' in args:
@@ -1184,10 +1165,10 @@ class CheckValidForCmd(cmd.CheckCmd):
         elif '--modelname' in args:
             args.remove('--modelname')
             modelname = True
-            
+
         if '--noprefix' in args:
             args.remove('--noprefix')
-            prefix = False  
+            prefix = False
 
         if args and args[0] == 'model' and '--last' in args:
             # finding last created directory
@@ -1197,14 +1178,14 @@ class CheckValidForCmd(cmd.CheckCmd):
             if 'PYTHONPATH' in os.environ:
                 to_search += os.environ['PYTHONPATH'].split(':')
                 to_search = [d for d in to_search if os.path.exists(d)]
-            
+
             models = []
             for d in to_search:
                 for p in misc.glob('*/particles.py', path=d ):
                     if p.endswith(('__REAL/particles.py','__COMPLEX/particles.py')):
                         continue
                     models.append(os.path.dirname(p))
-                
+
             lastmodel = max(models, key=os.path.getmtime)
             logger.info('last model found is %s', lastmodel)
             args.insert(1, lastmodel)
@@ -1239,11 +1220,8 @@ class CheckValidForCmd(cmd.CheckCmd):
         if modelname:
             args.append('-modelname')
 
-
-
     def check_install(self, args):
         """check that the install command is valid"""
-        
 
         install_options = {'options_for_HEPToolsInstaller':[],
                    'update_options':[]}
@@ -1252,7 +1230,7 @@ class CheckValidForCmd(cmd.CheckCmd):
         if len(args) < 1:
             self.help_install()
             raise self.InvalidCmd('install command require at least one argument')
-        
+
         if len(args) > 1:
             for arg in args[1:]:
                 try:
@@ -1265,16 +1243,16 @@ class CheckValidForCmd(cmd.CheckCmd):
                     if value is None:
                         install_options['update_options'].append(option)
                     else:
-                        install_options['update_options'].append('='.join([option,value]))                        
+                        install_options['update_options'].append('='.join([option,value]))
                 else:
                     # Other options will be directly added to the call to HEPToolsInstallers
                     # in the advanced_install function
                     install_options['options_for_HEPToolsInstaller'].append(arg)
             # Now that the options have been treated keep only the target tool
-            # to install as argument.   
+            # to install as argument.
             args = args[:1]
 
-        if args[0] not in self._install_opts + hidden_prog + self._advanced_install_opts: 
+        if args[0] not in self._install_opts + hidden_prog + self._advanced_install_opts:
             if not args[0].startswith('td'):
                 self.help_install()
                 raise self.InvalidCmd('Not recognize program %s ' % args[0])
@@ -1344,7 +1322,6 @@ This will take effect only in a NEW terminal
         # inform where we are for future command
         self._done_export = [path, mode]
 
-
     def find_import_type(self, path):
         """ identify the import type of a given path
         valid output: model/model_v4/proc_v4/command"""
@@ -1377,9 +1354,6 @@ This will take effect only in a NEW terminal
                 return 'banner'
         else:
             return 'proc_v4'
-
-
-
 
     def find_output_type(self, path):
         """ identify the type of output of a given directory:
@@ -1436,7 +1410,6 @@ This will take effect only in a NEW terminal
         if self._model_v4_path:
             raise self.InvalidCmd('Restriction of Model is not supported by v4 model.')
 
-
     def check_save(self, args):
         """ check the validity of the line"""
 
@@ -1466,10 +1439,18 @@ This will take effect only in a NEW terminal
                 elif arg.startswith('--'):
                     raise self.InvalidCmd('unknow command for \'save options\'')
                 elif arg == 'global':
-                    if 'HOME' in os.environ:
-                        args.remove('global')
-                        args.insert(1,pjoin(os.environ['HOME'],'.mg5','mg5_configuration.txt'))
-                        has_path = True
+                    legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+                    if os.path.exists(legacy_config_dir):
+                        config_dir = legacy_config_dir
+                    else:
+                        config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
+
+                    config_file = os.path.join(config_dir, 'mg5_configuration.txt')
+                    args.remove('global')
+                    args.insert(1, config_file)
+
+                    has_path = True
                 else:
                     basename = os.path.dirname(arg)
                     if not os.path.exists(basename):
@@ -1483,7 +1464,6 @@ This will take effect only in a NEW terminal
                         has_path = True
             if not has_path:
                 args.insert(1, pjoin(MG5DIR,'input','mg5_configuration.txt'))
-
 
     def check_set(self, args, log=True):
         """ check the validity of the line"""
@@ -1540,7 +1520,7 @@ This will take effect only in a NEW terminal
         if args[0] in ['timeout', 'max_npoint_for_channel', 'max_t_for_channel']:
             if not args[1].isdigit():
                 raise self.InvalidCmd('%s values should be a integer' % args[0])
-            
+
         if args[0] in ['loop_optimized_output', 'loop_color_flows', 'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
             try:
                 args[1] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
@@ -1554,9 +1534,6 @@ This will take effect only in a NEW terminal
                         raise Exception('python2.6 does not support such functionalities please use python2.7')
                 #else:
                 #    raise Exception('python3.x does not support such functionalities please use python2.7')
-        
-
-
 
         if args[0] in ['gauge']:
             if args[1] not in ['unitary','Feynman', 'axial']:
@@ -1620,7 +1597,6 @@ This will take effect only in a NEW terminal
         elif not os.path.isfile(args[0]):
             raise self.InvalidCmd('No default path for this file')
 
-
     def check_output(self, args, default='madevent'):
         """ check the validity of the line"""
 
@@ -1629,7 +1605,7 @@ This will take effect only in a NEW terminal
         elif args:
             # check for PLUGIN format
             output_cls = misc.from_plugin_import(self.plugin_path, 'new_output',
-                                                 args[0], warning=True, 
+                                                 args[0], warning=True,
                                                  info='Output will be done with PLUGIN: %(plug)s')
             if output_cls:
                 self._export_format = 'plugin'
@@ -1655,7 +1631,6 @@ This will take effect only in a NEW terminal
 
         if self._export_format == 'aloha':
             return
-
 
         if not self._curr_amps:
             text = 'No processes generated. Please generate a process first.'
@@ -1691,7 +1666,7 @@ This will take effect only in a NEW terminal
                 self.get_default_path()
                 if '-noclean' not in args and os.path.exists(self._export_dir):
                     args.append('-noclean')
-                    
+
             else:
                 if self.options['pythia8_path']:
                     self._export_dir = self.options['pythia8_path']
@@ -1699,7 +1674,6 @@ This will take effect only in a NEW terminal
                     self._export_dir = '.'
 
         self._export_dir = os.path.realpath(self._export_dir)
-
 
     def check_compute_widths(self, args):
         """ check and format calculate decay width:
@@ -1718,11 +1692,11 @@ This will take effect only in a NEW terminal
                    'min_br':None, 'body_decay':4.0025, 'precision_channel':0.01,
                    'nlo':False}
         # check that the firsts argument is valid
-        
+
         for i,arg in enumerate(args):
             if arg.startswith('--'):
                 if arg.startswith('--nlo'):
-                    options['nlo'] =True  
+                    options['nlo'] =True
                     continue
                 elif not '=' in arg:
                     raise self.InvalidCmd('Options required an equal (and then the value)')
@@ -1741,7 +1715,7 @@ This will take effect only in a NEW terminal
                 particles.update([abs(id) for id in self._multiparticles[args[0]]])
             else:
                 if not self._curr_model['case_sensitive']:
-                    arg = arg.lower()                
+                    arg = arg.lower()
                 for p in self._curr_model['particles']:
                     if p['name'] == arg or p['antiname'] == arg:
                         particles.add(abs(p.get_pdg_code()))
@@ -1788,7 +1762,6 @@ This will take effect only in a NEW terminal
             options['min_br'] = (float(options['body_decay']) % 1) / 5
         return particles, options
 
-
     check_decay_diagram = check_compute_widths
 
     def get_default_path(self):
@@ -1814,7 +1787,6 @@ This will take effect only in a NEW terminal
                     if 'TemplateVersion.txt' in self._export_dir:
                         return
 
-
         if self._export_format == 'NLO':
             name_dir = lambda i: 'PROCNLO_%s_%s' % \
                                     (self._curr_model['name'], i)
@@ -1829,7 +1801,7 @@ This will take effect only in a NEW terminal
             name_dir = lambda i: 'PROC_SA_%s_%s' % \
                                     (self._curr_model['name'], i)
             auto_path = lambda i: pjoin(self.writing_dir,
-                                               name_dir(i))                
+                                               name_dir(i))
         elif self._export_format == 'madweight':
             name_dir = lambda i: 'PROC_MW_%s_%s' % \
                                     (self._curr_model['name'], i)
@@ -1869,7 +1841,6 @@ This will take effect only in a NEW terminal
             raise self.InvalidCmd('Can\'t use auto path,' + \
                                   'more than 500 dirs already')
 
-
 #===============================================================================
 # CheckValidForCmdWeb
 #===============================================================================
@@ -1907,7 +1878,6 @@ class CheckValidForCmdWeb(CheckValidForCmd):
 
         if len(args) == 2 and args[1] not in ['.', 'clean']:
             raise self.WebRestriction('Path can\'t be specify on the web.')
-
 
     def check_import(self, args):
         """check the validity of line
@@ -1972,7 +1942,6 @@ class CheckValidForCmdWeb(CheckValidForCmd):
 #===============================================================================
 class CompleteForCmd(cmd.CompleteCmd):
     """ The Series of help routine for the MadGraphCmd"""
-
 
     def nlo_completion(self,args,text,line,allowed_loop_mode=None):
         """ complete the nlo settings within square brackets. It uses the
@@ -2085,7 +2054,7 @@ class CompleteForCmd(cmd.CompleteCmd):
             syntax.extend(['@','$','/','>',','])
             if '[' not in line and ',' not in line and len(pert_couplings_allowed)>0:
                 syntax.append('[')
-            
+
         # If information for the virtuals has been specified already, do not
         # propose syntax or particles input anymore
         if '[' in line:
@@ -2128,7 +2097,7 @@ class CompleteForCmd(cmd.CompleteCmd):
             return
         if args[-1].endswith('^2'):
             return self.list_completion(text,valid_sqso_operators)
-        match_op = [o for o in valid_sqso_operators if o.startswith(args[-1])]            
+        match_op = [o for o in valid_sqso_operators if o.startswith(args[-1])]
         if len(args)>2 and args[-2].endswith('^2') and len(match_op)>0:
             if args[-1] in valid_sqso_operators:
                 return self.list_completion(text,' ')
@@ -2156,7 +2125,7 @@ class CompleteForCmd(cmd.CompleteCmd):
         "Complete the compute_widths command"
 
         args = self.split_arg(line[0:begidx])
-        
+
         # Format
         if len(args) == 1:
             return self.list_completion(text, ['model'])
@@ -2165,7 +2134,6 @@ class CompleteForCmd(cmd.CompleteCmd):
             return self.path_completion(text, current_dir)
         else:
             return self.path_completion(text)
-        
 
     def complete_compute_widths(self, text, line, begidx, endidx,formatting=True):
         "Complete the compute_widths command"
@@ -2203,13 +2171,13 @@ class CompleteForCmd(cmd.CompleteCmd):
 
         if args[1] == 'process':
             return self.complete_generate(text, " ".join(args[1:]), begidx, endidx)
-        
+
         elif args[1] == 'model':
-            completion_categories = self.complete_import(text, line, begidx, endidx, 
+            completion_categories = self.complete_import(text, line, begidx, endidx,
                                                          allow_restrict=False, formatting=False)
             completion_categories['options'] = self.list_completion(text,['--modelname=','--recreate'])
-            return self.deal_multiple_categories(completion_categories, formatting) 
-            
+            return self.deal_multiple_categories(completion_categories, formatting)
+
     def complete_customize_model(self, text, line, begidx, endidx):
         "Complete the customize_model command"
 
@@ -2218,7 +2186,6 @@ class CompleteForCmd(cmd.CompleteCmd):
         # Format
         if len(args) == 1:
             return self.list_completion(text, ['--save='])
-
 
     def complete_check(self, text, line, begidx, endidx, formatting=True):
         "Complete the check command"
@@ -2229,7 +2196,6 @@ class CompleteForCmd(cmd.CompleteCmd):
         # Format
         if len(args) == 1:
             return self.list_completion(text, self._check_opts)
-
 
         cms_check_mode = len(args) >= 2 and args[1]=='cms'
 
@@ -2309,19 +2275,19 @@ class CompleteForCmd(cmd.CompleteCmd):
                                                      formatting)
             elif not any(arg.startswith('--') for arg in args):
                 if '>' in args:
-                    return self.deal_multiple_categories({'Process completion': 
+                    return self.deal_multiple_categories({'Process completion':
                         self.model_completion(text, ' '.join(args[2:]),
                         line, categories = False, allowed_loop_mode=['virt']),
                         'options': self.list_completion(text,options)},
                                                          formatting)
                 else:
-                    return self.deal_multiple_categories({'Process completion': 
+                    return self.deal_multiple_categories({'Process completion':
                         self.model_completion(text, ' '.join(args[2:]),
                         line, categories = False, allowed_loop_mode=['virt'])},
                                                          formatting)
             else:
                 return self.list_completion(text,options)
-            
+
         if len(args) == 2:
             return model_comp_and_path
         elif len(args) == 3:
@@ -2333,7 +2299,6 @@ class CompleteForCmd(cmd.CompleteCmd):
                 return model_comp_and_path
         elif len(args) > 3:
             return model_comp
-
 
     def complete_tutorial(self, text, line, begidx, endidx):
         "Complete the tutorial command"
@@ -2374,7 +2339,6 @@ class CompleteForCmd(cmd.CompleteCmd):
         if len(args) == 1:
             return self.path_completion(text, '.', only_dirs = True)
 
-
         #option
         if len(args) >= 2:
             opt = ['horizontal', 'external=', 'max_size=', 'add_gap=',
@@ -2400,7 +2364,6 @@ class CompleteForCmd(cmd.CompleteCmd):
                 out['Path from %s' % MG4DIR] =  self.path_completion(text,
                                      MG4DIR, only_dirs = True, relative=False)
 
-
         #option
         if len(args) >= 2:
             out={}
@@ -2413,7 +2376,6 @@ class CompleteForCmd(cmd.CompleteCmd):
                '-p','--parton','--interactive', '--laststep=parton', '--laststep=pythia',
                '--laststep=pgs', '--laststep=delphes','--laststep=auto']
             out['Options'] = self.list_completion(text, opt, line)
-
 
         return self.deal_multiple_categories(out,formatting)
 
@@ -2506,10 +2468,10 @@ class CompleteForCmd(cmd.CompleteCmd):
         #name of the run =>proposes old run name
         args = self.split_arg(line[0:begidx])
         if len(args) >= 1:
-            
+
             if len(args) > 1 and args[1] == 'pythia8':
-                possible_options_full = list(possible_options_full) + ['--version=8.1','--version=8.2'] 
-            
+                possible_options_full = list(possible_options_full) + ['--version=8.1','--version=8.2']
+
             if len(args) > 1 and args[1] == 'aloha':
                 try:
                     return self.aloha_complete_output(text, line, begidx, endidx)
@@ -2523,7 +2485,7 @@ class CompleteForCmd(cmd.CompleteCmd):
             # options
             if args[-1][0] == '-' or len(args) > 1 and args[-2] == '-':
                 return self.list_completion(text, possible_options)
-            
+
             if len(args) > 2:
                 return self.list_completion(text, possible_options_full)
             # Formats
@@ -2548,7 +2510,6 @@ class CompleteForCmd(cmd.CompleteCmd):
                             'mg5', 'DECAY', 'EventConverter', 'Models',
                             'ExRootAnalysis', 'Transfer_Fct', 'aloha',
                             'apidoc','vendor']
-
 
         # options
         options = ['--format=Fortran', '--format=Python','--format=gpu','--format=CPP','--output=']
@@ -2604,7 +2565,7 @@ class CompleteForCmd(cmd.CompleteCmd):
             elif args[1] == 'OLP':
                 return self.list_completion(text, MadGraphCmd._OLP_supported)
             elif args[1] == 'output_dependencies':
-                return self.list_completion(text, 
+                return self.list_completion(text,
                                      MadGraphCmd._output_dependencies_supported)
             elif args[1] == 'stdout_level':
                 return self.list_completion(text, ['DEBUG','INFO','WARNING','ERROR',
@@ -2631,7 +2592,7 @@ class CompleteForCmd(cmd.CompleteCmd):
                 return self.path_completion(text,
                         pjoin(*[a for a in args if a.endswith(os.path.sep)]),
                         only_dirs = True)
-        
+
     def complete_import(self, text, line, begidx, endidx, allow_restrict=True,
                         formatting=True):
         "Complete the import command"
@@ -2671,7 +2632,6 @@ class CompleteForCmd(cmd.CompleteCmd):
             # select the possibility according to the current line
             all_name = [name+' ' for name in  all_name if name.startswith(text)
                                                        and name.strip() != text]
-
 
             if all_name:
                 completion_categories['Restricted model'] = all_name
@@ -2746,11 +2706,11 @@ class CompleteForCmd(cmd.CompleteCmd):
                             continue
                         model_list += [name for name in self.path_completion(text,
                                        modeldir, only_dirs=True)
-                                       if os.path.exists(pjoin(modeldir,name, 'particles.py'))]                    
+                                       if os.path.exists(pjoin(modeldir,name, 'particles.py'))]
                 if mode == 'model':
                     model_list += [name for name in list(self._online_model.keys())+self._online_model2
                                     if name.startswith(text)]
-                    
+
                 if mode == 'model_v4':
                     completion_categories['model name'] = model_list
                 elif allow_restrict:
@@ -2761,10 +2721,10 @@ class CompleteForCmd(cmd.CompleteCmd):
                                             base_dir=pjoin(MG5DIR,'models'))
                 else:
                     all_name = model_list
-                
+
                 #avoid duplication
                 all_name = misc.make_unique(all_name)
-                
+
                 if mode == 'all':
                     cur_path = pjoin(*[a for a in args \
                                                         if a.endswith(os.path.sep)])
@@ -2778,8 +2738,8 @@ class CompleteForCmd(cmd.CompleteCmd):
                                             if a.endswith(os.path.sep)])
                 except Exception:
                     cur_path = os.getcwd()
-                all_path =  self.path_completion(text, cur_path)                
-                completion_categories['model name'] = all_path 
+                all_path =  self.path_completion(text, cur_path)
+                completion_categories['model name'] = all_path
 
         # Options
         if mode == 'all' and len(args)>1:
@@ -2792,12 +2752,12 @@ class CompleteForCmd(cmd.CompleteCmd):
                 completion_categories['options'] = self.list_completion(text, ['--modelname','-modelname','--noprefix'])
         if len(args) >= 3 and mode.startswith('banner') and not '--no_launch' in line:
             completion_categories['options'] = self.list_completion(text, ['--no_launch'])
-        
+
         return self.deal_multiple_categories(completion_categories,formatting)
-    
-    _online_model = {'2HDM':[], 
+
+    _online_model = {'2HDM':[],
                          'loop_qcd_qed_sm':['full','no_widths','with_b_mass ', 'with_b_mass_no_widths'],
-                         'loop_qcd_qed_sm_Gmu':['ckm', 'full', 'no_widths'], 
+                         'loop_qcd_qed_sm_Gmu':['ckm', 'full', 'no_widths'],
                          '4Gen':[],
                          'DY_SM':[],
                          'EWdim6':['full'],
@@ -2810,9 +2770,9 @@ class CompleteForCmd(cmd.CompleteCmd):
                          'triplet_diquarks':[''],
                          'uutt_sch_4fermion':[''],
                          'uutt_tch_scalar':['']
-                         }   
-    _online_model2 = [] # fill by model on the db if user do "display modellist" 
-    
+                         }
+    _online_model2 = [] # fill by model on the db if user do "display modellist"
+
     def find_restrict_card(self, model_name, base_dir='./', no_restrict=True,
                            online=True):
         """find the restriction file associate to a given model"""
@@ -2827,8 +2787,8 @@ class CompleteForCmd(cmd.CompleteCmd):
         # check that the model is a valid model
         if online and not local_model and model_name in self._online_model:
             output += ['%s-%s' % (model_name, tag) for tag in self._online_model[model_name]]
-            return output  
-        
+            return output
+
         if not local_model:
             # not valid UFO model
             return output
@@ -2861,12 +2821,12 @@ class CompleteForCmd(cmd.CompleteCmd):
             return self.list_completion(text, self._install_opts + self._advanced_install_opts)
         elif len(args) and args[0] == 'update':
             return self.list_completion(text, ['-f','--timeout='])
-        elif len(args)>=2 and args[1] in self._advanced_install_opts:           
+        elif len(args)>=2 and args[1] in self._advanced_install_opts:
             options = ['--keep_source','--logging=']
             if args[1]=='pythia8':
                 options.append('--pythia8_tarball=')
             elif args[1]=='mg5amc_py8_interface':
-                options.append('--mg5amc_py8_interface_tarball=') 
+                options.append('--mg5amc_py8_interface_tarball=')
             elif args[1] in ['MadAnalysis5','MadAnalysis']:
                 #options.append('--no_MA5_further_install')
                 options.append('--no_root_in_MA5')
@@ -2875,7 +2835,7 @@ class CompleteForCmd(cmd.CompleteCmd):
                 for prefix in ['--with', '--veto']:
                     for prog in ['fastjet', 'delphes', 'delphesMA5tune']:
                         options.append('%s_%s' % (prefix, prog))
-                         
+
             for opt in options[:]:
                 if any(a.startswith(opt) for a in args):
                     options.remove(opt)
@@ -2906,7 +2866,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
     _install_opts = ['Delphes', 'MadAnalysis4', 'ExRootAnalysis',
                      'update', 'Golem95', 'QCDLoop', 'maddm', 'maddump',
                      'looptools', 'MadSTR', 'RunningCoupling']
-    
+
     # The targets below are installed using the HEPToolsInstaller.py script
     _advanced_install_opts = ['pythia8','zlib','boost','lhapdf6','lhapdf5','collier',
                               'hepmc','mg5amc_py8_interface','ninja','oneloop','MadAnalysis5',
@@ -2915,7 +2875,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
     _install_opts.extend(_advanced_install_opts)
 
     _v4_export_formats = ['madevent', 'standalone', 'standalone_msP','standalone_msF',
-                          'matrix', 'standalone_rw', 'madweight'] 
+                          'matrix', 'standalone_rw', 'madweight']
     _export_formats = _v4_export_formats + ['standalone_cpp', 'pythia8', 'aloha',
                                             'matchbox_cpp', 'matchbox']
     _set_options = ['group_subprocesses',
@@ -3014,7 +2974,6 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                          'notification_center': True
                          }
 
-
     # Variables to store object information
     _curr_model = None  #base_objects.Model()
     _curr_amps = diagram_generation.AmplitudeList()
@@ -3026,7 +2985,6 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
     _curr_decaymodel = None
 
     helporder = ['Main commands', 'Documented commands']
-
 
     def preloop(self):
         """Initializing before starting the main loop"""
@@ -3041,7 +2999,6 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
 
         # preloop mother
         CmdExtended.preloop(self)
-
 
     def __init__(self, mgme_dir = '', *completekey, **stdin):
         """ add a tracker of the history """
@@ -3065,7 +3022,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
             shutil.copy(make_opts_source, make_opts)
         elif  os.path.getmtime(make_opts) <  os.path.getmtime(make_opts_source):
             shutil.copy(make_opts_source, make_opts)
-            
+
         # Variables to store state information
         self._multiparticles = {}
         self.options = {}
@@ -3080,7 +3037,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         self._cms_checks = []
         self._nlo_modes_for_completion = ['all','virt','real','LOonly']
 
-        # Load the configuration file,i.e.mg5_configuration.txt
+        # Load the configuration file,i.e. mg5_configuration.txt
         self.set_configuration()
 
     def setup(self):
@@ -3114,8 +3071,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         if madgraph.ReadWrite: #prevent to run on Read Only disk
             self.do_install('update --mode=mg5_end')
         misc.EasterEgg('quit')
-        
-        
+
         return value
 
     # Add a process to the existing multiprocess definition
@@ -3125,10 +3081,9 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         existing amplitudes
         or merge two model
         """
-        
+
         args = self.split_arg(line)
 
-        
         warning_duplicate = True
         if '--no_warning=duplicate' in args:
             warning_duplicate = False
@@ -3138,18 +3093,18 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
         if '--diagram_filter' in args:
             diagram_filter = True
             args.remove('--diagram_filter')
-        
+
         standalone_only = False
         if '--standalone' in args:
             standalone_only = True
-            args.remove('--standalone')            
+            args.remove('--standalone')
 
         # Check the validity of the arguments
         self.check_add(args)
 
         if args[0] == 'model':
             return self.add_model(args[1:])
-        
+
         # special option for 1->N to avoid generation of kinematically forbidden
         #decay.
         if args[-1].startswith('--optimize'):
@@ -3182,7 +3137,7 @@ This implies that with decay chains:
                     nb_proc = len([l for l in self.history if l.startswith(('generate','add process'))])
                     myprocdef, line = self.extract_decay_chain_process(line, proc_number=nb_proc)
                     # Redundant with above, but not completely as in the future
-                    # one might think of allowing the core process to be 
+                    # one might think of allowing the core process to be
                     # corrected by loops.
                     if myprocdef.are_decays_perturbed():
                         raise MadGraph5Error("Decay processes cannot be perturbed.")
@@ -3192,15 +3147,13 @@ This implies that with decay chains:
                     if myprocdef.decays_have_squared_orders() or \
                                                 myprocdef['squared_orders']!={}:
                         raise MadGraph5Error("Decay processes cannot specify "+\
-                                                  "squared orders constraints.")                        
+                                                  "squared orders constraints.")
                     if myprocdef.are_negative_orders_present():
                         raise MadGraph5Error("Decay processes cannot include negative"+\
-                                                " coupling orders constraints.")                    
+                                                " coupling orders constraints.")
             else:
                 nb_proc = len([l for l in self.history if l.startswith(('generate','add process'))])
                 myprocdef = self.extract_process(line, proc_number=nb_proc)
-
-            
 
             # Check that we have something
             if not myprocdef:
@@ -3209,7 +3162,7 @@ This implies that with decay chains:
             # existing processes
             if self._curr_amps and self._curr_amps[0].get_ninitial() != \
                myprocdef.get_ninitial() and not standalone_only:
-                raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
+                raise self.InvalidCmd("Can not mix processes with different number of initial states.")
 
             #Check that we do not have situation like z{T} z
             if not myprocdef.check_polarization():
@@ -3221,9 +3174,6 @@ This implies that with decay chains:
                 ans = self.ask('Do you want to continue', 'no',['yes','no'])
                 if ans == 'no':
                     raise self.InvalidCmd("Not supported syntax of type p p  > Z{T} Z")
-                    
-                
-                
 
             self._curr_proc_defs.append(myprocdef)
 
@@ -3235,17 +3185,17 @@ This implies that with decay chains:
                     raise MadGraph5Error("Negative coupling order constraints"+\
                       " can only be given on one type of coupling and either on"+\
                                    " squared orders or amplitude orders, not both.")
-    
+
                 if myprocdef.get_ninitial() ==1 and  myprocdef.get('squared_orders'):
-                    logger.warning('''Computation of interference term with decay is not 100% validated.  
+                    logger.warning('''Computation of interference term with decay is not 100% validated.
                     Please check carefully your result.
                     One suggestion is also to compare the generation of your process with and without
                     set group_subprocesses True
                     (to write Before the generate command)
                     ''')
-    
+
                 cpu_time1 = time.time()
-    
+
                 # Generate processes
                 if self.options['group_subprocesses'] == 'Auto':
                         collect_mirror_procs = True
@@ -3255,13 +3205,12 @@ This implies that with decay chains:
                                self.options['ignore_six_quark_processes'] if \
                                "ignore_six_quark_processes" in self.options \
                                else []
-    
+
                 myproc = diagram_generation.MultiProcess(myprocdef,
                                          collect_mirror_procs = collect_mirror_procs,
                                          ignore_six_quark_processes = ignore_six_quark_processes,
                                          optimize=optimize, diagram_filter=diagram_filter)
-    
-    
+
                 for amp in myproc.get('amplitudes'):
                     if amp not in self._curr_amps:
                         self._curr_amps.append(amp)
@@ -3280,17 +3229,17 @@ This implies that with decay chains:
             nprocs = len(myproc.get('amplitudes'))
             ndiags = sum([amp.get_number_of_diagrams() for \
                               amp in myproc.get('amplitudes')])
-            
+
             logger.info("%i processes with %i diagrams generated in %0.3f s" % \
                   (nprocs, ndiags, (cpu_time2 - cpu_time1)))
             ndiags = sum([amp.get_number_of_diagrams() for \
                               amp in self._curr_amps])
             logger.info("Total: %i processes with %i diagrams" % \
-                  (len(self._curr_amps), ndiags))        
-                
+                  (len(self._curr_amps), ndiags))
+
     def add_model(self, args):
         """merge two model"""
-        
+
         model_path = args[0]
         recreate = ('--recreate' in args)
         if recreate:
@@ -3309,7 +3258,7 @@ This implies that with decay chains:
             restrict_name = self._curr_model.get('restrict_name')
             output_dir = pjoin(MG5DIR, 'models', '%s__%s' % (name,
                                                   os.path.basename(model_path)))
-        
+
         if os.path.exists(output_dir):
             if recreate:
                 shutil.rmtree(output_dir)
@@ -3320,65 +3269,63 @@ This implies that with decay chains:
                 if restrict_name:
                     new_model_name = '%s-%s' % (output_dir, restrict_name)
                 try:
-                    self.exec_cmd('import model %s' % new_model_name, errorhandling=False, 
+                    self.exec_cmd('import model %s' % new_model_name, errorhandling=False,
                               printcmd=False, precmd=True, postcmd=True)
                 except Exception as error:
                     logger.debug('fail to load model %s with error:\n %s' % (output_dir, error))
                     logger.warning('Fail to load the model. Restore previous model')
-                    self.exec_cmd('import model %s' % oldmodel, errorhandling=False, 
-                              printcmd=False, precmd=True, postcmd=True)                    
+                    self.exec_cmd('import model %s' % oldmodel, errorhandling=False,
+                              printcmd=False, precmd=True, postcmd=True)
                     raise Exception('Invalid Model! Please retry with the option \'--recreate\'.')
                 else:
                     return
-        
-        #Need to do the work!!!        
+
+        #Need to do the work!!!
         import models.usermod as usermod
         base_model = copy.deepcopy(usermod.UFOModel(self._curr_model.get('modelpath')))
-        
+
         identify = dict(tuple(a.split('=')) for a in args if '=' in a)
         base_model.add_model(path=model_path, identify_particles=identify)
         base_model.write(output_dir)
-        
+
         if keep_decay and os.path.exists(pjoin(self._curr_model.get('modelpath'), 'decays.py')):
             base_model.mod_file(pjoin(pjoin(self._curr_model.get('modelpath'), 'decays.py')),
                                 pjoin(pjoin(output_dir, 'decays.py')))
-        
+
         new_model_name = output_dir
         if restrict_name:
             new_model_name = '%s-%s' % (output_dir, restrict_name)
-            
+
         if 'modelname' in self.history.get('full_model_line'):
             opts = '--modelname'
         else:
-            opts='' 
-        self.exec_cmd('import model %s %s' % (new_model_name, opts), errorhandling=False, 
-                              printcmd=False, precmd=True, postcmd=True)         
-        
-    
+            opts=''
+        self.exec_cmd('import model %s %s' % (new_model_name, opts), errorhandling=False,
+                              printcmd=False, precmd=True, postcmd=True)
+
     def do_convert(self, line):
         """convert model FULLPATH
            modify (in place) the UFO model to make it compatible with both python2 and python3
         """
-        
+
         args = self.split_arg(line)
         if hasattr(self, 'do_convert_%s' % args[0]):
             getattr(self, 'do_convert_%s' % args[0])(args[1:])
-            
+
     def do_convert_model(self, args):
         "Not in help: shortcut for convert model"
-        
+
         if not os.path.isdir(args[0]):
             raise Exception( 'model to convert need to provide a full path')
         model_dir = args[0]
-        
-        
-        if not ('-f' not in args or self.options['auto_convert_model']): 
+
+        if not ('-f' not in args or self.options['auto_convert_model']):
             answer = self.ask('model conversion to support both py2 and py3 are done in place.\n They are NO guarantee of success.\n It can make the model to stop working under PY2 as well.\n Do you want to proceed?',
                      'y', ['y','n'])
             if answer != 'y':
-                return 
-        
-        #Object_library 
+                return
+
+        #Object_library
         text = open(pjoin(model_dir, 'object_library.py')).read()
         #(.iteritems() -> .items())
         text = text.replace('.iteritems()', '.items()')
@@ -3386,11 +3333,11 @@ This implies that with decay chains:
         text = re.sub('raise (\w+)\s*,\s*["\']([^"]+)["\']',
                       'raise \g<1>("\g<2>")', text)
         text = open(pjoin(model_dir, 'object_library.py'),'w').write(text)
-        
+
         # write_param_card.dat -> copy the one of the sm model
         files.cp(pjoin(MG5DIR, 'models','sm','write_param_card.py'),
                  pjoin(model_dir, 'write_param_card.py'))
-        
+
         # __init__.py check that function_library and object_library are imported
         text = open(pjoin(model_dir, '__init__.py')).read()
         mod = False
@@ -3399,14 +3346,10 @@ This implies that with decay chains:
             if 'import %s' % lib in text:
                 continue
             mod = True
-            text = "import %s \n" % lib + text  
+            text = "import %s \n" % lib + text
         if mod:
             open(pjoin(model_dir, '__init__.py'),'w').write(text)
-        
-        
-        
-        
-    
+
     # Define a multiparticle label
     def do_define(self, line, log=True):
         """Define a multiparticle"""
@@ -3556,7 +3499,6 @@ This implies that with decay chains:
                 text += 'No matching for any interactions'
             pydoc.pager(text)
 
-
         elif args[0] == 'parameters' and len(args) == 1:
             text = "Current model contains %i parameters\n" % \
                     sum([len(part) for part in
@@ -3690,7 +3632,7 @@ This implies that with decay chains:
                         aloha_str += 'C' + 'C'.join([str(ia) for ia in aloha[1]])
                     aloha_str += "_%d" % aloha[2]
                     outstr += "\n" + aloha_str
-            
+
             outstr += '\n'
             for cms_check in self._cms_checks:
                 outstr += '*'*102+'\n'
@@ -3700,7 +3642,7 @@ This implies that with decay chains:
                 tmp_options = copy.copy(cms_check['options'])
                 tmp_options['show_plot']=False
                 outstr += process_checks.output_complex_mass_scheme(
-                            cms_check['cms_result'], cms_check['output_path'], 
+                            cms_check['cms_result'], cms_check['output_path'],
                                            tmp_options, self._curr_model) + '\n'
                 outstr += '*'*102+'\n\n'
             pydoc.pager(outstr)
@@ -3718,7 +3660,7 @@ This implies that with decay chains:
             for key in keys:
                 if not to_print(key):
                     continue
-                default = self.options_madgraph[key] 
+                default = self.options_madgraph[key]
                 value = self.options[key]
                 if value == default:
                     outstr += "  %25s \t:\t%s\n" % (key,value)
@@ -3756,7 +3698,7 @@ This implies that with decay chains:
             output.write(outstr)
         elif args[0] in  ["variable"]:
             super(MadGraphCmd, self).do_display(line, output)
-            
+
         elif args[0] in ["modellist", "model_list"]:
             outstr = []
             template = """%-30s | %-60s | %-25s """
@@ -3764,7 +3706,7 @@ This implies that with decay chains:
             outstr.append('*'*150)
             already_done = []
             #local model #use
-            
+
             if 'PYTHONPATH' in os.environ:
                 pythonpath = os.environ['PYTHONPATH'].split(':')
             else:
@@ -3775,13 +3717,13 @@ This implies that with decay chains:
                     continue
                 file_cond = lambda p : os.path.exists(pjoin(base,p,'particles.py'))
                 mod_name = lambda name: name
-                
+
                 model_list = [mod_name(name) for name in \
                                                 self.path_completion('',
                                                 base,
                                                 only_dirs = True) \
                                                 if file_cond(name)]
-                
+
                 for model_name in model_list:
                     if model_name in already_done:
                         continue
@@ -3789,9 +3731,9 @@ This implies that with decay chains:
                                             base_dir=base,
                                             online=False)
                     already_done.append(model_name)
-                    restrict = [name[len(model_name):] for name in all_name 
+                    restrict = [name[len(model_name):] for name in all_name
                                 if len(name)>len(model_name)]
-                    
+
                     comment = 'from models directory'
                     if base != pjoin(MG5DIR,'models'):
                         comment = 'from PYTHONPATH: %s' % base
@@ -3806,8 +3748,8 @@ This implies that with decay chains:
                     else:
                         outstr.append(template % (model_name, ', '.join(restrict), comment))
                 outstr.append('*'*150)
-                
-            # Still have to add the one with internal information 
+
+            # Still have to add the one with internal information
             for model_name in self._online_model:
                 if model_name in already_done:
                     continue
@@ -3815,8 +3757,8 @@ This implies that with decay chains:
                 comment = 'automatic download from MG5aMC server'
                 outstr.append(template % (model_name, ','.join(restrict), comment))
                 already_done.append(model_name)
-                
-            outstr.append('*'*150)  
+
+            outstr.append('*'*150)
             # other downloadable model
             data   = import_ufo.get_model_db()
             self._online_model2 = []
@@ -3826,7 +3768,7 @@ This implies that with decay chains:
                     continue
                 if model_name.endswith('_v4'):
                     continue
-                
+
                 if 'feynrules' in path:
                     comment = 'automatic download from FeynRules website'
                 elif 'madgraph.phys' in path:
@@ -3837,7 +3779,6 @@ This implies that with decay chains:
                 outstr.append(template % (model_name, restrict, comment))
                 self._online_model2.append(model_name)
             pydoc.pager('\n'.join(outstr))
-            
 
     def multiparticle_string(self, key):
         """Returns a nicely formatted string for the multiparticle"""
@@ -3879,8 +3820,6 @@ This implies that with decay chains:
                        "please run from a" + \
                        "\n\t         valid MG_ME directory.")
 
-
-
     def draw(self, line,selection='all',Dtype=''):
         """ draw the Feynman diagram for the given process.
         Dtype refers to born, real or loop"""
@@ -3899,14 +3838,11 @@ This implies that with decay chains:
         (options, args) = _draw_parser.parse_args(args)
         if madgraph.iolibs.drawing_eps.EpsDiagramDrawer.april_fool:
             options.horizontal = True
-            options.external = True  
-            options.max_size = 0.3 
-            options.add_gap = 0.5  
+            options.external = True
+            options.max_size = 0.3
+            options.add_gap = 0.5
         options = draw_lib.DrawOption(options)
         start = time.time()
-
-
-            
 
         # Collect amplitudes
         amplitudes = diagram_generation.AmplitudeList()
@@ -3936,7 +3872,6 @@ This implies that with decay chains:
                                           legend=amp.get('process').input_string(),
                                           diagram_type=Dtype)
 
-
             logger.info("Drawing " + \
                          amp.get('process').nice_string())
             plot.draw(opt=options)
@@ -3956,7 +3891,7 @@ This implies that with decay chains:
              by N values uniformly distributed. For example, lower_bound=1e-2
              and N=5 returns:
              [1, 0.8, 0.6, 0.4, 0.2, 0.1, 0.08, 0.06, 0.04, 0.02, 0.01]"""
-            
+
             lCMS_values = [1]
             exp = 0
             n   = 0
@@ -3966,13 +3901,13 @@ This implies that with decay chains:
                 if lCMS_values[-1]==lCMS_values[-2]:
                     lCMS_values.pop()
                 exp = (n+1)//N
-            
+
             lCMS_values = lCMS_values[:-1]
             if lCMS_values[-1]!=lower_bound:
                 lCMS_values.append(lower_bound)
-                
+
             return lCMS_values
-        
+
         ###### BEGIN do_check
 
         args = self.split_arg(line)
@@ -3991,7 +3926,7 @@ This implies that with decay chains:
         # Back up the gauge for later
         gauge = str(self.options['gauge'])
         options['reuse'] = args[1]=="-reuse"
-        args = args[:1]+args[2:] 
+        args = args[:1]+args[2:]
         # For the stability check the user can specify the statistics (i.e
         # number of trial PS points) as a second argument
         if args[0] in ['stability', 'profile']:
@@ -4031,10 +3966,10 @@ This implies that with decay chains:
                 if option[1]!='auto':
                     MLoptions['COLLIERRequiredAccuracy']=float(option[1])
             elif option[0]=='--collier_internal_stability_test':
-                MLoptions['COLLIERUseInternalStabilityTest']=eval(option[1])                
+                MLoptions['COLLIERUseInternalStabilityTest']=eval(option[1])
             elif option[0]=='--CTModeRun':
                 try:
-                    MLoptions['CTModeRun']=int(option[1])  
+                    MLoptions['CTModeRun']=int(option[1])
                 except ValueError:
                     raise self.InvalidCmd("The value of the 'CTModeRun' option"+\
                                        " must be an integer, not %s."%option[1])
@@ -4067,8 +4002,8 @@ This implies that with decay chains:
                                                        " option '%s'"%option[1])
                     if isinstance(resonances,int) and resonances>0:
                         CMS_options['resonances']  = resonances
-                    elif isinstance(resonances,list) and all(len(res)==2 and 
-                        isinstance(res[0],int) and all(isinstance(i, int) for i in 
+                    elif isinstance(resonances,list) and all(len(res)==2 and
+                        isinstance(res[0],int) and all(isinstance(i, int) for i in
                                                      res[1]) for res in resonances):
                         CMS_options['resonances']  = resonances
                     else:
@@ -4084,12 +4019,12 @@ This implies that with decay chains:
                       'allwidths->0.9*allwidths(widths_x_0.9)',
                       'allwidths->0.99*allwidths(widths_x_0.99)',
                       'allwidths->1.01*allwidths(widths_x_1.01)',
-                      'allwidths->1.1*allwidths(widths_x_1.1)',                      
+                      'allwidths->1.1*allwidths(widths_x_1.1)',
                       'logp->logm(logp2logm)','logm->logp(logm2logp)'])
                 try:
                     tweaks = eval(value)
                     if isinstance(tweaks, str):
-                        tweaks = [value]                         
+                        tweaks = [value]
                     elif not isinstance(tweaks,list):
                         tweaks = [value]
                 except:
@@ -4133,7 +4068,7 @@ This implies that with decay chains:
                             param = '__tmpprefix__%s'%param
                             res = float(eval(replacement.lower(),
                                          {'lambdacms':1.0,param.lower():98.85}))
-                        except:                    
+                        except:
                             raise self.InvalidCmd("The substitution expression "+
                         "'%s' for the tweaked parameter"%orig_replacement+
                         " '%s' could not be evaluated. It must be an "%orig_param+
@@ -4168,8 +4103,8 @@ This implies that with decay chains:
                     raise self.InvalidCmd("The plot range specified %s"%option[1]+\
                                    " is not a valid syntax. Error:\n%s"%str(e))
                 if not isinstance(plot_range,(list,tuple)) or \
-                    len(plot_range)!=2 or any(not isinstance(p,(float,int)) 
-                                                           for p in plot_range):                    
+                    len(plot_range)!=2 or any(not isinstance(p,(float,int))
+                                                           for p in plot_range):
                     raise self.InvalidCmd("The plot range specified %s"\
                                                        %option[1]+" is invalid")
                 CMS_options['lambda_plot_range']=list([float(p) for p in plot_range])
@@ -4190,7 +4125,7 @@ This implies that with decay chains:
                 elif isinstance(lambda_values,(tuple,float)):
                     # Format here is then (lower_bound, N) were lower_bound is
                     # the minimum lambdaCMS value that must be probed and the
-                    # integer N is the number of such values that must be 
+                    # integer N is the number of such values that must be
                     # uniformly distributed in each intervale [1.0e-i,1.0e-(i+1)]
                     if isinstance(lambda_values, float):
                         # Use default of 10 for the number of lambda values
@@ -4210,7 +4145,7 @@ This implies that with decay chains:
                                           " for either a float, tuple or list.")
                 lower_bound = lambda_values[-1]
                 # and finally add 5 points for stability test on the last values
-                # Depending on how the stab test will behave at NLO, we can 
+                # Depending on how the stab test will behave at NLO, we can
                 # consider automatically adding the values below
 #                for stab in range(1,6):
 #                    lambda_values.append((1.0+(stab/100.0))*lower_bound)
@@ -4223,7 +4158,7 @@ This implies that with decay chains:
                 except ValueError:
                     raise self.InvalidCmd("CMS expansion specification '%s'"%\
                                                        args[i]+" is incorrect.")
-                CMS_options['expansion_orders'] = [expansion_order for 
+                CMS_options['expansion_orders'] = [expansion_order for
                              expansion_order in CMS_expansion_orders.split('&')]
                 CMS_options['expansion_parameters'] = {}
                 for expansion_parameter in CMS_expansion_parameters.split('&'):
@@ -4242,7 +4177,7 @@ This implies that with decay chains:
                         param = '__tmpprefix__%s'%param
                         res = float(eval(replacement.lower(),
                                          {'lambdacms':1.0,param.lower():98.85}))
-                    except:                    
+                    except:
                         raise self.InvalidCmd("The substitution expression "+
                         "'%s' for CMS expansion parameter"%orig_replacement+
                         " '%s' could not be evaluated. It must be an "%orig_param+
@@ -4256,7 +4191,7 @@ This implies that with decay chains:
 
             i=i-1
         args = args[:i+1]
-        
+
         if args[0]=='options':
             # Simple printout of the check command options
             logger_check.info("Options for the command 'check' are:")
@@ -4273,19 +4208,19 @@ This implies that with decay chains:
             logger_check.info("-"*40)
             for key, value in CMS_options.items():
                 logger_check.info("{:<20} =   {}".format('--%s'%key,str(value)))
-            return        
-        
+            return
+
         # Set the seed here if not in cms check and if specified
         if args[0]!='cms' and options['seed']!=-1:
             # Not necessarily optimal as there could be additional call to
             # random() as the code develops, but at least it will encompass
             # everything in this way.
-            
+
             if not hasattr(random, 'mg_seedset'):
                 logger_check.info('Setting random seed to %d.'%options['seed'])
-                random.seed(options['seed'])  
+                random.seed(options['seed'])
                 random.mg_seedset = options['seed']
-        
+
         proc_line = " ".join(args[1:])
         # Don't try to extract the process if just re-analyzing a saved run
         if not (args[0]=='cms' and options['analyze']!='None'):
@@ -4299,7 +4234,7 @@ This implies that with decay chains:
                 myprocdef.set('NLO_mode','virt')
         else:
             myprocdef = None
-            
+
         # If the test has to write out on disk, it should do so at the location
         # specified below where the user must be sure to have writing access.
         output_path = os.getcwd()
@@ -4372,15 +4307,14 @@ This implies that with decay chains:
         else:
             if "MLReductionLib" in MLoptions:
                 if 3 in MLoptions["MLReductionLib"]:
-                    logger_check.warning('IREGI not available on your system; it will be skipped.')                    
+                    logger_check.warning('IREGI not available on your system; it will be skipped.')
                     MLoptions["MLReductionLib"].remove(3)
-
 
         if "MLReductionLib" in MLoptions:
             if 2 in MLoptions["MLReductionLib"]:
-                logger_check.warning('PJFRY not supported anymore; it will be skipped.')                    
+                logger_check.warning('PJFRY not supported anymore; it will be skipped.')
                 MLoptions["MLReductionLib"].remove(2)
-                    
+
         if 'golem' in self.options and isinstance(self.options['golem'],str):
             TIR_dir['golem_dir']=self.options['golem']
         else:
@@ -4388,7 +4322,7 @@ This implies that with decay chains:
                 if 4 in MLoptions["MLReductionLib"]:
                     logger_check.warning('GOLEM not available on your system; it will be skipped.')
                     MLoptions["MLReductionLib"].remove(4)
-        
+
         if 'samurai' in self.options and isinstance(self.options['samurai'],str):
             TIR_dir['samurai_dir']=self.options['samurai']
         else:
@@ -4396,7 +4330,7 @@ This implies that with decay chains:
                 if 5 in MLoptions["MLReductionLib"]:
                     logger_check.warning('Samurai not available on your system; it will be skipped.')
                     MLoptions["MLReductionLib"].remove(5)
-        
+
         if 'collier' in self.options and isinstance(self.options['collier'],str):
             TIR_dir['collier_dir']=self.options['collier']
         else:
@@ -4404,7 +4338,7 @@ This implies that with decay chains:
                 if 7 in MLoptions["MLReductionLib"]:
                     logger_check.warning('Collier not available on your system; it will be skipped.')
                     MLoptions["MLReductionLib"].remove(7)
-        
+
         if 'ninja' in self.options and isinstance(self.options['ninja'],str):
             TIR_dir['ninja_dir']=self.options['ninja']
         else:
@@ -4412,7 +4346,7 @@ This implies that with decay chains:
                 if 6 in MLoptions["MLReductionLib"]:
                     logger_check.warning('Ninja not available on your system; it will be skipped.')
                     MLoptions["MLReductionLib"].remove(6)
-        
+
         if args[0] in ['timing']:
             timings = process_checks.check_timing(myprocdef,
                                                   param_card = param_card,
@@ -4422,7 +4356,7 @@ This implies that with decay chains:
                                                   cmd = self,
                                                   output_path = output_path,
                                                   MLOptions = MLoptions
-                                                  )        
+                                                  )
 
         if args[0] in ['stability']:
             stability=process_checks.check_stability(myprocdef,
@@ -4455,7 +4389,7 @@ This implies that with decay chains:
             if gauge == 'unitary':
                 myprocdef_unit = myprocdef
                 self.do_set('gauge Feynman', log=False)
-                myprocdef_feyn = self.extract_process(line)              
+                myprocdef_feyn = self.extract_process(line)
             else:
                 myprocdef_feyn = myprocdef
                 self.do_set('gauge unitary', log=False)
@@ -4474,10 +4408,10 @@ This implies that with decay chains:
                                                 reuse = options['reuse'],
                                                 output_path = output_path,
                                                 cmd = self)
-            
+
             # restore previous settings
             self.do_set('gauge %s' % gauge, log=False)
-            nb_processes += len(gauge_result_no_brs)            
+            nb_processes += len(gauge_result_no_brs)
 
         if args[0] in  ['permutation', 'full']:
             comparisons = process_checks.check_processes(myprocdef,
@@ -4517,7 +4451,7 @@ This implies that with decay chains:
         # The CMS check is typically more complicated and slower than others
         # so we don't run it automatically with 'full'.
         if args[0] in ['cms']:
-            
+
             cms_original_setup = self.options['complex_mass_scheme']
             process_line = " ".join(args[1:])
             # Merge in the CMS_options to the options
@@ -4528,21 +4462,21 @@ This implies that with decay chains:
                     options[key] = value
                 else:
                     raise MadGraph5Error("Option '%s' is both in the option"%key+\
-                                                   " and CMS_option dictionary.") 
-            
+                                                   " and CMS_option dictionary.")
+
             if options['analyze']=='None':
                 cms_results = []
                 for tweak in CMS_options['tweak']:
                     options['tweak']=tweak
                     # Try to guess the save path and try to load it before running
                     guessed_proc = myprocdef.get_process(
-                      [leg.get('ids')[0] for leg in myprocdef.get('legs') 
+                      [leg.get('ids')[0] for leg in myprocdef.get('legs')
                                                        if not leg.get('state')],
                       [leg.get('ids')[0] for leg in myprocdef.get('legs')
                                                            if leg.get('state')])
                     save_path = process_checks.CMS_save_path('pkl',
                     {'ordered_processes':[guessed_proc.base_string()],
-                     'perturbation_orders':guessed_proc.get('perturbation_couplings')}, 
+                     'perturbation_orders':guessed_proc.get('perturbation_couplings')},
                              self._curr_model, options, output_path=output_path)
                     if os.path.isfile(save_path) and options['reuse']:
                         cms_result = save_load_object.load_from_file(save_path)
@@ -4551,7 +4485,7 @@ This implies that with decay chains:
                         if cms_result is None:
                             raise self.InvalidCmd('The complex mass scheme check result'+
                             " file below could not be read.\n     %s"%save_path)
-                    else:      
+                    else:
                         cms_result = process_checks.check_complex_mass_scheme(
                                               process_line,
                                               param_card = param_card,
@@ -4562,7 +4496,7 @@ This implies that with decay chains:
                                               MLOptions = MLoptions,
                                               options=options)
                         # Now set the correct save path
-                        save_path = process_checks.CMS_save_path('pkl', cms_result, 
+                        save_path = process_checks.CMS_save_path('pkl', cms_result,
                              self._curr_model, options, output_path=output_path)
                     cms_results.append((cms_result,save_path,tweak['name']))
             else:
@@ -4587,7 +4521,7 @@ This implies that with decay chains:
 
         if args[0] in ['cms']:
                 text = "Note that the complex mass scheme test in principle only\n"
-                text+= "works for stable particles in final states.\n\ns"            
+                text+= "works for stable particles in final states.\n\ns"
         if args[0] not in ['timing','stability', 'profile', 'cms']:
             if self.options['complex_mass_scheme']:
                 text = "Note that Complex mass scheme gives gauge/lorentz invariant\n"
@@ -4638,7 +4572,7 @@ This implies that with decay chains:
                         analyze.append('%s(%s)'%(save_path,tweakname))
                 options['analyze']=','.join(analyze)
                 options['tweak']  = CMS_options['tweak'][0]
-            
+
             self._cms_checks.append({'line':line, 'cms_result':cms_result,
                                   'options':options, 'output_path':output_path})
             text += process_checks.output_complex_mass_scheme(cms_result,
@@ -4672,7 +4606,6 @@ This implies that with decay chains:
         if not options['reuse']:
             process_checks.clean_up(self._mgme_dir)
 
-
     def clean_process(self):
         """ensure that all processes are cleaned from memory.
         typically called from import model and generate XXX command
@@ -4689,9 +4622,8 @@ This implies that with decay chains:
         # Reset _done_export, since we have new process
         self._done_export = False
         # Also reset _export_format and _export_dir
-        self._export_format = None        
-        
-            
+        self._export_format = None
+
     # Generate a new amplitude
     def do_generate(self, line):
         """Main commands: Generate an amplitude for a given process"""
@@ -4714,7 +4646,6 @@ This implies that with decay chains:
             self.do_help('generate')
             raise self.InvalidCmd('Wrong use of \">\" special character.')
 
-
         # Perform sanity modifications on the lines:
         # Add a space before and after any > , $ / | [ ]
         space_before = re.compile(r"(?P<carac>\S)(?P<tag>[\\[\\]/\,\\$\\>|])(?P<carac2>\S)")
@@ -4731,7 +4662,7 @@ This implies that with decay chains:
             proc_number = int(proc_number_re.group(2))
             line = proc_number_re.group(1)+ proc_number_re.group(3)
             #overall_order are already handle but it is better to pass the info to each group
-        
+
         # Now check for perturbation orders, specified in between squared brackets
         perturbation_couplings_pattern = \
           re.compile("^(?P<proc>.+>.+)\s*\[\s*((?P<option>\w+)\s*\=)?\s*"+\
@@ -4759,7 +4690,7 @@ This implies that with decay chains:
 
             line = perturbation_couplings_re.group("proc")+\
                      perturbation_couplings_re.group("rest")
-                        
+
         ## Now check for orders/squared orders/constrained orders
         order_pattern = re.compile(\
            "^(?P<before>.+>.+)\s+(?P<name>(\w|(\^2))+)\s*(?P<type>"+\
@@ -4768,8 +4699,8 @@ This implies that with decay chains:
         squared_orders = {}
         orders = {}
         constrained_orders = {}
-        
-        # define the various coupling order alias 
+
+        # define the various coupling order alias
         coupling_alias = {}
         model_orders = self._curr_model.get('coupling_orders')
         if 'EW' in model_orders:
@@ -4786,7 +4717,7 @@ This implies that with decay chains:
         if 'QCD' in model_orders:
             if 'aS' not in model_orders:
                 coupling_alias['aS'] = 'QCD^2=2*'
-        
+
         ## The 'split_orders' (i.e. those for which individual matrix element
         ## evalutations must be provided for each corresponding order value) are
         ## defined from the orders specified in between [] and any order for
@@ -4798,18 +4729,18 @@ This implies that with decay chains:
             value = int(order_re.group('value'))
             if name in coupling_alias:
                 old_name,old_value = name,value
-                
+
                 name = coupling_alias[name]
                 if name.endswith('=2*'):
                     name = name[:-3]
                     value *= 2
-                logger.info("change syntax %s=%s to %s=%s to correspond to UFO model convention", 
+                logger.info("change syntax %s=%s to %s=%s to correspond to UFO model convention",
                             old_name, old_value, name, value)
             if name.endswith('^2'):
                 basename = name[:-2]
                 if basename not in list(model_orders) + ['WEIGHTED']:
                     valid = list(model_orders) +list(coupling_alias.keys()) + ['WEIGHTED']
-                    raise self.InvalidCmd("model order %s not valid for this model (valid one are: %s). Please correct" % (name, ', '.join(valid))) 
+                    raise self.InvalidCmd("model order %s not valid for this model (valid one are: %s). Please correct" % (name, ', '.join(valid)))
 
                 if type not in self._valid_sqso_types:
                     raise self.InvalidCmd("Type of squared order "+\
@@ -4822,7 +4753,7 @@ This implies that with decay chains:
             else:
                 if name not in model_orders:
                     valid = list(model_orders) + list(coupling_alias.keys())
-                    raise self.InvalidCmd("model order %s not valid for this model (valid one are: %s). Please correct" % (name, ', '.join(valid))) 
+                    raise self.InvalidCmd("model order %s not valid for this model (valid one are: %s). Please correct" % (name, ', '.join(valid)))
                 if type not in self._valid_amp_so_types:
                     raise self.InvalidCmd("Amplitude order constraints can only be of type %s"%\
                     (', '.join(self._valid_amp_so_types))+", not '%s'."%type)
@@ -4831,7 +4762,7 @@ This implies that with decay chains:
                 if type in ['=', '<=']:
                     if type == '=' and value != 0:
                         logger.warning("Interpreting '%(n)s=%(v)s' as '%(n)s<=%(v)s'" %\
-                                       {'n':name, 'v': value}) 
+                                       {'n':name, 'v': value})
                     orders[name] = value
                 elif type == "==":
                     constrained_orders[name] = (value, type)
@@ -4839,36 +4770,36 @@ This implies that with decay chains:
                         squared_orders[name] = (2 * value,'==')
                     if True:#name not in orders:
                         orders[name] = value
-                    
+
                 elif type == ">":
                     constrained_orders[name] = (value, type)
                     if name not in squared_orders:
                         squared_orders[name] = (2 * value,'>')
-            
-            line = '%s %s' % (order_re.group('before'),order_re.group('after')) 
-            order_re = order_pattern.match(line)   
-                   
+
+            line = '%s %s' % (order_re.group('before'),order_re.group('after'))
+            order_re = order_pattern.match(line)
+
         # handle the case where default is not 99 and some coupling defined
         if self.options['default_unset_couplings'] != 99 and \
-                                                     (orders or squared_orders): 
-                           
+                                                     (orders or squared_orders):
+
                 to_set = [name for name in self._curr_model.get('coupling_orders')
                           if name not in orders and name not in squared_orders]
                 if to_set:
-                    logger.info('the following coupling will be allowed up to the maximal value of %s: %s' % 
+                    logger.info('the following coupling will be allowed up to the maximal value of %s: %s' %
                             (self.options['default_unset_couplings'], ', '.join(to_set)), '$MG:BOLD')
                 for name in to_set:
                     orders[name] = int(self.options['default_unset_couplings'])
-        
+
         #only allow amplitue restrctions >/ == for LO/tree level
         if constrained_orders and LoopOption != 'tree':
             raise self.InvalidCmd("Amplitude order constraints (for not LO processes) can only be of type %s"%\
                         (', '.join(['<=']))+", not '%s'."%type)
 
-        # If the squared orders are defined but not the orders, assume 
+        # If the squared orders are defined but not the orders, assume
         # orders=sq_orders. In case the squared order has a negative value or is
-        # defined with the '>' operato, then this order correspondingly set to 
-        # be maximal (99) since there is no way to know, during generation, if 
+        # defined with the '>' operato, then this order correspondingly set to
+        # be maximal (99) since there is no way to know, during generation, if
         # the amplitude being contstructed will be leading or not.
         # This only applies when no perturbation couplings are provided, ie
         # for LO-only generation
@@ -4878,7 +4809,6 @@ This implies that with decay chains:
                     orders[order]=squared_orders[order][0]
                 else:
                     orders[order]=99
-        
 
         if not self._curr_model['case_sensitive']:
             # Particle names lowercase
@@ -4954,7 +4884,7 @@ This implies that with decay chains:
             if '{' in part_name:
                 part_name, pol = part_name.split('{',1)
                 pol, rest = pol.split('}',1)
-                
+
                 no_dup_name = part_name
                 while True:
                     try:
@@ -5003,7 +4933,7 @@ This implies that with decay chains:
                     elif p in ['+']:
                         if i +1 < len(pol) and pol[i+1].isdigit():
                             p = int(pol[i+1])
-                            if abs(p) > 3: 
+                            if abs(p) > 3:
                                 raise self.InvalidCmd("polarization are between -3 and 3")
                             polarization.append(p)
                             ignore = True
@@ -5012,7 +4942,7 @@ This implies that with decay chains:
                     elif p in ['-']:
                         if i+1 < len(pol) and pol[i+1].isdigit():
                             p = int(pol[i+1])
-                            if abs(p) > 3: 
+                            if abs(p) > 3:
                                 raise self.InvalidCmd("polarization are between -3 and 3")
                             polarization.append(-p)
                             ignore = True
@@ -5029,7 +4959,7 @@ This implies that with decay chains:
                             polarization += [0]
                     elif p.isdigit():
                         p = int(p)
-                        if abs(p) > 3: 
+                        if abs(p) > 3:
                             raise self.InvalidCmd("polarization are between -3 and 3")
                         polarization.append(p)
                     else:
@@ -5051,7 +4981,7 @@ This implies that with decay chains:
                     raise self.InvalidCmd("No pdg_code %s in model" % part_name)
             else:
                 mypart = self._curr_model['particles'].get_copy(part_name)
-                
+
                 if mypart:
                     mylegids.append(mypart.get_pdg_code())
                 else:
@@ -5063,7 +4993,7 @@ This implies that with decay chains:
                                 raise self.InvalidCmd(\
                                       "Multiparticle %s is or-multiparticle" % part_name + \
                                       " which can be used only for required s-channels")
-                            mylegids.extend(self._multiparticles[part_name])                        
+                            mylegids.extend(self._multiparticles[part_name])
                         else:
                             mypart = self._curr_model['particles'].get_copy(part_name)
                             mylegids.append(mypart.get_pdg_code())
@@ -5096,7 +5026,6 @@ This implies that with decay chains:
                 LoopOption = 'LOonly'
             perturbation_couplings=' '.join(self._curr_model['perturbation_couplings'])
 
-
         if [leg for leg in myleglist if leg.get('state') == True]:
             # We have a valid process
             # Extract perturbation orders
@@ -5113,10 +5042,10 @@ This implies that with decay chains:
             except KeyError:
                 raise self.InvalidCmd("The loaded model does not defined a "+\
                     " coupling order hierarchy for these couplings: %s"%\
-                      str([so for so in split_orders if so!='WEIGHTED' and so not 
+                      str([so for so in split_orders if so!='WEIGHTED' and so not
                                  in list(self._curr_model['order_hierarchy'].keys())]))
 
-            # If the loopOption is 'tree' then the user used the syntax 
+            # If the loopOption is 'tree' then the user used the syntax
             # [tree= Orders] for the sole purpose of setting split_orders. We
             # then empty the perturbation_couplings_list at this stage.
             if LoopOption=='tree':
@@ -5138,7 +5067,7 @@ This implies that with decay chains:
                   ' coupling orders. MadLoop output will therefore not be'+\
                   ' able to provide such quantities.')
                 split_orders = []
-                       
+
             # Now extract restrictions
             forbidden_particle_ids = \
                               self.extract_particle_ids(forbidden_particles)
@@ -5164,14 +5093,14 @@ This implies that with decay chains:
             if required_schannel_ids and not \
                    isinstance(required_schannel_ids[0], list):
                 required_schannel_ids = [required_schannel_ids]
-            
+
             sqorders_values = dict([(k,v[0]) for k, v in squared_orders.items()])
             if len([1 for sqo_v in sqorders_values.values() if sqo_v<0])>1:
                 raise self.InvalidCmd(
                   "At most one negative squared order constraint can be specified.")
-            
-            sqorders_types = dict([(k,v[1]) for k, v in squared_orders.items()]) 
-            
+
+            sqorders_types = dict([(k,v[1]) for k, v in squared_orders.items()])
+
             out = base_objects.ProcessDefinition({'legs': myleglist,
                               'model': self._curr_model,
                               'id': proc_number,
@@ -5192,22 +5121,21 @@ This implies that with decay chains:
             return out
         #                       'is_decay_chain': decay_process\
 
-
     def create_loop_induced(self, line, myprocdef=None):
         """ Routine to create the MultiProcess for the loop-induced case"""
-        
+
         args = self.split_arg(line)
-        
+
         warning_duplicate = True
         if '--no_warning=duplicate' in args:
             warning_duplicate = False
             args.remove('--no_warning=duplicate')
-        
+
         # Check the validity of the arguments
         self.check_add(args)
         if args[0] == 'process':
             args = args[1:]
-        
+
         # special option for 1->N to avoid generation of kinematically forbidden
         #decay.
         if args[-1].startswith('--optimize'):
@@ -5216,38 +5144,37 @@ This implies that with decay chains:
         else:
             optimize = False
 
-        # Extract potential loop_filter  
-        loop_filter=None        
+        # Extract potential loop_filter
+        loop_filter=None
         for arg in args:
             if arg.startswith('--loop_filter='):
                 loop_filter = arg[14:]
             #if not isinstance(self, extended_cmd.CmdShell):
             #    raise self.InvalidCmd, "loop_filter is not allowed in web mode"
         args = [a for a in args if not a.startswith('--loop_filter=')]
-        
+
         if not myprocdef:
             myprocdef = self.extract_process(' '.join(args))
-        
+
         myprocdef.set('NLO_mode', 'noborn')
-            
+
         # store the first process (for the perl script)
         if not self._generate_info:
             self._generate_info = line
-                
+
         # Reset Helas matrix elements
         #self._curr_matrix_elements = helas_objects.HelasLoopInducedMultiProcess()
-
 
         # Check that we have the same number of initial states as
         # existing processes
         if self._curr_amps and self._curr_amps[0].get_ninitial() != \
                myprocdef.get_ninitial():
-            raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
-      
+            raise self.InvalidCmd("Can not mix processes with different number of initial states.")
+
         if self._curr_amps and (not isinstance(self._curr_amps[0], loop_diagram_generation.LoopAmplitude) or \
              self._curr_amps[0]['has_born']):
             raise self.InvalidCmd("Can not mix loop induced process with not loop induced process")
-            
+
         # Negative coupling order contraints can be given on at most one
         # coupling order (and either in squared orders or orders, not both)
         if len([1 for val in list(myprocdef.get('orders').values())+\
@@ -5423,7 +5350,7 @@ This implies that with decay chains:
                 if particle[1:] in pids:
                     final.add(pids[particle[1:]])
                 elif particle in self._multiparticles:
-                    final.update(set(self._multiparticles[particle[1:]]))                
+                    final.update(set(self._multiparticles[particle[1:]]))
 
         return final
 
@@ -5507,9 +5434,8 @@ This implies that with decay chains:
                 while order_re:
                     overall_orders[order_re.group(2)] = int(order_re.group(3))
                     order_line = order_re.group(1)
-                    order_re = order_pattern.match(order_line)            
+                    order_re = order_pattern.match(order_line)
             logger.info(line)
-            
 
         index_comma = line.find(",")
         index_par = line.find(")")
@@ -5535,7 +5461,7 @@ This implies that with decay chains:
             if line.lstrip()[0] == '(' and index_par !=-1 and \
                                                     not ',' in line[:index_par]:
                 par_start = line.find('(')
-                line = '%s %s' % (line[par_start+1:index_par], line[index_par+1:]) 
+                line = '%s %s' % (line[par_start+1:index_par], line[index_par+1:])
                 index_par = line.find(')')
             if line.lstrip()[0] == '(':
                 # Go down one level in process hierarchy
@@ -5579,7 +5505,6 @@ This implies that with decay chains:
         # more decays)
         return core_process, line
 
-
     # Import files
     def do_import(self, line, force=False, options={}):
         """Main commands: Import files with external formats"""
@@ -5609,7 +5534,7 @@ This implies that with decay chains:
                     aloha.aloha_prefix='mdl_'
                 else:
                     aloha.aloha_prefix=''
-                
+
                 try:
                     self._curr_model = import_ufo.import_model(args[1], prefix=prefix,
                         complex_mass_scheme=self.options['complex_mass_scheme'],
@@ -5618,7 +5543,7 @@ This implies that with decay chains:
                     model_path, _,_ = import_ufo.get_path_restrict(args[1])
                     if six.PY3 and self.options['auto_convert_model']:
                         logger.info("fail to load model but auto_convert_model is on True. Trying to convert the model")
-                        
+
                         self.exec_cmd('convert model %s' % model_path, errorhandling=False, printcmd=True, precmd=False, postcmd=False)
                         logger.info('retry the load of the model')
                         tmp_opt = dict(self.options)
@@ -5722,7 +5647,6 @@ This implies that with decay chains:
             else:
                 raise MadGraph5Error('No default directory in output')
 
-
             #convert and excecute the card
             self.import_mg4_proc_card(proc_card)
 
@@ -5770,7 +5694,6 @@ This implies that with decay chains:
                         remove_amp(decay.get('amplitudes'))
         remove_amp(self._curr_amps)
 
-
     def import_ufo_model(self, model_name):
         """ import the UFO model """
 
@@ -5790,7 +5713,6 @@ This implies that with decay chains:
                                         self._curr_model.get('interactions')], []))
 
         self.add_default_multiparticles()
-
 
     def import_mg4_proc_card(self, filepath):
         """ read a V4 proc card, convert it and run it in mg5"""
@@ -5813,7 +5735,6 @@ This implies that with decay chains:
             logging.error('No MG_ME installation detected')
             return
 
-
         # Now that we have the model we can split the information
         lines = reader.extract_command_lines(self._curr_model)
         for line in lines:
@@ -5829,7 +5750,7 @@ This implies that with decay chains:
         removed_multiparticles = []
         # First check if the defined multiparticles are allowed in the
         # new model
-        
+
         for key in list(self._multiparticles.keys()):
             try:
                 for part in self._multiparticles[key]:
@@ -5854,7 +5775,7 @@ This implies that with decay chains:
                 if multipart_name not in self._multiparticles:
                     #self.do_define(line)
                     self.exec_cmd('define %s' % line, printcmd=False, precmd=True)
-                
+
             except self.InvalidCmd as why:
                 logger.warning('impossible to set default multiparticles %s because %s' %
                                         (line.split()[0],why))
@@ -5892,7 +5813,7 @@ This implies that with decay chains:
             elif 22 in multi:
                 multi.remove(22)
                 photon = False
-                
+
         if scheme in [4,5] and not photon:
             self.optimize_order(multi)
             self._multiparticles[qcd_container] = multi
@@ -5901,8 +5822,8 @@ This implies that with decay chains:
                 if container in defined_multiparticles:
                     defined_multiparticles.remove(container)
             self.history.append("define p = %s # pass to %s flavors" % \
-                                (' ' .join([repr(i) for i in self._multiparticles['p']]), 
-                                 scheme) 
+                                (' ' .join([repr(i) for i in self._multiparticles['p']]),
+                                 scheme)
                                )
             self.history.append("define j = p")
 
@@ -5912,11 +5833,11 @@ This implies that with decay chains:
                 if container in defined_multiparticles:
                     defined_multiparticles.remove(container)
             self.history.append("define p = %s # pass to %s flavors" % \
-                                (' '.join([str(i) for i in self._multiparticles['p']]), 
-                                 scheme) 
+                                (' '.join([str(i) for i in self._multiparticles['p']]),
+                                 scheme)
                                )
             self.history.append("define j = p")
-        
+
         if defined_multiparticles:
             if 'all' in defined_multiparticles:
                 defined_multiparticles.remove('all')
@@ -5938,13 +5859,13 @@ This implies that with decay chains:
         line = 'all =' + ' '.join(line)
         self.do_define(line)
 
-    def advanced_install(self, tool_to_install, 
+    def advanced_install(self, tool_to_install,
                                HepToolsInstaller_web_address=None,
                                additional_options=[]):
         """ Uses the HEPToolsInstaller.py script maintened online to install
         HEP tools with more complicated dependences.
         Additional options will be added to the list when calling HEPInstaller"""
-        
+
         # prevent border effects
         add_options = list(additional_options)
 
@@ -5975,11 +5896,10 @@ This implies that with decay chains:
             # Untar the file
             returncode = misc.call(['tar', '-xzpf', 'HEPToolsInstallers.tar.gz'],
                      cwd=pjoin(MG5DIR,'HEPTools'), stdout=open(os.devnull, 'w'))
-            
+
             # Remove the tarball
             os.remove(pjoin(MG5DIR,'HEPTools','HEPToolsInstallers.tar.gz'))
 
-            
             # FOR DEBUGGING ONLY, Take HEPToolsInstaller locally
             if '--local' in add_options:
                 add_options.remove('--local')
@@ -5994,7 +5914,7 @@ This implies that with decay chains:
             tool = name_map[tool_to_install]
         except:
             tool = tool_to_install
-     
+
         # Compiler options
         compiler_options = []
         if self.options['cpp_compiler'] is not None:
@@ -6008,14 +5928,21 @@ This implies that with decay chains:
         else:
             compiler_options.append('--cpp_standard_lib=%s'%
                misc.detect_cpp_std_lib_dependence(None))
-            
+
         if not self.options['fortran_compiler'] is None:
             compiler_options.append('--fortran_compiler=%s'%
                                                self.options['fortran_compiler'])
 
         if 'heptools_install_dir' in self.options:
             prefix = self.options['heptools_install_dir']
-            config_file = '~/.mg5/mg5_configuration.txt'
+            legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+            if os.path.exists(legacy_config_dir):
+                config_dir = legacy_config_dir
+            else:
+                config_dir = os.getenv('XDG_CONFIG_HOME', os.path.join(os.environ['HOME'], '.config'))
+
+            config_file = os.path.join(config_dir, 'mg5_configuration.txt')
         else:
             prefix = pjoin(MG5DIR, 'HEPTools')
             config_file = ''
@@ -6063,11 +5990,11 @@ This implies that with decay chains:
                            [lhapdf_config,'--version'], stdout=subprocess.PIPE)
                     lhapdf_version = int(version.stdout.read().decode(errors='ignore')[0])
                     if lhapdf_version not in [5,6]:
-                        raise 
+                        raise
                 except:
                     raise self.InvalidCmd('Could not detect LHAPDF version. Make'+
                            " sure '%s --version ' runs properly."%lhapdf_config)
-        
+
             if lhapdf_version is None:
                 answer = self.ask(question=
 "\033[33;34mLHAPDF was not found. Do you want to install LHPADF6? "+
@@ -6092,7 +6019,7 @@ This implies that with decay chains:
             lhapdf_option = []
             if lhapdf_version is None:
                 lhapdf_option.append('--with_lhapdf6=OFF')
-                lhapdf_option.append('--with_lhapdf5=OFF')                
+                lhapdf_option.append('--with_lhapdf5=OFF')
             elif lhapdf_version==5:
                 lhapdf_option.append('--with_lhapdf5=%s'%lhapdf_path)
                 lhapdf_option.append('--with_lhapdf6=OFF')
@@ -6127,13 +6054,13 @@ This implies that with decay chains:
         if return_code == 0:
             logger.info("%s successfully installed in %s."%(
                    tool_to_install, prefix),'$MG:color:GREEN')
-            
+
             if tool=='madanalysis5':
                 if not any(o.startswith(('--with_','--veto_','--update')) for o in add_options):
                     logger.info('    To install recasting capabilities of madanalysis5 and/or', '$MG:BOLD')
                     logger.info('    to allow delphes analysis at parton level.','$MG:BOLD')
                     logger.info('    Please run \'install MadAnalysis5 --with_delphes --update\':', '$MG:BOLD')
-            
+
         elif return_code == 66:
             answer = self.ask(question=
 """\033[33;34mTool %s already installed in %s."""%(tool_to_install, prefix)+
@@ -6145,7 +6072,7 @@ This implies that with decay chains:
                 return
             else:
                 return self.advanced_install(tool_to_install,
-                              additional_options=add_options+['--force'])            
+                              additional_options=add_options+['--force'])
         else:
             if tool=='madanalysis5' and '--update' not in add_options and \
                                  ('--no_MA5_further_install' not in add_options or
@@ -6158,7 +6085,7 @@ This implies that with decay chains:
                     for option in ['--no_MA5_further_install', '--no_root_in_MA5', '--force']:
                         if option not in add_options:
                             add_options.append(option)
-                    self.advanced_install('madanalysis5', 
+                    self.advanced_install('madanalysis5',
                                HepToolsInstaller_web_address=HepToolsInstaller_web_address,
                                additional_options=add_options)
                 else:
@@ -6172,7 +6099,7 @@ This implies that with decay chains:
             # Automatically re-install the mg5amc_py8_interface after a fresh
             # Pythia8 installation
             self.advanced_install('mg5amc_py8_interface',
-                              additional_options=add_options+['--force'])          
+                              additional_options=add_options+['--force'])
         elif tool == 'lhapdf6':
             if six.PY3:
                 self.options['lhapdf_py3'] = pjoin(prefix,'lhapdf6_py3','bin', 'lhapdf-config')
@@ -6184,7 +6111,7 @@ This implies that with decay chains:
                 self.options['lhapdf'] = self.options['lhapdf_py2']
         elif tool == 'lhapdf5':
             self.options['lhapdf'] = pjoin(prefix,'lhapdf5','bin', 'lhapdf-config')
-            self.exec_cmd('save options %s lhapdf' % config_file, printcmd=False, log=False)            
+            self.exec_cmd('save options %s lhapdf' % config_file, printcmd=False, log=False)
         elif tool == 'madanalysis5':
             self.options['madanalysis5_path'] = pjoin(prefix, 'madanalysis5','madanalysis5')
             self.exec_cmd('save options madanalysis5_path', printcmd=False, log=False)
@@ -6193,11 +6120,11 @@ This implies that with decay chains:
             if self.options['pythia8_path'] in ['',None,'None']:
                 self.options['pythia8_path'] = pjoin(prefix,'pythia8')
             self.options['mg5amc_py8_interface_path'] = pjoin(prefix, 'MG5aMC_PY8_interface')
-            self.exec_cmd('save options %s mg5amc_py8_interface_path' % config_file, 
-                                                            printcmd=False, log=False)      
+            self.exec_cmd('save options %s mg5amc_py8_interface_path' % config_file,
+                                                            printcmd=False, log=False)
         elif tool == 'collier':
             self.options['collier'] = pjoin(prefix,'lib')
-            self.exec_cmd('save options %s collier' % config_file, printcmd=False, log=False)      
+            self.exec_cmd('save options %s collier' % config_file, printcmd=False, log=False)
         elif tool == 'ninja':
             if not misc.get_ninja_quad_prec_support(pjoin(
                                               prefix,'ninja','lib')):
@@ -6221,7 +6148,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                 self.options['rivet_path'] = pjoin(prefix, 'rivet')
                 to_save.append('rivet_path')
             self.exec_cmd('save options %s %s'  % (config_file,' '.join(to_save)),
-                 printcmd=False, log=False)  
+                 printcmd=False, log=False)
         elif tool == 'rivet':
             to_save = ['rivet_path']
             # check that rivet/yoda are correctly linked:
@@ -6230,11 +6157,11 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                 self.options['yoda_path'] = pjoin(prefix, 'yoda')
                 to_save.append('yoda_path')
             self.exec_cmd('save options %s %s'  % (config_file,' '.join(to_save)),
-                 printcmd=False, log=False) 
+                 printcmd=False, log=False)
         elif '%s_path' % tool in self.options:
             self.options['%s_path' % tool] = pjoin(prefix, tool)
-            self.exec_cmd('save options %s %s_path'  % (config_file,tool), printcmd=False, log=False)      
-            
+            self.exec_cmd('save options %s %s_path'  % (config_file,tool), printcmd=False, log=False)
+
         # Now warn the user if he didn't add HEPTools first in his environment
         # variables.
         path_to_be_set = []
@@ -6259,7 +6186,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                 os.path.abspath(path) for path in os.environ[variable].split(os.pathsep)):
                 path_to_be_set.append((variable,
                                os.path.abspath(pjoin(MG5DIR,'HEPTools','include'))))
-       
+
         if len(path_to_be_set)>0:
             shell_type = misc.get_shell_type()
             if shell_type in ['bash',None]:
@@ -6277,9 +6204,9 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
              " at runtime, MG5_aMC will use the tools you have just installed"+\
              " and not some other versions installed elsewhere on your system.\n"+\
              "You can do so by running the following command in your terminal:"
-             "\n   %s"%modification_line) 
+             "\n   %s"%modification_line)
             logger.debug("==========")
-    
+
          # Return true for successful installation
         return True
 
@@ -6303,7 +6230,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                           'maddm':['arXiv:1804.00444'],
                           'maddump':['arXiv:1812.06771'],
                           'MadSTR':['arXiv:1612.00440']}
-    
+
     install_server = ['http://madgraph.phys.ucl.ac.be/package_info.dat',
                          'http://madgraph.mi.infn.it/package_info.dat']
 
@@ -6321,13 +6248,13 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
         """Install optional package from the MG suite.
         The argument 'additional_options' will be passed to the advanced_install
         functions. If it contains the option '--force', then the advanced_install
-        function will overwrite any existing installation of the tool without 
+        function will overwrite any existing installation of the tool without
         warnings.
         """
 
         # Make sure to avoid any border effect on custom_additional_options
         add_options = list(additional_options)
-        
+
         args = self.split_arg(line)
         #check the validity of the arguments
         install_options = self.check_install(args)
@@ -6344,12 +6271,10 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
         elif args[0] == 'looptools':
             self.install_reduction_library(force=True)
             return
-        
 
         plugin = self.install_plugin
-        
-        advertisements = self.install_ad
 
+        advertisements = self.install_ad
 
         if args[0] in advertisements:
 #            logger.info('{:^80}'.format("-"*70), '$MG:BOLD')
@@ -6366,7 +6291,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
             path = paths
         else:
             path = {}
-    
+
             data_path = self.install_server
 
 #           Force here to choose one particular server
@@ -6381,14 +6306,12 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                         source += '/package_info.dat'
                     data_path.append(source)
                     r = [2]
-            else: 
+            else:
                 r = random.randint(0,1)
                 r = [r, (1-r)]
                 if 'MG5aMC_WWW' in os.environ and os.environ['MG5aMC_WWW']:
                     data_path.append(os.environ['MG5aMC_WWW']+'/package_info.dat')
                     r.insert(0, 2)
-
-
 
             for index in r:
                 cluster_path = data_path[index]
@@ -6399,9 +6322,9 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                     continue
                 if data.getcode() != 200:
                     continue
-                
+
                 break
-                
+
             else:
                 raise MadGraph5Error('''Impossible to connect any of us servers.
                 Please check your internet connection or retry later''')
@@ -6422,7 +6345,6 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
         if args[0] == 'Delphes':
             args[0] = 'Delphes3'
 
-
         try:
             name = self.install_name
             name = name[args[0]]
@@ -6433,7 +6355,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
         elif args[0] in ['madstr', 'madSTR']:
             args[0] = 'MadSTR'
             name = 'MadSTR'
-            
+
         if args[0] in self._advanced_install_opts:
             # Now launch the advanced installation of the tool args[0]
             # path['HEPToolsInstaller'] is the online adress where to downlaod
@@ -6446,15 +6368,12 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
             add_options.extend(install_options['options_for_HEPToolsInstaller'])
             if not any(opt.startswith('--logging=') for opt in add_options):
                 add_options.append('--logging=%d' % logger.level)
-                
 
             return self.advanced_install(name, path['HEPToolsInstaller'],
                                         additional_options = add_options)
 
-
         if args[0] == 'Delphes':
-            args[0] = 'Delphes3'        
-
+            args[0] = 'Delphes3'
 
         #check outdated install
         substitution={'Delphes2':'Delphes','pythia-pgs':'pythia8'}
@@ -6465,7 +6384,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
             ans = self.ask('Do you really want to continue?', 'n', ['y','n'])
             if ans !='y':
                 return
-            
+
         try:
             os.system('rm -rf %s' % pjoin(MG5DIR, name))
         except Exception:
@@ -6479,15 +6398,15 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                     othersource = 'uiuc'
                 # try with the mirror
                 misc.sprint('try other mirror', othersource, ' '.join(args))
-                return self.do_install('%s --source=%s' % (' '.join(args), othersource), 
-                                       paths, additional_options) 
+                return self.do_install('%s --source=%s' % (' '.join(args), othersource),
+                                       paths, additional_options)
             else:
                 if 'xxx' in advertisements[name][0]:
                     logger.warning("Program not yet released. Please try later")
                 else:
                     raise Exception("Online server are corrupted. No tarball available for %s" % name)
                 return
-            
+
         # Load that path
         logger.info('Downloading %s' % path[args[0]])
         misc.wget(path[args[0]], '%s.tgz' % name, cwd=MG5DIR)
@@ -6498,7 +6417,6 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
 
         if returncode:
             raise MadGraph5Error('Fail to download correctly the File. Stop')
-
 
         # Check that the directory has the correct name
         if not os.path.exists(pjoin(MG5DIR, name)):
@@ -6549,35 +6467,34 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                     text = text.replace(base,'FC=%s' % compiler)
                 open(path, 'w').writelines(text)
             os.environ['FC'] = compiler
-        
+
         # For Golem95, use autotools.
         if name == 'golem95':
             # Run the configure script
-            ld_path = misc.Popen(['./configure', 
+            ld_path = misc.Popen(['./configure',
             '--prefix=%s'%str(pjoin(MG5DIR, name)),'FC=%s'%os.environ['FC']],
             cwd=pjoin(MG5DIR,'golem95'),stdout=subprocess.PIPE).communicate()[0].decode(errors='ignore')
-
 
         # For QCDLoop, use autotools.
         if name == 'QCDLoop':
             # Run the configure script
-            ld_path = misc.Popen(['./configure', 
+            ld_path = misc.Popen(['./configure',
             '--prefix=%s'%str(pjoin(MG5DIR, name)),'FC=%s'%os.environ['FC'],
             'F77=%s'%os.environ['FC']], cwd=pjoin(MG5DIR,name),
                                         stdout=subprocess.PIPE).communicate()[0].decode(errors='ignore')
 
         # For Delphes edit the makefile to add the proper link to correct library
         if args[0] == 'Delphes3':
-            #change in the makefile 
+            #change in the makefile
             #DELPHES_LIBS = $(shell $(RC) --libs) -lEG $(SYSLIBS)
-            # to 
+            # to
             #DELPHES_LIBS = $(shell $(RC) --libs) -lEG $(SYSLIBS) -Wl,-rpath,/Applications/root_v6.04.08/lib/
             rootsys = os.environ['ROOTSYS']
             text = open(pjoin(MG5DIR, 'Delphes','Makefile')).read()
-            text = text.replace('DELPHES_LIBS = $(shell $(RC) --libs) -lEG $(SYSLIBS)', 
+            text = text.replace('DELPHES_LIBS = $(shell $(RC) --libs) -lEG $(SYSLIBS)',
                          'DELPHES_LIBS = $(shell $(RC) --libs) -lEG $(SYSLIBS) -Wl,-rpath,%s/lib/' % rootsys)
             open(pjoin(MG5DIR, 'Delphes','Makefile'),'w').write(text)
-            
+
         # For SysCalc link to lhapdf
         if name == 'SysCalc':
             if self.options['lhapdf']:
@@ -6592,12 +6509,11 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                     os.environ['LD_LIBRARY_PATH'] += ';%s' % ld_path
                 if self.options['lhapdf'] != 'lhapdf-config':
                     if misc.which('lhapdf-config') != os.path.realpath(self.options['lhapdf']):
-                        os.environ['PATH'] = '%s:%s' % (os.path.realpath(self.options['lhapdf']),os.environ['PATH']) 
+                        os.environ['PATH'] = '%s:%s' % (os.path.realpath(self.options['lhapdf']),os.environ['PATH'])
             else:
                 raise self.InvalidCmd('lhapdf is required to compile/use SysCalc. Specify his path or install it via install lhapdf6')
             if self.options['cpp_compiler']:
                 make_flags.append('CXX=%s' % self.options['cpp_compiler'])
-            
 
         if name in plugin:
             logger.info('no compilation needed for plugin. Loading plugin information')
@@ -6610,7 +6526,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
             pyvers=sys.version[0]
             try:
                 __import__('PLUGIN.%s' % name, globals(), locals(), [])
-                plugin = sys.modules['PLUGIN.%s' % name] 
+                plugin = sys.modules['PLUGIN.%s' % name]
                 new_interface = plugin.new_interface
                 new_output = plugin.new_output
                 latest_validated_version = plugin.latest_validated_version
@@ -6633,10 +6549,10 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
                 minimal_mg5amcnlo_version = ''
                 maximal_mg5amcnlo_version = ''
                 misc.sprint(pyvers)
-                    
+
             logger.info('Plugin %s correctly interfaced. Latest official validition for MG5aMC version %s.' % (name, '.'.join(repr(i) for i in latest_validated_version)))
             if new_interface:
-                ff = open(pjoin(MG5DIR, 'bin', '%s.py' % name) , 'w') 
+                ff = open(pjoin(MG5DIR, 'bin', '%s.py' % name) , 'w')
                 if __debug__:
                     text = '''#! /usr/bin/env python{1}
 import os
@@ -6645,7 +6561,7 @@ root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 exe_path = os.path.join(root_path,'bin','mg5_aMC')
 sys.argv.pop(0)
 os.system('%s  -tt %s %s --mode={0}' %(sys.executable, str(exe_path) , ' '.join(sys.argv) ))
-'''.format(name,'' if pyvers == 2 else pyvers)                    
+'''.format(name,'' if pyvers == 2 else pyvers)
                 else:
                     text = '''#! /usr/bin/env python{1}
 import os
@@ -6654,14 +6570,14 @@ root_path = os.path.split(os.path.dirname(os.path.realpath( __file__ )))[0]
 exe_path = os.path.join(root_path,'bin','mg5_aMC')
 sys.argv.pop(0)
 os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executable, str(exe_path) , ' '.join(sys.argv) ))
-'''.format(name,'' if pyvers == 2 else pyvers)                     
+'''.format(name,'' if pyvers == 2 else pyvers)
                 ff.write(text)
                 ff.close()
                 import stat
                 os.chmod(pjoin(MG5DIR, 'bin', '%s.py' % name), stat.S_IRWXU)
                 logger.info('To use this module, you need to quit MG5aMC and run the executable bin/%s.py' % name)
             status=0
-                
+
         elif logger.level <= logging.INFO:
             devnull = open(os.devnull,'w')
             try:
@@ -6672,7 +6588,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                 #SLC6 needs to have this first (don't ask why)
                 status = misc.call(['make'], cwd = pjoin(MG5DIR, name, 'libraries', 'pylib'))
             if name in ['golem95','QCDLoop']:
-                status = misc.call(['make','install'], 
+                status = misc.call(['make','install'],
                                                cwd = os.path.join(MG5DIR, name))
             else:
                 status = misc.call(['make']+make_flags, cwd = os.path.join(MG5DIR, name))
@@ -6686,7 +6602,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                 #SLC6 needs to have this first (don't ask why)
                 status = self.compile(mode='', cwd = pjoin(MG5DIR, name, 'libraries', 'pylib'))
             if name in ['golem95','QCDLoop']:
-                status = misc.compile(['install'], mode='', 
+                status = misc.compile(['install'], mode='',
                                           cwd = os.path.join(MG5DIR, name))
             else:
                 status = self.compile(make_flags, mode='',
@@ -6713,7 +6629,6 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             else:
                 logger.warning('Error detected during the compilation. Please check the compilation error and run make manually.')
 
-
         # Special treatment for TD/Ghostscript program (require by MadAnalysis)
         if args[0] == 'MadAnalysis':
             try:
@@ -6735,9 +6650,9 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                     logger.info('Downloading TD for Linux 64 bit')
                     target = 'https://home.fnal.gov/~parke/TD/td_linux_64bit.tar.gz'
                     #logger.warning('''td program (needed by MadAnalysis) is not compile for 64 bit computer.
-                #In 99% of the case, this is perfectly fine. If you do not have plot, please follow 
+                #In 99% of the case, this is perfectly fine. If you do not have plot, please follow
                 #instruction in https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/TopDrawer .''')
-                else:                    
+                else:
                     logger.info('Downloading TD for Linux 32 bit')
                     target = 'http://madgraph.phys.ucl.ac.be/Downloads/td'
                 misc.wget(target, 'td', cwd=pjoin(MG5DIR,'td'))
@@ -6767,7 +6682,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                      pjoin(MG5DIR,'Template', 'Common', 'Cards', 'delphes_card_CMS.dat'))
             files.cp(pjoin(card_dir,'delphes_card_ATLAS.tcl'),
                      pjoin(MG5DIR,'Template', 'Common', 'Cards', 'delphes_card_ATLAS.dat'))
-            
+
             if not self.options['pythia-pgs_path'] and not self.options['pythia8_path']:
                 logger.warning("We noticed that no parton-shower module are installed/linked. \n In order to use Delphes from MG5aMC please install/link pythia8.")
 
@@ -6789,7 +6704,6 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             elif self.options[opt] != self.options_configuration[opt]:
                 self.options[opt] = self.options_configuration[opt]
                 self.exec_cmd('save options %s' % opt, printcmd=False)
-                    
 
     def install_update(self, args, wget):
         """ check if the current version of mg5 is up-to-date.
@@ -6798,7 +6712,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
         def apply_patch(filetext):
             """function to apply the patch"""
             text = filetext.read().decode(errors='ignore')
-            
+
             pattern = re.compile(r'''^=== renamed directory \'(?P<orig>[^\']*)\' => \'(?P<new>[^\']*)\'''')
             #= = = renamed directory 'Template' => 'Template/LO'
             for orig, new in pattern.findall(text):
@@ -6938,7 +6852,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                 return True
             else:
                 return False
-        
+
         mode = [arg.split('=',1)[1] for arg in args if arg.startswith('--mode=')]
         if mode:
             mode = mode[-1]
@@ -7064,11 +6978,11 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             int(time.time()) - 3600 * 24 * (int(self.options['auto_update']) -1)))
             fsock.write("last_message   %s\n" % data['last_message'])
             fsock.close()
-            
+
         if os.path.exists(os.path.join(MG5DIR,'.bzr')):
             logger.info("bzr version: use bzr pull to update")
-            return 
-        
+            return
+
         if web_version == data['version_nb']:
             logger.info('No new version of MG5 available')
             # update .autoupdate to prevent a too close check
@@ -7092,7 +7006,6 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                                   default, options)
             else:
                 answer = default
-
 
         if answer == 'y':
             logger.info('start updating code')
@@ -7124,7 +7037,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             self.do_install('mg5amc_py8_interface',additional_options=['--force'])
             logger.info('Checking current version. (type ctrl-c to bypass the check)')
             subprocess.call([os.path.join('tests','test_manager.py')],
-                                                                  cwd=MG5DIR)            
+                                                                  cwd=MG5DIR)
             print('new version installed, please relaunch mg5')
             try:
                 os.remove(pjoin(MG5DIR, 'Template','LO','Source','make_opts'))
@@ -7152,8 +7065,6 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             #Do not use the set command here!!
             self.options['auto_update'] = -1 * self.options['auto_update']
 
-
-
     def set_configuration(self, config_path=None, final=True):
         """ assign all configuration variable from file
             ./input/mg5_configuration.txt. assign to default if not define """
@@ -7168,8 +7079,15 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                 config_path = pjoin(os.environ['MADGRAPH_BASE'],'mg5_configuration.txt')
                 self.set_configuration(config_path, final=False)
             if 'HOME' in os.environ:
-                config_path = pjoin(os.environ['HOME'],'.mg5',
-                                                        'mg5_configuration.txt')
+                legacy_config_dir = os.path.join(os.environ['HOME'], '.mg5')
+
+                if os.path.exists(legacy_config_dir):
+                    config_dir = legacy_config_dir
+                else:
+                    config_dir = os.getenv('XDG_STATE_HOME', os.path.join(os.environ['HOME'], '.local', 'state'))
+
+                config_path = os.path.join(config_dir, "mg5history")
+
                 if os.path.exists(config_path):
                     self.set_configuration(config_path, final=False)
             config_path = os.path.relpath(pjoin(MG5DIR,'input',
@@ -7197,7 +7115,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                     self.options[name] = value
                 if value.lower() == "none" or value=="":
                     self.options[name] = None
-        config_file.close()      
+        config_file.close()
         self.options['stdout_level'] = logging.getLogger('madgraph').level
         if not final:
             return self.options # the return is usefull for unittest
@@ -7209,7 +7127,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
             if key in ['pythia8_path', 'hwpp_path', 'thepeg_path', 'hepmc_path',
                        'mg5amc_py8_interface_path','madanalysis5_path']:
                 if self.options[key] in ['None', None]:
-                    self.options[key] = None 
+                    self.options[key] = None
                     continue
                 path = self.options[key]
                 #this is for pythia8
@@ -7235,7 +7153,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                             self.options['madanalysis5_path'] = None
                             logger.warning(message)
                             continue
- 
+
                 #this is for hw++
                 if key == 'hwpp_path' and not os.path.isfile(pjoin(MG5DIR, path, 'include', 'Herwig++', 'Analysis', 'BasicConsistency.hh')):
                     if not os.path.isfile(pjoin(path, 'include', 'Herwig++', 'Analysis', 'BasicConsistency.hh')):
@@ -7257,7 +7175,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
 
             elif key in ['golem','samurai']:
                 if isinstance(self.options[key],str) and self.options[key].lower() == 'auto':
-                    # try to find it automatically on the system                                                                                                                                            
+                    # try to find it automatically on the system
                     program = misc.which_lib('lib%s.a'%key)
                     if program != None:
                         fpath, _ = os.path.split(program)
@@ -7287,7 +7205,7 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                                 logger.info(
 """The version of 'samurai' automatically detected seems too old to be compatible
 with MG5aMC and it will be turned off. Ask the authors for the latest version if
-you want to use samurai. 
+you want to use samurai.
 If you want to enforce its use as-it-is, then specify directly its library folder
 in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto').""")
                                 logger.info('--------')
@@ -7313,7 +7231,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 else:
                     if key in self.options_madgraph:
                         self.history.append('set %s %s' % (key, self.options[key]))
-        
+
         warnings = madevent_interface.MadEventCmd.mg5amc_py8_interface_consistency_warning(self.options)
         if warnings:
             logger.warning(warnings)
@@ -7366,7 +7284,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                                                 options=self.options, **options)
         elif args[0] == 'madevent':
             if options['interactive']:
-                
+
                 if isinstance(self, cmd.CmdShell):
                     ME = madevent_interface.MadEventCmdShell(me_dir=args[1], options=self.options)
                 else:
@@ -7425,15 +7343,14 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 config_line = [l for l in self.history if l.strip().startswith('set')]
                 for line in config_line:
                     MW.exec_cmd(line)
-                stop = self.define_child_cmd_interface(MW)                
+                stop = self.define_child_cmd_interface(MW)
                 return stop
             ext_program = launch_ext.MWLauncher( self, args[1],
                                                  shell = isinstance(self, cmd.CmdShell),
-                                                 options=self.options,**options)            
+                                                 options=self.options,**options)
         else:
             os.chdir(start_cwd) #ensure to go to the initial path
             raise self.InvalidCmd('%s cannot be run from MG5 interface' % args[0])
-
 
         ext_program.run()
         os.chdir(start_cwd) #ensure to go to the initial path
@@ -7498,7 +7415,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             else:
                 raise self.RWError('Could not load processes from file %s' % args[1])
 
-
     def post_install_RunningCoupling(self):
 
         shutil.move(pjoin(MG5DIR,'RunningCoupling'), pjoin(MG5DIR,'Template', 'Running'))
@@ -7521,7 +7437,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         param_writer.ParamCardWriter(self._curr_model, out_path)
         # and load it to a python object
         param_card = check_param_card.ParamCard(out_path.getvalue().split('\n'))
-
 
         all_categories = self.ask('','0',[], ask_class=AskforCustomize)
         put_to_one = []
@@ -7572,7 +7487,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             param_writer.ParamCardWriter(self._curr_model, out_path)
             # and load it to a python object
             param_card = check_param_card.ParamCard(out_path.getvalue().split('\n'))
-            
+
             for (block, lhacode) in put_to_one:
                 try:
                     param_card[block].get(lhacode).value = 1
@@ -7589,7 +7504,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
     def do_save(self, line, check=True, to_keep={}, log=True):
         """Not in help: Save information to file"""
 
-        
         args = self.split_arg(line)
         # Check argument validity
         if check:
@@ -7612,21 +7526,21 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         elif args[0] == 'options':
             partial_save = False
             to_define = {}
-            
-            if any(not arg.startswith('--') and arg in self.options 
+
+            if any(not arg.startswith('--') and arg in self.options
                                                                for arg in args):
                 # store in file only those ones
                 partial_save = True
                 all_arg = [arg for arg in args[1:] if not arg.startswith('--') and
                            arg in self.options]
                 for key in all_arg:
-                    to_define[key] = self.options[key] 
+                    to_define[key] = self.options[key]
             else:
                 # First look at options which should be put in MG5DIR/input
                 for key, default in self.options_configuration.items():
                     if self.options_configuration[key] != self.options[key] and not self.options_configuration[key] is None:
                         to_define[key] = self.options[key]
-    
+
                 if not '--auto' in args:
                     for key, default in self.options_madevent.items():
                         if self.options_madevent[key] != self.options[key] != None:
@@ -7635,7 +7549,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                             to_define[key] = self.options[key]
                         elif key == 'cluster_queue' and self.options[key] is None:
                             to_define[key] = self.options[key]
-    
+
                 if '--all' in args:
                     for key, default in self.options_madgraph.items():
                         if self.options_madgraph[key] != self.options[key] != None and \
@@ -7652,14 +7566,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 filepath = args[1]
             else:
                 filepath = pjoin(MG5DIR, 'input', 'mg5_configuration.txt')
-            
+
             basedir = MG5DIR
             if partial_save:
                 basefile = filepath
             else:
                 basefile = pjoin(MG5DIR, 'input', '.mg5_configuration_default.txt')
-                
-            
 
             if to_keep:
                 to_define = to_keep
@@ -7757,7 +7669,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 if args[1] == 'unitary':
                     aloha.unitary_gauge = True
                 elif args[1] == 'axial':
-                    aloha.unitary_gauge = 2 
+                    aloha.unitary_gauge = 2
                 else:
                     aloha.unitary_gauge = False
                 aloha_lib.KERNEL.clean()
@@ -7791,8 +7703,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
             if self.options['gauge'] == args[1]:
                 return
-            
-            
+
             self.options[args[0]] = args[1]
 
             if able_to_mod and log and args[0] == 'gauge' and \
@@ -7801,8 +7712,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                   not self._curr_model['perturbation_couplings'] in [[],['QCD']]:
                 logger.warning('You will only be able to do tree level'+\
                                    ' and QCD corrections in the unitary gauge.')
-
-
 
             #re-init all variable
             model_name = self._curr_model.get('modelpath+restriction')
@@ -7847,11 +7756,11 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 if args[1] != 'None':
                     if log:
                         logger.info('set f2py compiler to %s' % args[1])
-                
+
                     self.options['f2py_compiler'] = args[1]
                 else:
                     self.options['f2py_compiler'] = None
-            
+
         elif args[0] == 'loop_optimized_output':
 
             if log:
@@ -7915,12 +7824,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     self.options[args[0]] = args[1]
                 else:
                     res = 1
-    
+
                 if res != 0 :
                     logger.warning('%s does not seem to correspond to a valid %s lib ' % (args[1],args[0]) + \
                             '. Please enter the full PATH/TO/%s/lib .\n'%args[0] + \
                             'You will NOT be able to run %s otherwise.\n'%args[0])
-                
+
         elif args[0].startswith('lhapdf'):
             to_do = True
             if args[0].endswith('_py2') and six.PY3:
@@ -7994,14 +7903,14 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             except Exception:
                 if args[1].lower() in ['never']:
                     tmp = args[1].lower()
-                else: 
+                else:
                     raise
             self.options[args[0]] = tmp
         elif args[0] in ['zerowidth_tchannel']:
             self.options[args[0]] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
         elif args[0] in ['cluster_queue']:
             self.options[args[0]] = args[1].strip()
-        elif args[0] in ['low_mem_multicore_nlo_generation']:	    
+        elif args[0] in ['low_mem_multicore_nlo_generation']:
             if six.PY3 and self.options['OLP'] != 'MadLoop':
                 raise self.InvalidCmd('Not possible to set \"low_mem_multicore_nlo_generation\" for an OLP different of MadLoop when running  python3')
             else:
@@ -8058,7 +7967,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         if '--noeps=True' in args:
             nojpeg = True
         flaglist = []
-                    
+
         if '--postpone_model' in args:
             flaglist.append('store_model')
         if '--hel_recycling=False' in args:
@@ -8068,7 +7977,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         if any(spin > 3 for spin in self._curr_model.get_all_spin()):
             flaglist.append('no_helrecycling')
             args.append('--hel_recycling=False')
-                    
+
         line_options = dict( (arg[2:].split('=')  if "=" in arg else (arg[2:], True))
                              for arg in args if arg.startswith('--'))
 #        line_options = dict(arg[2:].split('=') for arg in args if arg.startswith('--') and '=' not in arg)
@@ -8077,7 +7986,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             main_file_name = args[args.index('-name') + 1]
         except Exception:
             pass
-
 
         ################
         # ALOHA OUTPUT #
@@ -8138,7 +8046,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             options = {'check': self._export_plugin.check, 'exporter':self._export_plugin.exporter, 'output':self._export_plugin.output}
         else:
             options = config[self._export_format]
-            
+
         # check
         if os.path.realpath(self._export_dir) == os.getcwd():
             if len(args) == 0:
@@ -8148,7 +8056,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                         i+=1
                     else:
                         break
-                os.mkdir('Pythia8_proc_%i' %i) 
+                os.mkdir('Pythia8_proc_%i' %i)
                 self._export_dir = pjoin(self._export_dir, 'Pythia8_proc_%i' %i)
                 logger.info('Create output in %s' % self._export_dir)
             elif not args[0] in ['.', '-f']:
@@ -8179,7 +8087,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             # That applies only if there is more than one subprocess of course.
             if self._curr_amps[0].get_ninitial() == 1 and \
                                                      len(self._curr_amps)>1:
-                
+
                 processes = [amp.get('process') for amp in self._curr_amps if 'process' in  list(amp.keys())]
                 if len(set(proc.get('id') for proc in processes))!=len(processes):
                     # Special warning for loop-induced
@@ -8187,7 +8095,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                                processes) and self._export_format == 'madevent':
                         logger.warning("""
 || The loop-induced decay process you have specified contains several
-|| subprocesses and, in order to be able to compute individual branching ratios, 
+|| subprocesses and, in order to be able to compute individual branching ratios,
 || MG5_aMC will *not* group them. Integration channels will also be considered
 || for each diagrams and as a result integration will be inefficient.
 || It is therefore recommended to perform this simulation by setting the MG5_aMC
@@ -8197,18 +8105,18 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 ||   -> add process <proc_def>
 """)
                     group_processes = False
-    
+
         #Exporter + Template
         if options['exporter'] == 'v4':
-            self._curr_exporter = export_v4.ExportV4Factory(self, noclean, 
+            self._curr_exporter = export_v4.ExportV4Factory(self, noclean,
                                              group_subprocesses=group_processes,
                                              cmd_options=line_options)
         elif options['exporter'] == 'cpp':
             self._curr_exporter = export_cpp.ExportCPPFactory(self, group_subprocesses=group_processes,
                                                               cmd_options=line_options)
-        
+
         self._curr_exporter.pass_information_from_cmd(self)
-        
+
         if options['output'] == 'Template':
             self._curr_exporter.copy_template(self._curr_model)
         elif options['output'] == 'dir' and not os.path.isdir(self._export_dir):
@@ -8218,13 +8126,13 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         self._done_export = False
 
         if self._export_format == "madevent":
-            # for MadEvent with MadLoop decide if we keep the box as channel of 
+            # for MadEvent with MadLoop decide if we keep the box as channel of
             #integration or not. Forbid them for matching and for h+j
             if self.options['max_npoint_for_channel']:
                 base_objects.Vertex.max_n_loop_for_multichanneling = int(self.options['max_npoint_for_channel'])
             else:
-                base_objects.Vertex.max_n_loop_for_multichanneling = 3 
-            base_objects.Vertex.max_tpropa = int(self.options['max_t_for_channel'])   
+                base_objects.Vertex.max_n_loop_for_multichanneling = 3
+            base_objects.Vertex.max_tpropa = int(self.options['max_t_for_channel'])
 
         # Perform export and finalize right away
         self.export(nojpeg, main_file_name, group_processes, args)
@@ -8239,13 +8147,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         self._export_dir = None
 
     # Export a matrix element
-    def export(self, nojpeg = False, main_file_name = "", group_processes=True, 
+    def export(self, nojpeg = False, main_file_name = "", group_processes=True,
                                                                        args=[]):
         """Export a generated amplitude to file."""
 
-
         # Define the helas call  writer
-        if self._curr_exporter.exporter == 'cpp':       
+        if self._curr_exporter.exporter == 'cpp':
             self._curr_helas_model = helas_call_writers.CPPUFOHelasCallWriter(self._curr_model)
         elif self._model_v4_path:
             assert self._curr_exporter.exporter == 'v4'
@@ -8255,7 +8162,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             options = {'zerowidth_tchannel': self.options['zerowidth_tchannel']}
             if self._curr_amps and self._curr_amps[0].get_ninitial() == 1:
                 options['zerowidth_tchannel'] = False
-            
+
             self._curr_helas_model = helas_call_writers.FortranUFOHelasCallWriter(self._curr_model, options=options)
 
         version = [arg[10:] for arg in args if arg.startswith('--version=')]
@@ -8266,7 +8173,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
         def generate_matrix_elements(self, group_processes=True):
             """Helper function to generate the matrix elements before
-            exporting. Uses the main function argument 'group_processes' to decide 
+            exporting. Uses the main function argument 'group_processes' to decide
             whether to use group_subprocess or not. (it has been set in do_output to
             the appropriate value if the MG5 option 'group_subprocesses' was set
             to 'Auto'."""
@@ -8296,12 +8203,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     subproc_groups = group_subprocs.SubProcessGroupList()
                     matrix_elements_opts = {'optimized_output':
                                        self.options['loop_optimized_output']}
-                    
+
                     grouping_criteria = self._curr_exporter.grouped_mode
                     if non_dc_amps:
                         subproc_groups.extend(\
                           group_subprocs.SubProcessGroup.group_amplitudes(\
-                          non_dc_amps,grouping_criteria, 
+                          non_dc_amps,grouping_criteria,
                                      matrix_elements_opts=matrix_elements_opts))
 
                     if dc_amps:
@@ -8323,12 +8230,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                             me.get('processes')[0].set('uid', uid)
                 else: # Not grouped subprocesses
                     mode = {}
-                    if self._export_format in [ 'standalone_msP' , 
+                    if self._export_format in [ 'standalone_msP' ,
                                              'standalone_msF', 'standalone_rw']:
                         mode['mode'] = 'MadSpin'
                     # The conditional statement tests whether we are dealing
                     # with a loop induced process.
-                    if isinstance(self._curr_amps[0], 
+                    if isinstance(self._curr_amps[0],
                                          loop_diagram_generation.LoopAmplitude):
                         mode['optimized_output']=self.options['loop_optimized_output']
                         HelasMultiProcessClass = loop_helas_objects.LoopHelasProcess
@@ -8336,11 +8243,11 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     else:
                         HelasMultiProcessClass = helas_objects.HelasMultiProcess
                         compute_loop_nc = False
-                    
+
                     self._curr_matrix_elements = HelasMultiProcessClass(
                       self._curr_amps, compute_loop_nc=compute_loop_nc,
                                                        matrix_element_opts=mode)
-                    
+
                     ndiags = sum([len(me.get('diagrams')) for \
                                   me in self._curr_matrix_elements.\
                                   get_matrix_elements()])
@@ -8352,17 +8259,16 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
             cpu_time2 = time.time()
 
-
             return ndiags, cpu_time2 - cpu_time1
 
         # Start of the actual routine
-        
+
         ndiags, cpu_time = generate_matrix_elements(self,group_processes)
 
         calls = 0
 
         path = self._export_dir
-            
+
         cpu_time1 = time.time()
 
         # First treat madevent and pythia8 exports, where we need to
@@ -8372,7 +8278,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         if self._export_format == 'madevent':
             calls += self._curr_exporter.export_processes(self._curr_matrix_elements,
                                                          self._curr_helas_model)
-            
+
                 #try:
                 #    cmd.Cmd.onecmd(self, 'history .')
                 #except Exception:
@@ -8408,8 +8314,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                                                                process_names,
                                                                exporter,
                                                                main_file_name)
-                      
-                      
+
         matrix_elements = self._curr_matrix_elements.get_matrix_elements()
         # Just the matrix.f files
         if self._export_format == 'matrix':
@@ -8435,8 +8340,8 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             for me_number, me in enumerate(self._curr_matrix_elements):
                 calls = calls + \
                     self._curr_exporter.generate_subprocess_directory(\
-                        me, self._curr_helas_model, me_number)               
-        
+                        me, self._curr_helas_model, me_number)
+
         # ungroup mode
         else:
             for nb,me in enumerate(matrix_elements[:]):
@@ -8455,7 +8360,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             self._curr_exporter.write_procdef_mg5(card_path,
                                 self._curr_model['name'],
                                 self._generate_info)
-
 
         cpu_time2 = time.time() - cpu_time1
 
@@ -8502,7 +8406,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             logger.info('Copy %s model files to directory %s' % \
                             (os.path.basename(self._model_v4_path), self._export_dir))
             self._curr_exporter.export_model_files(self._model_v4_path)
-            self._curr_exporter.export_helas(pjoin(self._mgme_dir,'HELAS'))        
+            self._curr_exporter.export_helas(pjoin(self._mgme_dir,'HELAS'))
         else:
             # wanted_lorentz are the lorentz structures which are
             # actually used in the wavefunctions and amplitudes in
@@ -8516,35 +8420,33 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     if out == 0:
                         newflag = list(flag) + ['P1N']
                         wanted_lorentz.append((name, tuple(newflag), -1))
-                
+
             # For a unique output of multiple type of exporter need to store this
-            # information.             
+            # information.
             if hasattr(self, 'previous_lorentz'):
                 wanted_lorentz = misc.make_unique(self.previous_lorentz + wanted_lorentz)
                 wanted_couplings = misc.make_unique(self.previous_couplings + wanted_couplings)
                 del self.previous_lorentz
-                del self.previous_couplings        
+                del self.previous_couplings
             if 'store_model' in flaglist:
                 self.previous_lorentz = wanted_lorentz
                 self.previous_couplings = wanted_couplings
             else:
-                self._curr_exporter.convert_model(self._curr_model, 
+                self._curr_exporter.convert_model(self._curr_model,
                                                wanted_lorentz,
                                                wanted_couplings)
-        
+
         # move the old options to the flaglist system.
         if nojpeg:
             flaglist.append('nojpeg')
         if online:
             flaglist.append('online')
 
-            
-
         if self._export_format in ['NLO']:
-            ## write fj_lhapdf_opts file            
+            ## write fj_lhapdf_opts file
             # Create configuration file [path to executable] for amcatnlo
             filename = os.path.join(self._export_dir, 'Cards', 'amcatnlo_configuration.txt')
-            opts_to_keep = ['lhapdf', 'fastjet', 'pythia8_path', 'hwpp_path', 'thepeg_path', 
+            opts_to_keep = ['lhapdf', 'fastjet', 'pythia8_path', 'hwpp_path', 'thepeg_path',
                                                                     'hepmc_path']
             to_keep = {}
             for opt in opts_to_keep:
@@ -8553,7 +8455,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             self.do_save('options %s' % filename.replace(' ', '\ '), check=False, \
                     to_keep = to_keep)
 
-        elif self._export_format in ['madevent', 'madweight']:          
+        elif self._export_format in ['madevent', 'madweight']:
             # Create configuration file [path to executable] for madevent
             filename = os.path.join(self._export_dir, 'Cards', 'me5_configuration.txt')
             self.do_save('options %s' % filename.replace(' ', '\ '), check=False,
@@ -8592,8 +8494,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             else:
                 last_action_2 = 'none'
 
-
-
     # Calculate decay width
     def do_compute_widths(self, line, model=None, do2body=True, decaymodel=None):
         """Documented commands:Generate amplitudes for decay width calculation, with fixed
@@ -8616,20 +8516,18 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
         """
 
-
-
         self.change_principal_cmd('MadGraph')
         if '--nlo' not in line:
             warning_text = """Please note that the automatic computation of the width is
     only valid in narrow-width approximation and at tree-level."""
             logger.warning(warning_text)
-            
+
         if not model:
             modelname = self._curr_model.get('modelpath+restriction')
             with misc.MuteLogger(['madgraph'], ['INFO']):
                 model = import_ufo.import_model(modelname, decay=True)
         self._curr_model = model
-            
+
         if not isinstance(model, model_reader.ModelReader):
             model = model_reader.ModelReader(model)
 
@@ -8657,7 +8555,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     param_card.write(opts['path'])
 
         data = model.set_parameters_and_couplings(opts['path'])
-        
 
         # find UFO particles linked to the require names.
         if do2body:
@@ -8674,24 +8571,24 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 mass = abs(eval(str(particle.get('mass')), data).real)
                 data = model.set_parameters_and_couplings(opts['path'], scale= mass)
                 total = 0
-    
+
                 # check if the value of alphas is set to zero and raise warning if appropriate
                 if 'aS' in data and data['aS'] == 0 and particle.get('color') != 1:
                     logger.warning("aS set to zero for this particle since the running is not defined for such low mass.")
-                        
+
                 for mode, expr in particle.partial_widths.items():
                     tmp_mass = mass
                     for p in mode:
                         try:
                             value_mass = eval(str(p.mass), data)
                         except Exception:
-                            # the p object can still be UFO reference. since the 
+                            # the p object can still be UFO reference. since the
                             # mass name might hve change load back the MG5 one.
                             value_mass = eval(str(model.get_particle(p.pdg_code).get('mass')), data)
-                        tmp_mass -= abs(value_mass)             
+                        tmp_mass -= abs(value_mass)
                     if tmp_mass <=0:
                         continue
-    
+
                     decay_to = [p.get('pdg_code') for p in mode]
                     value = eval(expr,{'cmath':cmath},data).real
                     if -1e-10 < value < 0:
@@ -8707,7 +8604,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                         logger.warning("partial width of particle %s lower than QCD scale:%s. Set it to zero. (%s)" \
                                    % (particle.get('name'), value, decay_to))
                         value = 0
-                                     
+
                     decay_info[particle.get('pdg_code')].append([decay_to, value])
                     total += value
             else:
@@ -8721,7 +8618,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         #
         # add info from decay module
         #
-        
+
         self.do_decay_diagram('%s %s' % (' '.join([repr(id) for id in particles]),
                                          ' '.join('--%s=%s' % (key,value)
                                                   for key,value in opts.items()
@@ -8730,7 +8627,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
         if self._curr_amps:
             logger.info('Pass to numerical integration for computing the widths:')
-        else:            
+        else:
             logger.info('No need for N body-decay (N>2). Results are in %s' % opts['output'])
             return  decay_info
 
@@ -8740,7 +8637,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
             logger_mg.info('More info in temporary files:\n    %s/index.html' % (decay_dir))
             with misc.MuteLogger(['madgraph','ALOHA','cmdprint','madevent'], [40,40,40,40]):
                 self.exec_cmd('output madevent %s -f' % decay_dir,child=False)
-                
+
                 #modify some parameter of the default run_card
                 run_card = banner_module.RunCard(pjoin(decay_dir,'Cards','run_card.dat'))
                 if run_card['ickkw']:
@@ -8748,7 +8645,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     run_card['xqcut'] = 0
                     run_card.remove_all_cut()
                     run_card.write(pjoin(decay_dir,'Cards','run_card.dat'))
-                
+
                 # Need to write the correct param_card in the correct place !!!
                 if os.path.exists(opts['output']):
                     files.cp(opts['output'], pjoin(decay_dir, 'Cards', 'param_card.dat'))
@@ -8761,7 +8658,7 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 for name, val in self.options.items():
                     if name in me_cmd.options and me_cmd.options[name] != val:
                         try:
-                            me_cmd.exec_cmd('set %s %s --no_save' % (name, val)) 
+                            me_cmd.exec_cmd('set %s %s --no_save' % (name, val))
                         except madgraph.InvalidCmd:
                             continue
                 #me_cmd.options.update(self.options)
@@ -8787,13 +8684,12 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
 
         for pid in particles:
             width = param['decay'].get((pid,)).value
-            particle = self._curr_model.get_particle(pid) 
+            particle = self._curr_model.get_particle(pid)
             #if particle['color'] !=1 and 0 < width.real < 0.1:
             #    logger.warning("width of colored particle \"%s(%s)\" lower than QCD scale: %s. Set width to zero "
             #                   % (particle.get('name'), pid, width.real))
             #    width = 0
-                
-            
+
             if not pid in param['decay'].decay_table:
                 continue
             if pid not in decay_info:
@@ -8804,9 +8700,9 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                 if 0 < BR.value * width <0.1 and particle['color'] !=1:
                     logger.warning("partial width of particle %s lower than QCD scale:%s. Set it to zero. (%s)" \
                                    % (particle.get('name'), BR.value * width, BR.lhacode[1:]))
-                                     
+
                     continue
-                
+
                 decay_info[pid].append([BR.lhacode[1:], BR.value * width])
 
         madevent_interface.MadEventCmd.update_width_in_param_card(decay_info,
@@ -8815,8 +8711,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         if self._curr_model['name'] == 'mssm' or self._curr_model['name'].startswith('mssm-'):
             check_param_card.convert_to_slha1(opts['output'])
         return decay_info
-
-
 
     # Calculate decay width with SMWidth
     def compute_widths_SMWidth(self, line, model=None):
@@ -8945,7 +8839,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         if model:
             self._curr_decaymodel = model
 
-
         args = self.split_arg(line)
         #check the validity of the arguments
         particles, args = self.check_decay_diagram(args)
@@ -8964,7 +8857,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         self._done_export = False
         # Also reset _export_format and _export_dir
         self._export_format = None
-
 
         # Setup before find_channels
         if not model:
@@ -9025,7 +8917,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
                     if amp:
                         self._curr_amps.extend(amp)
                     part.update_decay_attributes(False, True, True, model)
-
 
         # Set _generate_info
         if len(self._curr_amps) > 0:
@@ -9119,8 +9010,6 @@ class AskforCustomize(cmd.SmartQuestion):
 
         cmd.SmartQuestion.__init__(self, question, allow_arg, default, mother_interface)
 
-
-
     def default(self, line):
         """Default action if line is not recognized"""
 
@@ -9160,15 +9049,12 @@ class AskforCustomize(cmd.SmartQuestion):
             logger.warning('Invalid set command. Not correct number of argument')
             return
 
-
         if args[1] in ['True','1','.true.','T',1,True,'true','TRUE']:
             self.name2options[args[0]].status = True
         elif args[1] in ['False','0','.false.','F',0,False,'false','FALSE']:
             self.name2options[args[0]].status = False
         else:
             logger.warning('%s is not True/False. Didn\'t do anything.' % args[1])
-
-
 
     def get_question(self):
         """define the current question."""
@@ -9186,7 +9072,6 @@ class AskforCustomize(cmd.SmartQuestion):
             question += 'For scripting this function, please type: \'help\''
         return question
 
-
     def complete_set(self, text, line, begidx, endidx):
         """ Complete the set command"""
         signal.alarm(0) # avoid timer if any
@@ -9197,7 +9082,6 @@ class AskforCustomize(cmd.SmartQuestion):
             return self.list_completion(text, possibilities, line)
         else:
             return self.list_completion(text,['True', 'False'], line)
-
 
     def do_help(self, line):
         '''help message'''
@@ -9227,8 +9111,6 @@ class AskforCustomize(cmd.SmartQuestion):
     def cmdloop(self, intro=None):
         cmd.SmartQuestion.cmdloop(self, intro)
         return self.all_categories
-
-
 
 #===============================================================================
 # __main__


### PR DESCRIPTION
This update involves moving the history files (mg5history, me5history, mw5history, decayhistory) used by mg5amcnlo to a new directory called "$XDG_STATE_HOME/mg5/" to conform with the XDG Base Directory Specification. The change will only take place if the user's $HOME/.mg5/ directory doesn't already exist. This ensures backward compatibility and prevents data loss or confusion for existing users.

The update is meant to improve the user experience by ensuring that critical state data is stored in a location that is accessible and portable and follows a widely recognized standard. 

The configuration file $HOME/.mg5/mg5_configuration.txt could also be migrated to $XDG_CONFIG_HOME/mg5/mg5_configuration.txt, but since it involves more complicated files, such as madgraph/interface/{extended_cmd.py, extended_cmd.py, madgraph_interface.py, madgraph_interface.py, common_run_interface.py}, I'd prefer to have approval before proceeding.

Furthermore, to prevent redundant code, it would be best to store the state_dir (and potentially config_dir) as a global variable, but I'm not sufficiently proficient in Python to do so without some assistance.