### PR TITLE
Remove plugin_input and plugin_run_card completely

### DIFF
--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -1006,18 +1006,10 @@ class ConfigFile(dict):
         self.allowed_value = {}
         
         self.default_setup()
-        self.plugin_input(finput)
-        
 
         # if input is define read that input
         if isinstance(finput, (file, str, StringIO.StringIO)):
             self.read(finput, **opt)
-        
-
-
-
-    def plugin_input(self, finput=None):
-        pass
 
 
     def default_setup(self):
@@ -2654,26 +2646,6 @@ class RunCard(ConfigFile):
     donewarning = []
     include_as_parameter = []
 
-    def plugin_input(self, finput):
-
-        if not finput and not MADEVENT:
-            return
-        curr_dir = None
-        if isinstance(finput, file):
-            # expected path to be like "XXXX/Cards/run_card.dat"
-            curr_dir = os.path.dirname(os.path.dirname(finput.name))
-        elif isinstance(finput, str):
-            curr_dir = os.path.dirname(os.path.dirname(finput))
-        
-        if curr_dir:
-            if os.path.exists(pjoin(curr_dir, 'bin', 'internal', 'plugin_run_card')):
-                # expected format {} passing everything as optional argument
-                for line in open(pjoin(curr_dir, 'bin', 'internal', 'plugin_run_card')):
-                    if line.startswith('#'):
-                        continue
-                    opts = dict(eval(line))
-                    self.add_param(**opts)
-        
     @classmethod
     def fill_post_set_from_blocks(cls):
         """set the post_set function for any parameter defined in a run_block"""


### PR DESCRIPTION
Hi @oliviermattelaer this is a WIP PR to remove plugin_input and plugin_run_card completely

> I do not like this PR ... I either see this has half full or half empty PR. (meaning it either due too much or too little).
> 
> So here are two counter proposal:
> 
>     1. fully remove "plugin_run_card" mechanism from 3.6.1 and the associate "plugin_input" API, and see this as deprecated by the launch_plugin API (both API were designed for the cudacpp case so this will not break anything)

It is meant to address your comment above in https://github.com/madgraph5/madgraph4gpu/pull/1016#issuecomment-2399079924

Is this what you had in mind?

Thanks
Andrea