### PR TITLE
Remove the TO_PDF common block from auto_dsig1.

### DIFF
--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -277,12 +277,6 @@ C     Keep track of whether cuts already calculated for this event
       integer selected_hel(VECSIZE_MEMMAX)
       integer selected_col(VECSIZE_MEMMAX)
       double precision all_rwgt(VECSIZE_MEMMAX)
-      
-C     Common blocks
-      CHARACTER*7         PDLABEL,EPA_LABEL
-      INTEGER       LHAID
-      COMMON/TO_PDF/LHAID,PDLABEL,EPA_LABEL     
-
 c
 c     local
 c


### PR DESCRIPTION
The common block triggered a warning, because it was declared with different contents in other places.
Since it doesn't seem to be in use, removing it seems to be the easiest way to fix the warning.