### PR TITLE
fix the to_pdf common block bug

### DIFF
--- a/Template/LO/Source/PDF/gammaUPC/photonpdfsquare.f
+++ b/Template/LO/Source/PDF/gammaUPC/photonpdfsquare.f
@@ -20,10 +20,11 @@ C     Include
 C
 C      include '../pdf.inc'
 C     Common block
-      character*7 pdlabel,epa_label
-      character*7 pdsublabel(2)
-      integer lhaid
-      common/to_pdf/lhaid,pdlabel,epa_label,pdsublabel
+      include '../pdf.inc'
+c      character*7 pdlabel,epa_label
+c      character*7 pdsublabel(2)
+c      integer lhaid
+c      common/to_pdf/lhaid,pdlabel,epa_label,pdsublabel
 
       double precision xx1,xx2
 

--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -1457,11 +1457,12 @@ c
       COMMON/TO_MATRIX/ISUM_HEL, MULTI_CHANNEL
       logical cutsdone, cutspassed
       COMMON/TO_CUTSDONE/CUTSDONE,CUTSPASSED
- 
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      character*7 pdsublabel(2)
-      INTEGER       LHAID
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL,pdsublabel
+
+      include './PDF/pdf.inc'
+c      CHARACTER*7         PDLABEL,EPA_LABEL
+c      character*7 pdsublabel(2)
+c      INTEGER       LHAID
+c      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL,pdsublabel
 c     
 c     Begin code
 c

--- a/Template/LO/Source/setrun.f
+++ b/Template/LO/Source/setrun.f
@@ -199,12 +199,14 @@ C-------------------------------------------------
       integer mpdf
       integer npdfs,i,pdfgup(2),pdfsup(2),lhaid
 
-      parameter (npdfs=19)
+      parameter (npdfs=21)
       character*7 pdflabs(npdfs)
       data pdflabs/
      $   'none',
      $   'eva',
      $   'iww',
+     $   'edff',
+     $   'chff',
      $     'dressed', 
      $   'mrs02nl',
      $   'mrs02nn',
@@ -226,7 +228,9 @@ C-------------------------------------------------
      $   00000,
      $   00000,
      $   00000,
-     $   00000, 
+     $   00000,
+     $   00000,
+     $   00000,
      $   20250,
      $   20270,
      $   19150,

--- a/Template/LO/SubProcesses/genps.f
+++ b/Template/LO/SubProcesses/genps.f
@@ -146,10 +146,11 @@ c
 c     Global
 c
 C     Common blocks
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      INTEGER       LHAID
-      character*7 pdsublabel(2)
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL, pdsublabel
+      include '../../Source/PDF/pdf.inc'
+c      CHARACTER*7         PDLABEL,EPA_LABEL
+c      INTEGER       LHAID
+c      character*7 pdsublabel(2)
+c      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL, pdsublabel
 
       double precision pmass(nexternal)
       common/to_mass/  pmass

--- a/madgraph/iolibs/template_files/auto_dsig_mw.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_mw.inc
@@ -55,10 +55,11 @@ C
 %(define_subdiag_lines)s
       include 'coupl.inc'
       include 'run.inc'
+      include '../../Source/PDF/pdf.inc'
 C     Common blocks
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      INTEGER       LHAID
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
+C      CHARACTER*7         PDLABEL,EPA_LABEL
+C      INTEGER       LHAID
+C      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
 C  
 C DATA
 C  

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -76,10 +76,11 @@ C     Keep track of whether cuts already calculated for this event
 %(define_subdiag_lines)s
       include 'coupl.inc'
       include 'run.inc'
+      include '../../Source/PDF/pdf.inc'
 C     Common blocks
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      INTEGER       LHAID
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
+C      CHARACTER*7         PDLABEL,EPA_LABEL
+C      INTEGER       LHAID
+C      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
 c
 c     local
 c

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -70,10 +70,11 @@ C
 C GLOBAL VARIABLES
 C  
 C     Common blocks
- 
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      INTEGER       LHAID
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
+
+      include '../../Source/PDF/pdf.inc'
+C      CHARACTER*7         PDLABEL,EPA_LABEL
+C      INTEGER       LHAID
+C      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL
 
       integer nb_spin_state(2)
       data  nb_spin_state /%(nb_spin_state1)i,%(nb_spin_state2)i/

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -282,9 +282,9 @@ def has_f2py():
     has_f2py = False
     if which('f2py'):
         has_f2py = True
-    elif misc.which('f2py%d.%d' %(sys.version_info.major, sys.version_info.minor)):
+    elif which('f2py%d.%d' %(sys.version_info.major, sys.version_info.minor)):
         has_f2py = True
-    elif misc.which('f2py%d' %(sys.version_info.major)):
+    elif which('f2py%d' %(sys.version_info.major)):
         has_f2py = True
 
     return has_f2py       


### PR DESCRIPTION
Hi, I just quickly fixed the problem with the to_pdf common block, which now uses the include '/PATH/TO/pdf.inc' instead of hard-coded the common block.