### PR TITLE
Patch for CPP writer to mach fortran for FDgauge

### DIFF
--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -1484,6 +1484,8 @@ class ALOHAWriterForCPP(WriteALOHA):
             shift = 0
         else:
             shift =  self.momentum_size - 1
+            if aloha.unitary_gauge == 3 and match.group('var').startswith('S'):
+                shift += 4 #to match Fortran
         return '%s[%s]' % (match.group('var'), int(match.group('num')) + shift)
               
     


### PR DESCRIPTION
Just added 2 lines to match shifting of indices for scalar variables for FD gauge in CPP writer.

## Summary by Sourcery

Bug Fixes:
- Correct scalar variable index offsets in the C++ writer when using FD gauge with unitary_gauge == 3 to match the Fortran implementation.