### PR TITLE
fix: Use ninja GitHub as Bitbucket repo 404s

### DIFF
--- a/bin/create_release.py
+++ b/bin/create_release.py
@@ -345,7 +345,7 @@ os.system(install_str)
 
 collier_link = "http://collier.hepforge.org/collier-latest.tar.gz" 
 misc.wget(collier_link, os.path.join(filepath, 'vendor', 'collier.tar.gz'))
-ninja_link = "https://bitbucket.org/peraro/ninja/downloads/ninja-latest.tar.gz"
+ninja_link = "https://github.com/peraro/ninja/archive/344f2379fd22d7e44ae14c02eb225f98b38d7b12.tar.gz"
 misc.wget(ninja_link, os.path.join(filepath, 'vendor', 'ninja.tar.gz'))
 
 # Add the tarball for SMWidth

--- a/tests/parallel_tests/test_MG5aMC_distribution.py
+++ b/tests/parallel_tests/test_MG5aMC_distribution.py
@@ -103,7 +103,7 @@ class TestMG5aMCDistribution(unittest.TestCase):
             """ Test whether the current Offline Ninja+oneloop+collier tarball is up to date."""
         
             test_tarballs = [
-                    ('ninja','https://bitbucket.org/peraro/ninja/downloads/ninja-latest.tar.gz',pjoin(MG5DIR,'vendor','ninja.tar.gz')),
+                    ('ninja','https://github.com/peraro/ninja/archive/344f2379fd22d7e44ae14c02eb225f98b38d7b12.tar.gz',pjoin(MG5DIR,'vendor','ninja.tar.gz')),
                     ('collier','http://collier.hepforge.org/collier-latest.tar.gz',pjoin(MG5DIR,'vendor','collier.tar.gz')),
                     ('oneloop','http://helac-phegas.web.cern.ch/helac-phegas/tar-files/OneLOop-3.6.tgz',pjoin(MG5DIR,'vendor','oneloop.tar.gz'))]
             with misc.TMP_directory() as tmp_path:


### PR DESCRIPTION
Resolves #153 

* https://bitbucket.org/peraro/ninja/ no longer exists and now 404s, so migrate to using https://github.com/peraro/ninja and use a fixed commit for stability to avoid vendoring unversioned code.
   - c.f. https://github.com/peraro/ninja/commit/344f2379fd22d7e44ae14c02eb225f98b38d7b12