### PR TITLE
Fix quotes and permissions in PYTHIA8 script

### DIFF
--- a/Template/NLO/MCatNLO/Scripts/MCatNLO_MadFKS_PYTHIA8.Script
+++ b/Template/NLO/MCatNLO/Scripts/MCatNLO_MadFKS_PYTHIA8.Script
@@ -228,20 +228,20 @@ export PYTHIA8LOCATION=$PY8PATH
 
 # check the PYTHIA8 version by the position of certain files
 
-if [ ! -d $PYTHIA8LOCATION/xmldoc ]
+if [ ! -d "$PYTHIA8LOCATION/xmldoc" ]
 then
-  if [ -f $PYTHIA8LOCATION/share/Pythia8/xmldoc/Version.xml ]
+  if [ -f "$PYTHIA8LOCATION/share/Pythia8/xmldoc/Version.xml" ]
   then
     while read line; do
     if [[ $line == *"Pythia:versionNumber"*"8.2"* ]]; then PY8VER="8.2" ; echo ' USING PYTHIA 8.2xy' ; fi
     if [[ $line == *"Pythia:versionNumber"*"8.3"* ]]; then PY8VER="8.3" ; echo ' USING PYTHIA 8.3xy' ; fi
-    done < $PYTHIA8LOCATION/share/Pythia8/xmldoc/Version.xml
+    done < "$PYTHIA8LOCATION/share/Pythia8/xmldoc/Version.xml"
   else
     echo "Cannot determine Pythia8 version, stopping run"
     exit -1
   fi
-  chmod +x $PYTHIA8LOCATION/bin/pythia8-config
-  read HEPMCINCLIB <<< $($PYTHIA8LOCATION/bin/pythia8-config --hepmc2)
+  [ -x "$PYTHIA8LOCATION/bin/pythia8-config" ] || chmod +x "$PYTHIA8LOCATION/bin/pythia8-config"
+  read HEPMCINCLIB <<< $("$PYTHIA8LOCATION/bin/pythia8-config" --hepmc2)
 else
   PY8VER="8.1"
   echo ' USING PYTHIA 8.1xy'


### PR DESCRIPTION
I got this error:
```
chmod: changing permissions of '/usr/bin/pythia8-config': Operation not permitted
make: *** No rule to make target '/usr/lib/libpythia8.a', needed by 'Pythia83'.  Stop.
```
which is already executable and owned by root.

This changes the code to only call `chmod +x` if it is not already executable. Also `$PYTHIA8LOCATION` could have spaces => quote it.

## Summary by Sourcery

Fix quoting and conditional permission changes in the PYTHIA8 setup script

Bug Fixes:
- Quote $PYTHIA8LOCATION path to support locations containing spaces
- Only invoke chmod +x when the target file is not already executable