### PR TITLE
Multi gpu support

### DIFF
--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -632,7 +632,7 @@ class MultiCore(Cluster):
             if len(new_var) == 2:
                 gpu_variables.insert(0, new_var)
             else:
-                self.logger.error('Invalid format for %s=%s, it should be a comma-separated list of two elements' % (mg5_gpu_env_str, os.environ[mg5_gpu_env_str]))
+                logger.error('Invalid format for %s=%s, it should be a comma-separated list of two elements' % (mg5_gpu_env_str, os.environ[mg5_gpu_env_str]))
 
         for get_var,set_var in gpu_variables:
             if get_var in os.environ:

--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -602,6 +602,7 @@ class MultiCore(Cluster):
         self.submitted = six.moves.queue.Queue() # one entry by job submitted
         self.stoprequest = threading.Event() #flag to ensure everything to close
         self.demons = []
+        self.gpus_list = []
         self.nb_done =0
         if 'nb_core' in opt:
             self.nb_core = opt['nb_core']
@@ -636,13 +637,15 @@ class MultiCore(Cluster):
                 logger.info('Found %s GPUs: %s' % (self.gpus_count, self.gpus_list))
         
     def start_demon(self):
+        import threading
         env2 = None
         if len(self.gpus_list):
             env2 = os.environ.copy()
             this_gpu_idx = len(self.demons) % self.gpus_count
             env2[self.gpu_set_var] = self.gpus_list[this_gpu_idx]
-        import threading
-        t = threading.Thread(target=self.worker, kwargs={'env2': env2})
+            t = threading.Thread(target=self.worker, kwargs={'env2': env2})
+        else:
+            t = threading.Thread(target=self.worker)
         t.daemon = True
         t.start()
         self.demons.append(t)

--- a/madgraph/various/cluster.py
+++ b/madgraph/various/cluster.py
@@ -627,7 +627,12 @@ class MultiCore(Cluster):
         mg5_gpu_env_str = 'MG5_GPU_VISIBLE_DEVICES'
         gpu_variables = [['NVIDIA_VISIBLE_DEVICES', 'CUDA_VISIBLE_DEVICES'],
                          ['ROCR_VISIBLE_DEVICES', 'HIP_VISIBLE_DEVICES'],]
-        if mg5_gpu_env_str in os.environ: gpu_variables.insert(0, os.environ[mg5_gpu_env_str].split(',')) 
+        if mg5_gpu_env_str in os.environ:
+            new_var = os.environ[mg5_gpu_env_str].split(',')
+            if len(new_var) == 2:
+                gpu_variables.insert(0, new_var)
+            else:
+                self.logger.error('Invalid format for %s=%s, it should be a comma-separated list of two elements' % (mg5_gpu_env_str, os.environ[mg5_gpu_env_str]))
 
         for get_var,set_var in gpu_variables:
             if get_var in os.environ:


### PR DESCRIPTION
In case there is a variable "NVIDIA_VISIBLE_DEVICES" or "ROCR_VISIBLE_DEVICES" in the environment (default names for NVidia and AMD), those will be used to denote the available GPUs on the node. In a later stage when spawning the daemons one of the GPU names from those variables will be set to to "CUDA_VISIBLE_DEVICES" or "HIP_VISIBLE_DEVICES" to target a specific GPU. If those pairs of variable names NVIDIA_VISIBLE_DEVICES/CUDA_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES/HIP_VISIBLE_DEVICES are not the ones used on the system the variable names can be set explicitly via the environment variable "MG5_GPU_VISIBLE_DEVICES". If none of those variables are present mg5 will fall back to the default behavior ie. use the GPU that the driver selects.

## Summary by Sourcery

Enable multi-GPU support by detecting available GPUs from environment variables and assigning them to cluster daemons.

New Features:
- Detect available GPUs from NVIDIA_VISIBLE_DEVICES, ROCR_VISIBLE_DEVICES, or a custom MG5_GPU_VISIBLE_DEVICES environment variable
- Assign each spawned daemon a specific GPU in round-robin by setting CUDA_VISIBLE_DEVICES or HIP_VISIBLE_DEVICES accordingly