### PR TITLE
Fix import error in tarball

### DIFF
--- a/madgraph/iolibs/files.py
+++ b/madgraph/iolibs/files.py
@@ -153,7 +153,7 @@ def cp(path1, path2, log=True, error=False):
     except IOError as why:
         try:
             import madgraph.various.misc as misc
-        except ImportError:
+        except ModuleNotFoundError:
             import internal.misc as misc
         try: 
             if 'same file' in  str(why):

--- a/madgraph/iolibs/files.py
+++ b/madgraph/iolibs/files.py
@@ -151,7 +151,10 @@ def cp(path1, path2, log=True, error=False):
         logger.debug('no cp since identical: %s', why)
         return
     except IOError as why:
-        import madgraph.various.misc as misc
+        try:
+            import madgraph.various.misc as misc
+        except ImportError:
+            import internal.misc as misc
         try: 
             if 'same file' in  str(why):
                 return


### PR DESCRIPTION
Fix an import error when the madgraph module is named internal, e.g. in a tarball.

See https://answers.launchpad.net/mg5amcnlo/+question/823283

## Summary by Sourcery

Bug Fixes:
- Fall back to importing misc utilities from an internal module if the standard madgraph package import fails during IOError handling in file copy operations.