### PR TITLE
preserve negative iseed in run_card across runs

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -326,10 +326,10 @@ jobs:
       - uses: actions/checkout@v5
 
       # Runs a set of commands using the runners shell
-      - name: test one of the test test_autodef_nomissmatch test_basic test_check_valid_LO test_custom_fcts test_default test_fixed_fac_scale_block test_guess_entry_fromname test_pdlabel_block test_analyse_card_analyse test_analyse_card_default test_create_param_dict test_define_not_dep_param test_order_param test_write_block test_write_param test_write_qnumber test_define_not_dep_param test_full_write test_write_orders test_write_particles test_write_vertices test_add_external_parameters test_add_particle test_couplings test_identify_particle
+      - name: test one of the test test_autodef_nomissmatch test_basic test_check_valid_LO test_custom_fcts test_default test_fixed_fac_scale_block test_guess_entry_fromname test_negative_iseed test_pdlabel_block test_analyse_card_analyse test_analyse_card_default test_create_param_dict test_define_not_dep_param test_order_param test_write_block test_write_param test_write_qnumber test_define_not_dep_param test_full_write test_write_orders test_write_particles test_write_vertices test_add_external_parameters test_add_particle test_couplings test_identify_particle
         run: |
             cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_autodef_nomissmatch test_basic test_check_valid_LO test_custom_fcts test_default test_fixed_fac_scale_block test_guess_entry_fromname test_pdlabel_block test_analyse_card_analyse test_analyse_card_default test_create_param_dict test_define_not_dep_param test_order_param test_write_block test_write_param test_write_qnumber test_define_not_dep_param test_full_write test_write_orders test_write_particles test_write_vertices test_add_external_parameters test_add_particle test_couplings test_identify_particle -t0
+            ./tests/test_manager.py test_autodef_nomissmatch test_basic test_check_valid_LO test_custom_fcts test_default test_fixed_fac_scale_block test_guess_entry_fromname test_negative_iseed test_pdlabel_block test_analyse_card_analyse test_analyse_card_default test_create_param_dict test_define_not_dep_param test_order_param test_write_block test_write_param test_write_qnumber test_define_not_dep_param test_full_write test_write_orders test_write_particles test_write_vertices test_add_external_parameters test_add_particle test_couplings test_identify_particle -t0
 
 
 

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -1904,10 +1904,12 @@ class aMCatNLOCmd(CmdExtended, HelpToCmd, CompleteForCmd, common_run.CommonRunCm
 
 
     def update_random_seed(self):
-        """Update random number seed with the value from the run_card. 
+        """Update random number seed with the value from the run_card.
         If this is 0, update the number according to a fresh one.
-        If a specific seed is set, reset it to 0 in the run_card after use
-        to ensure that subsequent runs will be statistically independent."""
+        If a positive seed is set, reset it to 0 in the run_card after use
+        to ensure that subsequent runs will be statistically independent.
+        A negative seed is preserved in the run_card across runs and its
+        absolute value is used as the actual seed for the Fortran code."""
         iseed = self.run_card['iseed']
         if iseed == 0:
             randinit = open(pjoin(self.me_dir, 'SubProcesses', 'randinit'))
@@ -1915,6 +1917,7 @@ class aMCatNLOCmd(CmdExtended, HelpToCmd, CompleteForCmd, common_run.CommonRunCm
             randinit.close()
         else:
             self.reset_iseed_in_run_card()
+            iseed = abs(iseed)
         randinit = open(pjoin(self.me_dir, 'SubProcesses', 'randinit'), 'w')
         randinit.write('r=%d' % iseed)
         randinit.close()

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4980,12 +4980,14 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         return libdir
 
     def reset_iseed_in_run_card(self):
-        """If iseed is set to a non-zero value in the run_card, reset it to 0
+        """If iseed is set to a positive value in the run_card, reset it to 0
         and write the updated run_card to disk.  This ensures that subsequent
         runs will use an automatically-generated (independent) seed rather than
-        repeating the same one."""
+        repeating the same one. A negative iseed is preserved so the user can
+        keep reusing the same seed across runs (the absolute value is the
+        actual seed passed to the Fortran code)."""
         iseed = self.run_card['iseed']
-        if iseed != 0:
+        if iseed > 0:
             self.run_card['iseed'] = 0
             # Reset seed in run_card to 0, to ensure that following runs
             # will be statistically independent

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -6128,7 +6128,9 @@ tar -czf split_$1.tar.gz split_$1
         
         # set random number
         if self.run_card['iseed'] != 0:
-            self.random = int(self.run_card['iseed'])
+            # negative iseed: keep it in the run_card across runs and use its
+            # absolute value as the actual seed for the Fortran code
+            self.random = abs(int(self.run_card['iseed']))
             self.reset_iseed_in_run_card()
             time_mod = max([os.path.getmtime(pjoin(self.me_dir,'Cards','run_card.dat')),
                         os.path.getmtime(pjoin(self.me_dir,'Cards','param_card.dat'))])

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -3317,6 +3317,12 @@ class RunCard(ConfigFile):
         else:
             return value
 
+    def mod_inc_iseed(self, value):
+        """A negative iseed in the run_card is preserved across runs (so the
+        same seed can be reused), but the Fortran code expects a non-negative
+        seed, so export the absolute value to the include file."""
+        return abs(value)
+
     def edit_dummy_fct_from_file(self, filelist, outdir):
         """
         filelist is a list of input files (given by the user)

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -1163,6 +1163,76 @@ c
         self.assertIn("True = fixed_fac_scale2", f.getvalue())
 
 
+    def test_negative_iseed(self):
+        """Check that a negative iseed is preserved on disk across runs but
+        exported as its absolute value to the Fortran include file. This is
+        verified for both LO and NLO run cards, and for the
+        `reset_iseed_in_run_card` helper used at run time.
+        """
+        import madgraph.interface.common_run_interface as common_run
+
+        for run_card_class in (bannermod.RunCardLO, bannermod.RunCardNLO):
+            # 1. write_include_file must export abs(iseed)
+            run_card = run_card_class()
+            run_card.set('iseed', -42, user=True)
+            f = io.StringIO()
+            run_card.write_include_file(None, output_file=f)
+            content = f.getvalue()
+            self.assertIn("iseed = 42", content)
+            self.assertNotIn("iseed = -42", content)
+
+            # positive value is unchanged
+            run_card = run_card_class()
+            run_card.set('iseed', 7, user=True)
+            f = io.StringIO()
+            run_card.write_include_file(None, output_file=f)
+            self.assertIn("iseed = 7", content := f.getvalue())
+            self.assertNotIn("iseed = -7", content)
+
+            # 2. reset_iseed_in_run_card preserves negative iseed on disk
+            #    but resets a positive iseed to 0
+            me_dir = tempfile.mkdtemp(prefix='amc_iseed_')
+            os.mkdir(pjoin(me_dir, 'Cards'))
+            try:
+                # negative case: must NOT be reset to 0
+                run_card = run_card_class()
+                run_card.set('iseed', -42, user=True)
+                run_card.write(pjoin(me_dir, 'Cards', 'run_card.dat'))
+
+                class FakeCmd:
+                    pass
+                fake = FakeCmd()
+                fake.run_card = run_card
+                fake.me_dir = me_dir
+
+                common_run.CommonRunCmd.reset_iseed_in_run_card(fake)
+                self.assertEqual(run_card['iseed'], -42)
+                # also check the on-disk value
+                reloaded = bannermod.RunCard(pjoin(me_dir, 'Cards', 'run_card.dat'))
+                self.assertEqual(reloaded['iseed'], -42)
+
+                # positive case: must be reset to 0
+                run_card = run_card_class()
+                run_card.set('iseed', 7, user=True)
+                run_card.write(pjoin(me_dir, 'Cards', 'run_card.dat'))
+                fake.run_card = run_card
+                common_run.CommonRunCmd.reset_iseed_in_run_card(fake)
+                self.assertEqual(run_card['iseed'], 0)
+                reloaded = bannermod.RunCard(pjoin(me_dir, 'Cards', 'run_card.dat'))
+                self.assertEqual(reloaded['iseed'], 0)
+
+                # zero case: nothing happens, stays at zero
+                run_card = run_card_class()
+                run_card.set('iseed', 0, user=True)
+                run_card.write(pjoin(me_dir, 'Cards', 'run_card.dat'))
+                fake.run_card = run_card
+                common_run.CommonRunCmd.reset_iseed_in_run_card(fake)
+                self.assertEqual(run_card['iseed'], 0)
+            finally:
+                import shutil
+                shutil.rmtree(me_dir)
+
+
 MadLoopParam = bannermod.MadLoopParam
 class TestMadLoopParam(unittest.TestCase):
     """ A class to test the MadLoopParam functionality """


### PR DESCRIPTION
## Summary

- Allow a negative `iseed` in the `run_card` as an opt-out to the existing reset-to-0 behavior. A negative value is preserved on disk so subsequent runs reuse the same seed.
- The Fortran code still receives a non-negative seed: the absolute value is exported both to the `run_card.inc` include file and to the `randinit` file. This means `iseed = -5` produces the exact same effective seed as `iseed = 5` for a single run.
- Behavior is consistent at LO (madevent) and NLO (amc@nlo).

## Changes

- `madgraph/interface/common_run_interface.py` — `reset_iseed_in_run_card` only resets when `iseed > 0`, preserving negative values.
- `madgraph/interface/madevent_interface.py` — LO uses `abs(iseed)` for `self.random`.
- `madgraph/interface/amcatnlo_run_interface.py` — NLO writes `abs(iseed)` to `randinit` when negative.
- `madgraph/various/banner.py` — adds `mod_inc_iseed` on `RunCard` so the include file always gets `abs(iseed)` (covers both LO and NLO via the existing `mod_inc_<key>` mechanism).
- `tests/unit_tests/various/test_banner.py` — new `test_negative_iseed` covers both LO and NLO: include-file export, on-disk preservation of negative iseed, and unchanged reset for positive iseed.
- `.github/workflows/unittest.yml` — wires the new test into `unittest_15`.

## Test plan

- [x] `./tests/test_manager.py test_negative_iseed -t0` passes.
- [x] All 29 existing tests in `test_banner.py` still pass.
- [x] CI (`unittest_15`) green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow negative random seeds in run cards to be preserved across runs while still providing non-negative seeds to the Fortran backends, with consistent behavior at LO and NLO.

Bug Fixes:
- Prevent unintended resetting of user-chosen negative random seeds in run cards by only zeroing positive seeds between runs.

Enhancements:
- Export the absolute value of the random seed from run cards to the Fortran include files and NLO randinit file so negative seeds are handled transparently.
- Unify random seed handling between LO and NLO interfaces so they both interpret negative seeds as reusable while passing their absolute value to the generator.

CI:
- Include the new negative-seed behavior test in the unittest_15 GitHub Actions workflow.

Tests:
- Add a unit test covering negative iseed behavior for both LO and NLO run cards, including include-file export and on-disk persistence.