### PR TITLE
Change the handling on how Source/makefile is written for second exporter handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ptest*
 *.pkl
 p_ME_*
 *.log
+.DS_Store
 input/default_run_card_lo.dat
 input/default_run_card_nlo.dat
 input/mg5_configuration.txt

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -1534,7 +1534,7 @@ This will take effect only in a NEW terminal
 
         if args[0] in ['group_subprocesses']:
             if args[1].lower() not in ['false', 'true', 'auto', 'gpu']:
-                raise self.InvalidCmd('%s needs argument False, True or Auto, got %s' % \
+                raise self.InvalidCmd('%s needs argument False, True, gpu or Auto, got %s' % \
                                       (args[0], args[1]))
         if args[0] in ['ignore_six_quark_processes']:
             if args[1] not in list(self._multiparticles.keys()) and args[1].lower() != 'false':
@@ -2597,11 +2597,13 @@ class CompleteForCmd(cmd.CompleteCmd):
             return self.list_completion(text, opts)
 
         if len(args) == 2:
-            if args[1] in ['group_subprocesses', 'complex_mass_scheme',\
+            if args[1] in ['complex_mass_scheme',\
                            'loop_optimized_output', 'loop_color_flows',\
                            'include_lepton_initiated_processes',\
                            'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
                 return self.list_completion(text, ['False', 'True', 'default'])
+            elif args[1] in ['group_subprocesses']:
+                return self.list_completion(text, ['False', 'True', 'Auto', 'gpu', 'nlo'])
             elif args[1] in ['ignore_six_quark_processes']:
                 return self.list_completion(text, list(self._multiparticles.keys()))
             elif args[1].lower() == 'ewscheme':

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -741,6 +741,7 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
                        'model':model_line,
                        'additional_dsample': '',
                        'additional_dependencies':'',
+                       'additional_clean':'',
                        'running': ''} 
 
         if self.opt['running']:

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -3013,6 +3013,7 @@ CF2PY integer, intent(in) :: new_value
                        'model':model_line,
                        'additional_dsample': '',
                        'additional_dependencies':'',
+                       'additional_clean':'',
                        'running': running_line} 
 
         text = open(path).read() % replace_dict

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -359,9 +359,7 @@ class ProcessExporterFortran(VirtualExporter):
                                                               MG_version['version'])
 
         # add the makefile in Source directory 
-        filename = pjoin(self.dir_path,'Source','makefile')
-        self.write_source_makefile(writers.FileWriter(filename))
-
+        # now moved to finalize
 
         self.write_vector_size(writers.FortranWriter('vector.inc'))
         
@@ -476,7 +474,14 @@ class ProcessExporterFortran(VirtualExporter):
     #===========================================================================
     def finalize(self, matrix_elements, history='', mg5options={}, flaglist=[], second_exporter=None):
         """Function to finalize v4 directory, for inheritance.""" 
-        
+
+        filename = pjoin(self.dir_path,'Source','makefile')
+        if not second_exporter:
+            self.write_source_makefile(writers.FileWriter(filename))
+        else:
+           replace_dict = self.write_source_makefile(None)
+           second_exporter.write_source_makefile(writers.FileWriter(filename), default=replace_dict)  
+
         if second_exporter:
             self.has_second_exporter = second_exporter
 
@@ -725,11 +730,11 @@ class ProcessExporterFortran(VirtualExporter):
         path = pjoin(_file_path,'iolibs','template_files','madevent_makefile_source')
         set_of_lib = ' '.join(['$(LIBRARIES)']+self.get_source_libraries_list())
         if self.opt['model'] == 'mssm' or self.opt['model'].startswith('mssm-'):
-            model_line='''$(LIBDIR)libmodel.$(libext): MODEL param_card.inc\n\tcd MODEL; make
+            model_line='''$(LIBDIR)libmodel.$(libext): MODEL param_card.inc vector.inc\n\tcd MODEL; make
 MODEL/MG5_param.dat: ../Cards/param_card.dat\n\t../bin/madevent treatcards param
 param_card.inc: MODEL/MG5_param.dat\n\t../bin/madevent treatcards param\n'''
         else:
-            model_line='''$(LIBDIR)libmodel.$(libext): MODEL param_card.inc\n\tcd MODEL; make    
+            model_line='''$(LIBDIR)libmodel.$(libext): MODEL param_card.inc vector.inc\n\tcd MODEL; make    
 param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
         
         replace_dict= {'libraries': set_of_lib, 
@@ -6795,7 +6800,15 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
             self.has_second_exporter = second_exporter
         super(ProcessExporterFortranMEGroup, self).finalize(*args, second_exporter=None, **opts)
         #ensure that the grouping information is on the correct value
-        self.proc_characteristic['grouped_matrix'] = True        
+        self.proc_characteristic['grouped_matrix'] = True
+
+        filename = pjoin(self.dir_path,'Source','makefile')
+        if not second_exporter:
+            self.write_source_makefile(writers.FileWriter(filename))
+        else:
+           replace_dict = self.write_source_makefile(None)
+           second_exporter.write_source_makefile(writers.FileWriter(filename), default=replace_dict)  
+
         if second_exporter:
             second_exporter.finalize(*args, **opts)
 

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -6263,7 +6263,6 @@ class ProcessExporterFortranMEGroup(ProcessExporterFortranME):
 
             if second_exporter:
                 process_exporter_cpp = second_exporter.oneprocessclass(matrix_element,second_helas, prefix=ime)
-                misc.sprint(process_exporter_cpp)
                 dirpath = '.'
                 with misc.chdir(dirpath):
                     logger.info('Creating files in directory %s' % dirpath)

--- a/madgraph/iolibs/template_files/madevent_makefile_source
+++ b/madgraph/iolibs/template_files/madevent_makefile_source
@@ -115,7 +115,7 @@ $(LIBDIR)libiregi.a: $(IREGIDIR)
 	cd $(IREGIDIR); make
 	ln -sf ../Source/$(IREGIDIR)libiregi.a $(LIBDIR)libiregi.a
 
-cleanSource:
+cleanSource: # Clean builds: fortran in this Source
 	$(RM) *.o $(LIBRARIES) $(BINARIES)
 	cd PDF; make clean; cd ..
 	cd PDF/gammaUPC; make clean; cd ../../
@@ -128,7 +128,7 @@ cleanSource:
 	if [ -d $(CUTTOOLSDIR) ]; then cd $(CUTTOOLSDIR); make clean; cd ..; fi
 	if [ -d $(IREGIDIR) ]; then cd $(IREGIDIR); make clean; cd ..; fi
 
-clean: cleanSource
+clean: cleanSource # Clean builds: fortran in this Source and in all P*
 	for i in `ls -d ../SubProcesses/P*`; do cd $$i; make clean; cd -; done;
 
 %(additional_clean)s

--- a/madgraph/iolibs/template_files/madevent_makefile_source
+++ b/madgraph/iolibs/template_files/madevent_makefile_source
@@ -68,15 +68,14 @@ $(BINDIR)gensudgrid: $(GENSUDGRID) $(LIBDIR)libpdf.$(libext) $(LIBDIR)libgammaUP
 
 # Dependencies
 
-dsample.o: DiscreteSampler.o dsample.f genps.inc StringCast.o
+dsample.o: DiscreteSampler.o dsample.f genps.inc StringCast.o vector.inc
 DiscreteSampler.o: StringCast.o
 invarients.o: invarients.f genps.inc
-setrun.o: setrun.f nexternal.inc leshouche.inc genps.inc
-gen_ximprove.o: gen_ximprove.f run_config.inc run_card.inc
+gen_ximprove.o: gen_ximprove.f run_config.inc run_card.inc 
 #combine_events.o: combine_events.f run_config.inc run_card.inc
 combine_runs.o: combine_runs.f run_config.inc run_card.inc
 select_events.o: select_events.f run_config.inc
-setrun.o: setrun.f nexternal.inc leshouche.inc run_card.inc run_config.inc
+setrun.o: setrun.f nexternal.inc leshouche.inc run_card.inc run_config.inc genps.inc vector.inc
 rw_events.o: rw_events.f run_config.inc
 %(additional_dependencies)s
 run_card.inc: ../Cards/run_card.dat

--- a/madgraph/iolibs/template_files/madevent_makefile_source
+++ b/madgraph/iolibs/template_files/madevent_makefile_source
@@ -115,7 +115,7 @@ $(LIBDIR)libiregi.a: $(IREGIDIR)
 	cd $(IREGIDIR); make
 	ln -sf ../Source/$(IREGIDIR)libiregi.a $(LIBDIR)libiregi.a
 
-clean:
+cleanSource:
 	$(RM) *.o $(LIBRARIES) $(BINARIES)
 	cd PDF; make clean; cd ..
 	cd PDF/gammaUPC; make clean; cd ../../
@@ -127,4 +127,8 @@ clean:
 	cd BIAS/ptj_bias; make clean; cd ../..
 	if [ -d $(CUTTOOLSDIR) ]; then cd $(CUTTOOLSDIR); make clean; cd ..; fi
 	if [ -d $(IREGIDIR) ]; then cd $(IREGIDIR); make clean; cd ..; fi
+
+clean: cleanSource
 	for i in `ls -d ../SubProcesses/P*`; do cd $$i; make clean; cd -; done;
+
+%(additional_clean)s

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -3157,7 +3157,6 @@ class RunCard(ConfigFile):
         if path does not exists return the current value in self for all parameter"""
 
         #WARNING DOES NOT HANDLE LIST/DICT so far
-
         # handle case where file is missing
         if not os.path.exists(pjoin(output_dir,path)):
             misc.sprint("include file not existing", pjoin(output_dir,path))
@@ -3166,13 +3165,9 @@ class RunCard(ConfigFile):
         with open(pjoin(output_dir,path), 'r') as fsock:
             text = fsock.read()
         
-        for name in list_of_params:
-            misc.sprint(name, name in self.fortran_name)
-            misc.sprint(self.fortran_name[name] if name in self.fortran_name[name] else name)
         to_track = [self.fortran_name[name] if name in self.fortran_name else name for name in list_of_params]
         pattern = re.compile(r"\(?(%(names)s)\s?=\s?([^)]*)\)?" % {'names':'|'.join(to_track)}, re.I)
         out =  dict(pattern.findall(text))
-        misc.sprint(out)
         for name in list_of_params:
             if name in self.fortran_name:
                 value = out[self.fortran_name[name]]

--- a/models/template_files/fortran/makefile_madevent
+++ b/models/template_files/fortran/makefile_madevent
@@ -41,7 +41,8 @@ $(LIBDIR)$(LIBRARY): $(MODEL)
 clean: 
 	$(RM) *.o $(LIBDIR)$(LIBRARY)
 
-couplings.f: ../maxparticles.inc ../run.inc
+couplings.o: ../maxparticles.inc ../run.inc ../vector.inc
+couplings2.o: ../vector.inc
 
 ../run.inc:
 	touch ../run.inc

--- a/models/template_files/fortran/makefile_standalone
+++ b/models/template_files/fortran/makefile_standalone
@@ -35,7 +35,8 @@ $(LIBDIR)$(LIBRARY): $(MODEL)
 clean: 
 	$(RM) *.o $(LIBDIR)$(LIBRARY)
 
-couplings.f: ../maxparticles.inc ../run.inc ../cuts.inc
+couplings.o: ../maxparticles.inc ../run.inc ../cuts.inc ../vector.inc
+
 
 ../maxparticles.inc:
 	touch ../maxparticles.inc


### PR DESCRIPTION
OK 

This change the way the source makefile is handle which is needed in order to correctly write such makefile in presence of second exporter
This is in particular important to fix the CI related to the recompilation when vector_size is changed

This also does some side change (like updating auto-completion and cleaning) which are not controversial.