### PR TITLE
fix printout error

### DIFF
--- a/madgraph/madevent/gen_ximprove.py
+++ b/madgraph/madevent/gen_ximprove.py
@@ -1877,8 +1877,8 @@ class gen_ximprove_gridpack(gen_ximprove_v4):
                 continue # no event to generate events
             self.gscalefact[tag] = max(1, 1/(goal_lum * C.get('axsec')/ self.ngran))
             #need to generate events
-            logger.debug('request events for ', C.get('name'), 'cross=',
-                  C.get('axsec'), 'needed events = ', goal_lum * C.get('axsec'))
+            logger.debug('request events for %s cross=%d needed events = %d',
+                         C.get('name'), C.get('axsec'), goal_lum * C.get('axsec'))
             to_refine.append(C) 
          
         logger.info('need to improve %s channels' % len(to_refine))    


### PR DESCRIPTION
This is a tiny PR to fix a printout error, which I only observe on Mac OS when running the gridpack event generation. I admit I didn't check why this wasn't happening on Linux. 

The full errror message is 

```
--- Logging error ---
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/coloring_logging.py", line 72, in format
    message   = logging.Formatter.format(self, record)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/./madevent/bin/gridrun", line 94, in <module>
    cmd_line = cmd_interface.GridPackCmd(me_dir=root_path, nb_event=args[0], seed=args[1], gran=args[2])
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/madevent_interface.py", line 6770, in __init__
    self.launch(nb_event, seed)
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/madevent_interface.py", line 6877, in launch
    self.refine4grid(nb_event)
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/madevent_interface.py", line 6921, in refine4grid
    x_improve.launch() # create the ajob for the refinment and run those!
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/gen_ximprove.py", line 1084, in launch
    self.get_job_for_event()
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/gen_ximprove.py", line 1892, in get_job_for_event
    goal_lum, to_refine = self.find_job_for_event()
  File "/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/bin/internal/gen_ximprove.py", line 1880, in find_job_for_event
    logger.debug('request events for ', C.get('name'), 'cross=',
Message: 'request events for '
Arguments: ('/Users/roiser/sw/madgraph/madgraph4gpu/MG5aMC/mg5amcnlo/PROC_gg_ttx.gridpack/madevent/SubProcesses/P1_gg_ttx/G1', 'cross=', 48.324, 'needed events = ', 109.54742884087013)
```