### PR TITLE
Remove valgrind warning in madevent_driver.f template

### DIFF
--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -402,7 +402,6 @@ c
       fopened=.false.
       tempname=filename 	 
       fine=index(tempname,' ') 	 
-      fine2=index(path,' ')-1	 
       if(fine.eq.0) fine=len(tempname)
       open(unit=lun,file=tempname,status='old',ERR=20)
       fopened=.true.


### PR DESCRIPTION
Hi @oliviermattelaer another small PR to slowly move stuff out of cudacpp patchMad.sh

Warning from valgrind is "Conditional jump or move depends on uninitialised value(s)"

Looks ok?

Thanks
Andrea
