### PR TITLE
WIP: Fix icolamp in export_cpp.py (against gpucpp)

### DIFF
--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -1803,7 +1803,7 @@ class OneProcessExporterGPU(OneProcessExporterCPP):
                                           [ijamp+1]
                 #else:
                 #    self.proc_characteristic['single_color'] = False
-        ###misc.sprint('get_icolamp_lines F77',diag_jamp)
+        ###misc.sprint('get_icolamp_lines CPP',diag_jamp)
 
         colamps = ijamp + 1
         for iconfig, num_diag_key in enumerate(mapconfigs):  

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -1770,6 +1770,7 @@ class OneProcessExporterGPU(OneProcessExporterCPP):
         booldict = {False: "false", True: "true"}
 
         # Only want to include leading color flows, so find max_Nc
+        misc.sprint('get_icolamp_lines CPP',mapconfigs)
         color_basis = matrix_element.get('color_basis')
         if not color_basis:
             # No color, so only one color factor. Simply write a ".true." 
@@ -1802,11 +1803,16 @@ class OneProcessExporterGPU(OneProcessExporterCPP):
                                           [ijamp+1]
                 #else:
                 #    self.proc_characteristic['single_color'] = False
+        ###misc.sprint('get_icolamp_lines F77',diag_jamp)
 
         colamps = ijamp + 1
-        for iconfig, num_diag in enumerate(mapconfigs):  
-            # mapconfigs can be a list or a dictionary.
-            # In case of dictionary the num_diag will be the key of the dictionary.    
+        for iconfig, num_diag_key in enumerate(mapconfigs):  
+            # [AV fix bug #114: icolamp array is different in Fortran and CPP]
+            # Variable mapconfigs can be a list or a dictionary
+            # In the old (buggy) implementation num_diag was the key of the dictionary
+            # In the new (fixed) implementation num_diag is the value of the dictionary, extracting the first list element, and adding +1 (F77/CPP indexing?)
+            num_diag = mapconfigs[num_diag_key][0]+1
+            ###misc.sprint('get_icolamp_lines CPP',iconfig,num_diag)
             if num_diag == 0:
                 continue
 

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -1186,6 +1186,7 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
 
         booldict = {False: ".false.", True: ".true."}
 
+        misc.sprint('get_icolamp_lines F77',mapconfigs)
         if not matrix_element.get('color_basis'):
             # No color, so only one color factor. Simply write a ".true." 
             # for each config (i.e., each diagram with only 3 particle
@@ -1224,9 +1225,11 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
                                           [ijamp+1]
                 else:
                     self.proc_characteristic['single_color'] = False
+        ###misc.sprint('get_icolamp_lines F77',diag_jamp)
 
         colamps = ijamp + 1
         for iconfig, num_diag in enumerate(mapconfigs):        
+            ###misc.sprint('get_icolamp_lines F77',iconfig,num_diag)
             if num_diag == 0:
                 continue
 


### PR DESCRIPTION
Hi @oliviermattelaer again I am reposting my previous #115, as you modified it to be against gpucpp_june24 and to include stuff now in gpucpp_june24.

This new MR *is meant to be against gpucpp*, not gpucpp_june24. I keep #115 open for later discussions about gpucpp_june24.

Can you please review (with respect to gpucpp)?

Thanks
Andrea