### PR TITLE
Fix borntilde

### DIFF
--- a/madgraph/iolibs/template_files/born_cnt_splitorders_fks.inc
+++ b/madgraph/iolibs/template_files/born_cnt_splitorders_fks.inc
@@ -351,15 +351,14 @@ c          Jamp2(i,J)=Jamp2(i,J)+Jamp(i,J)*dconjg(Jamp(i,J))
         ZTEMP = (0.D0,0.D0)
         DO J = I, NCOLOR
           CF_INDEX = CF_INDEX + 1
-          ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-        ENDDO
-	DO N = 1, NAMPSO
-        ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))= ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N)) + ZTEMP*DCONJG(JAMPH(1,I,N))
+          DO N = 1, NAMPSO
+             ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))= ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N)) + CF(CF_INDEX)*JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))+CF(CF_INDEX)*JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N))
+          ENDDO
         ENDDO
       ENDDO
 
 	DO N = 1, NAMPSO
-        ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))= ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))/DENOM 
+        ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))= ANS(2,SQSOINDEXB_CNT%(proc_prefix)s(M,N))/(2d0*DENOM) 
         ENDDO
       ENDDO
       nhel(glu_ij) = back_hel

--- a/madgraph/iolibs/template_files/born_fks.inc
+++ b/madgraph/iolibs/template_files/born_fks.inc
@@ -270,10 +270,10 @@ C ----------
         ZTEMP = (0.D0,0.D0)
         DO J = I, NCOLOR
           CF_INDEX = CF_INDEX +1
-          ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J)
+          BORNTILDE = BORNTILDE + CF(CF_INDEX)*JAMPH(2,J)*DCONJG(JAMPH(1,I))+CF(CF_INDEX)*JAMPH(2,I)*DCONJG(JAMPH(1,J))
         ENDDO
-        BORNTILDE = BORNTILDE + ZTEMP*DCONJG(JAMPH(1,I))
       ENDDO
+      BORNTILDE = BORNTILDE/(2d0*DENOM)
       if (glu_ij.ne.0) nhel(glu_ij) = back_hel
       END
        

--- a/madgraph/iolibs/template_files/bornmatrix_splitorders_fks.inc
+++ b/madgraph/iolibs/template_files/bornmatrix_splitorders_fks.inc
@@ -626,15 +626,14 @@ C ----------
         ZTEMP = (0.D0,0.D0)
         DO J = I, NCOLOR
           CF_INDEX = CF_INDEX +1
-          ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-        ENDDO
-	DO N = 1, NAMPSO
-        ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP*DCONJG(JAMPH(1,I,N))
+          DO  N = 1, NAMPSO
+             ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))+JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+          ENDDO
         ENDDO
       ENDDO
 
       DO N = 1, NAMPSO
-      ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+      ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2d0*DENOM)
       ENDDO
       ENDDO
       if (glu_ij.ne.0) nhel(glu_ij) = back_hel

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_bbx_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_bbx_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_bxb_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_bxb_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ccx_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ccx_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_cxc_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_cxc_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ddx_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ddx_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_dxd_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_dxd_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_gg_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_gg_ttx%born.f
@@ -707,16 +707,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ssx_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_ssx_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_sxs_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_sxs_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_uux_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_uux_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_uxu_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_pptt_ewsudakovSA/%SubProcesses%P0_uxu_ttx%born.f
@@ -699,16 +699,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_bbx_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_bbx_zz%born.f
@@ -719,16 +719,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_bxb_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_bxb_zz%born.f
@@ -720,16 +720,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ccx_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ccx_zz%born.f
@@ -719,16 +719,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_cxc_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_cxc_zz%born.f
@@ -720,16 +720,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ddx_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ddx_zz%born.f
@@ -719,16 +719,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_dxd_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_dxd_zz%born.f
@@ -720,16 +720,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ssx_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_ssx_zz%born.f
@@ -719,16 +719,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_sxs_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_sxs_zz%born.f
@@ -720,16 +720,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_uux_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_uux_zz%born.f
@@ -719,16 +719,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_uxu_zz%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportEWSudTest/test_ppzz_ewsudakov/%SubProcesses%P0_uxu_zz%born.f
@@ -720,16 +720,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_gg_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_gg_ttx%born.f
@@ -707,16 +707,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_uux_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_uux_ttx%born.f
@@ -711,16 +711,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_uxu_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fks_loonly/%SubProcesses%P0_uxu_ttx%born.f
@@ -711,16 +711,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_gg_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_gg_ttx%born.f
@@ -707,16 +707,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_uux_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_uux_ttx%born.f
@@ -711,16 +711,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_uxu_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_uxu_ttx%born.f
@@ -711,16 +711,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ag_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ag_ttx%born.f
@@ -700,16 +700,16 @@ C         JAMPs contributing to orders QCD=1 QED=1
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ddx_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ddx_ttx%born.f
@@ -713,16 +713,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_dxd_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_dxd_ttx%born.f
@@ -712,16 +712,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ga_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_ga_ttx%born.f
@@ -700,16 +700,16 @@ C         JAMPs contributing to orders QCD=1 QED=1
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_gg_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_gg_ttx%born.f
@@ -709,16 +709,16 @@ C         JAMPs contributing to orders QCD=2 QED=0
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_uux_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_uux_ttx%born.f
@@ -713,16 +713,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_uxu_ttx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksrealew/%SubProcesses%P0_uxu_ttx%born.f
@@ -712,16 +712,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_dxu_wp%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_dxu_wp%born.f
@@ -694,16 +694,16 @@ C         JAMPs contributing to orders QCD=0 QED=1
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_udx_wp%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_udx_wp%born.f
@@ -694,16 +694,16 @@ C         JAMPs contributing to orders QCD=0 QED=1
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_tdecay_fksreal/%SubProcesses%P0_t_budx%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_tdecay_fksreal/%SubProcesses%P0_t_budx%born.f
@@ -700,16 +700,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_dxu_veep%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_dxu_veep%born.f
@@ -701,16 +701,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_udx_veep%born.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_udx_veep%born.f
@@ -701,16 +701,16 @@ C         JAMPs contributing to orders QCD=0 QED=2
           ZTEMP = (0.D0,0.D0)
           DO J = I, NCOLOR
             CF_INDEX = CF_INDEX +1
-            ZTEMP = ZTEMP + CF(CF_INDEX)*JAMPH(2,J,M)
-          ENDDO
-          DO N = 1, NAMPSO
-            ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) + ZTEMP
-     $       *DCONJG(JAMPH(1,I,N))
+            DO  N = 1, NAMPSO
+              ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N)) +
+     $          CF(CF_INDEX)*(JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N))
+     $         +JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N)))
+            ENDDO
           ENDDO
         ENDDO
 
         DO N = 1, NAMPSO
-          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/DENOM
+          ANS(2,SQSOINDEXB(M,N))= ANS(2,SQSOINDEXB(M,N))/(2D0*DENOM)
         ENDDO
       ENDDO
       IF (GLU_IJ.NE.0) NHEL(GLU_IJ) = BACK_HEL


### PR DESCRIPTION
Hi Rik,

So here is the PR to fix the amount of failed soft and collinear test in multiple process.
As you were identifying this is indeed related to the computation of the color-matrix.

However, the argument that the element on the left and right are not identical is not enough to break the implementation.
(which is good news since this means that the implementation is fine for interference computation).

In order to break what I did, you also need to not sum symmetrically over all helicity, which I think is the case due the condition NHEL(GLU_IJ,IHEL).EQ.NHEL(GLU_IJ,1)
(which likely explains why MadSpin was not impacted)

I will continue to investigate this further for the density branch, but anyway this should be merge fast.

Olivier

## Summary by Sourcery

Fix incorrect Born-tilde color correlator computation by summing color factor contributions symmetrically over helicities and correcting the normalization divisor.

Bug Fixes:
- Include both interference terms (JAMPH(2,J,M)*DCONJG(JAMPH(1,I,N)) and JAMPH(2,I,M)*DCONJG(JAMPH(1,J,N))) in the BORNTILDE and ANS calculations.
- Adjust normalization to divide by 2*DENOM instead of DENOM for the Born-tilde contributions.

Tests:
- Update generated test input files to reflect the corrected color-matrix calculations.