### PR TITLE
Fixes in vecsize (define VECSIZE_MEMMAX_COUPL in addition to VECSIZE_MEMMAX)

### DIFF
--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -17,7 +17,7 @@ c                    but the SIMD vector size and GPU warp size are smaller)
 c**************************************************************************
       implicit none
       include 'genps.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
 c     
 c Arguments
 c
@@ -667,7 +667,7 @@ c
       include 'genps.inc'
       include 'maxconfigs.inc'
       include 'run.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
 c
 c     Arguments
 c

--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -12,6 +12,8 @@ c     dsig           Function to be integrated
 c     ninvar         Number of invarients to keep grids on (s,t,u, s',t' etc)
 c     nconfigs       Number of different pole configurations 
 c     VECSIZE_USED   Number of events in parallel out of VECSIZE_MEMMAX
+c                    (NB this is the #events handled by the cudacpp bridge,
+c                    but the SIMD vector size and GPU warp size are smaller)
 c**************************************************************************
       implicit none
       include 'genps.inc'
@@ -169,7 +171,7 @@ c            write(*,*) 'iter/ievent/ivec', iter, ievent, ivec
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
             CUTSDONE=.FALSE.
             CUTSPASSED=.FALSE.
-            if (passcuts(p)) then
+            if (passcuts(p,VECSIZE_USED)) then
                ivec=ivec+1
 c              write(*,*) 'pass_point ivec is ', ivec
                all_p(:,ivec) = p(:)

--- a/Template/LO/Source/setrun.f
+++ b/Template/LO/Source/setrun.f
@@ -15,7 +15,7 @@ c
       include 'PDF/pdf.inc'
       include 'run.inc'
       include 'alfas.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'MODEL/coupl.inc'
 
       double precision D

--- a/Template/LO/Source/setrun.f
+++ b/Template/LO/Source/setrun.f
@@ -15,7 +15,6 @@ c
       include 'PDF/pdf.inc'
       include 'run.inc'
       include 'alfas.inc'
-      include 'vector.inc'
       include 'MODEL/coupl.inc'
 
       double precision D

--- a/Template/LO/SubProcesses/cluster.inc
+++ b/Template/LO/SubProcesses/cluster.inc
@@ -3,7 +3,7 @@ c	Parameters used by cluster
 c*************************************************************************
       include 'ncombs.inc'
       include 'ngraphs.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
       include 'maxconfigs.inc'
 c     parameters for clustering:
 c     id_cl gives diagrams for propagators     

--- a/Template/LO/SubProcesses/cuts.f
+++ b/Template/LO/SubProcesses/cuts.f
@@ -71,7 +71,7 @@ C     GLOBAL
 C
       include 'run.inc'
       include 'cuts.inc'
-      include '../../Source/vector.inc'
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
       
       double precision ptjet(nexternal)
       double precision ptheavyjet(nexternal)

--- a/Template/LO/SubProcesses/cuts.f
+++ b/Template/LO/SubProcesses/cuts.f
@@ -21,13 +21,14 @@ c-----
 c      pass_point = passcuts(p)
       end
 C 
-      LOGICAL FUNCTION PASSCUTS(P)
+      LOGICAL FUNCTION PASSCUTS(P, VECSIZE_USED)
 C**************************************************************************
 C     INPUT:
 C            P(0:3,1)           MOMENTUM OF INCOMING PARTON
 C            P(0:3,2)           MOMENTUM OF INCOMING PARTON
 C            P(0:3,3)           MOMENTUM OF ...
 C            ALL MOMENTA ARE IN THE REST FRAME!!
+C            VECSIZE_USED (used only on 1st call) #events in parallel
 C            COMMON/JETCUTS/   CUTS ON JETS
 C     OUTPUT:
 C            TRUE IF EVENTS PASSES ALL CUTS LISTED
@@ -42,6 +43,7 @@ C
 C     ARGUMENTS
 C
       REAL*8 P(0:3,nexternal)
+      INTEGER VECSIZE_USED
 
 C
 C     LOCAL
@@ -257,14 +259,12 @@ c               call set_ren_scale(P,scale)
 c            endif
 c         endif
 
-c     If scale is fixed, update G-dependent couplings for VECSIZE_MEMMAX events
+c     If scale is fixed, update G-dependent couplings for VECSIZE_USED events
 c     This is called only once in the application (FIRSTTIME=.true.)
-c     Only VECSIZE_USED events are needed, but this variable is unknown here
-c     Using VECSIZE_MEMMAX is correct and has a negligible performance overhead
 
          if(fixed_ren_scale) then
             G = SQRT(4d0*PI*ALPHAS(scale))
-            do i =1, VECSIZE_MEMMAX ! no need to use VECSIZE_USED here
+            do i =1, VECSIZE_USED
                call update_as_param(i)
             enddo
          endif

--- a/Template/LO/SubProcesses/genps.f
+++ b/Template/LO/SubProcesses/genps.f
@@ -1772,7 +1772,7 @@ c     find the boost momenta --sum of particles--
       include 'nexternal.inc'
       include 'genps.inc'
       include 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 c     include 'run.inc'
 

--- a/Template/LO/SubProcesses/genps.f
+++ b/Template/LO/SubProcesses/genps.f
@@ -1772,7 +1772,6 @@ c     find the boost momenta --sum of particles--
       include 'nexternal.inc'
       include 'genps.inc'
       include 'maxamps.inc'
-      include 'vector.inc'
       include 'coupl.inc'
 c     include 'run.inc'
 

--- a/Template/LO/SubProcesses/idenparts.f
+++ b/Template/LO/SubProcesses/idenparts.f
@@ -31,7 +31,6 @@ c
 c
 c     Global
 c
-      include 'vector.inc'
       include 'coupl.inc'                     !Mass and width info
       double precision stot
       common/to_stot/stot

--- a/Template/LO/SubProcesses/idenparts.f
+++ b/Template/LO/SubProcesses/idenparts.f
@@ -31,7 +31,7 @@ c
 c
 c     Global
 c
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'                     !Mass and width info
       double precision stot
       common/to_stot/stot

--- a/Template/LO/SubProcesses/myamp.f
+++ b/Template/LO/SubProcesses/myamp.f
@@ -52,7 +52,6 @@ c
       logical             OnBW(-nexternal:0)     !Set if event is on B.W.
       common/to_BWEvents/ OnBW
       
-      include 'vector.inc'
       include 'coupl.inc'
 
       integer idup(nexternal,maxproc,maxsproc)
@@ -286,7 +285,6 @@ c
       double precision stot,m1,m2
       common/to_stot/stot,m1,m2
 
-      include 'vector.inc'
       include 'coupl.inc'
       include 'cuts.inc'
 C

--- a/Template/LO/SubProcesses/myamp.f
+++ b/Template/LO/SubProcesses/myamp.f
@@ -52,7 +52,7 @@ c
       logical             OnBW(-nexternal:0)     !Set if event is on B.W.
       common/to_BWEvents/ OnBW
       
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 
       integer idup(nexternal,maxproc,maxsproc)
@@ -286,7 +286,7 @@ c
       double precision stot,m1,m2
       common/to_stot/stot,m1,m2
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
       include 'cuts.inc'
 C

--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -1790,7 +1790,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 C      include 'maxparticles.inc'
       
@@ -1817,7 +1817,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 C      include 'maxparticles.inc'
       

--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -1790,7 +1790,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'coupl.inc'
 C      include 'maxparticles.inc'
       
@@ -1817,7 +1817,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'coupl.inc'
 C      include 'maxparticles.inc'
       

--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -1790,7 +1790,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-c     include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
       include 'maxamps.inc'
       include 'cluster.inc'
       include 'coupl.inc'
@@ -1819,7 +1819,7 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-c     include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
       include 'maxamps.inc'
       include 'cluster.inc'
       include 'coupl.inc'

--- a/Template/LO/SubProcesses/setcuts.f
+++ b/Template/LO/SubProcesses/setcuts.f
@@ -8,7 +8,6 @@ c     INCLUDE
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
       include 'cuts.inc'

--- a/Template/LO/SubProcesses/setcuts.f
+++ b/Template/LO/SubProcesses/setcuts.f
@@ -8,7 +8,7 @@ c     INCLUDE
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
       include 'cuts.inc'

--- a/Template/LO/SubProcesses/setscales.f
+++ b/Template/LO/SubProcesses/setscales.f
@@ -11,7 +11,7 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 
       integer i
@@ -106,7 +106,7 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
 c--masses and poles

--- a/Template/LO/SubProcesses/setscales.f
+++ b/Template/LO/SubProcesses/setscales.f
@@ -11,7 +11,6 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc'
       include 'coupl.inc'
 
       integer i
@@ -106,7 +105,6 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
 c--masses and poles

--- a/Template/LO/SubProcesses/unwgt.f
+++ b/Template/LO/SubProcesses/unwgt.f
@@ -35,7 +35,7 @@ C
       double precision xzoomfact
       common/to_zoom/  xzoomfact
       include 'run.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
 c
 c     DATA

--- a/Template/LO/SubProcesses/unwgt.f
+++ b/Template/LO/SubProcesses/unwgt.f
@@ -35,7 +35,6 @@ C
       double precision xzoomfact
       common/to_zoom/  xzoomfact
       include 'run.inc'
-      include 'vector.inc'
       include 'coupl.inc'
 c
 c     DATA

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -6941,10 +6941,8 @@ class UFO_model_to_mg4(object):
         file = open(os.path.join(MG5DIR,\
                               'models/template_files/fortran/rw_para.f')).read()
 
-        includes=["include \'../vector.inc\'",
-                  "include \'coupl.inc\'",
-                  "include \'input.inc\'",
-                  "include \'model_functions.inc\'"]
+        includes=["include \'coupl.inc\'","include \'input.inc\'",
+                                              "include \'model_functions.inc\'"]
         if self.opt['mp']:
             includes.extend(["include \'mp_coupl.inc\'","include \'mp_input.inc\'"])
         # In standalone and madloop we do no use the compiled param card but
@@ -7516,7 +7514,6 @@ C
         fsock.writelines("""logical updateloop
                             common /to_updateloop/updateloop
                             include \'input.inc\'
-                            include \'../vector.inc\'
                             include \'coupl.inc\'
                             READLHA = .true.
                             include \'intparam_definition.inc\'""")
@@ -7582,7 +7579,6 @@ C
                             """)
 
         fsock.writelines("""include \'input.inc\'
-                            include \'../vector.inc\'
                             include \'coupl.inc\'
                             READLHA = .false.""")
         fsock.writelines("""    
@@ -7647,7 +7643,6 @@ C
                             'args_dep': ' integer vecid' if self.vector_size else ''
                             })
         fsock.writelines("""include \'input.inc\'
-                            include \'../vector.inc\'
                             include \'coupl.inc\'
                             double precision model_scale
                             common /model_scale/model_scale
@@ -7679,7 +7674,6 @@ C
         #                     double precision mu_r2, as2
         #                     include \'model_functions.inc\'""")
         # fsock.writelines("""include \'input.inc\'
-        #                     include \'../vector.inc\'
         #                     include \'coupl.inc\'
         #                     """)
         # fsock.writelines("""
@@ -7704,7 +7698,6 @@ C
                                     include \'mp_coupl.inc\'
                             """%self.mp_real_format)
             fsock.writelines("""include \'input.inc\'
-                                include \'../vector.inc\'
                                 include \'coupl.inc\'
                                 include \'actualize_mp_ext_params.inc\'
                                 READLHA = .false.
@@ -8102,7 +8095,6 @@ C
               parameter  (PI=3.141592653589793d0)
               parameter  (ZERO=0d0)
               include 'input.inc'
-              include '../vector.inc'
               include 'coupl.inc'""")
         if mp:
             fsock.writelines("""%s MP__PI, MP__ZERO

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5021,6 +5021,14 @@ C only VECSIZE_USED (<= VECSIZE_MEMAMX) are used in Fortran loops.
 C The value of VECSIZE_USED can be chosen at runtime
 C (typically 8k-16k for GPUs, 16-32 for vectorized C++).
 C
+C The value of VECSIZE_USED represents the number of events
+C handled by one call to the Fortran/cudacpp "bridge".
+C This is not necessarily the number of events which are
+C processed in lockstep within a single SIMD vector on CPUs
+C or within a single "warp" of threads on GPUs. These parameters
+C are internal to the cudacpp bridge and need not be exposed
+C to the Fortran program which calls the cudacpp bridge.
+C
 C NB: THIS FILE CANNOT CONTAIN #ifdef DIRECTIVES
 C BECAUSE IT DOES NOT GO THROUGH THE CPP PREPROCESSOR
 C (see https://github.com/madgraph5/madgraph4gpu/issues/458).

--- a/madgraph/iolibs/template_files/addmothers.f
+++ b/madgraph/iolibs/template_files/addmothers.f
@@ -4,9 +4,9 @@
       implicit none
       include 'genps.inc'
       include 'nexternal.inc'
+      include 'coupl.inc'
       include 'maxamps.inc'
       include 'cluster.inc'
-      include 'coupl.inc'
       include 'message.inc'
       include 'run.inc'
 

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -75,7 +75,6 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
-      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
 C     Common blocks

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -75,7 +75,7 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
-      include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+      include '../../Source/vector.inc'
       include 'run.inc'
 C     Common blocks
       CHARACTER*7         PDLABEL,EPA_LABEL
@@ -205,7 +205,7 @@ C ****************************************************
 C  
 C CONSTANTS
 C
-      include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+      include '../../Source/vector.inc'
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxconfigs.inc'
@@ -406,7 +406,7 @@ C
      implicit none
 
      include 'nexternal.inc'
-     include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+     include '../../Source/vector.inc'
      include 'maxamps.inc'
      INTEGER                 NCOMB
      PARAMETER (             NCOMB=%(ncomb)d)

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -75,7 +75,8 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
-      include '../../Source/vector.inc'
+      include 'vector.inc'
+      include 'coupl.inc'
       include 'run.inc'
 C     Common blocks
       CHARACTER*7         PDLABEL,EPA_LABEL
@@ -269,6 +270,7 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
+      include 'coupl.inc'
       include 'run.inc'
 
       double precision p_multi(0:3, nexternal, VECSIZE_MEMMAX)

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -206,7 +206,7 @@ C ****************************************************
 C  
 C CONSTANTS
 C
-      include '../../Source/vector.inc'
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMXAX
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxconfigs.inc'
@@ -408,7 +408,7 @@ C
      implicit none
 
      include 'nexternal.inc'
-     include '../../Source/vector.inc'
+     include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
      include 'maxamps.inc'
      INTEGER                 NCOMB
      PARAMETER (             NCOMB=%(ncomb)d)

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -75,7 +75,8 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
-      include 'coupl.inc'
+      INCLUDE 'vector.inc'  ! defines VECSIZE_MEMMAX
+      INCLUDE 'coupl.inc'  ! defines VECSIZE_MEMMAX_COUPL
       include 'run.inc'
 C     Common blocks
       CHARACTER*7         PDLABEL,EPA_LABEL

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -71,7 +71,6 @@ c      double precision xsec,xerr
 c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
 c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
-      include 'vector.inc'
       include 'coupl.inc'
       INTEGER VECSIZE_USED
       DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -81,6 +81,14 @@ C  BEGIN CODE
 C----- 
       call cpu_time(t_before)
       CUMULATED_TIMING = t_before
+
+c Sanity check (see https://github.com/madgraph5/madgraph4gpu/issues/629)
+      IF ( VECSIZE_MEMMAX .NE. VECSIZE_MEMMAX_COUPL ) THEN
+        WRITE(6,*) 'ERROR! Stopping in program DRIVER: VECSIZE_MEMMAX != VECSIZE_MEMMAX_COUPL!'
+        WRITE(6,*) 'ERROR! VECSIZE_MEMMAX       =', VECSIZE_MEMMAX
+        WRITE(6,*) 'ERROR! VECSIZE_MEMMAX_COUPL =', VECSIZE_MEMMAX_COUPL
+      ENDIF
+
 c
 c     Read process number
 c

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -71,7 +71,8 @@ c      double precision xsec,xerr
 c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
 c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
-      include 'coupl.inc'
+      INCLUDE 'vector.inc'  ! defines VECSIZE_MEMMAX
+      INCLUDE 'coupl.inc'  ! defines VECSIZE_MEMMAX_COUPL
       INTEGER VECSIZE_USED
       DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime
 

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -71,7 +71,7 @@ c      double precision xsec,xerr
 c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
 c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
       INTEGER VECSIZE_USED
       DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime

--- a/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
+++ b/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
@@ -42,7 +42,6 @@ c     /* ********************************************************* *
 	parameter (eva_pi   = 3.141592653589793d0)
 	parameter (eva_sqr2 = 1.414213562373095d0)
 
-	include '../vector.inc'
 	include '../MODEL/coupl.inc'
 
 	logical first

--- a/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
+++ b/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
@@ -42,7 +42,7 @@ c     /* ********************************************************* *
 	parameter (eva_pi   = 3.141592653589793d0)
 	parameter (eva_sqr2 = 1.414213562373095d0)
 
-	include '../vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+	include '../vector.inc'
 	include '../MODEL/coupl.inc'
 
 	logical first

--- a/madgraph/iolibs/template_files/madevent_symmetry.f
+++ b/madgraph/iolibs/template_files/madevent_symmetry.f
@@ -38,7 +38,6 @@ c
 c
 c     Global
 c
-      include '../../Source/vector.inc' ! for coupl.inc
       include 'coupl.inc'
       logical gridpack
       common/to_gridpack/gridpack
@@ -323,7 +322,6 @@ c
 c
 c     Global
 c
-      include '../../Source/vector.inc' ! for coupl.inc
       include 'coupl.inc'                     !Mass and width info
       double precision stot
       common/to_stot/stot
@@ -461,7 +459,6 @@ c
       common/to_bwcutoff/bwcutoff
       double precision stot
       common/to_stot/stot
-      include '../../Source/vector.inc' ! for coupl.inc      
       include 'coupl.inc'                     !Mass and width info
 
 c-----

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -77,7 +77,7 @@ C GLOBAL VARIABLES
 C  
     logical init_mode
     common /to_determine_zero_hel/init_mode
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
    
 
@@ -311,7 +311,7 @@ C
 C  
 C GLOBAL VARIABLES
 C
-   include '../../Source/vector.inc'
+   include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
     include 'coupl.inc'
 

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -58,7 +58,7 @@ C
 C  
 C GLOBAL VARIABLES
 C
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
 
 
@@ -225,7 +225,7 @@ C
 C  
 C GLOBAL VARIABLES
 C
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
     include 'coupl.inc'
 

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -735,7 +735,7 @@ C     ****************************************************
       INCLUDE 'maxamps.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
 C     
 C     ARGUMENTS 
 C     
@@ -869,7 +869,7 @@ C     ****************************************************
       INCLUDE 'maxamps.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
-      include '../../Source/vector.inc'
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
 C     
 C     ARGUMENTS 
 C

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -411,7 +411,6 @@ C     Common blocks
       data  nb_spin_state /%(nb_spin_state1)i,%(nb_spin_state2)i/
       common /nb_hel_state/ nb_spin_state
 
-      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
 C   ICONFIG has this config number
@@ -726,9 +725,9 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
+      include 'vector.inc'
 C     
 C     ARGUMENTS 
 C     
@@ -859,9 +858,9 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
+      include '../../Source/vector.inc'
 C     
 C     ARGUMENTS 
 C

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -411,7 +411,7 @@ C     Common blocks
       data  nb_spin_state /%(nb_spin_state1)i,%(nb_spin_state2)i/
       common /nb_hel_state/ nb_spin_state
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       include 'coupl.inc'
       include 'run.inc'
 C   ICONFIG has this config number
@@ -726,7 +726,7 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
 C     
@@ -859,7 +859,7 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include 'vector.inc'
       INCLUDE 'coupl.inc'
       INCLUDE 'run.inc'
 C     

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -805,10 +805,11 @@ C       Flip CM_RAP (to get rapidity right)
 
       DSIGPROC=0D0
 
-c    not needed anymore ... can be removed ... set for debugging only   
-     IF (.not.PASSCUTS(P1)) THEN
-        stop 1
-     endif
+c     not needed anymore ... can be removed ... set for debugging only   
+c     IF (.not.PASSCUTS(P1)) THEN
+c       stop 1
+c     endif
+
 c     set the running scale 
 c     and update the couplings accordingly
       IF (VECSIZE_MEMMAX.LE.1) THEN ! no-vector (NB not VECSIZE_USED!)

--- a/models/template_files/fortran/printout.f
+++ b/models/template_files/fortran/printout.f
@@ -9,7 +9,7 @@ c************************************************************************
       subroutine printout
       implicit none
 
-      include '../vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
+      include '../vector.inc'
       include 'coupl.inc'
       include 'input.inc'
       

--- a/models/template_files/fortran/printout.f
+++ b/models/template_files/fortran/printout.f
@@ -9,7 +9,6 @@ c************************************************************************
       subroutine printout
       implicit none
 
-      include '../vector.inc'
       include 'coupl.inc'
       include 'input.inc'
       


### PR DESCRIPTION
Hi @oliviermattelaer @roiser this is the full set of upstream fixes for https://github.com/madgraph5/madgraph4gpu/issues/629

My previous two MRs vecsize (https://github.com/mg5amcnlo/mg5amcnlo/pull/23) and vecsize2 (https://github.com/mg5amcnlo/mg5amcnlo/pull/24) had broken the "launch" functionality for a simple Fortran case. Now this is fixed.

The fix is ugly, as it introduces two separate variables VECSIZE_MEMMAX_COUPL and VECSIZE_MEMMAX (and a sanity check that they are equal). But it's as good as it gets (or at least as good as I was able to make it), given that the Fortran include statement does not use the preprocessor include guards, and that I did not want to modify every Fortran "include" in madgraph into a "#include". Anyway the values are set by code generation anyway.

I also include the minor fixes that were previosuly in https://github.com/mg5amcnlo/mg5amcnlo/pull/31 (which I will close), addressing some changes suggested by Olivier.

All in all, the code now looks much more like the madgraph previous to my two changes - which is good IMO.

@oliviermattelaer I set you as reviewer - but I will base all my developments in madgraph4gpu on this, so if you can have a quick look that would be great. Otherwise I can merge it (on gpucpp, anyway), and we discuss possible improvements later on.

Thanks Andrea 
