### PR TITLE
WIP add optional fortran profiling in various templates

### DIFF
--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -175,7 +175,9 @@ c
          if (iter .le. itmax) then
 c            write(*,*) 'iter/ievent/ivec', iter, ievent, ivec
             ievent=ievent+1
+%(start_profiling_x2f)s
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
+%(stop_profiling_x2f)s
             CUTSDONE=.FALSE.
             CUTSPASSED=.FALSE.
             if (passcuts(p,VECSIZE_USED)) then
@@ -247,6 +249,7 @@ c     write(*,*) i, all_wgt(i), fx, all_wgt(i)*fx
                do I=1, VECSIZE_USED
                   all_wgt(i) = all_wgt(i)*all_fx(i)
               enddo
+%(start_profiling_putpoint_vec)s
                do i =1, VECSIZE_USED
 c     if last paremeter is true -> allow grid update so only for a full page
                   lastbin(:) = all_lastbin(:,i)
@@ -254,6 +257,7 @@ c     if last paremeter is true -> allow grid update so only for a full page
 c                  write(*,*) 'put point in sample kevent', kevent, 'allow_update', ivec.eq.VECSIZE_USED                   
                   call sample_put_point(all_wgt(i),all_x(1,i),iter,ipole, i.eq.VECSIZE_USED) !Store result
                enddo
+%(stop_profiling_putpoint_vec)s
                if (VECSIZE_USED.ne.1.and.force_reset)then
                   call reset_cumulative_variable()
                   force_reset=.false.
@@ -264,7 +268,9 @@ c     if (wgt .ne. 0d0) call graph_point(p,wgt) !Update graphs
             else
                fx =0d0
                wgt=0d0
+%(start_profiling_putpoint)s
                call sample_put_point(wgt,x(1),iter,ipole,.true.) !Store result
+%(stop_profiling_putpoint)s
             endif
 
          endif
@@ -429,7 +435,9 @@ c
          call sample_get_config(wgt,iter,ipole)
          if (iter .le. itmax) then
             ievent=ievent+1
+%(start_profiling_x2f)s
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
+%(stop_profiling_x2f)s
             if (pass_point(p)) then
                xzoomfact = 1d0
                fx = dsig(p,wgt,0) !Evaluate function
@@ -445,7 +453,9 @@ c
             endif
             
             if (nzoom .le. 0) then
+%(start_profiling_putpoint)s
                call sample_put_point(wgt,x(1),iter,ipole,.true.) !Store result
+%(stop_profiling_putpoint)s
             else
                nzoom = nzoom -1
                ievent=ievent-1

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -125,7 +125,9 @@ C     Continue only if IMODE is 0, 4 or 5
       ! for no grouping update the scale here (done in main autodsig for grouping  
       call update_scale_coupling(PP, WGT)
 ## }	 
+%(start_profiling_pdf)s
 %(pdf_lines)s
+%(stop_profiling_pdf)s
          IF (IMODE.EQ.4)THEN
             DSIG%(proc_id)s = PD(0)
             RETURN
@@ -158,7 +160,9 @@ C     Select a flavor combination (need to do here for right sign)
             R=R-DABS(PD(IPSEL))/PD(0)
          ENDDO
 	 
+%(start_profiling_rewgt)s
          DSIGUU=DSIGUU*REWGT(PP,1)
+%(stop_profiling_rewgt)s
 
 C        Apply the bias weight specified in the run card (default is 1.0)
          DSIGUU=DSIGUU*CUSTOM_BIAS(PP,DSIGUU,%(numproc)d,1)
@@ -319,7 +323,9 @@ C     Continue only if IMODE is 0, 4 or 5
       IF(IMODE.NE.0.AND.IMODE.NE.4.and.IMODE.NE.5) RETURN
 
 %(passcuts_begin)s
+%(start_profiling_pdf_vec)s
 %(pdf_lines_vec)s
+%(stop_profiling_pdf_vec)s
 
 	 
          IF (IMODE.EQ.4)THEN
@@ -352,8 +358,9 @@ C     Select a flavor combination (need to do here for right sign)
        ENDDO
        %(get_channel_vec)s
 
-
+%(start_profiling_rewgt)s
        ALL_RWGT(IVEC) = REWGT(all_PP(0,1,IVEC), ivec)
+%(stop_profiling_rewgt)s
 
 	 if(frame_id.ne.6)then
            call boost_to_frame(ALL_PP(0,1,IVEC), frame_id, p_multi(0,1,IVEC))
@@ -406,8 +413,10 @@ c           Set sign of dsig based on sign of PDF and matrix element
          ENDIF
 C       Generate events only if IMODE is 0.
         IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
+%(start_profiling_unwgt)s
 C       Call UNWGT to unweight and store events
            CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),%(numproc)d, selected_hel(IVEC), selected_col(IVEC), IVEC)
+%(stop_profiling_unwgt)s
         ENDIF
 	ENDDO
 %(passcuts_end)s

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -402,7 +402,6 @@ c
       fopened=.false.
       tempname=filename 	 
       fine=index(tempname,' ') 	 
-      fine2=index(path,' ')-1	 
       if(fine.eq.0) fine=len(tempname)
       open(unit=lun,file=tempname,status='old',ERR=20)
       fopened=.true.

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -87,6 +87,7 @@ C-----
 c
 c     Read process number
 c
+%(start_profiling_driver_init)s
       call open_file(lun+1, 'dname.mg', fopened)
       if (.not.fopened)then
          goto 11
@@ -157,6 +158,7 @@ c   If CKKW-type matching, read IS Sudakov grid
           print *,'Running CKKW as lower mult sample'
         endif
       endif
+%(stop_profiling_driver_init)s
 
 c     
 c     Get user input

--- a/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
+++ b/madgraph/iolibs/template_files/super_auto_dsig_group_v4.inc
@@ -309,7 +309,9 @@ c      	ENDDO
 
 c     set the running scale 
 c     and update the couplings accordingly
+%(start_profiling_update_scale_coupling_vec)s
       call update_scale_coupling_vec(all_p, all_wgt, all_q2fact, VECSIZE_USED)
+%(stop_profiling_update_scale_coupling_vec)s
 
       IF(grouped_MC_grid_status.eq.0) then
 C       If we were in the initialization phase of the grid for MC over grouped processes, we must instruct the matrix<i> subroutine not to add again an entry in the grid for this PS point at the call DSIGPROC just below.


### PR DESCRIPTION
Hi @oliviermattelaer this is a WIP PR to add optional fortran profiling in various templates

The idea is to allow the cudacpp patches in https://github.com/madgraph5/madgraph4gpu/pull/962

This is WIP and will stay so for a while. I will mak echep results based on these things but I have no time to clean this up now.

I just wanted to get a heads-up, does this look like the right direction?

Two details
- I have not modified the python yet to define these extra strings as empty by default in mg5amcnlo. And I have not moved the cudacpp patches from patch.P1 to these optional strings.
- I see that three files are .inc which probably allow this mechanism. For dsample.f I guess (I need to check) that this is simply copied. Should this be renamed if it also becomes a template accepting string substitution?

Thanks!
Andrea

PS Ah and this includes internally #151