### PR TITLE
Change to the PS restriction for electron beam

### DIFF
--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -3919,6 +3919,8 @@ class RunCardLO(RunCard):
         self.add_param("time_of_flight", -1.0, include=False)
         self.add_param("nevents", 10000)        
         self.add_param("iseed", 0)
+        self.add_param("bypass_check", [], typelist=str, include=False, hidden=True,
+                       allowed=['partonshower'], comment="list of check that can be bypassed manually.")
         self.add_param("python_seed", -2, include=False, hidden=True, comment="controlling python seed [handling in particular the final unweighting].\n -1 means use default from random module.\n -2 means set to same value as iseed")
         self.add_param("lpp1", 1, fortran_name="lpp(1)", allowed=[-1,1,0,2,3,9,-2,-3,4,-4],
                         comment='first beam energy distribution:\n 0: fixed energy\n 1: PDF of proton\n -1: PDF of antiproton\n 2:elastic photon from proton, +/-3:PDF of electron/positron, +/-4:PDF of muon/antimuon, 9: PLUGIN MODE')


### PR DESCRIPTION
So the following script now works:
generate e+ e- > t t~
output
launch
shower=PY8
set lpp2 3
set lpp1 -3
set pdlabel cepc240ll
set bypass_check partonshower

as well as this one:
generate e+ e- > t t~
output
launch
shower=PY8
set lpp2 3
set lpp1 -3
set pdlabel isronlyll


in the last one, I do force that QED shower is on automatically (this force can also be turned off by the "bypass_check partonshower".
