### PR TITLE
Fix typo: Correct icckw to ickkw

### DIFF
--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -552,7 +552,7 @@ ANNOUNCEMENT:
       OM: Change user interface related to FxFx mode
           - If you have multiple multiplicities at NLO,
 	    - the default run_card is modified accordingly
-	        - has icckw=3 and follow the official FxFx recomendation (i.e. for
+	        - has ickkw=3 and follow the official FxFx recomendation (i.e. for
 		  scale and jet algo)
             - the shower card has two parameter that are dynamically set 
                 - njmax (default: -1) is automatically set depending of the process definition

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -4449,11 +4449,11 @@ class RunCardLO(RunCard):
                 time.sleep(5)
             if self['drjj'] != 0:
                 if 'drjj' in self.user_set:
-                    logger.warning('Since icckw>0, changing the value of \'drjj\' to 0')
+                    logger.warning('Since ickkw>0, changing the value of \'drjj\' to 0')
                 self['drjj'] = 0
             if self['drjl'] != 0:
                 if 'drjl' in self.user_set:
-                    logger.warning('Since icckw>0, changing the value of \'drjl\' to 0')
+                    logger.warning('Since ickkw>0, changing the value of \'drjl\' to 0')
                 self['drjl'] = 0    
             if not self['auto_ptj_mjj']:         
                 if self['mmjj'] > self['xqcut']:


### PR DESCRIPTION
Hi,

This PR fixes a typo where `ickkw` was incorrectly written as `icckw` in a couple files.

Best,
Bruno

## Summary by Sourcery

Bug Fixes:
- Fix a typo in warning messages where 'icckw' was incorrectly used instead of 'ickkw' in the banner.py file