### PR TITLE
Add 'volatile' in function rotxxx to prevent crashes in optimized code 

### DIFF
--- a/aloha/template_files/aloha_functions.f
+++ b/aloha/template_files/aloha_functions.f
@@ -1201,7 +1201,7 @@ c       real    prot(0:3)      : four-momentum p in the rotated frame
 c
       implicit none
       double precision p(0:3),q(0:3),prot(0:3),qt2,qt,psgn,qq,p1
-
+      volatile qt, p1, qq ! prevent optimizations with -O3 (workaround for SIGFPE crashes in rotxxx: madgraph5/madgraph4gpu#855)
       double precision rZero, rOne
       parameter( rZero = 0.0d0, rOne = 1.0d0 )
 


### PR DESCRIPTION
Hi @oliviermattelaer , as discussed: I have moved to upstream gpucpp the addition of 'volatile' in function rotxxx to prevent crashes in optimized code 

This is meant to fix https://github.com/madgraph5/madgraph4gpu/issues/855

See also the extensive discussion in https://github.com/madgraph5/madgraph4gpu/pull/857

Note in particular the crashes in the madgraph4gpu CI
![343335749-dad4af6e-338b-4d37-88db-b37b15f0af60](https://github.com/mg5amcnlo/mg5amcnlo/assets/3473550/0a4c5690-cf62-425e-ae6e-00045c98c7d5)
These crashes disappear after adding 'volatile'

Can you please review?

Thanks!
Andrea

