### PR TITLE
HotFix: Import logging before using it in ./bin/mg5_aMC

### DIFF
--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -23,7 +23,6 @@ and call immediately the command line interface scripts"""
 import sys
 import logging
 import logging.config
-import madgraph.interface.coloring_logging
 if sys.version_info < (3, 7):
    sys.exit('MadGraph5_aMC@NLO works with python 3.7 or higher.\n\
               Please upgrade your version of python.')
@@ -80,6 +79,9 @@ if __debug__ and not options.debug and \
         result.communicate()
         return_code = result.returncode
         sys.exit(return_code)
+
+import madgraph.interface.coloring_logging
+
 
 if ' ' in os.getcwd():
     logging.warning("\033[91mThe current working directory (%s) does contain spaces. We advise that you change the location of the code/working area to avoid to have space in such path.\033[0m", os.getcwd())

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -21,6 +21,9 @@ start = time.time()
 and call immediately the command line interface scripts"""
 
 import sys
+import logging
+import logging.config
+import madgraph.interface.coloring_logging
 if sys.version_info < (3, 7):
    sys.exit('MadGraph5_aMC@NLO works with python 3.7 or higher.\n\
               Please upgrade your version of python.')
@@ -77,11 +80,6 @@ if __debug__ and not options.debug and \
         result.communicate()
         return_code = result.returncode
         sys.exit(return_code)
-
-import logging
-import logging.config
-import madgraph.interface.coloring_logging
-
 
 if ' ' in os.getcwd():
     logging.warning("\033[91mThe current working directory (%s) does contain spaces. We advise that you change the location of the code/working area to avoid to have space in such path.\033[0m", os.getcwd())


### PR DESCRIPTION
In case of python < 3.10, logging is used in the deprecation warning before being imported.
Easy fix is to move the import up.

@roiser

## Summary by Sourcery

Bug Fixes:
- Prevent failures in Python versions prior to 3.10 where logging was used in a deprecation warning before being imported.