### PR TITLE
Fixed typo in UFO parser for cpp output

### DIFF
--- a/madgraph/iolibs/ufo_expression_parsers.py
+++ b/madgraph/iolibs/ufo_expression_parsers.py
@@ -873,7 +873,7 @@ class UFOExpressionParserCPP(UFOExpressionParser):
         elif p[1] == 'reglog': p[0] = 'reglog' + p[2]
         elif p[1] == 'reglogp': p[0] = 'reglogp' + p[2]
         elif p[1] == 'reglogm': p[0] = 'reglogm' + p[2]
-        elif p[1] in self.buitin_equiv: p[0] = self.builtin_equiv[p[1]] + p[2]
+        elif p[1] in self.builtin_equiv: p[0] = self.builtin_equiv[p[1]] + p[2]
         
 
     def p_expression_real(self, p):


### PR DESCRIPTION
Fixed small bug where non-standard UFO models could not be exported using cpp output (simple typo)