### PR TITLE
Fix: implicit typing bug in `GET_JAMP`/`GET_LNJAMP` (matchbox split-orders template)

### DIFF
--- a/madgraph/iolibs/template_files/matrix_standalone_matchbox_splitOrders_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_standalone_matchbox_splitOrders_v4.inc
@@ -351,11 +351,11 @@ C ----------
 
       SUBROUTINE %(proc_prefix)sGET_JAMP(njamp, SOINDEX, ONEJAMP)
 
-      INTEGER     NCOLOR, NJAMP
+      INTEGER     NCOLOR, NJAMP, SOINDEX
       PARAMETER (NCOLOR=%(ncolor)d) 
       INTEGER NAMPSO
       PARAMETER (NAMPSO=%(nAmpSplitOrders)d)
-      COMPLEX*16  JAMP(NCOLOR,NAMPSO), ONEJAMP
+      COMPLEX*16  JAMP(NCOLOR,NAMPSO), LNJAMP(NCOLOR,NAMPSO), ONEJAMP
       COMMON/%(proc_prefix)sJAMP/JAMP,LNJAMP
 	
 	  ONEJAMP = JAMP(njamp+1, SOINDEX) ! +1 since njamp start at zero (c convention)
@@ -363,7 +363,7 @@ C ----------
 
        SUBROUTINE %(proc_prefix)sGET_LNJAMP(njamp, SOINDEX, ONEJAMP)
 
-      INTEGER     NCOLOR, NJAMP
+      INTEGER     NCOLOR, NJAMP, SOINDEX
       PARAMETER (NCOLOR=%(ncolor)d) 
       INTEGER NAMPSO
       PARAMETER (NAMPSO=%(nAmpSplitOrders)d)
@@ -393,7 +393,7 @@ C ----------
     return 
     end
 
-    subroutine %(proc_prefix)sget_chosen_so_config(M,N, out)
+    subroutine %(proc_prefix)s_get_chosen_so_config(M,N, out)
 
     integer M, N
     logical out


### PR DESCRIPTION
This is related to #223. 

## Summary of changes

### Problem

When calling `GET_JAMP` / `GET_LNJAMP` from C (via Herwig's Matchbox interface), the array bounds check crashed with:                                                     

```
Index '0' of dimension 2 of array 'jamp' below lower bound of 1
```
### Cause

In `matrix_standalone_matchbox_splitOrders_v4.inc`, the subroutines `GET_JAMP` and `GET_LNJAMP` take `SOINDEX` as an argument but never declare it. `GET_JAMP` also references `LNJAMP` in its `COMMON` block without declaring it, producing a silent size mismatch against `MATRIX` / `BORN`.

### Fix

In both `GET_JAMP` and `GET_LNJAMP`:
- Add `SOINDEX` to the `INTEGER` declaration.
- Declare `LNJAMP(NCOLOR,NAMPSO)` alongside `JAMP` so the `COMMON` block matches the other subroutines for backwards compatibility.

## Note

I opened this PR targeting 3.5.14 branch. I am not sure if this is the correct procedure, but I am happy to adjust the target if needed.

## Summary by Sourcery

Fix implicit typing and common-block declarations in matchbox split-orders standalone matrix interface to prevent array bound errors when accessing JAMP data from C.

Bug Fixes:
- Declare SOINDEX as an integer argument in GET_JAMP and GET_LNJAMP to avoid out-of-bounds array access in JAMP when called from C.
- Declare LNJAMP in the GET_JAMP common block with the correct dimensions to match other subroutines and prevent size mismatches.

Enhancements:
- Normalize the name of the get_chosen_so_config helper subroutine to use the consistent proc_prefix-based naming convention.