### PR TITLE
Update input events when calculating maxwgt in get_maxwgt_for_onshell

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -1652,11 +1652,13 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         self.efficiency = 1. / self.options['max_weight_ps_point']
         start = time.time()
+        
+        orig_lhe.seek(0)
+        
         for i in range(nevents):
             if i % 5 ==1:
                 logger.info( "Event %s/%s :  %2fs" % (i, nevents, time.time()-start))
             maxwgt = 0
-            orig_lhe.seek(0)
             base_event = next(orig_lhe)
             if self.options['fixed_order']:
                 base_event = base_event[0]


### PR DESCRIPTION
In `get_maxwgt_for_onshell`, `orig_lhe.seek(0)` was called from inside the loop over the input events and as a result, the input events were never updated (instead of probing the first 75 events, only the 1st event was probed). 

I move the `orig_lhe.seek(0)` outside of the loop, so that the input events are updated.

@oliviermattelaer maybe you also propagate this to the main branch, since it's also affected?