### PR TITLE
3 6 x scan uncertainties

### DIFF
--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -4372,13 +4372,16 @@ RESTART = %(mint_mode)s
                 self.run_tag = tag
                 self.results.add_run(self.run_name, self.run_card)
             else:
-                for tag in upgrade_tag[level]:
-                    if getattr(self.results[self.run_name][-1], tag):
-                        tag = self.get_available_tag()
-                        self.run_card['run_tag'] = tag
-                        self.run_tag = tag
-                        self.results.add_run(self.run_name, self.run_card)                        
-                        break
+                try:
+                    for tag in upgrade_tag[level]:
+                        if getattr(self.results[self.run_name][-1], tag):
+                            tag = self.get_available_tag()
+                            self.run_card['run_tag'] = tag
+                            self.run_tag = tag
+                            self.results.add_run(self.run_name, self.run_card)                        
+                            break
+                except:
+                    return
             return # Nothing to do anymore
         
         # save/clean previous run

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -2011,6 +2011,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                         )
 
             sys_obj.print_cross_sections(all_cross, nb_event, result_file)
+            result_file.close()
 
             #concatenate the output file
             subprocess.call(['cat']+\

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -8045,7 +8045,8 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                             mux_log, pdf_log = getSysSummaryFromLog_aMCnlo(kpath=card_path,knext_name=next_name)
                         gotFirstScaleVar=True
                         logger.info("Storing scale/PDF variation for scan summary %s" % next_name)
-                    except:
+                    except Exception as err:
+                        logger.debug(str(err))
                         logger.info("Failed to collect scale/PDF variation for scan summary from %s (first run). Dropping all variations from scan summary." % next_name)
                         gotFirstScaleVar=False
                         mux_log, pdf_log = [], []
@@ -8070,10 +8071,12 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                                 else: # running as mg5amc
                                     mux_log, pdf_log = getSysSummaryFromLog_aMCnlo(kpath=card_path,knext_name=next_name)
                                 logger.info("Storing scale/PDF variation for scan summary %s" % next_name)
-                            except AssertionError:
+                            except AssertionError as err:
+                                logger.debug(str(err))
                                 logger.info("Not collecting scale/PDF variation for scan summary")
                                 mux_log, pdf_log = [], []
-                            except:
+                            except Exception as err:
+                                logger.debug(str(err))
                                 logger.info("Failed to collect scale/PDF variation for scan summary from %s. Setting individual variations to zero." % next_name)
                                 mux_log, pdf_log = [], []
                             # store xsec and unc

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -7918,7 +7918,7 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                     #first run of the function
                     original_fct(obj, *args, **opts)
                     return
-            
+
             with restore_iterator(param_card_iterator, card_path):
                 # this with statement ensure that the original card is restore
                 # whatever happens inside those block
@@ -7933,27 +7933,50 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                     # run for the first time
                     original_fct(obj, *args, **opts)
                     # try retrieving sys info for scan
+                    run_card_iterator = run_card_iteratorclass(card_path)
+                    #print(f"{dir(run_card_iterator.run_card)=}")
+                    #print(f"{run_card_iterator.run_card=}")
+                    #sys.exit()
+                    ismg5amc= not run_card_iterator.run_card.LO
+                    mux_log = []
+                    pdf_log = []
                     try:
-                        sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"parton_systematics.log")
-                        #sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"summary.txt")
-                        sys_out = open(sys_log,'r')
-                        mux_log = []
-                        pdf_log = []
-                        for sysLine in sys_out.readlines():
-                            if(sysLine.startswith("#     scale variation")):
-                                # does not work for full integers
-                                # e.g., # PDF variation: + 2% - 2%
-                                #varHi=sysLine.split(" ")[-2].replace("%","")
-                                #varLo=sysLine.split(" ")[-1].replace("%","")
-                                varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
-                                varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
-                                mux_log = [varHi,varLo]
-                                continue
-                            if(sysLine.startswith("# PDF variation")):
-                                varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
-                                varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
-                                pdf_log = [varHi,varLo]
-                                continue
+                        if(ismg5amc): # running as mg5amc
+                            sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"summary.txt")
+                            sys_out = open(sys_log,'r')
+                            sys_lst = list(sys_out.readlines())
+                            for kk, line in enumerate(sys_lst):
+                                tmpLine=line.replace(" ","")
+                                if(tmpLine.startswith("Scalevariation")):
+                                    sysLine = sys_lst[kk+2]
+                                    varHi=sysLine.split("pb")[1].split("%")[0].replace(" ","")
+                                    varLo=sysLine.split("pb")[1].split("%")[1].replace(" ","")
+                                    mux_log = [varHi,varLo]
+                                    continue
+                                if(tmpLine.startswith("PDFvariation")):
+                                    sysLine = sys_lst[kk+2]
+                                    varHi=sysLine.split("pb")[1].split("%")[0].replace(" ","")
+                                    varLo=sysLine.split("pb")[1].split("%")[1].replace(" ","")
+                                    pdf_log = [varHi,varLo]
+                                    continue
+                        else: # running as madgraph
+                            sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"parton_systematics.log")
+                            sys_out = open(sys_log,'r')
+                            for sysLine in sys_out.readlines():
+                                if(sysLine.startswith("#     scale variation")):
+                                    # does not work for full integers
+                                    # e.g., # PDF variation: + 2% - 2%
+                                    #varHi=sysLine.split(" ")[-2].replace("%","")
+                                    #varLo=sysLine.split(" ")[-1].replace("%","")
+                                    varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
+                                    varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
+                                    mux_log = [varHi,varLo]
+                                    continue
+                                if(sysLine.startswith("# PDF variation")):
+                                    varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
+                                    varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
+                                    pdf_log = [varHi,varLo]
+                                    continue
                         sys_out.close()
                         gotFirstScaleVar=True
                         logger.info("Storing scale/PDF variation for scan summary %s" % next_name)
@@ -7978,25 +8001,44 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                             # try retrieving sys info for scan
                             try:
                                 assert gotFirstScaleVar # skip altogether if missing first entry
-                                sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"parton_systematics.log")
-                                sys_out = open(sys_log,'r')
-                                mux_log = []
-                                pdf_log = []
-                                for sysLine in sys_out.readlines():
-                                    if(sysLine.startswith("#     scale variation")):
-                                        # does not work for full integers
-                                        # e.g., # PDF variation: + 2% - 2%
-                                        #varHi=sysLine.split(" ")[-2].replace("%","")
-                                        #varLo=sysLine.split(" ")[-1].replace("%","")
-                                        varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
-                                        varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
-                                        mux_log = [varHi,varLo]
-                                        continue
-                                    if(sysLine.startswith("# PDF variation")):
-                                        varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
-                                        varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
-                                        pdf_log = [varHi,varLo]
-                                        continue
+                                if(ismg5amc): # running as mg5amc
+                                    sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"summary.txt")
+                                    sys_out = open(sys_log,'r')
+                                    sys_lst = list(sys_out.readlines())
+                                    for kk, line in enumerate(sys_lst):
+                                        tmpLine=line.replace(" ","")
+                                        if(tmpLine.startswith("Scalevariation")):
+                                            sysLine = sys_lst[kk+2]
+                                            varHi=sysLine.split("pb")[1].split("%")[0].replace(" ","")
+                                            varLo=sysLine.split("pb")[1].split("%")[1].replace(" ","")
+                                            mux_log = [varHi,varLo]
+                                            continue
+                                        if(tmpLine.startswith("PDFvariation")):
+                                            sysLine = sys_lst[kk+2]
+                                            varHi=sysLine.split("pb")[1].split("%")[0].replace(" ","")
+                                            varLo=sysLine.split("pb")[1].split("%")[1].replace(" ","")
+                                            pdf_log = [varHi,varLo]
+                                            continue
+                                else: # running as madgraph
+                                    sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"parton_systematics.log")
+                                    sys_out = open(sys_log,'r')
+                                    mux_log = []
+                                    pdf_log = []
+                                    for sysLine in sys_out.readlines():
+                                        if(sysLine.startswith("#     scale variation")):
+                                            # does not work for full integers
+                                            # e.g., # PDF variation: + 2% - 2%
+                                            #varHi=sysLine.split(" ")[-2].replace("%","")
+                                            #varLo=sysLine.split(" ")[-1].replace("%","")
+                                            varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
+                                            varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
+                                            mux_log = [varHi,varLo]
+                                            continue
+                                        if(sysLine.startswith("# PDF variation")):
+                                            varHi=sysLine.split(":")[1].split("%")[0].replace(" ","")
+                                            varLo=sysLine.split(":")[1].split("%")[1].replace(" ","")
+                                            pdf_log = [varHi,varLo]
+                                            continue
                                 sys_out.close()
                                 logger.info("Storing scale/PDF variation for scan summary %s" % next_name)
                             except AssertionError:

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -7932,14 +7932,16 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                     set_run_name(obj)(next_name)
                     # run for the first time
                     original_fct(obj, *args, **opts)
-                    # try retrieving sys info for scan
-                    run_card_iterator = run_card_iteratorclass(card_path)
-                    #print(f"{dir(run_card_iterator.run_card)=}")
-                    #print(f"{run_card_iterator.run_card=}")
-                    #sys.exit()
+                    # check whether mg5/MadEvent or mg5amc/MC@NLO type event
+                    if isinstance(input_path, str):
+                        run_path = run_card_input
+                    else:
+                        run_path = run_card_input(obj)
+                    run_card_iterator = run_card_iteratorclass(run_path)
                     ismg5amc= not run_card_iterator.run_card.LO
                     mux_log = []
                     pdf_log = []
+                    # try retrieving sys info for scan
                     try:
                         if(ismg5amc): # running as mg5amc
                             sys_log = pjoin(card_path.rsplit("/", 2)[0],"Events",next_name,"summary.txt")

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -2011,7 +2011,8 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                                         )
 
             sys_obj.print_cross_sections(all_cross, nb_event, result_file)
-            result_file.close()
+            if result_file is not sys.stdout:
+                result_file.close()
 
             #concatenate the output file
             subprocess.call(['cat']+\

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -7946,7 +7946,6 @@ def scanparamcardhandling(input_path=lambda obj: pjoin(obj.me_dir, 'Cards', 'par
                     set_run_name(obj)(next_name)
                     # run for the first time
                     original_fct(obj, *args, **opts)
-                    # try retrieving sys info for scan
                     # store xsec and unc
                     param_card_iterator.store_entry(next_name, store_for_scan(obj)(), param_card_path=card_path)
                     for card in param_card_iterator:


### PR DESCRIPTION
New features: When carrying out parameter scans in MadGraph/MadEvent or MG5aMC@NLO with systematics (use_syst True or reweight_scale/pdf True), then the uncertain information is also recorded in the scan summary.

Base version: 3.6.4 ($ git merge origin/3.6.4: Already up to date.)

Changes limited to madgraph/interface/common_run_interface.py

Sample output:
<img width="1683" height="781" alt="image" src="https://github.com/user-attachments/assets/549710ea-afb7-42ad-9a75-555395b7af45" />

One additional note: Changes include a bug fix as reported on launchpad (I accidentally merged this fix with 3.6.4 😅)
https://bugs.launchpad.net/mg5amcnlo/+bug/2119521

## Summary by Sourcery

Introduce systematic uncertainty recording for parameter scans, ensure proper file handling and error resilience, enforce deterministic code generation ordering, add fake_id support across templates and exports, and update tests to reflect these changes.

New Features:
- Record scale and PDF systematic uncertainties in parameter scan summaries

Bug Fixes:
- Close result_file in do_systematics to prevent resource leaks

Enhancements:
- Extend store_scan_result to accept extraMUX and extraPDF for uncertainty data and update scan runner to parse systematics logs from summary or log files
- Wrap run_tag upgrade logic in amcatnlo_run_interface in try/except and refine PDF reset condition in do_systematics
- Add custom sorting of functions in aloha_writers for deterministic ordering
- Introduce fake_id support in export logic and Fortran templates and assign default helicity 9 for intermediate states
- Relocate EW Sudakov warning message in amcatnlo_interface and fix gnuplot output version detection in histograms

Tests:
- Update unit and acceptance tests to expect fake_id entries in configuration exports and validate intermediate helicity in MadSpin