### PR TITLE
add compile flags for gcc14 compilation

### DIFF
--- a/vendor/StdHEP/mcfio/src/GNUmakefile
+++ b/vendor/StdHEP/mcfio/src/GNUmakefile
@@ -13,7 +13,7 @@ BINDIR = ../../bin
 include ../arch_mcfio
 
 FFLAGS += -std=legacy
-CFLAGS += -Wno-implicit-function-declaration
+CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
 FINC = -I.
 CINC = -I. -I/usr/include/tirpc

--- a/vendor/StdHEP/src/stdhep/GNUmakefile
+++ b/vendor/StdHEP/src/stdhep/GNUmakefile
@@ -8,7 +8,7 @@ STDHEP_DIR = ../..
 #this has been added by MZ
 FFLAGS+= -fd-lines-as-code -fPIE
 FFLAGS += -std=legacy
-CFLAGS += -Wno-implicit-function-declaration
+CFLAGS += -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
 
 SLIB = $(STDHEP_DIR)/lib
 SBIN = $(STDHEP_DIR)/bin


### PR DESCRIPTION
This disables pointer mismatch warnings which are now errors in gcc14.