### PR TITLE
Fix validity time check for UFO pickle

### DIFF
--- a/madgraph/iolibs/files.py
+++ b/madgraph/iolibs/files.py
@@ -117,7 +117,7 @@ def is_uptodate(picklefile, path_list=None, min_time=1343682423):
     
     assert type(path_list) == list, 'is_update expect a list of files'
     
-    pickle_date = os.path.getmtime(picklefile) # FIX BUG mg5amcnlo/mg5amcnlo#89 (use getmtime instead of getctime)
+    pickle_date = os.path.getctime(picklefile)
     if pickle_date < min_time:
         return False
     

--- a/madgraph/iolibs/files.py
+++ b/madgraph/iolibs/files.py
@@ -117,25 +117,17 @@ def is_uptodate(picklefile, path_list=None, min_time=1343682423):
     
     assert type(path_list) == list, 'is_update expect a list of files'
     
-    ###pickle_date = os.path.getctime(picklefile) # BUG! mg5amcnlo/mg5amcnlo#89
-    pickle_date = os.path.getmtime(picklefile) # FIX BUG mg5amcnlo/mg5amcnlo#89
-    ###import madgraph.various.misc as misc # debug mg5amcnlo/mg5amcnlo#89
-    ###misc.sprint(pickle_date, min_time) # debug mg5amcnlo/mg5amcnlo#89
+    pickle_date = os.path.getmtime(picklefile) # FIX BUG mg5amcnlo/mg5amcnlo#89 (use getmtime instead of getctime)
     if pickle_date < min_time:
-        ###misc.sprint('False') # debug mg5amcnlo/mg5amcnlo#89
         return False
     
     for path in path_list:
-        ###misc.sprint(path) # debug mg5amcnlo/mg5amcnlo#89
         try:
-            ###misc.sprint(pickle_date, os.path.getmtime(path)) # debug mg5amcnlo/mg5amcnlo#89
             if os.path.getmtime(path) > pickle_date:
-                ###misc.sprint('False') # debug mg5amcnlo/mg5amcnlo#89
                 return False
         except Exception:
             continue
     #all pass
-    ###misc.sprint('True') # debug mg5amcnlo/mg5amcnlo#89
     return True
 
 

--- a/madgraph/iolibs/files.py
+++ b/madgraph/iolibs/files.py
@@ -117,17 +117,25 @@ def is_uptodate(picklefile, path_list=None, min_time=1343682423):
     
     assert type(path_list) == list, 'is_update expect a list of files'
     
-    pickle_date = os.path.getctime(picklefile)
+    ###pickle_date = os.path.getctime(picklefile) # BUG! mg5amcnlo/mg5amcnlo#89
+    pickle_date = os.path.getmtime(picklefile) # FIX BUG mg5amcnlo/mg5amcnlo#89
+    ###import madgraph.various.misc as misc # debug mg5amcnlo/mg5amcnlo#89
+    ###misc.sprint(pickle_date, min_time) # debug mg5amcnlo/mg5amcnlo#89
     if pickle_date < min_time:
+        ###misc.sprint('False') # debug mg5amcnlo/mg5amcnlo#89
         return False
     
     for path in path_list:
+        ###misc.sprint(path) # debug mg5amcnlo/mg5amcnlo#89
         try:
+            ###misc.sprint(pickle_date, os.path.getmtime(path)) # debug mg5amcnlo/mg5amcnlo#89
             if os.path.getmtime(path) > pickle_date:
+                ###misc.sprint('False') # debug mg5amcnlo/mg5amcnlo#89
                 return False
         except Exception:
             continue
     #all pass
+    ###misc.sprint('True') # debug mg5amcnlo/mg5amcnlo#89
     return True
 
 

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -361,7 +361,6 @@ def import_full_model(model_path, decay=False, prefix=''):
         pickle_name = 'py3_%s' % pickle_name
     
     allow_reload = False
-    ###misc.sprint('Check', pickle_name, 'against:\n', '\n'.join(files_list)) # debug mg5amcnlo/mg5amcnlo#89
     if files.is_uptodate(os.path.join(model_path, pickle_name), files_list):
         allow_reload = True
         try:

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -349,7 +349,7 @@ def import_full_model(model_path, decay=False, prefix=''):
                 raise UFOImportError("%s directory is not a valid UFO model: \n %s is missing" % \
                                                          (model_path, filename))
         files_list.append(filepath)
-    files_list.append(os.path.join(MG5DIR, 'models', 'import_ufo.py')) # see mg5amcnlo/mg5amcnlo#89
+    files_list.append(__file__) # include models/import_ufo.py itself, see mg5amcnlo/mg5amcnlo#89
     # use pickle files if defined and up-to-date
     if aloha.unitary_gauge: 
         pickle_name = 'model.pkl'

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -349,6 +349,7 @@ def import_full_model(model_path, decay=False, prefix=''):
                 raise UFOImportError("%s directory is not a valid UFO model: \n %s is missing" % \
                                                          (model_path, filename))
         files_list.append(filepath)
+    files_list.append(os.path.join(MG5DIR, 'models', 'import_ufo.py')) # see mg5amcnlo/mg5amcnlo#89
     # use pickle files if defined and up-to-date
     if aloha.unitary_gauge: 
         pickle_name = 'model.pkl'
@@ -360,6 +361,7 @@ def import_full_model(model_path, decay=False, prefix=''):
         pickle_name = 'py3_%s' % pickle_name
     
     allow_reload = False
+    ###misc.sprint('Check', pickle_name, 'against:\n', '\n'.join(files_list)) # debug mg5amcnlo/mg5amcnlo#89
     if files.is_uptodate(os.path.join(model_path, pickle_name), files_list):
         allow_reload = True
         try:


### PR DESCRIPTION
Hi @oliviermattelaer this is a fix for the issues discussed in #89, can you please have a look?

- First, checking the validity of a model's pickle should also include import_ufo.py itself (your fix was in this model-agnostic file, not in a model-specific file)
- Second, mtime should be used instead of ctime: this is because ctime is just the inode time and does not change, while mtime is the time of the contents (by the way the same function was already using mtime further down for each file, so it is not clear why it uses ctime for the pickle)

Thanks
Andrea