### PR TITLE
Changes to implement CUDACPP patches in upstream

### DIFF
--- a/Template/LO/SubProcesses/makefile
+++ b/Template/LO/SubProcesses/makefile
@@ -77,7 +77,7 @@ $(LIBDIR)libgammaUPC.$(libext):
 $(MATRIX): %.o: %.f
 	$(FC) $(FFLAGS) $(MATRIX_FLAG) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
 %.o: %.f
-	$(FC) $(FFLAGS) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
+	$(FC) -cpp $(FFLAGS) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
 
 # Dependencies
 

--- a/Template/LO/SubProcesses/makefile
+++ b/Template/LO/SubProcesses/makefile
@@ -77,7 +77,7 @@ $(LIBDIR)libgammaUPC.$(libext):
 $(MATRIX): %.o: %.f
 	$(FC) $(FFLAGS) $(MATRIX_FLAG) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
 %.o: %.f
-	$(FC) -cpp $(FFLAGS) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
+	$(FC) $(FFLAGS) -c $< -I../../Source/ -I../../Source/PDF/gammaUPC
 
 # Dependencies
 

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5878,6 +5878,11 @@ c           This is dummy particle used in multiparticle vertices
         replace_dict['DRIVER_EXTRA_INITIALISE'] = ""
         replace_dict['DRIVER_EXTRA_FINALISE'] = ""
 
+        # Default values
+        replace_dict['CUDACPP_EXTRA_HEADER'] = "      DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime"
+        replace_dict['CUDACPP_EXTRA_INITIALISE'] = ""
+        replace_dict['CUDACPP_EXTRA_FINALISE'] = ""
+
         if writer:
             text = open(path).read() % replace_dict
             writer.write(text)

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -93,6 +93,58 @@ C  BEGIN CODE
 C----- 
       call cpu_time(t_before)
       CUMULATED_TIMING = t_before
+
+#ifdef _OPENMP
+      CALL OMPNUMTHREADS_NOT_SET_MEANS_ONE_THREAD()
+#endif
+
+#ifdef MG5AMC_MEEXPORTER_CUDACPP
+      CALL COUNTERS_INITIALISE()
+      fbridge_mode = 1 ! CppOnly=1, default for CUDACPP
+      env_name = 'CUDACPP_RUNTIME_FBRIDGEMODE'
+      call get_environment_variable(env_name, env_value, env_length, env_status)
+      if( env_status.eq.0 ) then
+        write(*,*) 'Found environment variable "', trim(env_name), '" with value "', trim(env_value), '"'
+        read(env_value,'(I255)') FBRIDGE_MODE ! see https://gcc.gnu.org/onlinedocs/gfortran/ICHAR.html
+        write(*,*) 'FBRIDGE_MODE (from env) = ', FBRIDGE_MODE
+      else if( env_status.eq.1 ) then ! 1 = not defined
+        write(*,*) 'FBRIDGE_MODE (default) = ', FBRIDGE_MODE
+      else ! -1 = too long for env_value, 2 = not supported by O/S
+        write(*,*) 'ERROR! get_environment_variable failed for "', trim(env_name), '"'
+        STOP
+      endif
+      vecsize_used = vecsize_memmax ! default ! CppOnly=1, default for CUDACPP
+      env_name = 'CUDACPP_RUNTIME_VECSIZEUSED'
+      call get_environment_variable(env_name, env_value, env_length, env_status)
+      if( env_status.eq.0 ) then
+        write(*,*) 'Found environment variable "', trim(env_name), '" with value "', trim(env_value), '"'
+        read(env_value,'(I255)') VECSIZE_USED ! see https://gcc.gnu.org/onlinedocs/gfortran/ICHAR.html
+        write(*,*) 'VECSIZE_USED (from env) = ', VECSIZE_USED
+      else if( env_status.eq.1 ) then ! 1 = not defined
+        write(*,*) 'VECSIZE_USED (default) = ', VECSIZE_USED
+      else ! -1 = too long for env_value, 2 = not supported by O/S
+        write(*,*) 'ERROR! get_environment_variable failed for "', trim(env_name), '"'
+        STOP
+      endif
+      if( VECSIZE_USED.gt.VECSIZE_MEMMAX .or. VECSIZE_USED.le.0 ) then
+        write(*,*) 'ERROR! Invalid VECSIZE_USED = ', VECSIZE_USED
+        STOP
+      endif
+
+      CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, VECSIZE_USED, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
+      FBRIDGE_NCBYF1 = 0
+      FBRIDGE_CBYF1SUM = 0
+      FBRIDGE_CBYF1SUM2 = 0
+      FBRIDGE_CBYF1MAX = -1D100
+      FBRIDGE_CBYF1MIN = 1D100
+#else
+      fbridge_mode = 0 ! FortranOnly=0, default for FORTRAN
+      if( fbridge_mode.ne.0 ) then
+        write(*,*) 'ERROR! Invalid fbridge_mode (in FORTRAN backend mode) = ', fbridge_mode
+        STOP
+      endif
+#endif
+
 %(DRIVER_EXTRA_INITIALISE)s
 c
 c     Read process number

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -76,75 +76,14 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
       include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       INTEGER VECSIZE_USED
-
-#ifdef MG5AMC_MEEXPORTER_CUDACPP
-      INCLUDE 'fbridge.inc'
-      INCLUDE 'fbridge_common.inc'
-      character*255 env_name, env_value
-      integer env_length, env_status
-#else
-      INTEGER*4 FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
-      DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime
-#endif
-
+%(CUDACPP_EXTRA_HEADER)s
 %(DRIVER_EXTRA_HEADER)s
 C-----
 C  BEGIN CODE
 C----- 
       call cpu_time(t_before)
       CUMULATED_TIMING = t_before
-
-#ifdef _OPENMP
-      CALL OMPNUMTHREADS_NOT_SET_MEANS_ONE_THREAD()
-#endif
-
-#ifdef MG5AMC_MEEXPORTER_CUDACPP
-      CALL COUNTERS_INITIALISE()
-      fbridge_mode = 1 ! CppOnly=1, default for CUDACPP
-      env_name = 'CUDACPP_RUNTIME_FBRIDGEMODE'
-      call get_environment_variable(env_name, env_value, env_length, env_status)
-      if( env_status.eq.0 ) then
-        write(*,*) 'Found environment variable "', trim(env_name), '" with value "', trim(env_value), '"'
-        read(env_value,'(I255)') FBRIDGE_MODE ! see https://gcc.gnu.org/onlinedocs/gfortran/ICHAR.html
-        write(*,*) 'FBRIDGE_MODE (from env) = ', FBRIDGE_MODE
-      else if( env_status.eq.1 ) then ! 1 = not defined
-        write(*,*) 'FBRIDGE_MODE (default) = ', FBRIDGE_MODE
-      else ! -1 = too long for env_value, 2 = not supported by O/S
-        write(*,*) 'ERROR! get_environment_variable failed for "', trim(env_name), '"'
-        STOP
-      endif
-      vecsize_used = vecsize_memmax ! default ! CppOnly=1, default for CUDACPP
-      env_name = 'CUDACPP_RUNTIME_VECSIZEUSED'
-      call get_environment_variable(env_name, env_value, env_length, env_status)
-      if( env_status.eq.0 ) then
-        write(*,*) 'Found environment variable "', trim(env_name), '" with value "', trim(env_value), '"'
-        read(env_value,'(I255)') VECSIZE_USED ! see https://gcc.gnu.org/onlinedocs/gfortran/ICHAR.html
-        write(*,*) 'VECSIZE_USED (from env) = ', VECSIZE_USED
-      else if( env_status.eq.1 ) then ! 1 = not defined
-        write(*,*) 'VECSIZE_USED (default) = ', VECSIZE_USED
-      else ! -1 = too long for env_value, 2 = not supported by O/S
-        write(*,*) 'ERROR! get_environment_variable failed for "', trim(env_name), '"'
-        STOP
-      endif
-      if( VECSIZE_USED.gt.VECSIZE_MEMMAX .or. VECSIZE_USED.le.0 ) then
-        write(*,*) 'ERROR! Invalid VECSIZE_USED = ', VECSIZE_USED
-        STOP
-      endif
-
-      CALL FBRIDGECREATE(FBRIDGE_PBRIDGE, VECSIZE_USED, NEXTERNAL, 4) ! this must be at the beginning as it initialises the CUDA device
-      FBRIDGE_NCBYF1 = 0
-      FBRIDGE_CBYF1SUM = 0
-      FBRIDGE_CBYF1SUM2 = 0
-      FBRIDGE_CBYF1MAX = -1D100
-      FBRIDGE_CBYF1MIN = 1D100
-#else
-      fbridge_mode = 0 ! FortranOnly=0, default for FORTRAN
-      if( fbridge_mode.ne.0 ) then
-        write(*,*) 'ERROR! Invalid fbridge_mode (in FORTRAN backend mode) = ', fbridge_mode
-        STOP
-      endif
-#endif
-
+%(CUDACPP_EXTRA_INITIALISE)s
 %(DRIVER_EXTRA_INITIALISE)s
 c
 c     Read process number
@@ -281,33 +220,7 @@ c      write(*,*) 'Final xsec: ',xsec
       rewind(lun)
 
       close(lun)
-
-#ifdef MG5AMC_MEEXPORTER_CUDACPP
-      CALL FBRIDGEDELETE(FBRIDGE_PBRIDGE) ! this must be at the end as it shuts down the CUDA device
-      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
-        WRITE(*,'(a,f10.8,a,e8.2)')
-     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: MIN = ',
-     &    FBRIDGE_CBYF1MIN + 1, ' = 1 - ', -FBRIDGE_CBYF1MIN
-        WRITE(*,'(a,f10.8,a,e8.2)')
-     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: MAX = ',
-     &    FBRIDGE_CBYF1MAX + 1, ' = 1 + ', FBRIDGE_CBYF1MAX
-        WRITE(*,'(a,i6)')
-     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES = ',
-     &    FBRIDGE_NCBYF1
-c        WRITE(*,'(a,e8.2)')
-c    &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = ',
-c    &    FBRIDGE_CBYF1SUM / FBRIDGE_NCBYF1
-c       WRITE(*,'(a,e8.2)')
-c    &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: STD = ',
-c    &    SQRT( FBRIDGE_CBYF1SUM2 / FBRIDGE_NCBYF1 ) ! ~standard deviation
-        WRITE(*,'(a,e8.2,a,e8.2)')
-     &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = ',
-     &    FBRIDGE_CBYF1SUM / FBRIDGE_NCBYF1, ' +- ',
-     &    SQRT( FBRIDGE_CBYF1SUM2 ) / FBRIDGE_NCBYF1 ! ~standard error
-      ENDIF
-      CALL COUNTERS_FINALISE()
-#endif
-
+%(CUDACPP_EXTRA_FINALISE)s
 %(DRIVER_EXTRA_FINALISE)s
       end
 

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -281,6 +281,33 @@ c      write(*,*) 'Final xsec: ',xsec
       rewind(lun)
 
       close(lun)
+
+#ifdef MG5AMC_MEEXPORTER_CUDACPP
+      CALL FBRIDGEDELETE(FBRIDGE_PBRIDGE) ! this must be at the end as it shuts down the CUDA device
+      IF( FBRIDGE_MODE .LE. -1 ) THEN ! (BothQuiet=-1 or BothDebug=-2)
+        WRITE(*,'(a,f10.8,a,e8.2)')
+     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: MIN = ',
+     &    FBRIDGE_CBYF1MIN + 1, ' = 1 - ', -FBRIDGE_CBYF1MIN
+        WRITE(*,'(a,f10.8,a,e8.2)')
+     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: MAX = ',
+     &    FBRIDGE_CBYF1MAX + 1, ' = 1 + ', FBRIDGE_CBYF1MAX
+        WRITE(*,'(a,i6)')
+     &    ' [MERATIOS] ME ratio CudaCpp/Fortran: NENTRIES = ',
+     &    FBRIDGE_NCBYF1
+c        WRITE(*,'(a,e8.2)')
+c    &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = ',
+c    &    FBRIDGE_CBYF1SUM / FBRIDGE_NCBYF1
+c       WRITE(*,'(a,e8.2)')
+c    &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: STD = ',
+c    &    SQRT( FBRIDGE_CBYF1SUM2 / FBRIDGE_NCBYF1 ) ! ~standard deviation
+        WRITE(*,'(a,e8.2,a,e8.2)')
+     &    ' [MERATIOS] ME ratio CudaCpp/Fortran - 1: AVG = ',
+     &    FBRIDGE_CBYF1SUM / FBRIDGE_NCBYF1, ' +- ',
+     &    SQRT( FBRIDGE_CBYF1SUM2 ) / FBRIDGE_NCBYF1 ! ~standard error
+      ENDIF
+      CALL COUNTERS_FINALISE()
+#endif
+
 %(DRIVER_EXTRA_FINALISE)s
       end
 

--- a/madgraph/iolibs/template_files/madevent_driver.f
+++ b/madgraph/iolibs/template_files/madevent_driver.f
@@ -76,7 +76,17 @@ c      common/to_colstats/ncols,ncolflow,ncolalt,ic
 
       include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
       INTEGER VECSIZE_USED
+
+#ifdef MG5AMC_MEEXPORTER_CUDACPP
+      INCLUDE 'fbridge.inc'
+      INCLUDE 'fbridge_common.inc'
+      character*255 env_name, env_value
+      integer env_length, env_status
+#else
+      INTEGER*4 FBRIDGE_MODE ! (CppOnly=1, FortranOnly=0, BothQuiet=-1, BothDebug=-2)
       DATA VECSIZE_USED/VECSIZE_MEMMAX/ ! can be changed at runtime
+#endif
+
 %(DRIVER_EXTRA_HEADER)s
 C-----
 C  BEGIN CODE


### PR DESCRIPTION
Implement the changes originally imported via `patchMad.sh` from the CUDACPP plugin.
They are protected through `#ifdef`, and makefile has been updated to accept preprocessor macros with the `-cpp` flag.

See also related [madgraph4gpu#1040](https://github.com/madgraph5/madgraph4gpu/pull/1040).

## Summary by Sourcery

Implement upstream support for the CUDACPP plugin in the Fortran driver and enable preprocessing in the build system.

New Features:
- Add MG5AMC_MEEXPORTER_CUDACPP guard in madevent_driver.f to initialize and finalize the CUDA-accelerated Fortran-CPP bridge (FBRIDGE)
- Allow configuring FBRIDGE mode and vector sizes at runtime via CUDACPP_RUNTIME_FBRIDGEMODE and CUDACPP_RUNTIME_VECSIZEUSED environment variables
- Output MERATIOS performance metrics when running in mixed debug or quiet modes

Enhancements:
- Enable Fortran preprocessing by adding the -cpp flag to FC invocations in Template/LO/SubProcesses makefile