### PR TITLE
Remove invalid XML characters from info line

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -220,10 +220,10 @@ class CmdExtended(cmd.Cmd):
                                 bzrversion)
         elif os.path.exists(pjoin(MG5DIR, 'bin', 'create_release.py')):
             logger_stderr.critical("Note that this is a development version.\nThis version is intended for development/beta testing and NOT for production.\nThis version has not been fully tested (if at all) and might have limited user support (if at all)")
-            info_line += "\033[1;31m#*%s*\033[1;0m\n" % (' '*58)
-            info_line += "\033[1;31m#*          WARNING: UNKNOWN DEVELOPMENT VERSION.           *\033[1;0m\n"
-            info_line += "\033[1;31m#*            WARNING: DO NOT USE FOR PRODUCTION            *\033[1;0m\n"
-            info_line += "\033[1;31m#*%s*\033[1;0m\n" % (' '*58)
+            info_line += "#*%s*\n" % (' '*58)
+            info_line += "#*          WARNING: UNKNOWN DEVELOPMENT VERSION.           *\n"
+            info_line += "#*            WARNING: DO NOT USE FOR PRODUCTION            *\n"
+            info_line += "#*%s*\n" % (' '*58)
 
         # Create a header for the history file.
         # Remember to fill in time at writeout time!


### PR DESCRIPTION
I think formally lhe files should satisfy XML conventions. `xmllint` does not like the ASCII colors in the info line output of the development version:

```bash
$ xmllint unweighted_events.lhe
unweighted_events.lhe:48: parser error : CData section not finished

#************************************************
#*                                                          *
^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*                                                          *
^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*                                                          *
                                                                    ^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*          WARNING: UNKNOWN DEVELOPMENT VERSION.           *
^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*          WARNING: UNKNOWN DEVELOPMENT VERSION.           *
                                                                    ^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*            WARNING: DO NOT USE FOR PRODUCTION            *
^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*            WARNING: DO NOT USE FOR PRODUCTION            *
                                                                    ^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*                                                          *
^
unweighted_events.lhe:48: parser error : PCDATA invalid Char value 27
#*                                                          *
                                                                    ^
unweighted_events.lhe:82: parser error : Sequence ']]>' not allowed in content
set default_unset_couplings 99
```

This is a problem for `pylhe`  which uses pythons `ET.iterparse` that crashes on these characters with a `Parse Error: not well-formed (invalid token): line 48, column 0` [1]. We could patch pylhe to filter ASCII color characters, but before that ugly patch maybe it is better to fix the issue in madgraph itself?

[1] https://github.com/scikit-hep/pylhe/issues/323

## Summary by Sourcery

Bug Fixes:
- Strip ASCII color codes from the info line to prevent XML parsing errors

## Summary by Sourcery

Bug Fixes:
- Strip ASCII color codes from the info line to prevent invalid XML characters during parsing.