### PR TITLE
WIP: fix standalone output for vector.inc production and usage

### DIFF
--- a/madgraph/iolibs/template_files/check_sa.f
+++ b/madgraph/iolibs/template_files/check_sa.f
@@ -14,6 +14,7 @@ C
 C     INCLUDE FILES
 C     
 C---  the include file with the values of the parameters and masses	
+      INCLUDE '../../Source/vector.inc'
       INCLUDE "coupl.inc"
 C---  integer nexternal ! number particles (incoming+outgoing) in the me 
       INCLUDE "nexternal.inc" 

--- a/madgraph/iolibs/template_files/matrix_standalone_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_standalone_v4.inc
@@ -202,6 +202,7 @@ C
 C  
 C GLOBAL VARIABLES
 C  
+      include '../../Source/vector.inc'
       include 'coupl.inc'
 %(global_variable)s
 C  
@@ -245,6 +246,7 @@ CF2PY INTENT(IN) :: P(0:3,NEXTERNAL)
 CF2PY INTENT(IN) :: ALPHAS
 C     ROUTINE FOR F2PY to read the benchmark point.    
 C     the include file with the values of the parameters and masses 
+      INCLUDE '../../Source/vector.inc'
       include "coupl.inc"
       
       pi = 3.141592653589793d0


### PR DESCRIPTION
This fix applies to the "gpucpp" branch of the repo. When running e.g. 

```
generate e+ e- > mu+ mu-
output standalone test --vector_size=32
```

there this will produce the error 

```
The compilation fails with the following output message:
	    cd MODEL; make
	    make[1]: Entering directory '/afs/cern.ch/work/r/roiser/sw/madgraph4gpu/MG5aMC/mg5amcnlo/guttu2.sa/Source/MODEL'
	    /opt/rh/gcc-toolset-11/root/usr/bin/gfortran -w -fPIC  -ffixed-line-length-132  -c -o couplings.o couplings.f
	    couplings.f:16: Error: Can't open included file '../vector.inc'
	    make[1]: *** [<builtin>: couplings.o] Error 1
	    make[1]: Leaving directory '/afs/cern.ch/work/r/roiser/sw/madgraph4gpu/MG5aMC/mg5amcnlo/guttu2.sa/Source/MODEL'
	    make: *** [makefile:59: ../lib/libmodel.a] Error 2
```

the reason being that the ```vector.inc``` file containing the vector size for the parallel execution is not being produced. This PR changes the relevant ```madgraph/iolibs/export_v4.py``` in three places

- it calls self.write_vector_size also for the SA output
- it moves the write_vector_size from the ```ProcessExporterFortranME``` class to its base ```ProcessExporterFortran``` so that it can be used also in ```ProcessExporterFortranSA```
- it adds one missing include of vector.inc in couplings.f which maybe was overlooked