### PR TITLE
Workaround for unitialised goodjet in function setclscales in reweight.f

### DIFF
--- a/Template/LO/SubProcesses/reweight.f
+++ b/Template/LO/SubProcesses/reweight.f
@@ -633,6 +633,17 @@ c     Variables for keeping track of jets
       external is_octet
       setclscales=.true.
 
+       setclscales=.true.
+
+c Workaround for valgrind 'Conditional jump or move depends on uninitialised value(s)'
+c See https://github.com/mg5amcnlo/mg5amcnlo/issues/111
+c FIXME: this is just a workaround to avoid uninitialised values and undefined behaviour...
+c FIXME: a real bug is probably hidden in the code (goodjet must be correctly defined!)...
+c FIXME: adding this workaround may change the behaviour of existing code...
+      do i=1,n_max_cl
+        goodjet(i)=.false. !!FIXME!! there is no reason to choose false instead of true here...
+      end do
+
       if(ickkw.le.0.and.xqcut.le.0d0.and.q2fact(1).gt.0.and.q2fact(2).gt.0.and.scale.gt.0) then
          if(use_syst)then
             s_scale(ivec)=scale
@@ -1227,7 +1238,7 @@ c
          do i=1,2
             do j=1,2
 c              First adjust goodjet based on iqjets
-               if(goodjet(ida(i)).and.ipart(j,ida(i)).gt.2)then
+               if(goodjet(ida(i)).and.ipart(j,ida(i)).gt.2)then ! FIXME: goodjet is uninitialised #111
                   if(iqjets(ipart(j,ida(i))).eq.0) goodjet(ida(i))=.false.
                endif
 c              Now reset ptclus if jet vertex

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -94,6 +94,7 @@ c      open (unit=lun+1,file='../dname.mg',status='unknown',err=11)
       l2=index(buf,'_')
       if(l1.ne.0.and.l2.ne.0.and.l1.lt.l2-1)
      $     read(buf(l1+1:l2-1),*,err=11) ngroup
+      close (lun+1)
  11   print *,'Process in group number ',ngroup
 
 c     Read weight from results.dat if present, to allow event generation


### PR DESCRIPTION
Hi @oliviermattelaer this is the PR for #111, i.e. the workaround for unitialised godjet in function setclscales in reweight.f

As discussed in #111, this is only a workaround, NOT a real fix

The disadvantages of adding the workaround are
- It hides the issue even from valgrind (but I added many FIXME reminders in the code...)
- It potentially changes the behaviour of existing code (but the behaviour of existing code was undefined anyway, by definition, so it cannot be worse...)

The advantage of adding the workaround are
- It removes undefined behaviour (at least, if there is a bug, the bug will always give the same issue rather than a random behaviour)

I would tend to add it. But up to you to decide... Can you please review?
Thanks
Andrea