### PR TITLE
fix: hepmc2 extrapaths for system installed pythia

### DIFF
--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -4,6 +4,11 @@ ANNOUNCEMENT:
    2.9.X version as a LONG TERM STABLE has now an end of life for bug fixing/support in december 2025.
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
+3.6.5 (17/10/25):
+     MZ: Ensure that the code is crashing at NLO when the analysis contains a syntax error
+     OM: add a "compile" command at LO
+     OM: Fix a bug in the cudacpp where the color of the events was wrongly selected when writting the events into lhef file
+
 3.6.4 (13/9/25):
      RF: Fixed critical bug in FxFx merging, introduced in version 3.3.1. This resulted in too many negatively weighted events,
          and too many high-pT jets. Particularly relevant for merging with up to 2 or 3 jets at NLO. Thanks to Lenart Jerala

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-version = 3.6.4
-date = 2025-09-13
+version = 3.6.5
+date = 2025-10-17

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -5622,10 +5622,8 @@ PYTHIA8LINKLIBS=%(pythia8_prefix)s/lib/libpythia8.a -lz -ldl"""%{'pythia8_prefix
             compile_cluster.wait(self.me_dir, update_status)
         except Exception as  error:
             logger.warning("Compilation of the Subprocesses failed")
-            if __debug__:
-                raise
             compile_cluster.remove()
-            self.do_quit('')
+            raise aMCatNLOError(error)
 
         logger.info('Checking test output:')
         for p_dir in p_dirs:

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -3922,7 +3922,9 @@ RESTART = %(mint_mode)s
             #this gives all the flags, i.e.
             #-I/Path/to/HepMC/include -L/Path/to/HepMC/lib -lHepMC
             # we just need the path to the HepMC libraries
-            extrapaths.append(hepmc.split()[1].replace('-L', '')) 
+            for token in hepmc.split():
+                if token.startswith('-L'):
+                    extrapaths.append(token.replace('-L', ''))
 
         # check that if FxFx is activated the correct shower plugin is present
         if shower == 'PYTHIA8' and self.run_card['ickkw'] == 3:

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -3924,7 +3924,7 @@ RESTART = %(mint_mode)s
             # we just need the path to the HepMC libraries
             for token in hepmc.split():
                 if token.startswith('-L'):
-                    extrapaths.append(token.replace('-L', ''))
+                    extrapaths.append(token[2:])
 
         # check that if FxFx is activated the correct shower plugin is present
         if shower == 'PYTHIA8' and self.run_card['ickkw'] == 3:

--- a/madgraph/iolibs/template_files/auto_dsig_v4.inc
+++ b/madgraph/iolibs/template_files/auto_dsig_v4.inc
@@ -371,7 +371,16 @@ C     Select a flavor combination (need to do here for right sign)
          call SMATRIX%(proc_id)s_MULTI(p_multi, hel_rand, col_rand, channels, ALL_OUT , selected_hel, selected_col, VECSIZE_USED)
 
 
-	 DO IVEC=1,VECSIZE_USED
+	 DO CURR_WARP=1, NB_WARP_USED
+	   if(IMIRROR_VEC(CURR_WARP).EQ.1)then
+	     IB(1) = 1
+	     IB(2) = 2
+	   else
+	     IB(1) = 2
+	     IB(2) = 1	   
+	   endif
+	   DO IWARP=1, WARP_SIZE
+       IVEC = (CURR_WARP-1)*WARP_SIZE+IWARP
 	 DSIGUU = ALL_OUT(IVEC)
 	 IF (IMODE.EQ.5) THEN
             IF (DSIGUU.LT.1D199) THEN		 
@@ -411,10 +420,11 @@ c           Set sign of dsig based on sign of PDF and matrix element
 C       Generate events only if IMODE is 0.
         IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
 C       Call UNWGT to unweight and store events
-           ICONFIG = CHANNELS(IVEC)
+           ICONFIG = SYMCONF(ICONF_VEC(CURR_WARP))
            CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),%(numproc)d, selected_hel(IVEC), selected_col(IVEC), IVEC)
         ENDIF
 	ENDDO
+    ENDDO
 %(passcuts_end)s
       END
 

--- a/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_group/auto_dsig.f
+++ b/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_group/auto_dsig.f
@@ -446,52 +446,62 @@ C         Select a flavor combination (need to do here for right sign)
      $  ALL_OUT , SELECTED_HEL, SELECTED_COL, VECSIZE_USED)
 
 
-      DO IVEC=1,VECSIZE_USED
-        DSIGUU = ALL_OUT(IVEC)
-        IF (IMODE.EQ.5) THEN
-          IF (DSIGUU.LT.1D199) THEN
-            ALL_OUT(IVEC) = DSIGUU*CONV
-          ELSE
-            ALL_OUT(IVEC) = 0.0D0
+      DO CURR_WARP=1, NB_WARP_USED
+        IF(IMIRROR_VEC(CURR_WARP).EQ.1)THEN
+          IB(1) = 1
+          IB(2) = 2
+        ELSE
+          IB(1) = 2
+          IB(2) = 1
+        ENDIF
+        DO IWARP=1, WARP_SIZE
+          IVEC = (CURR_WARP-1)*WARP_SIZE+IWARP
+          DSIGUU = ALL_OUT(IVEC)
+          IF (IMODE.EQ.5) THEN
+            IF (DSIGUU.LT.1D199) THEN
+              ALL_OUT(IVEC) = DSIGUU*CONV
+            ELSE
+              ALL_OUT(IVEC) = 0.0D0
+            ENDIF
+            RETURN
           ENDIF
-          RETURN
-        ENDIF
 
-        XBK(:) = ALL_XBK(:,IVEC)
-C       CM_RAP = ALL_CM_RAP(IVEC)
-        Q2FACT(:) = ALL_Q2FACT(:, IVEC)
+          XBK(:) = ALL_XBK(:,IVEC)
+C         CM_RAP = ALL_CM_RAP(IVEC)
+          Q2FACT(:) = ALL_Q2FACT(:, IVEC)
 
-        IF(FRAME_ID.NE.6)THEN
-          CALL BOOST_TO_FRAME(ALL_PP(0,1,IVEC), FRAME_ID, P1)
-        ELSE
-          P1 = ALL_PP(:,:,IVEC)
-        ENDIF
-C       call restore_cl_val_to(ivec)
-C       DSIGUU=DSIGUU*REWGT(P1,ivec)
-        DSIGUU=DSIGUU*ALL_RWGT(IVEC)
+          IF(FRAME_ID.NE.6)THEN
+            CALL BOOST_TO_FRAME(ALL_PP(0,1,IVEC), FRAME_ID, P1)
+          ELSE
+            P1 = ALL_PP(:,:,IVEC)
+          ENDIF
+C         call restore_cl_val_to(ivec)
+C         DSIGUU=DSIGUU*REWGT(P1,ivec)
+          DSIGUU=DSIGUU*ALL_RWGT(IVEC)
 
-C       Apply the bias weight specified in the run card (default is
-C        1.0)
-        DSIGUU=DSIGUU*CUSTOM_BIAS(P1,DSIGUU,1, IVEC)
+C         Apply the bias weight specified in the run card (default is
+C          1.0)
+          DSIGUU=DSIGUU*CUSTOM_BIAS(P1,DSIGUU,1, IVEC)
 
-        DSIGUU=DSIGUU*NFACT
+          DSIGUU=DSIGUU*NFACT
 
-        IF (DSIGUU.LT.1D199) THEN
-C         Set sign of dsig based on sign of PDF and matrix element
-          ALL_OUT(IVEC)=DSIGN(CONV*ALL_PD(0,IVEC)*DSIGUU,DSIGUU
-     $     *ALL_PD(IPSEL,IVEC))
-        ELSE
-          WRITE(*,*) 'Error in matrix element'
-          DSIGUU=0D0
-          ALL_OUT(IVEC)=0D0
-        ENDIF
-C       Generate events only if IMODE is 0.
-        IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
-C         Call UNWGT to unweight and store events
-          ICONFIG = CHANNELS(IVEC)
-          CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),1,
-     $      SELECTED_HEL(IVEC), SELECTED_COL(IVEC), IVEC)
-        ENDIF
+          IF (DSIGUU.LT.1D199) THEN
+C           Set sign of dsig based on sign of PDF and matrix element
+            ALL_OUT(IVEC)=DSIGN(CONV*ALL_PD(0,IVEC)*DSIGUU,DSIGUU
+     $       *ALL_PD(IPSEL,IVEC))
+          ELSE
+            WRITE(*,*) 'Error in matrix element'
+            DSIGUU=0D0
+            ALL_OUT(IVEC)=0D0
+          ENDIF
+C         Generate events only if IMODE is 0.
+          IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
+C           Call UNWGT to unweight and store events
+            ICONFIG = SYMCONF(ICONF_VEC(CURR_WARP))
+            CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),1
+     $       , SELECTED_HEL(IVEC), SELECTED_COL(IVEC), IVEC)
+          ENDIF
+        ENDDO
       ENDDO
 
       END

--- a/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_nogroup/auto_dsig.f
+++ b/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_nogroup/auto_dsig.f
@@ -479,52 +479,62 @@ C         Select a flavor combination (need to do here for right sign)
      $  ALL_OUT , SELECTED_HEL, SELECTED_COL, VECSIZE_USED)
 
 
-      DO IVEC=1,VECSIZE_USED
-        DSIGUU = ALL_OUT(IVEC)
-        IF (IMODE.EQ.5) THEN
-          IF (DSIGUU.LT.1D199) THEN
-            ALL_OUT(IVEC) = DSIGUU*CONV
-          ELSE
-            ALL_OUT(IVEC) = 0.0D0
+      DO CURR_WARP=1, NB_WARP_USED
+        IF(IMIRROR_VEC(CURR_WARP).EQ.1)THEN
+          IB(1) = 1
+          IB(2) = 2
+        ELSE
+          IB(1) = 2
+          IB(2) = 1
+        ENDIF
+        DO IWARP=1, WARP_SIZE
+          IVEC = (CURR_WARP-1)*WARP_SIZE+IWARP
+          DSIGUU = ALL_OUT(IVEC)
+          IF (IMODE.EQ.5) THEN
+            IF (DSIGUU.LT.1D199) THEN
+              ALL_OUT(IVEC) = DSIGUU*CONV
+            ELSE
+              ALL_OUT(IVEC) = 0.0D0
+            ENDIF
+            RETURN
           ENDIF
-          RETURN
-        ENDIF
 
-        XBK(:) = ALL_XBK(:,IVEC)
-C       CM_RAP = ALL_CM_RAP(IVEC)
-        Q2FACT(:) = ALL_Q2FACT(:, IVEC)
+          XBK(:) = ALL_XBK(:,IVEC)
+C         CM_RAP = ALL_CM_RAP(IVEC)
+          Q2FACT(:) = ALL_Q2FACT(:, IVEC)
 
-        IF(FRAME_ID.NE.6)THEN
-          CALL BOOST_TO_FRAME(ALL_PP(0,1,IVEC), FRAME_ID, P1)
-        ELSE
-          P1 = ALL_PP(:,:,IVEC)
-        ENDIF
-C       call restore_cl_val_to(ivec)
-C       DSIGUU=DSIGUU*REWGT(P1,ivec)
-        DSIGUU=DSIGUU*ALL_RWGT(IVEC)
+          IF(FRAME_ID.NE.6)THEN
+            CALL BOOST_TO_FRAME(ALL_PP(0,1,IVEC), FRAME_ID, P1)
+          ELSE
+            P1 = ALL_PP(:,:,IVEC)
+          ENDIF
+C         call restore_cl_val_to(ivec)
+C         DSIGUU=DSIGUU*REWGT(P1,ivec)
+          DSIGUU=DSIGUU*ALL_RWGT(IVEC)
 
-C       Apply the bias weight specified in the run card (default is
-C        1.0)
-        DSIGUU=DSIGUU*CUSTOM_BIAS(P1,DSIGUU,1, IVEC)
+C         Apply the bias weight specified in the run card (default is
+C          1.0)
+          DSIGUU=DSIGUU*CUSTOM_BIAS(P1,DSIGUU,1, IVEC)
 
-        DSIGUU=DSIGUU*NFACT
+          DSIGUU=DSIGUU*NFACT
 
-        IF (DSIGUU.LT.1D199) THEN
-C         Set sign of dsig based on sign of PDF and matrix element
-          ALL_OUT(IVEC)=DSIGN(CONV*ALL_PD(0,IVEC)*DSIGUU,DSIGUU
-     $     *ALL_PD(IPSEL,IVEC))
-        ELSE
-          WRITE(*,*) 'Error in matrix element'
-          DSIGUU=0D0
-          ALL_OUT(IVEC)=0D0
-        ENDIF
-C       Generate events only if IMODE is 0.
-        IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
-C         Call UNWGT to unweight and store events
-          ICONFIG = CHANNELS(IVEC)
-          CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),1,
-     $      SELECTED_HEL(IVEC), SELECTED_COL(IVEC), IVEC)
-        ENDIF
+          IF (DSIGUU.LT.1D199) THEN
+C           Set sign of dsig based on sign of PDF and matrix element
+            ALL_OUT(IVEC)=DSIGN(CONV*ALL_PD(0,IVEC)*DSIGUU,DSIGUU
+     $       *ALL_PD(IPSEL,IVEC))
+          ELSE
+            WRITE(*,*) 'Error in matrix element'
+            DSIGUU=0D0
+            ALL_OUT(IVEC)=0D0
+          ENDIF
+C         Generate events only if IMODE is 0.
+          IF(IMODE.EQ.0.AND.DABS(ALL_OUT(IVEC)).GT.0D0)THEN
+C           Call UNWGT to unweight and store events
+            ICONFIG = SYMCONF(ICONF_VEC(CURR_WARP))
+            CALL UNWGT(ALL_PP(0,1,IVEC), ALL_OUT(IVEC)*ALL_WGT(IVEC),1
+     $       , SELECTED_HEL(IVEC), SELECTED_COL(IVEC), IVEC)
+          ENDIF
+        ENDDO
       ENDDO
 
       END


### PR DESCRIPTION
Running on my computer:
```bash
$ pythia8-config --hepmc2
-lHepMC
```
results in the `extrapath` append code failing with an `IndexError`.

## Summary by Sourcery

Bug Fixes:
- Iterate over hepmc2 output tokens to extract '-L' library paths instead of using a fixed index, avoiding IndexError when no '-L' flag is present