### PR TITLE
symmetry factor for standalone_cpp

### DIFF
--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -1857,11 +1857,11 @@ class ALOHAWriterForCPP(WriteALOHA):
 
                 out.write('   int flv_index1 = F1.flv_index;\n')
                 out.write('   int flv_index2 = F2.flv_index;\n')
-                out.write('   if(flv_index1 != flv_index2 || flv_index1 == 0d0){  \n %s\n  return;\n}\n' % fail)
+                out.write('   if(flv_index1 != flv_index2 || flv_index1 == 0.){  \n %s\n  return;\n}\n' % fail)
             else:
                 incoming = [i+1 for i in range(len(self.particles)) if i+1 != self.outgoing and self.particles[self.outgoing-1] == 'F'][0]
                 outgoing = self.outgoing
-                out.write('  F%i.flv_index = F%i.flv_indexi;\n' % (outgoing, incoming))
+                out.write('  F%i.flv_index = F%i.flv_index;\n' % (outgoing, incoming))
 
             return out.getvalue()    
         

--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -20,7 +20,7 @@ import fractions
 import glob
 import itertools
 import logging
-from math import fmod
+from math import fmod, factorial
 import os
 import re
 import shutil
@@ -958,6 +958,17 @@ class OneProcessExporterCPP(object):
                                                               'CPPProcess')
         
         replace_dict['nexternal'] = len(self.matrix_elements[0].get('processes')[0].get('legs'))
+        data = self.matrix_elements[0].get('processes')[0].get_final_ids_after_decay()
+        pids = str(data).replace('[', '{').replace(']', '}')
+        replace_dict['get_pid'] = ' int pid[] = %s;' % (pids)
+        replace_dict['get_old_symmmetry_value'] = 1
+        done = []
+        for value in data:
+            if value not in done:
+                done.append(value)
+                replace_dict['get_old_symmmetry_value'] *= factorial(data.count(value)) 
+        _, nincoming = self.matrix_elements[0].get_nexternal_ninitial()
+        replace_dict['nincoming'] = nincoming
     
         if write:
             file = self.read_template_file(self.process_definition_template) %\

--- a/madgraph/iolibs/template_files/cpp_process_class.inc
+++ b/madgraph/iolibs/template_files/cpp_process_class.inc
@@ -62,4 +62,7 @@ private:
   // Initial particle ids
   int id1, id2;
 
+  // function to compute missing symmetry factors after flavor consolidation
+  int broken_sym(int* flavor);
+
 };

--- a/madgraph/iolibs/template_files/cpp_process_function_definitions.inc
+++ b/madgraph/iolibs/template_files/cpp_process_function_definitions.inc
@@ -49,3 +49,29 @@ double CPPProcess::sigmaHat() {
 // Evaluate |M|^2 for each subprocess
 
 %(all_sigmaKin)s
+
+//--------------------------------------------------------------------------
+// Evaluate |M|^2 for each subprocess
+
+int CPPProcess::broken_sym(int* flavor)
+{
+    int old_factor = %(get_old_symmmetry_value)s;
+    %(get_pid)s
+    int nincoming = %(nincoming)d;
+    for (int i = 0; i < (nexternal - nincoming - 1); i++)
+    {
+        if(pid[i] == 0)
+            continue;
+        int n_tot = 1;
+        for (int j = i + 1; j < (nexternal - nincoming - 1); j++)
+        {
+            if((pid[i] == pid[j]) && (flavor[i] == flavor[j]))
+            {
+                pid[j] = 0;
+                n_tot = n_tot + 1;
+                old_factor = old_factor / n_tot;
+            }
+        }
+    }
+    return old_factor;
+}

--- a/madgraph/iolibs/template_files/cpp_process_sigmaKin_function.inc
+++ b/madgraph/iolibs/template_files/cpp_process_sigmaKin_function.inc
@@ -64,6 +64,6 @@ else
 }
 
 for (int i=0;i < nprocesses; i++)
-    matrix_element[i] /= denominators[i];
+    matrix_element[i] /= (denominators[i] * broken_sym(flavor));
 
 


### PR DESCRIPTION
Adds corrections to the symmetry factors introduced by flavor consolidation to standalone_cpp

## Summary by Sourcery

Modify symmetry factor calculations in standalone C++ code to correctly handle flavor consolidation

Bug Fixes:
- Correct symmetry factor calculations to account for particle flavor and identity duplications

Enhancements:
- Implement a new method `broken_sym()` to recalculate symmetry factors after flavor consolidation

Chores:
- Update matrix element calculation to incorporate the new symmetry factor correction