### PR TITLE
Parallelize untar operation in case of gridpack

### DIFF
--- a/Template/LO/bin/internal/restore_data
+++ b/Template/LO/bin/internal/restore_data
@@ -45,29 +45,25 @@ for i in `cat subproc.mg` ; do
     else
 	cp  results.dat $1_results.dat  >& /dev/null
     fi
-    for k in G* ; do
-	if [[ ! -d $k ]]; then
-	    continue
-	fi
-	cd $k
-	for j in $1_results.dat ; do
-	    if [[ -e $j ]] ; then
-		cp  $j results.dat
-	    else
-		cp  results.dat $j
-	    fi
-	done
-	for j in $1_ftn26.gz ; do
-	    if [[ -e $j ]]; then
-		rm -f ftn26 >& /dev/null
-		rm -f $1_ftn26 >& /dev/null
-		gunzip $j
-		cp $1_ftn26 ftn26
-		gzip $1_ftn26
-	    fi
-	done
-	cd ../
+    find . -type d -name "G*" -print0 | xargs --null -P $(nproc --all) -I{} bash -c "
+    cd {}
+    for j in $1_results.dat ; do
+        if [[ -e \$j ]] ; then
+            cp \$j results.dat
+        else
+            cp results.dat \$j
+        fi
     done
+    for j in $1_ftn26.gz ; do
+        if [[ -e \$j ]]; then
+            rm -f ftn26 >& /dev/null
+            rm -f $1_ftn26 >& /dev/null
+            gunzip \$j
+            cp $1_ftn26 ftn26
+            gzip $1_ftn26
+        fi
+    done
+    cd ../"
     cd ../
 done
 

--- a/Template/LO/bin/internal/restore_data
+++ b/Template/LO/bin/internal/restore_data
@@ -45,26 +45,25 @@ for i in `cat subproc.mg` ; do
     else
 	cp  results.dat $1_results.dat  >& /dev/null
     fi
-    find . -type d -name "G*" -print0 | xargs --null -P $(nproc --all) -I{} bash -c "
-    cd {}
-    for j in $1_results.dat ; do
-        if [[ -e \$j ]] ; then
-            cp \$j results.dat
-        else
-            cp results.dat \$j
-        fi
-    done
-    for j in $1_ftn26.gz ; do
-        if [[ -e \$j ]]; then
-            rm -f ftn26 >& /dev/null
-            rm -f $1_ftn26 >& /dev/null
-            gunzip \$j
-            cp $1_ftn26 ftn26
-            gzip $1_ftn26
-        fi
-    done
-    cd ../"
     cd ../
 done
 
-
+find . -mindepth 2 -maxdepth 2 -type d -name 'G*' -print0 \
+    | xargs --null -P "$(nproc --all)" -I{} bash -c "
+cd {}
+for j in $1_results.dat ; do
+    if [[ -e \$j ]] ; then
+        cp \$j results.dat
+    else
+        cp results.dat \$j
+    fi
+done
+for j in $1_ftn26.gz ; do
+    if [[ -e \$j ]]; then
+        rm -f ftn26 >& /dev/null
+        rm -f $1_ftn26 >& /dev/null
+        gunzip \$j
+        cp $1_ftn26 ftn26
+        gzip $1_ftn26
+    fi
+done"

--- a/Template/LO/bin/internal/restore_data
+++ b/Template/LO/bin/internal/restore_data
@@ -62,8 +62,7 @@ for j in $1_ftn26.gz ; do
     if [[ -e \$j ]]; then
         rm -f ftn26 >& /dev/null
         rm -f $1_ftn26 >& /dev/null
-        gunzip \$j
-        cp $1_ftn26 ftn26
-        gzip $1_ftn26
+        gunzip --keep \$j
+        mv $1_ftn26 ftn26
     fi
 done"


### PR DESCRIPTION
This PR improves the untarring of the zip files created when using the `gridpack` option, by parallelizing the operation using `xargs`.

On a separate, but related, issue, the unzipping is performed by following lines of `bin/internal/restore_data`:
```bash
gunzip \$j
cp $1_ftn26 ftn26
gzip $1_ftn26
```
However, re-zipping the file can be avoided by using the `--keep` option of `gunzip`, maybe we can save even more time.