### PR TITLE
Second option for externals include path

### DIFF
--- a/madgraph/iolibs/export_fks.py
+++ b/madgraph/iolibs/export_fks.py
@@ -4763,8 +4763,12 @@ class ProcessOptimizedExporterFortranFKS(loop_exporters.LoopProcessOptimizedExpo
                     # We must add the corresponding includes for these TIR
                     if tir in ['golem','samurai','ninja','collier']:
                         trg_path = pjoin(os.path.dirname(libpath),'include')
+                        trg_path2 = pjoin(trg_path,tir)
                         if os.path.isdir(trg_path):
                             to_include = misc.find_includes_path(trg_path,
+                                                        self.include_names[tir])
+                        elif os.path.isdir(trg_path2):
+                            to_include = misc.find_includes_path(trg_path2,
                                                         self.include_names[tir])
                         else:
                             to_include = None
@@ -4774,7 +4778,7 @@ class ProcessOptimizedExporterFortranFKS(loop_exporters.LoopProcessOptimizedExpo
                                pjoin(libpath,'modules'),self.include_names[tir])
                         if to_include is None:
                             logger.error(
-'Could not find the include directory for %s, looking in %s.\n' % (tir ,str(trg_path))+
+'Could not find the include directory for %s, looking in %s and %s.\n' % (tir ,str(trg_path), str(trg_path2))+
 'Generation carries on but you will need to edit the include path by hand in the makefiles.')
                             to_include = '<Not_found_define_it_yourself>'
                         tir_include.append('-I %s'%to_include)

--- a/madgraph/iolibs/export_fks.py
+++ b/madgraph/iolibs/export_fks.py
@@ -4764,14 +4764,13 @@ class ProcessOptimizedExporterFortranFKS(loop_exporters.LoopProcessOptimizedExpo
                     if tir in ['golem','samurai','ninja','collier']:
                         trg_path = pjoin(os.path.dirname(libpath),'include')
                         trg_path2 = pjoin(trg_path,tir)
+                        to_include = None
                         if os.path.isdir(trg_path):
                             to_include = misc.find_includes_path(trg_path,
                                                         self.include_names[tir])
-                        elif os.path.isdir(trg_path2):
+                        if to_include is None and os.path.isdir(trg_path2):
                             to_include = misc.find_includes_path(trg_path2,
                                                         self.include_names[tir])
-                        else:
-                            to_include = None
                         # Special possible location for collier
                         if to_include is None and tir=='collier':
                             to_include = misc.find_includes_path(


### PR DESCRIPTION
For many installations, the headers are in an include directory, but then in a sub-directory that has the name of the package. This just provides a second option for looking for headers (it just so happens that this is the structure used by genser on cvmfs as well)

There are a bunch of ways to do this, and this is only one, so no hard feelings if you'd prefer a different implementation!

Cheers,
Zach

## Summary by Sourcery

Enhance header include path detection for external libraries by adding a second search option in a package-specific subdirectory

Bug Fixes:
- Improve error logging to show both searched include paths when header detection fails

Enhancements:
- Modify include path detection to check for headers in a secondary location within an 'include' directory