### PR TITLE
Fix BROKEN_SYM for grouped flavor rows in decayed/polarized processes

### DIFF
--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5382,6 +5382,19 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         for i, flav in enumerate(all_flav):
             flav_positions = [str(pdg_to_group_pos.get(f, f)) for f in flav[0]]
             replace_dict['get_flavor_matrix'] += ' DATA (FLAVOR(i,  %d),i=  1, NEXTERNAL) /%s/\n' % (i+1, ', '.join(flav_positions))
+
+        # In addition to the IFLAV-indexed FLAVOR table above (one row per
+        # coupling-equivalence group), emit a second table indexed by the
+        # global IPSEL (leshouche row).  BROKEN_SYM needs row-level flavor
+        # information to distinguish same-flavor vs different-flavor decay
+        # configurations within a single coupling group — without this, the
+        # identical-particle factor is never cancelled when it should be.
+        all_flav_flat = sum((list(group) for group in all_flav), [])
+        replace_dict['max_flavor_row'] = len(all_flav_flat)
+        replace_dict['get_flavor_row_matrix'] = ''
+        for i, flav_tuple in enumerate(all_flav_flat):
+            flav_positions = [str(pdg_to_group_pos.get(f, f)) for f in flav_tuple]
+            replace_dict['get_flavor_row_matrix'] += ' DATA (FLAVOR_ROW(i,  %d),i=  1, NEXTERNAL) /%s/\n' % (i+1, ', '.join(flav_positions))
         
         # information for computing the correct symmetry factor for each flavor
         process = matrix_element.get('processes')[0]

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5389,7 +5389,7 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         # information to distinguish same-flavor vs different-flavor decay
         # configurations within a single coupling group — without this, the
         # identical-particle factor is never cancelled when it should be.
-        all_flav_flat = sum((list(group) for group in all_flav), [])
+        all_flav_flat = [flav_tuple for group in all_flav for flav_tuple in group]
         replace_dict['max_flavor_row'] = len(all_flav_flat)
         replace_dict['get_flavor_row_matrix'] = ''
         for i, flav_tuple in enumerate(all_flav_flat):

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -60,6 +60,15 @@ C
         REAL*8 R,SUMHEL,TS(NCOMB)
         INTEGER I,IDEN
         INTEGER FLAVOR(NEXTERNAL)
+        INTEGER FLAVOR_FOR_SYM(NEXTERNAL)
+C       Per-row FLAVOR lookup used by BROKEN_SYM. The IFLAV-indexed FLAVOR
+C       table above can collapse distinct same-flavor / different-flavor
+C       leshouche rows that share the same coupling group; BROKEN_SYM needs
+C       row-level information to apply the identical-particle correction.
+        INTEGER FLAVOR_ROW(NEXTERNAL,%(max_flavor_row)s)
+        %(get_flavor_row_matrix)s
+        INTEGER IPSEL
+        COMMON /SUBPROC/ IPSEL
         REAL*8 HWGT, XTOT, XTRY, XREJ, XR, YFRAC(0:NCOMB)
         INTEGER NGOOD
         INTEGER J, JJ
@@ -237,7 +246,12 @@ c         Set right sign for ANS, based on sign of chosen helicity
 	    endif
         ENDIF
     ENDIF
-    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR)
+    IF (IPSEL.GE.1.AND.IPSEL.LE.%(max_flavor_row)s) THEN
+       FLAVOR_FOR_SYM(:) = FLAVOR_ROW(:, IPSEL)
+    ELSE
+       FLAVOR_FOR_SYM(:) = FLAVOR(:)
+    ENDIF
+    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR_FOR_SYM)
 
     call select_color(rcol, jamp2, iconfig,%(proc_id)s,  icol, ivec)
 

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -50,6 +50,15 @@ C
         REAL*8 R,SUMHEL,TS(NCOMB)
         INTEGER I,IDEN
         INTEGER FLAVOR(NEXTERNAL)
+        INTEGER FLAVOR_FOR_SYM(NEXTERNAL)
+C       Per-row FLAVOR lookup used by BROKEN_SYM. The IFLAV-indexed FLAVOR
+C       table above can collapse distinct same-flavor / different-flavor
+C       leshouche rows that share the same coupling group; BROKEN_SYM needs
+C       row-level information to apply the identical-particle correction.
+        INTEGER FLAVOR_ROW(NEXTERNAL,%(max_flavor_row)s)
+        %(get_flavor_row_matrix)s
+        INTEGER IPSEL
+        COMMON /SUBPROC/ IPSEL
         INTEGER BROKEN_SYM%(proc_id)s
         REAL*8 XTOT
         INTEGER  J, JJ
@@ -153,7 +162,12 @@ c         Set right sign for ANS, based on sign of chosen helicity
 	        stop 1
         ENDIF
     ENDIF
-    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR)
+    IF (IPSEL.GE.1.AND.IPSEL.LE.%(max_flavor_row)s) THEN
+       FLAVOR_FOR_SYM(:) = FLAVOR_ROW(:, IPSEL)
+    ELSE
+       FLAVOR_FOR_SYM(:) = FLAVOR(:)
+    ENDIF
+    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR_FOR_SYM)
 
     call select_color(rcol, jamp2, iconfig,%(proc_id)s,  icol, ivec)
 

--- a/madgraph/iolibs/template_files/matrix_madevent_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_v4.inc
@@ -59,6 +59,15 @@ C
     REAL     XRAN1
     EXTERNAL XRAN1
     INTEGER FLAVOR(NEXTERNAL)
+    INTEGER FLAVOR_FOR_SYM(NEXTERNAL)
+C   Per-row FLAVOR lookup used by BROKEN_SYM. The IFLAV-indexed FLAVOR
+C   table above can collapse distinct same-flavor / different-flavor
+C   leshouche rows that share the same coupling group; BROKEN_SYM needs
+C   row-level information to apply the identical-particle correction.
+    INTEGER FLAVOR_ROW(NEXTERNAL,%(max_flavor_row)s)
+    %(get_flavor_row_matrix)s
+    INTEGER IPSEL
+    COMMON /SUBPROC/ IPSEL
     INTEGER BROKEN_SYM%(proc_id)s
 
 C
@@ -188,7 +197,12 @@ c          WRITE(HEL_BUFF,'(20i5)')(NHEL(II,I),II=1,NEXTERNAL)
             stop 1
         ENDIF
     ENDIF
-    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR)
+    IF (IPSEL.GE.1.AND.IPSEL.LE.%(max_flavor_row)s) THEN
+       FLAVOR_FOR_SYM(:) = FLAVOR_ROW(:, IPSEL)
+    ELSE
+       FLAVOR_FOR_SYM(:) = FLAVOR(:)
+    ENDIF
+    ANS=ANS/DBLE(IDEN)*BROKEN_SYM%(proc_id)s(FLAVOR_FOR_SYM)
 
     CALL SELECT_COLOR(RCOL, JAMP2, ICONFIG, 1,  SELECTED_COL, IVEC)
 


### PR DESCRIPTION
## Summary

Fixes the `test_short_cross_pol` failure (P2 and P3 sub-processes) on this branch. The two failing sub-processes (`u u~ > z{0} z{T}, z > l+ l-` and `u u~ > z{T} z{T}, z > l+ l-`) were returning cross sections ~3/4 of the expected value.

## Root cause

The IFLAV-indexed FLAVOR table emitted in `matrix*.f` has one row per coupling-equivalence group. `get_external_flavors_with_iden()` groups distinct flavor configurations (`e+e- e+e-`, `e+e- mu+mu-`, `mu+mu- mu+mu-`) into a single coupling group because the SM Z couplings are flavor-blind, and the matrix-element emitter at `export_v4.py:5366-5384` then writes only `flav[0]` (the first tuple) into the DATA statement.

Inside `SMATRIX`, `BROKEN_SYM<i>(FLAVOR)` is supposed to return 2 (cancelling the identical-Z 1/2! in `IDEN`) when the two Z decays go to *different* lepton flavors, and 1 otherwise. With only one FLAVOR row, it always saw the same flavor index in both decay blocks and always returned 1, so the different-flavor configurations got divided by 72 instead of 36. Arithmetic: 3 same-vs-different combos contributing as `(2·M/72 + M/36)` collapse to `3·M/72 = (3/4)·expected`. Matches the observed ratio.

`leshouche.inc` was already correct (one IDUP per row, generated via `sum(allow_flavor, [])`); only the FLAVOR table was collapsed.

## Fix

Emit a second per-row table `FLAVOR_ROW(NEXTERNAL, n_rows)` alongside the existing per-group `FLAVOR(NEXTERNAL, n_groups)` table. Inside `SMATRIX`, read the global `IPSEL` from `COMMON /SUBPROC/` to pick the right row, copy it into `FLAVOR_FOR_SYM`, and pass that to `BROKEN_SYM<i>`. The IFLAV-indexed FLAVOR table — and therefore the rest of the matrix-element / `auto_dsig` / PDF flow — is unchanged.

Defensive fallback: if `IPSEL` is out of `[1, n_rows]` (e.g. for a caller that hasn't seeded `/SUBPROC/`) we fall back to the old per-group FLAVOR.

Touches:

- `madgraph/iolibs/export_v4.py` — emit `max_flavor_row` and `get_flavor_row_matrix`
- `madgraph/iolibs/template_files/matrix_madevent_v4.inc`
- `madgraph/iolibs/template_files/matrix_madevent_group_v4.inc`
- `madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc`

## Verification

`test_short_cross_pol` cross sections after the fix:

| Sub-process | Expected | Before | After |
|---|---|---|---|
| P0 `z{0} z{T}, z > e+ e-`              | 0.00016429  | 0.16053e-3 (0.977×) | 0.16053e-3 (0.977×) |
| P1 `z{0} z{T}, z > e+ e-, z > mu+ mu-` | 0.0001721   | 0.17210e-3 (1.000×) | 0.17210e-3 (1.000×) |
| P2 `z{0} z{T}, z > l+ l-`              | 0.00066055  | 0.50284e-3 (**0.761×**) | 0.66133e-3 (1.001×) |
| P3 `z{T} z{T}, z > l+ l-`              | 0.0019198   | 0.14433e-2 (**0.752×**) | 0.19040e-2 (0.992×) |

## Test plan

- [x] `./tests/test_manager.py -t0 -pP test_short_cross_pol` passes
- [x] `./tests/test_manager.py -t0 -pP "test_short_cross_sm1|test_short_cross_sm2|test_short_cross_sm3|test_short_cross_pol"` all 4 pass
- [x] `./tests/test_manager.py -t0 -pP test_short_polarization` passes
- [x] IO snapshot tests under `tests/unit_tests/iolibs/test_export_v4.py` show the same 4 preexisting failures with or without this change (no new regressions)
- [ ] CI on the full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct symmetry-factor handling for grouped flavor rows in decayed/polarized matrix elements by providing BROKEN_SYM with per-leshouche-row flavor information.

Bug Fixes:
- Fix underestimation of cross sections for processes with flavor-grouped Z→ℓℓ decays by restoring proper identical-particle symmetry cancellation.

Enhancements:
- Generate and use a separate per-row FLAVOR_ROW table, keyed by IPSEL, alongside the existing per-group FLAVOR table in matrix element templates to supply accurate flavor data to symmetry logic.