### PR TITLE
Fixes two bugs in FxFx

### DIFF
--- a/Template/NLO/SubProcesses/cluster.f
+++ b/Template/NLO/SubProcesses/cluster.f
@@ -475,7 +475,7 @@ c     the renormalisation scale.
 c Determine which particles need clustering and which do not
       call matching_particles(next,nbr,ipdg,cluster_pdg,cluster_ij,iord
      $     ,need_matching)
-
+      
       nqcdrenscale=0       ! number of alpha-s needing reweighting
       nqcdrenscalecentral=0
       hard_qcd_scale=0d0   ! hardest scale in all clusterings so far.

--- a/Template/NLO/SubProcesses/cuts.f
+++ b/Template/NLO/SubProcesses/cuts.f
@@ -398,8 +398,11 @@ C now check that there are enough photons
       external pt,eta
       include "run.inc" 
       include "cuts.inc"
-
       integer i, j 
+      integer need_matching_S(nexternal),need_matching_H(nexternal)
+     $     ,need_matching_cuts(nexternal)
+      common /c_need_matching/ need_matching_S,need_matching_H
+     $     ,need_matching_cuts
 
 c
 c JET CUTS
@@ -427,6 +430,7 @@ c more than the Born).
          nQCD=0
          do j=nincoming+1,nexternal
             if (is_a_j(j)) then
+               if (ickkw.eq.3 .and. need_matching_cuts(j).eq.-1) cycle ! skip the 'EW-jets'
                nQCD=nQCD+1
                do i=0,3
                   pQCD(i,nQCD)=p(i,j)
@@ -458,14 +462,14 @@ c In case of FxFx merging, use the lowest clustering scale to apply the cut
       passcuts_fxfx=.true.
 c First apply a numerical stability cut
 c Define jet clustering parameters with a pTmin=1 GeV
-      palg=1.0                  ! jet algorithm: 1.0=kt, 0.0=C/A, -1.0 = anti-kt
-      rfj=1.0                   ! the radius parameter
-      sycut=1.0                 ! minimum transverse momentum
+      palg=1d0                  ! jet algorithm: 1.0=kt, 0.0=C/A, -1.0 = anti-kt
+      rfj=1d0                   ! the radius parameter
+      sycut=ptj                 ! minimum transverse momentum
       etaj_max=1000d0
 c     call FASTJET to get all the jets
       call amcatnlo_fastjetppgenkt_etamax_timed(
      $     pQCD,nQCD,rfj,sycut,etaj_max,palg,pjet,njet,jet)
-c Apply the jet cut
+c     Apply the jet cut
       if (njet .ne. nQCD .and. njet .ne. nQCD-1) then
          passcuts_fxfx=.false.
          return

--- a/Template/NLO/SubProcesses/driver_mintMC.f
+++ b/Template/NLO/SubProcesses/driver_mintMC.f
@@ -828,6 +828,8 @@ c for different nFKSprocess.
 c Every contribution has to have a viable set of Born momenta (even if
 c counter-event momenta do not exist).
             if (p_born(0,1).lt.0d0) cycle
+c Compute the n1-body prefactors
+            call compute_prefactors_n1body(vegas_wgt,jac)
 c Set the shower scales            
             if (ickkw.eq.3) then
                call set_FxFx_scale(0,p) ! reset the FxFx scales
@@ -844,8 +846,6 @@ c Set the shower scales
                   call set_FxFx_scale(3,p)
                endif
             endif              
-c Compute the n1-body prefactors
-            call compute_prefactors_n1body(vegas_wgt,jac)
 c check if event or counter-event passes cuts
             call set_cms_stuff(izero)
             if (ickkw.eq.3) call set_FxFx_scale(-2,p1_cnt(0,1,0))

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -4,6 +4,11 @@ ANNOUNCEMENT:
    2.9.X version as a LONG TERM STABLE has now an end of life for bug fixing/support in december 2025.
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
+3.6.4
+     RF: Fixed critical bug in FxFx merging, introduced in version 3.3.1. This resulted in too many negatively weighted events,
+         and too many high-pT jets. Particularly relevant for merging with up to 2 or 3 jets at NLO. Thanks to Lenart Jerala
+	 for pointing this out and testing the fixes.
+
 
 3.6.3 (12/6/25):
      OM: Fix conversion model for the FD gauge


### PR DESCRIPTION
This fix corrects two bugs in FxFx merging, introduced in version 3.3.1.

One is a "coding bug", in driver_mintMC.f the FxFx terms relevant to the n+1-body contributions were computed before the prefactors for these contributions was set, resulting in overwriting of the FxFx contributions.

The second is the application of the generation-level cuts. From versions 3.3.2 these were applied exclusively on the clustering scales, ignoring any dependence on DeltaR. This is incorrect at large pTs, were these should be taken into account.

This should also be fixed in the LTS version.

## Summary by Sourcery

Fix two bugs in FxFx merging: ensure n+1-body prefactors are computed before scale resets to prevent overwriting FxFx contributions, and apply generation-level cuts correctly by introducing a pt-dependent jet threshold and a need_matching_cuts flag to account for DeltaR at high pT

Bug Fixes:
- Compute n+1-body prefactors before resetting FxFx scales in driver_mintMC to preserve FxFx terms
- Introduce need_matching_cuts and replace fixed sycut with pt-dependent threshold in passcuts_fxfx to enforce generation-level cuts including DeltaR