### PR TITLE
fix: preserve user multiparticles when reloading model for NLO unmerge

### DIFF
--- a/madgraph/interface/loop_interface.py
+++ b/madgraph/interface/loop_interface.py
@@ -17,6 +17,7 @@
 """
 
 from __future__ import absolute_import
+import copy
 import os
 import shutil
 import time
@@ -310,7 +311,14 @@ class CommonLoopInterface(mg_interface.MadGraphCmd):
             self.exec_cmd('set apply_flavor_grouping False', precmd=True)
             assert self.options['apply_flavor_grouping'] == False
             model_name = self._curr_model.get('name')
+            # Preserve user-defined multiparticles: reloading the model triggers
+            # add_default_multiparticles which auto-removes the photon from p/j
+            # when the plain (non-loop) model has no QED perturbation couplings.
+            # Since this reload is an internal NLO operation (not a user model
+            # switch), all previously valid multiparticle definitions must survive.
+            saved_multiparticles = copy.deepcopy(self._multiparticles)
             self.exec_cmd(" import model %s" % (model_name), precmd=True)
+            self._multiparticles = saved_multiparticles
         
         if not isinstance(self._curr_model,loop_base_objects.LoopModel) or \
            self._curr_model['perturbation_couplings']==[] or \


### PR DESCRIPTION
When validate_model() in loop_interface.py detects merged particles, it reloads the same SM model via exec_cmd to strip flavor merging before NLO generation. That import model call triggers add_default_multiparticles() which auto-removes the photon (PDG 22) from p/j because the reloaded plain tree-level SM model has no QED in its perturbation_couplings. This silently erased any user-defined 'define p p a' customization, producing 9 born processes instead of 12.

Fix: deep-copy _multiparticles before the internal model reload and restore it afterwards. This reload is an internal NLO operation, not a user-level model switch, so all previously valid multiparticle definitions must survive unchanged.

## Summary by Sourcery

Bug Fixes:
- Prevent loss of user-customized multiparticle configurations (such as including the photon in p/j) when validate_model() reloads the model for NLO unmerge handling.