### PR TITLE
Walk amplitude ancestors when pre-tagging flavor externals

### DIFF
--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1542,7 +1542,9 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 return ans
 
         # check special case for external wavefunction
-        assert( len(self.get('mothers'))!=0)
+        assert len(self.get('mothers')) != 0, \
+            "propagate_flavor_tag called on external wavefunction; " \
+            "caller must use tag_external_flavor or ensure externals are pre-tagged"
         try:
             del self[tag_name]
         except:
@@ -3704,7 +3706,10 @@ class HelasDiagram(base_objects.PhysicsObject):
         # loop below, so they remain un-tagged when propagate_flavor_tag tries
         # to access them — triggering an AssertionError.
         # Fix: before the main loop, walk the full ancestor tree of every
-        # wavefunction and tag any external ancestor not already in the list.
+        # wavefunction *and amplitude* and tag any external ancestor not
+        # already in the list.  Amplitudes must be included because decay-chain
+        # insertion (insert_decay) can rewrite amplitude mothers to wavefunctions
+        # that live outside self['wavefunctions'].
         def _tag_external_ancestors(wf):
             """Recursively tag external (no-mothers) wavefunctions."""
             if len(wf.get('mothers')) == 0:
@@ -3714,11 +3719,10 @@ class HelasDiagram(base_objects.PhysicsObject):
                     _tag_external_ancestors(m)
 
         wf_in_list = set(id(wfct) for wfct in self['wavefunctions'])
-        for wfct in self['wavefunctions']:
-            if len(wfct.get('mothers')) > 0:
-                for m in wfct.get('mothers'):
-                    if id(m) not in wf_in_list:
-                        _tag_external_ancestors(m)
+        for obj in list(self['wavefunctions']) + list(self['amplitudes']):
+            for m in obj.get('mothers'):
+                if id(m) not in wf_in_list:
+                    _tag_external_ancestors(m)
 
         if debug:misc.sprint(len(self['wavefunctions']), len(self['amplitudes']), [id(w) for w in self['wavefunctions']], [id(w) for w in self['amplitudes']])
         for wfct in self['wavefunctions']:

--- a/madgraph/various/lhe_parser.py
+++ b/madgraph/various/lhe_parser.py
@@ -2829,7 +2829,6 @@ class Event(list):
               for easier development debug output allow to return internal variable for the unittest to check
         """  
 
-        misc.sprint(self)
         p = self.get_momenta(get_order, allow_reversed, merged_map=merged_map)
 
         # When the ME legs use merged-particle IDs, event PDGs need the same


### PR DESCRIPTION
## Summary
- `HelasDiagram.check_flavor` pre-pass now walks both `self['wavefunctions']` and `self['amplitudes']`, so externals reachable only through an amplitude (typical after decay-chain insertion) get tagged before `propagate_flavor_tag` recurses into them.
- Promote the bare `assert(len(self.get('mothers'))!=0)` in `HelasWavefunction.propagate_flavor_tag` to one with a message naming the contract it enforces (caller must use `tag_external_flavor` or pre-tag externals).

## Why
`test_madspin_gridpack` (`g g > t t~, t~ > W- b > q q~ b`) was tripping the assert restored in d4395c2dc. The previous pre-pass iterated only wavefunctions, but `insert_decay` can rewrite an amplitude's mothers to wavefunctions outside `self['wavefunctions']`, with their own external ancestors also outside the list. Those externals were never tagged, so when `HelasAmplitude.propagate_flavor_tag` recursed into them via `HelasWavefunction.propagate_flavor_tag`, the contract assert fired. Just removing the assert would silently mishandle merged-particle externals (wrong flavor index, or `interaction_dict[0]` lookup) — fixing the pre-pass is the root-cause fix.

## Test plan
- [x] `python tests/test_manager.py -pA -t0 test_madspin_gridpack -l INFO` — passes (53s, was failing on the assert)
- [x] `python tests/test_manager.py -p U test_madspin` — 22 unit tests OK

## Summary by Sourcery

Ensure flavor-tag prepass covers ancestors reachable via amplitudes and tighten contracts around external wavefunction tagging.

Bug Fixes:
- Tag external wavefunctions reachable only through amplitudes during flavor-check pre-pass to prevent assertion failures when propagating flavor tags.

Enhancements:
- Clarify the assertion in external wavefunction flavor-tag propagation to document the expected pre-tagging contract.
- Remove leftover debug printing from LHE momentum extraction to reduce noisy output.