### PR TITLE
Use a try except with shutil.copystat

### DIFF
--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -1001,7 +1001,11 @@ def call_stdout(arg, *args, **opt):
 def copytree(src, dst, symlinks = False, ignore = None):
   if not os.path.exists(dst):
     os.makedirs(dst)
-    shutil.copystat(src, dst)
+    try:
+      shutil.copystat(src, dst)
+    except PermissionError:
+      print('Warning: could not copy permissions from %s to %s' % (src, dst))
+      print('If you have the right permissions ignore this warning.')
   lst = os.listdir(src)
   if ignore:
     excl = ignore(src, lst)

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -1006,9 +1006,9 @@ def copytree(src, dst, symlinks = False, ignore = None):
     except PermissionError:
         if os.path.realpath(src).startswith('/cvmfs') and os.path.realpath(dst).startswith('/afs'):
            # allowing missmatch from cvmfs to afs since sounds to not create issue --at least in general-- 
-           logger.critical('Ignoring that we could not copy permissions from %s to %s', src, dst)
+           logger.critical(f'Ignoring that we could not copy permissions from {src} to {dst}')
         else:
-           logger.critical('Permission error detected from %s to %s.\n'+\
+           logger.critical(f'Permission error detected from {src} to {dst}.\n'+\
                           'If you are using WSL with windows partition, please try using python3.12\n'+\
                           'or avoid moving your data from the WSL partition to the UNIX one')
            # we do not have enough experience in WSL to allow it to get trough.

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -1004,8 +1004,16 @@ def copytree(src, dst, symlinks = False, ignore = None):
     try:
       shutil.copystat(src, dst)
     except PermissionError:
-      print('Warning: could not copy permissions from %s to %s' % (src, dst))
-      print('If you have the right permissions ignore this warning.')
+        if os.path.realpath(src).startswith('/cvmfs') and os.path.realpath(dst).startswith('/afs'):
+           # allowing missmatch from cvmfs to afs since sounds to not create issue --at least in general-- 
+           logger.critical('Ignoring that we could not copy permissions from %s to %s', src, dst)
+        else:
+           logger.critical('Permission error detected from %s to %s.\n'+\
+                          'If you are using WSL with windows partition, please try using python3.12\n'+\
+                          'or avoid moving your data from the WSL partition to the UNIX one')
+           # we do not have enough experience in WSL to allow it to get trough.
+           raise
+      
   lst = os.listdir(src)
   if ignore:
     excl = ignore(src, lst)


### PR DESCRIPTION
shutil.copystat fails when the source file is on cvmfs and we are
trying to copy the permissions. This prints a warning when this happens (for example with madgraph on cvmfs and trying to run it from AFS on lxplus at CERN). When this happens, this prints the warning several times (around 10 when running, which may be too many).

The issue can be reproduced by doing (from AFS)

``` python
import os
import shutil
os.makedirs('models')
shutil.copystat('/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-04-24/x86_64-almalinux9-gcc11.3.1-opt/madgraph5amc/3.5.4-euoakt/models', './models')
```

And then one gets the following error:

``` python
PermissionError                           Traceback (most recent call last)
Cell In [4], line 1
----> 1 shutil.copystat('/cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-04-24/x86_64-almalinux9-gcc11.3.1-opt/madgraph5amc/3.5.4-euoakt/models', './models')

File /usr/lib64/python3.9/shutil.py:390, in copystat(src, dst, follow_symlinks)
    388 _copyxattr(src, dst, follow_symlinks=follow)
    389 try:
--> 390     lookup("chmod")(dst, mode, follow_symlinks=follow)
    391 except NotImplementedError:
    392     # if we got a NotImplementedError, it's because
    393     #   * follow_symlinks=False,
   (...)
    400     # symlink.  give up, suppress the error.
    401     # (which is what shutil always did in this circumstance.)
    402     pass

PermissionError: [Errno 13] Permission denied: './models'
```

Any directory works, it's probably an issue with AFS but I don't know why. From a different place this works but many users have their home folder in AFS and will run from it.

Error when running madgraph:

``` python
> PermissionError : [Errno 13] Permission denied:
> '/afs/cern.ch/user/d/dzerwas/public/key4hep/lcgmg5/Output'
> Please report this bug on https://bugs.launchpad.net/mg5amcnlo
> More information is found in 'MG5_debug'.
> Please attach this file to your report.

```