### PR TITLE
do not remove GpuAbstraction.h in madevent_interface.py

### DIFF
--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -3967,7 +3967,7 @@ Beware that this can be dangerous for local multicore runs.""")
         for P in Pdir: 
             allG = misc.glob('G*', path=P)
             for G in allG:
-                if not os.path.isdir(G): continue
+                if not os.path.isdir(G): continue # avoid deleting GpuAbstraction.h (madgraph5/madgraph4gpu#947)
                 if pjoin(P, G) not in Gdir:
                     logger.debug('removing %s', pjoin(P,G))
                     shutil.rmtree(pjoin(P,G))

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -3967,7 +3967,9 @@ Beware that this can be dangerous for local multicore runs.""")
         for P in Pdir: 
             allG = misc.glob('G*', path=P)
             for G in allG:
-                if not os.path.isdir(G): continue # avoid deleting GpuAbstraction.h (madgraph5/madgraph4gpu#947)
+                # avoid case where some file starts with G (madgraph5/madgraph4gpu#947)
+                if not os.path.isdir(G): 
+                    continue
                 if pjoin(P, G) not in Gdir:
                     logger.debug('removing %s', pjoin(P,G))
                     shutil.rmtree(pjoin(P,G))

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -3967,6 +3967,7 @@ Beware that this can be dangerous for local multicore runs.""")
         for P in Pdir: 
             allG = misc.glob('G*', path=P)
             for G in allG:
+                if not os.path.isdir(G): continue
                 if pjoin(P, G) not in Gdir:
                     logger.debug('removing %s', pjoin(P,G))
                     shutil.rmtree(pjoin(P,G))


### PR DESCRIPTION
Hi @oliviermattelaer as discussed in https://github.com/madgraph5/madgraph4gpu/issues/947

- I added one line in madevent_interface.py to avoid deleting a G* path if it is not a directory (as you suggested - this will avoid deleting GpuAbstraction.h in particular)
- I moved this here upstream so that it is not in a patch

Can you please review? Hopefully not controversial

Thanks
Andrea