### PR TITLE
3 x index out of range

### DIFF
--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -1995,18 +1995,28 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                        self.run_card['event_norm'] in ['unity']:
                 all_cross= [cross/nb_event for cross in all_cross]
                 
-            sys_obj = systematics.call_systematics([input, None] + opts, 
+            # RR 2025 0515
+            # 'old_run_mode' only defined to bypass crash.
+            # if exists, no need to re-re-run print
+            if 'old_run_mode' in locals():
+                self.update_status('Skipping (re)run of call_systematics', level='parton', makehtml=False)
+                self.update_status('Skipping (re)run of print_cross_sections', level='parton', makehtml=False)
+                self.update_status('Skipping (re)concatenation', level='parton', makehtml=False)
+            else:
+                sys_obj = systematics.call_systematics([input, None] + opts,
                                          log=lambda x: logger.info(str(x)),
                                          result=result_file,
                                          running=False
-                                         )                    
-            sys_obj.print_cross_sections(all_cross, nb_event, result_file)
-            
-            #concatenate the output file
-            subprocess.call(['cat']+\
-                            ['./tmp_%s_%s' % (i, os.path.basename(output)) for i in range(nb_submit)],
-                            stdout=open(output,'w'),
-                            cwd=os.path.dirname(output))
+                                         )
+
+                sys_obj.print_cross_sections(all_cross, nb_event, result_file)
+
+                #concatenate the output file
+                subprocess.call(['cat']+\
+                                ['./tmp_%s_%s' % (i, os.path.basename(output)) for i in range(nb_submit)],
+                                stdout=open(output,'w'),
+                                cwd=os.path.dirname(output))
+                
             for i in range(nb_submit):
                 os.remove('%s/tmp_%s_%s' %(os.path.dirname(output),i,os.path.basename(output)))
             #    os.remove('%s/log_sys_%s.txt' % (os.path.dirname(output),i))

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -1964,12 +1964,16 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 self.cluster.wait(os.path.dirname(output), update_status, update_first=update_status)
             except Exception:
                 self.cluster.remove()
+                for i in range(nb_submit):
+                    os.remove('%s/tmp_%s_%s' %(os.path.dirname(output),i,os.path.basename(output)))
                 old_run_mode = self.options['run_mode']
                 self.options['run_mode'] =0
+                out =False
                 try:
                     out = self.do_systematics(line)
                 finally:
                     self.options['run_mode']  =  old_run_mode
+                return out
             #collect the data
             all_cross = []
             for i in range(nb_submit):
@@ -1995,27 +1999,20 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                        self.run_card['event_norm'] in ['unity']:
                 all_cross= [cross/nb_event for cross in all_cross]
                 
-            # RR 2025 0515
-            # 'old_run_mode' only defined to bypass crash.
-            # if exists, no need to re-re-run print
-            if 'old_run_mode' in locals():
-                self.update_status('Skipping (re)run of call_systematics', level='parton', makehtml=False)
-                self.update_status('Skipping (re)run of print_cross_sections', level='parton', makehtml=False)
-                self.update_status('Skipping (re)concatenation', level='parton', makehtml=False)
-            else:
-                sys_obj = systematics.call_systematics([input, None] + opts,
-                                         log=lambda x: logger.info(str(x)),
-                                         result=result_file,
-                                         running=False
-                                         )
 
-                sys_obj.print_cross_sections(all_cross, nb_event, result_file)
+            sys_obj = systematics.call_systematics([input, None] + opts,
+                                        log=lambda x: logger.info(str(x)),
+                                        result=result_file,
+                                        running=False
+                                        )
 
-                #concatenate the output file
-                subprocess.call(['cat']+\
-                                ['./tmp_%s_%s' % (i, os.path.basename(output)) for i in range(nb_submit)],
-                                stdout=open(output,'w'),
-                                cwd=os.path.dirname(output))
+            sys_obj.print_cross_sections(all_cross, nb_event, result_file)
+
+            #concatenate the output file
+            subprocess.call(['cat']+\
+                            ['./tmp_%s_%s' % (i, os.path.basename(output)) for i in range(nb_submit)],
+                            stdout=open(output,'w'),
+                            cwd=os.path.dirname(output))
                 
             for i in range(nb_submit):
                 os.remove('%s/tmp_%s_%s' %(os.path.dirname(output),i,os.path.basename(output)))


### PR DESCRIPTION
Fixing "list index out-of-range" bug that appeared between 3.6.1 and 3.62

## Summary by Sourcery

Fix list index out-of-range errors and improve model import, phase‐space constraints, and color algebra while introducing new validation checks and HEFT acceptance testing.

New Features:
- Add model consistency checks (check_model_all and check_model_aS) to enforce α_s assignment in SMINPUTS#3.

Bug Fixes:
- Constrain goldstone–vector merging to spin-3 candidates to prevent list index errors.
- Refine goldstone interaction merging to avoid duplicate vertices.
- Fix histogram parsing by removing erroneous weight header boundary checks.

Enhancements:
- Introduce dsqrt_shatmax parameter and enforce ŝ limits in phase-space generation, CMS sampling, and cuts.
- Extend ALOHA CombineAmpS to support larger wave function sizes.
- Incorporate denominator scaling and symmetric indexing in color amplitude templates.
- Enhance FKS export include path search with secondary directory fallback and clearer error messages.
- Update vertex color reordering logic to handle deep-copy anomalies and proper ColorString conversion.
- Use maximum instead of minimum denominator in export_v4 for consistent color matrix data.

CI:
- Add acceptancetest_heft job in GitHub Actions for HEFT generation.

Tests:
- Add test_generation_heft acceptance test to catch HEFT exporter crashes.