### PR TITLE
No integration channels -> suggest masses too high or beam energy too low

### DIFF
--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -2074,7 +2074,7 @@ class aMCatNLOCmd(CmdExtended, HelpToCmd, CompleteForCmd, common_run.CommonRunCm
                     with open(pjoin(self.me_dir,'SubProcesses',p_dir,'channels.txt')) as chan_file:
                         channels=chan_file.readline().split()
                 except IOError:
-                    logger.warning('No integration channels found for contribution %s' % p_dir)
+                    logger.warning('No integration channels found for contribution %s (too large masses?)' % p_dir)
                     continue
                 if fixed_order:
                     lch=len(channels)

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -2074,7 +2074,7 @@ class aMCatNLOCmd(CmdExtended, HelpToCmd, CompleteForCmd, common_run.CommonRunCm
                     with open(pjoin(self.me_dir,'SubProcesses',p_dir,'channels.txt')) as chan_file:
                         channels=chan_file.readline().split()
                 except IOError:
-                    logger.warning('No integration channels found for contribution %s (too large masses?)' % p_dir)
+                    logger.warning('No integration channels found for contribution %s (too large masses/low energy?)' % p_dir)
                     continue
                 if fixed_order:
                     lch=len(channels)


### PR DESCRIPTION
I think if there are no integration channels the user should also be suggested/warned that maybe the beam energy is too low or masses too large. Because after the "No integration channels..." warning all I got was a ArrayIndex out of bounds error on the empty jobs array.

In the end I found out by manually running `gensym` to see why there is no `channels.txt` and it told me about the energy.
![image](https://github.com/mg5amcnlo/mg5amcnlo/assets/4533248/fa2ed7dd-e25e-4358-b57f-386c3ab48bd6)



I wasted a bit too much time wondering if there is an error with a specific model (http://feynrules.irmp.ucl.ac.be/wiki/MSSMatNLO) or specific MadGraph versions because of this.
