### PR TITLE
Enhance flavour simplified

### DIFF
--- a/Template/NLO/Source/run.inc
+++ b/Template/NLO/Source/run.inc
@@ -102,3 +102,8 @@ C stuff for alpha running in lepton collisions
       common /to_afromee/ photons_from_lepton
 C  PDFs with beamstrahlung use specific initialisation/evaluation
       common /to_has_bs/ has_bstrahl
+
+
+c for biassed generation based on the particle flavours of the processes
+      integer flavour_bias(0:2)
+      common /c_flavour_bias/ flavour_bias

--- a/Template/NLO/SubProcesses/driver_mintMC.f
+++ b/Template/NLO/SubProcesses/driver_mintMC.f
@@ -302,11 +302,11 @@ c fill the information for the write_header_init common block
 c Randomly pick the contribution that will be written in the event file
             call pick_unweight_contr(iFKS_picked,ifold_picked)
             call update_fks_dir(iFKS_picked)
-            call fill_rwgt_lines
             if (event_norm(1:4).eq.'bias') then
                call include_inverse_bias_wgt(inv_bias)
                weight=event_weight*inv_bias
             endif
+            call fill_rwgt_lines
             call finalize_event(x_save(1,ifold_picked),weight,lunlhe
      $           ,putonshell)
          enddo

--- a/Template/NLO/SubProcesses/fks_singular.f
+++ b/Template/NLO/SubProcesses/fks_singular.f
@@ -2145,6 +2145,8 @@ c overwrite the relevant information.]
 c Special for the soft-virtual needed for the virt-tricks. The
 c *_wgt_mint variable should be directly passed to the mint-integrator
 c and not be part of the plots nor computation of the cross section.
+            if (flavour_bias(2).ne.1) 
+     $           call recompute_xlum_for_wgt_mint(i,xlum)
             virt_wgt_mint(0)=virt_wgt_mint(0)*xlum
      &           *rwgt_muR_dep_fac(sqrt(mu2_r),sqrt(mu2_r),cpower(i))
             born_wgt_mint(0)=born_wgt_mint(0)*xlum
@@ -2166,6 +2168,36 @@ c and not be part of the plots nor computation of the cross section.
       return
       end
 
+      subroutine recompute_xlum_for_wgt_mint(i,xlum)
+      use weight_lines
+      implicit none
+      include 'nexternal.inc'
+      include 'run.inc'
+      include 'genps.inc'
+      double precision xlum,conv
+      parameter (conv=389379660d0) ! conversion to picobarns
+      integer i,j,iproc
+      DOUBLE PRECISION PD(0:MAXPROC)
+      COMMON /SUBPROC/ PD, IPROC
+      xlum=0d0
+      do j=1,iproc
+         if (any(abs(parton_pdg_uborn(1:nexternal-1,j
+     $        ,i)).eq.Flavour_Bias(1))) then
+            if (nincoming.eq.2) then
+               xlum=xlum+pd(j)*conv*dble(Flavour_Bias(2))
+            else
+               xlum=xlum+pd(j)*dble(Flavour_Bias(2))
+            endif
+         else
+            if (nincoming.eq.2) then
+               xlum=xlum+pd(j)*conv
+            else
+               xlum=xlum+pd(j)
+            endif
+         endif
+      enddo
+      end
+      
       subroutine include_bias_wgt
 c Include the weight from the bias_wgt_function to all the contributions
 c in icontr. This only changes the weight of the central value (after
@@ -2178,7 +2210,9 @@ c coefficients for PDF and scale computations.
       use weight_lines
       use mint_module
       implicit none
+      include 'nexternal.inc'
       include 'orders.inc'
+      include 'run.inc'
       integer orders(nsplitorders)
       integer i,j,iamp
       logical virt_found
@@ -2208,12 +2242,27 @@ c loop over all contributions
          endif
          bias_wgt(i)=bias
 c Update the weights:
-         wgts(1,i)=wgts(1,i)*bias_wgt(i)
          do j=1,niproc(i)
             parton_iproc(j,i)=parton_iproc(j,i)*bias_wgt(i)
+            if (Flavour_bias(2).ne.1) then ! non-trivial flavour bias in the run_card.
+               if (H_event(i)) then
+                  if (any(abs(parton_pdg(1:nexternal,j
+     $                 ,i)).eq.Flavour_Bias(1))) parton_iproc(j,i)
+     $                 =parton_iproc(j,i)*dble(Flavour_Bias(2))
+               else
+                  if (any(abs(parton_pdg_uborn(1:nexternal-1,j
+     $                 ,i)).eq.Flavour_Bias(1))) parton_iproc(j,i)
+     $                 =parton_iproc(j,i)*dble(Flavour_Bias(2))
+               endif
+            endif
          enddo
+         wgts(1,i)=sum(parton_iproc(1:niproc(i),i))
          do j=1,3
             wgt(j,i)=wgt(j,i)*bias_wgt(i)
+            ! Do not update the wgt() with the Flavour_Bias here; only
+            ! do it once the iproc_picked has been set (i.e., only for
+            ! the events that are written out). In practice, we can do
+            ! it in the include_inverse_bias_wgt() subroutine.
          enddo
          if (itype(i).eq.14 .and. .not.virt_found) then
             virt_found=.true.
@@ -2235,9 +2284,11 @@ c the rwgt_lines is NOT updated.
       use weight_lines
       use extra_weights
       implicit none
+      include 'nexternal.inc'
       include 'genps.inc'
       include 'nFKSconfigs.inc'
-      integer i,ict,ipro,ii
+      include 'run.inc'
+      integer i,ict,ipro,ii,flavour_bias_consistency
       double precision wgt_num,wgt_denom,inv_bias
       character*7 event_norm
       common /event_normalisation/event_norm
@@ -2252,6 +2303,7 @@ c the rwgt_lines is NOT updated.
       endif
       wgt_num=0d0
       wgt_denom=0d0
+      flavour_bias_consistency=0
       do i=1,icontr_sum(0,icontr_picked)
          ict=icontr_sum(i,icontr_picked)
          if (bias_wgt(ict).eq.0d0) then
@@ -2268,11 +2320,47 @@ c keeps its contribution from the bias_wgt.
                if (eto(ii,nFKS(ict)).ne.ipro) cycle
                wgt_denom=wgt_denom+parton_iproc(ii,ict)
                wgt_num=wgt_num+parton_iproc(ii,ict)/bias_wgt(ict)
+               if (Flavour_Bias(2).ne.1) then ! non-trivial Flavour bias. Check consistency of flavour configuration
+                  if (any(abs(parton_pdg_uborn(1:nexternal-1,ipro
+     $                 ,ict)).eq.Flavour_Bias(1))) then
+                     if (flavour_bias_consistency .ge. 0) then
+                        flavour_bias_consistency=1
+                     else
+                        write (*,*) 'Inconsistent Flavour Bias #1'
+                        stop 1
+                     endif
+                  else
+                     if (flavour_bias_consistency .le. 0) then
+                        flavour_bias_consistency=-1
+                     else
+                        write (*,*) 'Inconsistent Flavour Bias #2'
+                        stop 1
+                     endif
+                  endif
+               endif
             enddo
          else
             ipro=iproc_picked
             wgt_denom=wgt_denom+parton_iproc(ipro,ict)
             wgt_num=wgt_num+parton_iproc(ipro,ict)/bias_wgt(ict)
+            if (Flavour_Bias(2).ne.1) then ! non-trivial Flavour bias. Check consistency of flavour configuration
+               if (any(abs(parton_pdg(1:nexternal,ipro,ict)) .eq.
+     $              Flavour_Bias(1))) then
+                  if (flavour_bias_consistency .ge. 0) then
+                     flavour_bias_consistency=1
+                  else
+                     write (*,*) 'Inconsistent Flavour Bias #1'
+                     stop 1
+                  endif
+               else
+                  if (flavour_bias_consistency .le. 0) then
+                     flavour_bias_consistency=-1
+                  else
+                     write (*,*) 'Inconsistent Flavour Bias #2'
+                     stop 1
+                  endif
+               endif
+            endif
          endif
       enddo
       if (abs((wgtref-wgt_denom)/(wgtref+wgt_denom)).gt.1d-10) then
@@ -2283,6 +2371,12 @@ c keeps its contribution from the bias_wgt.
       endif
 c update the event weight to be written in the file
       inv_bias=wgt_num/wgt_denom
+      if (flavour_bias_consistency.eq.1) then
+         inv_bias=inv_bias/dble(Flavour_Bias(2))
+         do i=1,icontr_sum(0,icontr_picked)
+            ict=icontr_sum(i,icontr_picked)
+            wgt(1:3,ict)=wgt(1:3,ict)*dble(Flavour_Bias(2))
+         enddo
       return
       end
       

--- a/Template/NLO/SubProcesses/fks_singular.f
+++ b/Template/NLO/SubProcesses/fks_singular.f
@@ -2377,6 +2377,7 @@ c update the event weight to be written in the file
             ict=icontr_sum(i,icontr_picked)
             wgt(1:3,ict)=wgt(1:3,ict)*dble(Flavour_Bias(2))
          enddo
+      endif
       return
       end
       

--- a/Template/NLO/SubProcesses/fks_singular.f
+++ b/Template/NLO/SubProcesses/fks_singular.f
@@ -2363,6 +2363,7 @@ c keeps its contribution from the bias_wgt.
             endif
          endif
       enddo
+      wgtref=unwgt(iproc_picked,icontr_picked)
       if (abs((wgtref-wgt_denom)/(wgtref+wgt_denom)).gt.1d-10) then
          write (*,*) "ERROR in include_inverse_bias_wgt: "/
      $        /"reference weight not equal to recomputed weight",wgtref

--- a/Template/NLO/SubProcesses/fks_singular.f
+++ b/Template/NLO/SubProcesses/fks_singular.f
@@ -2321,7 +2321,7 @@ c keeps its contribution from the bias_wgt.
                wgt_denom=wgt_denom+parton_iproc(ii,ict)
                wgt_num=wgt_num+parton_iproc(ii,ict)/bias_wgt(ict)
                if (Flavour_Bias(2).ne.1) then ! non-trivial Flavour bias. Check consistency of flavour configuration
-                  if (any(abs(parton_pdg_uborn(1:nexternal-1,ipro
+                  if (any(abs(parton_pdg_uborn(1:nexternal-1,ii
      $                 ,ict)).eq.Flavour_Bias(1))) then
                      if (flavour_bias_consistency .ge. 0) then
                         flavour_bias_consistency=1
@@ -2349,14 +2349,14 @@ c keeps its contribution from the bias_wgt.
                   if (flavour_bias_consistency .ge. 0) then
                      flavour_bias_consistency=1
                   else
-                     write (*,*) 'Inconsistent Flavour Bias #1'
+                     write (*,*) 'Inconsistent Flavour Bias #3'
                      stop 1
                   endif
                else
                   if (flavour_bias_consistency .le. 0) then
                      flavour_bias_consistency=-1
                   else
-                     write (*,*) 'Inconsistent Flavour Bias #2'
+                     write (*,*) 'Inconsistent Flavour Bias #4'
                      stop 1
                   endif
                endif

--- a/Template/NLO/SubProcesses/fks_singular.f
+++ b/Template/NLO/SubProcesses/fks_singular.f
@@ -2377,6 +2377,7 @@ c update the event weight to be written in the file
          do i=1,icontr_sum(0,icontr_picked)
             ict=icontr_sum(i,icontr_picked)
             wgt(1:3,ict)=wgt(1:3,ict)*dble(Flavour_Bias(2))
+            bias_wgt(ict)=bias_wgt(ict)*dble(Flavour_Bias(2))
          enddo
       endif
       return

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -4,6 +4,12 @@ ANNOUNCEMENT:
    2.9.X version has a LONG TERM STABLE has now an end of life for bug fixing/support in december 2025.
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
+
+3.x.x
+      RF: Implemented flavour_bias parameter in the NLO run-card to allow for biassed event generation
+          based on the flavours of the external particles, as used in 2403.14419.
+
+
 3.6.1 (29/11/24):
       OM+MZ: Fix a bug for lhapdf at NLO where the code was incorectly changed like the LO version (and was crashing at compilation)
       OM: Fixing various compilation issue at LO

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -5575,6 +5575,9 @@ class RunCardNLO(RunCard):
 
         #technical
         self.add_param('folding', [1,1,1], include=False)
+
+        #bias
+        self.add_param('flavour_bias',[5,1], hidden=True, comment="Example: '5,100' means that the probability to generate an event with a bottom (or anti-bottom) quark is increased by a factor 100, but the weight of those events is reduced by a factor 100. Requires that the 'event_norm' is set to 'bias'.")
         
         #merging
         self.add_param('ickkw', 0, allowed=[-1,0,3,4], comment=" - 0: No merging\n - 3:  FxFx Merging :  http://amcatnlo.cern.ch/FxFx_merging.htm\n - 4: UNLOPS merging (No interface within MG5aMC)\n - -1:  NNLL+NLO jet-veto computation. See arxiv:1412.8408 [hep-ph]")
@@ -5788,6 +5791,17 @@ class RunCardNLO(RunCard):
         if self['mcatnlo_delta'] and not self['parton_shower'].lower() == 'pythia8':
             raise InvalidRunCard("MC@NLO-DELTA only possible with matching to Pythia8")
 
+    # check that the flavour_bias is consistent
+        if len(self['flavour_bias']) != 2:
+            raise InvalidRunCard("'flavour_bias' should contain exactly two numbers: the abs(PDG) of the flavour to enhance, and the enhancement multiplication factor.")
+        for i in self['flavour_bias']:
+            if i < 0:
+                raise InvalidRunCard("flavour and multiplication factor should be positive in the flavour_bias parameter")
+        if self['flavour_bias'][1] != 1 and self['event_norm'] != 'bias':
+            logger.warning('Non-trivial flavour enhancement factor: setting event normalisation to "bias"')
+            self['event_norm']='bias'
+            
+    
         # check that ebeam is bigger than the proton mass.
         for i in [1,2]:
             # do not for proton mass if not proton PDF (or when scan initialization)


### PR DESCRIPTION
Relevant for NLO event generation.

This is a greatly simplified version of the code that was originally developed for biassed event generation based on the flavours present in the process, as used in 2403.14419. Mostly useful for increasing the number of events with b-quarks (before showering) in a multi-jet (merged) sample.

It introduces in new parameter 'Flavour_Bias' to the run card: it requires two values, the absolute value of the PDG code of the flavour to enhance, and the enhancement factor. (Both are integers). For example, setting
 5, 100  = Flavour_Bias
increases the probability of writing an event with an (initial or final) b quark by a factor 100, reducing the corresponding event weight by 100. 
