### PR TITLE
change nlo rule to be more nlo friendly

### DIFF
--- a/madgraph/interface/amcatnlo_interface.py
+++ b/madgraph/interface/amcatnlo_interface.py
@@ -563,7 +563,12 @@ Please also cite ref. 'arXiv:1804.10017' when using results from this code.
                 # set all the other coupling to zero
                 for o in myprocdef['model'].get_coupling_orders():
                     if o not in ['QED', 'QCD']:
-                        orders[o] = 0
+                        if self._curr_model.get('order_hierarchy')[o] == self._curr_model.get('order_hierarchy')['QCD']:
+                            orders[o] = 2*qcd
+                        elif self._curr_model.get('order_hierarchy')[o] == self._curr_model.get('order_hierarchy')['QED']:
+                            orders[o] = 2*qed
+                        else:
+                            orders[o] = 0
 
                 myprocdef.set('squared_orders', orders)
                 # warn the user of what happened
@@ -571,14 +576,24 @@ Please also cite ref. 'arXiv:1804.10017' when using results from this code.
                                 'If this is not what you need, please regenerate with the correct orders.'), 
                                 ' '.join(['%s^2<=%s' %(k,v) if v else '%s=%s' % (k,v) for k,v in myprocdef['squared_orders'].items()]), 
                                 '$MG:BOLD')
-            else:
+            else: 
                 orders = {'QED': qed, 'QCD': qcd}
                 sqorders = {'QED': 2*qed, 'QCD': 2*qcd}
                 # set all the other coupling to zero
                 for o in myprocdef['model'].get_coupling_orders():
                     if o not in ['QED', 'QCD']:
-                        orders[o] = 0
-                        sqorders[o] = 0
+                        if self._curr_model.get('order_hierarchy')[o] == self._curr_model.get('order_hierarchy')['QCD']:
+                            orders[o] = qcd
+                            sqorders[o] = 2*qcd
+                        elif self._curr_model.get('order_hierarchy')[o] == self._curr_model.get('order_hierarchy')['QED']:
+                            orders[o] = qed
+                            sqorders[o] = 2*qed
+                        elif o in self._curr_model.get('expansion_order') and self._curr_model.get('expansion_order')[o]<50:
+                            orders[o] = self._curr_model.get('expansion_order')[o]
+                            sqorders[o] = 2*self._curr_model.get('expansion_order')[o]
+                        else:
+                            orders[o] = 0
+                            sqorders[o] = 0
 
                 myprocdef.set('orders', orders)
                 myprocdef.set('squared_orders', sqorders)


### PR DESCRIPTION
Hi,

This is mostly to open the discussion and show how we can improve the situation.
This was trigger by a report of mawatari:
That the syntax:
import model DMsimp_s_spin1; generate p p > xd xd~ j [QCD]
crash in 3.x while it was working fine in 2.x

The reason is the automatic restriction of coupling square which are systematically set to zero.

The patch that I propose here, relax this condition by handling coupling order according to their hierarchy.
In top of that if the nlo_mixed_expansion is False then I relax the condition even more (but likely not needed in practise).

Cheers,

Olivier

## Summary by Sourcery

Relax the automatic zeroing of non-QED/QCD coupling orders in NLO process generation by assigning orders based on the model's order_hierarchy and expansion_order to prevent crashes.

Bug Fixes:
- Prevent crashes when generating NLO processes with non-QED/QCD couplings by avoiding indiscriminate zeroing of coupling squares

Enhancements:
- Assign non-QED/QCD coupling orders according to the model's order_hierarchy instead of setting them to zero
- Further relax coupling order restrictions when nlo_mixed_expansion is False by incorporating the model's expansion_order for eligible couplings