### PR TITLE
Gpucpp install

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -2929,7 +2929,8 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
     # The targets below are installed using the HEPToolsInstaller.py script
     _advanced_install_opts = ['pythia8','zlib','boost','lhapdf6','lhapdf5','collier',
                               'hepmc','mg5amc_py8_interface','ninja','oneloop','MadAnalysis5',
-                              'yoda', 'rivet', 'fastjet', 'fjcontrib', 'contur', 'cmake', 'eMELA']
+                              'yoda', 'rivet', 'fastjet', 'fjcontrib', 'contur', 'cmake', 'eMELA',
+                              'cudacpp']
 
     _install_opts.extend(_advanced_install_opts)
 

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -6184,9 +6184,13 @@ This implies that with decay chains:
               'HEPToolsInstallers', 'HEPToolInstaller.py'), tool,'--prefix=%s'%
               prefix] + compiler_options + add_options)
         if return_code in [0,11]:
-            logger.info("%s successfully installed in %s."%(
+            if tool_to_install not in self.install_plugin:
+                logger.info("%s successfully installed in %s."%(
                    tool_to_install, prefix),'$MG:color:GREEN')
-            
+            else:
+                logger.info("%s successfully installed in PLUGIN directory."%(
+                   tool_to_install),'$MG:color:GREEN')                
+
             if tool=='madanalysis5':
                 if not any(o.startswith(('--with_','--veto_','--update')) for o in add_options):
                     logger.info('    To install recasting capabilities of madanalysis5 and/or', '$MG:BOLD')
@@ -6362,7 +6366,7 @@ MG5aMC that supports quadruple precision (typically g++ based on gcc 4.6+).""")
          # Return true for successful installation
         return True
 
-    install_plugin = ['maddm', 'maddump', 'MadSTR']
+    install_plugin = ['maddm', 'maddump', 'MadSTR', 'cudacpp']
     install_ad = {'pythia-pgs':['arXiv:0603175'],
                           'Delphes':['arXiv:1307.6346'],
                           'Delphes2':['arXiv:0903.2225'],


### PR DESCRIPTION
This is the change to add the install command inside mg5amc.
This PR is in itself a no brainer, since the change here are ONLY the auto-completion and related log information when the instalation is done.

The real detail of the installation is within another repo (and not really relevant):

So for the moment to test you need the following action:

git clone git@github.com:mg5amcnlo/mg5amcnlo.git
cd mg5amcnlo
git switch gpucpp_install
cd ..
git clone git@github.com:mg5amcnlo/HEPToolsInstallers.git
cd HEPToolsInstallers
git switch cudacpp
cd ../ mg5amcnlo
./bin/mg5_aMC
mg5> install cudacpp --local

caveat:
- This rely on a online file: http://madgraph.phys.ucl.ac.be/Downloads/cudacpp/version_info.dat
that we need to either maintain manually or to setup a CI for it...
- This rely on a tarball existing (did one by hand, but here we clearly need a CI)
- In production, the installation of HEPToolsinstaller is done on the flight (and always use the last master revision), so no need for the --local and the branching of that repo obviously.


Cheers,

Olivier
