### PR TITLE
Properly prefix regex strings with r

### DIFF
--- a/madgraph/iolibs/export_cpp.py
+++ b/madgraph/iolibs/export_cpp.py
@@ -79,8 +79,8 @@ class UFOModelConverterCPP(object):
                  "complex": "std::complex<double>"}
 
     # Regular expressions for cleaning of lines from Aloha files
-    compiler_option_re = re.compile('^#\w')
-    namespace_re = re.compile('^using namespace')
+    compiler_option_re = re.compile(r'^#\w')
+    namespace_re = re.compile(r'^using namespace')
 
     slha_to_depend = {('SMINPUTS', (3,)): ('aS',),
                       ('SMINPUTS', (1,)): ('aEM',)}

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -4186,7 +4186,7 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         elif '%(W)s' in arg['mass']:
             raise Exception
 
-        arg['coup'] = re.sub('coup(\d+)\)s','coup\g<1>)s%(vec\g<1>)s', arg['coup'])
+        arg['coup'] = re.sub(r'coup(\d+)\)s',r'coup\g<1>)s%(vec\g<1>)s', arg['coup'])
 
         return call, arg
     

--- a/madgraph/iolibs/helas_call_writers.py
+++ b/madgraph/iolibs/helas_call_writers.py
@@ -1726,7 +1726,7 @@ class CPPUFOHelasCallWriter(UFOHelasCallWriter):
 class GPUFOHelasCallWriter(CPPUFOHelasCallWriter):
 
 
-    findcoupling = re.compile('pars->([-]*[\d\w_]+)\s*,')
+    findcoupling = re.compile(r'pars->([-]*[\d\w_]+)\s*,')
     usepointerforvertex = True
 
     def format_coupling(self, call):

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -939,7 +939,7 @@ class UFOMG5Converter(object):
     def get_symmetric_color(old_color, substitution):
         """ """
         all_color_flag = ['f','d', 'Epsilon', 'EpsilonBar', 'K6', 'K6Bar', 'T', 'T6', 'Tr' ]
-        split = re.split("(%s)\(([\d,\s\-\+]*)\)" % '|'.join(all_color_flag), old_color)
+        split = re.split(r"(%s)\(([\d,\s\-\+]*)\)" % '|'.join(all_color_flag), old_color)
         new_expr = ''
         for i in range(len(split)):
             if i % 3 == 0:
@@ -996,7 +996,7 @@ class UFOMG5Converter(object):
         for old,new in substitution.items():
                 new_spins[new] = lor_orig.spins[old]
 
-        split = re.split("(%s)\(([\d,\s\-\+]*)\)" % '|'.join(self.all_aloha_obj), lor_orig.structure )
+        split = re.split(r"(%s)\(([\d,\s\-\+]*)\)" % '|'.join(self.all_aloha_obj), lor_orig.structure )
         new_expr = ''
         for i in range(len(split)):
             if i % 3 == 0:


### PR DESCRIPTION
with python3.13 I get these warnings
```
/opt/madgraph/iolibs/export_cpp.py:82: SyntaxWarning: invalid escape sequence '\w'
  compiler_option_re = re.compile('^#\w')
/opt/madgraph/iolibs/helas_call_writers.py:1729: SyntaxWarning: invalid escape sequence '\d'
  findcoupling = re.compile('pars->([-]*[\d\w_]+)\s*,')
/opt/madgraph/iolibs/export_v4.py:4189: SyntaxWarning: invalid escape sequence '\d'
  arg['coup'] = re.sub('coup(\d+)\)s','coup\g<1>)s%(vec\g<1>)s', arg['coup'])
/opt/madgraph/iolibs/export_v4.py:4189: SyntaxWarning: invalid escape sequence '\g'
  arg['coup'] = re.sub('coup(\d+)\)s','coup\g<1>)s%(vec\g<1>)s', arg['coup'])
/opt/models/import_ufo.py:942: SyntaxWarning: invalid escape sequence '\('
  split = re.split("(%s)\(([\d,\s\-\+]*)\)" % '|'.join(all_color_flag), old_color)
/opt/models/import_ufo.py:999: SyntaxWarning: invalid escape sequence '\('
  split = re.split("(%s)\(([\d,\s\-\+]*)\)" % '|'.join(self.all_aloha_obj), lor_orig.structure )
  ```

Using r-strings avoids adding escape characters. This is probably not the complete set of regex-string calls, but just what I  noticed first.

## Summary by Sourcery

Enhancements:
- Convert regex patterns to raw strings across modules to eliminate invalid escape sequence warnings