### PR TITLE
Minor 'vecsize3' changes (improve passcuts interface and add comments about vector.inc)

### DIFF
--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -17,7 +17,7 @@ c                    but the SIMD vector size and GPU warp size are smaller)
 c**************************************************************************
       implicit none
       include 'genps.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
 c     
 c Arguments
 c
@@ -667,7 +667,7 @@ c
       include 'genps.inc'
       include 'maxconfigs.inc'
       include 'run.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
 c
 c     Arguments
 c

--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -12,6 +12,8 @@ c     dsig           Function to be integrated
 c     ninvar         Number of invarients to keep grids on (s,t,u, s',t' etc)
 c     nconfigs       Number of different pole configurations 
 c     VECSIZE_USED   Number of events in parallel out of VECSIZE_MEMMAX
+c                    (NB this is the #events handled by the cudacpp bridge,
+c                    but the SIMD vector size and GPU warp size are smaller)
 c**************************************************************************
       implicit none
       include 'genps.inc'
@@ -169,7 +171,7 @@ c            write(*,*) 'iter/ievent/ivec', iter, ievent, ivec
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
             CUTSDONE=.FALSE.
             CUTSPASSED=.FALSE.
-            if (passcuts(p)) then
+            if (passcuts(p,VECSIZE_USED)) then
                ivec=ivec+1
 c              write(*,*) 'pass_point ivec is ', ivec
                all_p(:,ivec) = p(:)

--- a/Template/LO/Source/setrun.f
+++ b/Template/LO/Source/setrun.f
@@ -15,8 +15,8 @@ c
       include 'PDF/pdf.inc'
       include 'run.inc'
       include 'alfas.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'MODEL/coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'MODEL/coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
       double precision D
       common/to_dj/D

--- a/Template/LO/SubProcesses/cluster.inc
+++ b/Template/LO/SubProcesses/cluster.inc
@@ -3,7 +3,7 @@ c	Parameters used by cluster
 c*************************************************************************
       include 'ncombs.inc'
       include 'ngraphs.inc'
-      include 'vector.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
       include 'maxconfigs.inc'
 c     parameters for clustering:
 c     id_cl gives diagrams for propagators     

--- a/Template/LO/SubProcesses/cuts.f
+++ b/Template/LO/SubProcesses/cuts.f
@@ -71,7 +71,7 @@ C     GLOBAL
 C
       include 'run.inc'
       include 'cuts.inc'
-      include '../../Source/vector.inc'
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
       
       double precision ptjet(nexternal)
       double precision ptheavyjet(nexternal)
@@ -183,7 +183,7 @@ C     Sort array of results: ismode>0 for real, isway=0 for ascending order
       parameter (isway=0)
       parameter (izero=0)
 
-      include 'coupl.inc'
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
 C
 C

--- a/Template/LO/SubProcesses/cuts.f
+++ b/Template/LO/SubProcesses/cuts.f
@@ -21,13 +21,14 @@ c-----
 c      pass_point = passcuts(p)
       end
 C 
-      LOGICAL FUNCTION PASSCUTS(P)
+      LOGICAL FUNCTION PASSCUTS(P, VECSIZE_USED)
 C**************************************************************************
 C     INPUT:
 C            P(0:3,1)           MOMENTUM OF INCOMING PARTON
 C            P(0:3,2)           MOMENTUM OF INCOMING PARTON
 C            P(0:3,3)           MOMENTUM OF ...
 C            ALL MOMENTA ARE IN THE REST FRAME!!
+C            VECSIZE_USED (used only on 1st call) #events in parallel
 C            COMMON/JETCUTS/   CUTS ON JETS
 C     OUTPUT:
 C            TRUE IF EVENTS PASSES ALL CUTS LISTED
@@ -42,6 +43,7 @@ C
 C     ARGUMENTS
 C
       REAL*8 P(0:3,nexternal)
+      INTEGER VECSIZE_USED
 
 C
 C     LOCAL
@@ -257,14 +259,12 @@ c               call set_ren_scale(P,scale)
 c            endif
 c         endif
 
-c     If scale is fixed, update G-dependent couplings for VECSIZE_MEMMAX events
+c     If scale is fixed, update G-dependent couplings for VECSIZE_USED events
 c     This is called only once in the application (FIRSTTIME=.true.)
-c     Only VECSIZE_USED events are needed, but this variable is unknown here
-c     Using VECSIZE_MEMMAX is correct and has a negligible performance overhead
 
          if(fixed_ren_scale) then
             G = SQRT(4d0*PI*ALPHAS(scale))
-            do i =1, VECSIZE_MEMMAX ! no need to use VECSIZE_USED here
+            do i =1, VECSIZE_USED
                call update_as_param(i)
             enddo
          endif

--- a/Template/LO/SubProcesses/genps.f
+++ b/Template/LO/SubProcesses/genps.f
@@ -1772,8 +1772,8 @@ c     find the boost momenta --sum of particles--
       include 'nexternal.inc'
       include 'genps.inc'
       include 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 c     include 'run.inc'
 
       double precision p(0:3, nexternal)

--- a/Template/LO/SubProcesses/idenparts.f
+++ b/Template/LO/SubProcesses/idenparts.f
@@ -31,8 +31,8 @@ c
 c
 c     Global
 c
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'                     !Mass and width info
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! mass and width info - needs VECSIZE_MEMMAX (defined in vector.inc)
       double precision stot
       common/to_stot/stot
 

--- a/Template/LO/SubProcesses/myamp.f
+++ b/Template/LO/SubProcesses/myamp.f
@@ -52,8 +52,8 @@ c
       logical             OnBW(-nexternal:0)     !Set if event is on B.W.
       common/to_BWEvents/ OnBW
       
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
       integer idup(nexternal,maxproc,maxsproc)
       integer mothup(2,nexternal)
@@ -286,8 +286,8 @@ c
       double precision stot,m1,m2
       common/to_stot/stot,m1,m2
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'cuts.inc'
 C
 C     SPECIAL CUTS

--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -24,7 +24,8 @@ c**************************************************
       include 'nexternal.inc'
       include 'message.inc'
       include 'maxamps.inc'
-      include 'cluster.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
       include 'sudakov.inc'
       include 'maxparticles.inc'
       include 'run.inc'
@@ -97,7 +98,8 @@ c**************************************************
       include 'message.inc'
       include 'nexternal.inc'
       include 'maxamps.inc'
-      include 'cluster.inc'      
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
       integer ipdg,imode
       double precision q0, Q11
       double precision gamma,DGAUSS
@@ -562,9 +564,10 @@ c**************************************************
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxamps.inc'
-      include 'cluster.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
       include 'run.inc'
-      include 'coupl.inc'
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'run_config.inc'
 C   
 C   ARGUMENTS 
@@ -1315,9 +1318,10 @@ c**************************************************
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxamps.inc'
-      include 'cluster.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
       include 'run.inc'
-      include 'coupl.inc'
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'run_config.inc'
 C   
 C   ARGUMENTS 
@@ -1790,10 +1794,10 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-c     include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'maxamps.inc'
-      include 'cluster.inc'
-      include 'coupl.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 C      include 'maxparticles.inc'
       
       double precision all_p(4*maxdim/3+14,1), all_wgt(1)
@@ -1819,10 +1823,10 @@ C
       include 'genps.inc'
       include 'run.inc'
       include 'nexternal.inc'
-c     include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
       include 'maxamps.inc'
-      include 'cluster.inc'
-      include 'coupl.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 C      include 'maxparticles.inc'
       
       double precision all_p(4*maxdim/3+14,*), all_wgt(*)

--- a/Template/LO/SubProcesses/setcuts.f
+++ b/Template/LO/SubProcesses/setcuts.f
@@ -8,8 +8,8 @@ c     INCLUDE
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'run.inc'
       include 'cuts.inc'
 c

--- a/Template/LO/SubProcesses/setscales.f
+++ b/Template/LO/SubProcesses/setscales.f
@@ -11,8 +11,8 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
       integer i
       include 'maxamps.inc'
@@ -106,8 +106,8 @@ c     INCLUDE and COMMON
 c
       include 'genps.inc'
       include 'nexternal.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'run.inc'
 c--masses and poles
 c

--- a/Template/LO/SubProcesses/unwgt.f
+++ b/Template/LO/SubProcesses/unwgt.f
@@ -35,8 +35,8 @@ C
       double precision xzoomfact
       common/to_zoom/  xzoomfact
       include 'run.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 c
 c     DATA
 c
@@ -463,7 +463,8 @@ c
       include 'nexternal.inc'
       include 'maxamps.inc'
       include 'message.inc'
-      include 'cluster.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
       include 'run.inc'
       include 'run_config.inc'
 
@@ -543,7 +544,7 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 c      data ncolflow/maxamps*0/
 c      data ncolalt/maxamps*0/
 
-      include 'coupl.inc'
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
       include 'lhe_event_infos.inc'
       data AlreadySetInBiasModule/.False./

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5021,6 +5021,14 @@ C only VECSIZE_USED (<= VECSIZE_MEMAMX) are used in Fortran loops.
 C The value of VECSIZE_USED can be chosen at runtime
 C (typically 8k-16k for GPUs, 16-32 for vectorized C++).
 C
+C The value of VECSIZE_USED represents the number of events
+C handled by one call to the Fortran/cudacpp "bridge".
+C This is not necessarily the number of events which are
+C processed in lockstep within a single SIMD vector on CPUs
+C or within a single "warp" of threads on GPUs. These parameters
+C are internal to the cudacpp bridge and need not be exposed
+C to the Fortran program which calls the cudacpp bridge.
+C
 C NB: THIS FILE CANNOT CONTAIN #ifdef DIRECTIVES
 C BECAUSE IT DOES NOT GO THROUGH THE CPP PREPROCESSOR
 C (see https://github.com/madgraph5/madgraph4gpu/issues/458).

--- a/madgraph/iolibs/template_files/addmothers.f
+++ b/madgraph/iolibs/template_files/addmothers.f
@@ -5,8 +5,9 @@
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxamps.inc'
-      include 'cluster.inc'
-      include 'coupl.inc'
+c     include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'cluster.inc' ! includes vector.inc that defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'message.inc'
       include 'run.inc'
 

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -75,7 +75,7 @@ C     Keep track of whether cuts already calculated for this event
       LOGICAL cutsdone,cutspassed
       COMMON/TO_CUTSDONE/cutsdone,cutspassed
 %(define_subdiag_lines)s
-      include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
       include 'run.inc'
 C     Common blocks
       CHARACTER*7         PDLABEL,EPA_LABEL
@@ -205,7 +205,7 @@ C ****************************************************
 C  
 C CONSTANTS
 C
-      include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
       include 'genps.inc'
       include 'nexternal.inc'
       include 'maxconfigs.inc'
@@ -406,7 +406,7 @@ C
      implicit none
 
      include 'nexternal.inc'
-     include '../../Source/vector.inc' ! needed to define VECSIZE_MEMMAX
+     include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
      include 'maxamps.inc'
      INTEGER                 NCOMB
      PARAMETER (             NCOMB=%(ncomb)d)

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -71,8 +71,8 @@ c      double precision xsec,xerr
 c      integer ncols,ncolflow(maxamps),ncolalt(maxamps),ic
 c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       INTEGER VECSIZE_USED
       DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime
 

--- a/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
+++ b/madgraph/iolibs/template_files/madevent_electroweakFlux.inc
@@ -42,8 +42,8 @@ c     /* ********************************************************* *
 	parameter (eva_pi   = 3.141592653589793d0)
 	parameter (eva_sqr2 = 1.414213562373095d0)
 
-	include '../vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-	include '../MODEL/coupl.inc'
+	include '../vector.inc' ! defines VECSIZE_MEMMAX
+	include '../MODEL/coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
 	logical first
 	data first /.true./

--- a/madgraph/iolibs/template_files/madevent_symmetry.f
+++ b/madgraph/iolibs/template_files/madevent_symmetry.f
@@ -38,8 +38,8 @@ c
 c
 c     Global
 c
-      include '../../Source/vector.inc' ! for coupl.inc
-      include 'coupl.inc'
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       logical gridpack
       common/to_gridpack/gridpack
       double precision stot
@@ -323,8 +323,8 @@ c
 c
 c     Global
 c
-      include '../../Source/vector.inc' ! for coupl.inc
-      include 'coupl.inc'                     !Mass and width info
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! mass and width info - needs VECSIZE_MEMMAX (defined in vector.inc)
       double precision stot
       common/to_stot/stot
 
@@ -461,8 +461,8 @@ c
       common/to_bwcutoff/bwcutoff
       double precision stot
       common/to_stot/stot
-      include '../../Source/vector.inc' ! for coupl.inc      
-      include 'coupl.inc'                     !Mass and width info
+      include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! mass and width info - needs VECSIZE_MEMMAX (defined in vector.inc)
 
 c-----
 c  Begin Code

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -77,7 +77,7 @@ C GLOBAL VARIABLES
 C  
     logical init_mode
     common /to_determine_zero_hel/init_mode
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
    
 
@@ -311,9 +311,9 @@ C
 C  
 C GLOBAL VARIABLES
 C
-   include '../../Source/vector.inc'
+   include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
-    include 'coupl.inc'
+    include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
 	double precision small_width_treatment
 	common/narrow_width/small_width_treatment

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -58,7 +58,7 @@ C
 C  
 C GLOBAL VARIABLES
 C
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     DOUBLE PRECISION AMP2(MAXAMPS), JAMP2(0:MAXFLOW)
 
 
@@ -225,9 +225,9 @@ C
 C  
 C GLOBAL VARIABLES
 C
-    include '../../Source/vector.inc'
+    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
-    include 'coupl.inc'
+    include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
 
        double precision tmin_for_channel
        integer sde_strat ! 1 means standard single diagram enhancement strategy,

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -419,8 +419,8 @@ C     Common blocks
       data  nb_spin_state /%(nb_spin_state1)i,%(nb_spin_state2)i/
       common /nb_hel_state/ nb_spin_state
 
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'run.inc'
 C   ICONFIG has this config number
       INTEGER MAPCONFIG(0:LMAXCONFIGS), ICONFIG
@@ -734,8 +734,8 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      INCLUDE 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       INCLUDE 'run.inc'
 C     
 C     ARGUMENTS 
@@ -868,8 +868,8 @@ C     ****************************************************
       include 'maxconfigs.inc'
       INCLUDE 'nexternal.inc'
       INCLUDE 'maxamps.inc'
-      include 'vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      INCLUDE 'coupl.inc'
+      include 'vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       INCLUDE 'run.inc'
 C     
 C     ARGUMENTS 

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -814,10 +814,11 @@ C       Flip CM_RAP (to get rapidity right)
 
       DSIGPROC=0D0
 
-c    not needed anymore ... can be removed ... set for debugging only   
-     IF (.not.PASSCUTS(P1)) THEN
-        stop 1
-     endif
+c     not needed anymore ... can be removed ... set for debugging only   
+c     IF (.not.PASSCUTS(P1)) THEN
+c       stop 1
+c     endif
+
 c     set the running scale 
 c     and update the couplings accordingly
       IF (VECSIZE_MEMMAX.LE.1) THEN ! no-vector (NB not VECSIZE_USED!)

--- a/models/template_files/fortran/printout.f
+++ b/models/template_files/fortran/printout.f
@@ -9,8 +9,8 @@ c************************************************************************
       subroutine printout
       implicit none
 
-      include '../vector.inc' ! needed by coupl.inc (defines VECSIZE_MEMMAX)
-      include 'coupl.inc'
+      include '../vector.inc' ! defines VECSIZE_MEMMAX
+      include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       include 'input.inc'
       
       include 'formats.inc'


### PR DESCRIPTION
This is a (final?) followup to my previous MRs vecsize (https://github.com/mg5amcnlo/mg5amcnlo/pull/23) and vecsize2 (https://github.com/mg5amcnlo/mg5amcnlo/pull/24). 
- First, it includes a few improvements suggested by @oliviermattelaer in #24 about the passcuts interface, which now includes VECSIZE_USED (https://github.com/mg5amcnlo/mg5amcnlo/pull/24#discussion_r1087085378). This patch was originally in MR #31, which had been closed without merging.
- Second, it consistently adds comments about VECSIZE_MEMMAX whenever vector.inc, coupl.inc or cluster.inc are included, as discussed with @oliviermattelaer in #49.

This MR replaces #49, which has been closed. The main point of that MR was to fix https://github.com/madgraph5/madgraph4gpu/issues/629, which I had attempted to do by adding VECSIZE_MEMMAX_COUPL to the coupl.inc file. However the actual issue ("launch" was broken because symmetry.f was not building) was instead fixed by Olivier in https://github.com/mg5amcnlo/mg5amcnlo/commit/c1d10f42631378d4c5ea6f594c9318cedff72953. It is then unnecessary and cumbersome to add a different VECSIZE_MEMMAX_COUPL and Olivier suggested to keep things as they were before (what I call "option 2" in #49).

**NB** : I imagine that there are other issues hidden in the code because of this choice. For instance, export_v4.py creates code which includes coupl.inc without including vector.inc first. I propose that we will try to fix these issues as they come along. *For the moment I have not attempted to fix export_v4.py*.

cc @roiser 