### PR TITLE
 ensure that cpp data structure for is_LC is the same in fortran and cpp (madgraph4gpu 880) 

### DIFF
--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -1517,8 +1517,8 @@ class OneProcessExporterGPU(OneProcessExporterCPP):
             """
             replace_dict['madE_caclwfcts_call'] = '&multi_chanel_num, &multi_chanel_denom'
             replace_dict['madE_update_answer'] = '   allMEs[iproc*nprocesses + ievt] *= multi_chanel_num/multi_chanel_denom;'
+
             multi_channel = self.get_multi_channel_dictionary(self.matrix_elements[0].get('diagrams'), self.include_multi_channel)
-            replace_dict['is_LC'] = self.get_icolamp_lines(multi_channel, self.matrix_elements[0], 1)
             replace_dict['nb_channel'] = len(multi_channel)
             replace_dict['nb_color'] = max(1, len(self.matrix_elements[0].get('color_basis')))
 

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -1760,7 +1760,6 @@ class OneProcessExporterGPU(OneProcessExporterCPP):
             return replace_dict
 
 
-
     def get_icolamp_lines(self, mapconfigs, matrix_element, num_matrix_element):
         """Return the ICOLAMP matrix, showing which JAMPs contribute to
         which configs (diagrams)."""

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -6582,16 +6582,8 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
 
         # Create a map from subprocess (matrix element) to a list of
         # the diagrams corresponding to each config
-
+        subproc_to_confdiag = self.get_confdiag_from_group_mapconfig(diagrams_for_config)
         lines = []
-
-        subproc_to_confdiag = {}
-        for config in diagrams_for_config:
-            for subproc, diag in enumerate(config):
-                try:
-                    subproc_to_confdiag[subproc].append(diag)
-                except KeyError:
-                    subproc_to_confdiag[subproc] = [diag]
 
         for subproc in sorted(subproc_to_confdiag.keys()):
             lines.extend(self.get_icolamp_lines(subproc_to_confdiag[subproc],
@@ -6695,6 +6687,35 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
         return output
                            
 
+    #===========================================================================
+    # write_configs_file
+    #===========================================================================
+    @staticmethod
+    def get_confdiag_from_group_mapconfig(config_subproc_map, subprocid=None):
+            """ This is converting the  mapconfigs generated from the 
+                    subproc_group.get('diagrams_for_configs')
+                and convert it to a datastructure like expected from the 
+                get_icolamp_lines (which does not handle grouping) 
+                
+                if subproc is None it returns the full output as a dictionary
+                with subproc_id as key.
+                if provided it returned the associated list for that subproc id.
+
+                Static method since need to be used from cpp case as well.
+            """
+
+            subproc_to_confdiag = {}
+            for config in config_subproc_map:
+                for subproc, diag in enumerate(config):
+                    try:
+                        subproc_to_confdiag[subproc].append(diag)
+                    except KeyError:
+                        subproc_to_confdiag[subproc] = [diag]
+                        
+            if subprocid is None:
+                return subproc_to_confdiag
+            else:
+                return subproc_to_confdiag[subprocid]
 
     #===========================================================================
     # write_configs_file


### PR DESCRIPTION
Hi @oliviermattelaer I noticed that the fix that you committed for https://github.com/madgraph5/madgraph4gpu/pull/880 is in a standalone branch datastructure_coloramp, not yet in gpucpp. This MR is about merging it into gpucpp.

Since we reciprocally approved those changes, I take the liberty of merging myself, assuming it is all approved. Otherwise we get too many branches in flight (see also https://github.com/madgraph5/madgraph4gpu/issues/886)