### PR TITLE
Patch to running plugins from the PYTHONPATH

### DIFF
--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -161,12 +161,13 @@ if options.plugin:
     if not os.path.exists(os.path.join(root_path, 'PLUGIN', options.plugin)):
         try:
             __import__('MG5aMC_PLUGIN.%s' % options.plugin)
+            plugin = sys.modules['MG5aMC_PLUGIN.%s' % options.plugin]
         except:
             print( "ERROR: %s is not present in the PLUGIN directory. Please install it first" % options.plugin)
-
+            sys.exit()
     else:
         __import__('PLUGIN.%s' % options.plugin)
-    plugin = sys.modules['PLUGIN.%s' % options.plugin]
+        plugin = sys.modules['PLUGIN.%s' % options.plugin]
     if not plugin.new_interface:
         logging.warning("Plugin: %s do not define dedicated interface and should be used without the --mode options" % options.plugin)
         sys.exit()


### PR DESCRIPTION
Two minor patches to the plugin setup:

- First, if a plugin isn't installed, the code crashes in a rather non-obvious way. This changes it to simply sys.exit after the plugin has not been found and an error message has been printed.

- Second, in case a plugin is brought in via the PYTHONPATH (MG5aMC_PLUGIN), it needs to then be loaded from there with the sys module. The current setup leads to it not being found in the module dictionary.

I hope these two are clear enough, but as this is my first pull request please let me know if there's anything else I should do here, any other documentation that would be useful, tests to run, etc.