### PR TITLE
Patch to indentation in plugin handling

### DIFF
--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -161,9 +161,10 @@ if options.plugin:
     if not os.path.exists(os.path.join(root_path, 'PLUGIN', options.plugin)):
         try:
             __import__('MG5aMC_PLUGIN.%s' % options.plugin)
+            plugin = sys.modules['MG5aMC_PLUGIN.%s' % options.plugin]
         except:
             print( "ERROR: %s is not present in the PLUGIN directory. Please install it first" % options.plugin)
-
+            sys.exit()
     else:
         __import__('PLUGIN.%s' % options.plugin)
         plugin = sys.modules['PLUGIN.%s' % options.plugin]

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -166,7 +166,7 @@ if options.plugin:
 
     else:
         __import__('PLUGIN.%s' % options.plugin)
-    plugin = sys.modules['PLUGIN.%s' % options.plugin]
+        plugin = sys.modules['PLUGIN.%s' % options.plugin]
     if not plugin.new_interface:
         logging.warning("Plugin: %s do not define dedicated interface and should be used without the --mode options" % options.plugin)
         sys.exit()


### PR DESCRIPTION
It looks like commit 7c52d7d491baf12ee0aa49356cec3dc8e68407eb introduced a bug in the plugin handling. In the PR over here:

https://github.com/mg5amcnlo/mg5amcnlo/pull/94/files

The plugin line is indented by four spaces. That's very important - we only want to redefine plugin using PLUGIN.blah in the case that it's imported that way. Otherwise it should be defined as MG5aMC_PLUGIN.blah, as it is a few lines above.

This PR adds the spaces back in.