### PR TITLE
IOTests -U: auto-reuse decision for identical diffs within a session

### DIFF
--- a/tests/IOTests.py
+++ b/tests/IOTests.py
@@ -462,9 +462,20 @@ class IOTestManager(unittest.TestCase):
         
         if not file_name.startswith('%'):
             return file_name
-        
+
         return pjoin(file_name[1:].split('%'))
-    
+
+    @staticmethod
+    def normalize_diff(diff_output):
+        """ Build a fingerprint of a 'diff' output that is independent of where
+        the change occurs (line numbers) and of which file it concerns, so that
+        the same logical modification appearing in several files can be matched.
+        Only the changed content lines ('<', '>' and the '---' separator) are
+        kept; the hunk headers (e.g. '5c5', '10,12d9') are dropped."""
+        kept = [line for line in diff_output.split('\n')
+                if line[:1] in ('<', '>', '-')]
+        return '\n'.join(kept)
+
 #    def test_IOTests(self):
 #        """ A test function in the mother so that all childs automatically run
 #        their tests when scanned with the test_manager. """
@@ -542,7 +553,14 @@ class IOTestManager(unittest.TestCase):
         # The key of the dictionary are the filenames and the value are string
         # determining the user answer for that file.
         reviewed_file_names = {}
-        
+
+        # Cache the decision taken for a given diff (fingerprinted by its
+        # content only, see normalize_diff) so that an identical diff appearing
+        # in another file during this same session reuses the same answer
+        # automatically. This cache is intentionally session-local and never
+        # persisted to disk.
+        accepted_diffs = {}
+
         # Chose what test to cover
         if testKeys == 'instanceList':
             testKeys = self.instance_tests
@@ -783,38 +801,48 @@ class IOTestManager(unittest.TestCase):
                             file.close()
                             if force==0 or ((force==1 or force==2) and path.basename(\
                             comparison_path) not in list(reviewed_file_names.keys())):
-                                text = \
-"""File %s in test %s/%s differs by the following (reference file first):
-"""%(fname,folder_name,test_name)
-                                text += misc.Popen(['diff',str(comparison_path),
+                                diff_output = misc.Popen(['diff',str(comparison_path),
                                   str(tmp_path)],stdout=subprocess.PIPE).\
                                                                 communicate()[0].decode('utf-8')
-                                # Remove the last newline
-                                if text[-1]=='\n':
-                                    text=text[:-1]
-                                if (len(text.split('\n'))<15) or force==2:
-                                    print(text)
+                                diff_key = self.normalize_diff(diff_output)
+                                if diff_key in accepted_diffs:
+                                    # An identical diff was already reviewed in
+                                    # this session: reuse that decision silently.
+                                    answer = accepted_diffs[diff_key]
+                                    if verbose: print("    > [ %s ] %s "%\
+                                       (colored%(34,"AUTO"),fname)+\
+                                       "(identical diff already answered '%s')"%answer)
                                 else:
-                                    pydoc.pager(text)
-                                    print("Difference displayed in editor.")
-                                answer = ''
-                                if force == 2:
-                                    answer = 'y'
-                                while answer not in ['y', 'n']:
-                                    answer = Cmd.timed_input(question=
+                                    text = \
+"""File %s in test %s/%s differs by the following (reference file first):
+"""%(fname,folder_name,test_name)
+                                    text += diff_output
+                                    # Remove the last newline
+                                    if text[-1]=='\n':
+                                        text=text[:-1]
+                                    if (len(text.split('\n'))<15) or force==2:
+                                        print(text)
+                                    else:
+                                        pydoc.pager(text)
+                                        print("Difference displayed in editor.")
+                                    answer = ''
+                                    if force == 2:
+                                        answer = 'y'
+                                    while answer not in ['y', 'n']:
+                                        answer = Cmd.timed_input(question=
 """Ref. file %s differs from the new one (see diff. before), update it? [y/n/h/r] >"""%fname
                                                                    ,default="y")
-                                    if answer not in ['y','n']:
-                                        if answer == 'r':
-                                            pydoc.pager(text)
-                                        else:
-                                            print("reference path: %s" % comparison_path)
-                                            print("code returns: %s" % tmp_path)
-                                
-                                
+                                        if answer not in ['y','n']:
+                                            if answer == 'r':
+                                                pydoc.pager(text)
+                                            else:
+                                                print("reference path: %s" % comparison_path)
+                                                print("code returns: %s" % tmp_path)
+                                    accepted_diffs[diff_key] = answer
+
                                 os.remove(tmp_path)
                                 reviewed_file_names[path.basename(\
-                                                      comparison_path)] = answer        
+                                                      comparison_path)] = answer
                             elif ((force==1 or force==2) and path.basename(\
                                 comparison_path) in list(reviewed_file_names.keys())):
                                 answer = reviewed_file_names[path.basename(\


### PR DESCRIPTION
## Summary
When running IOTests in `-U` (update) mode, the same logical change often appears in many reference files (e.g. a version-string or formatting change), forcing the user to answer y/n for each one. This adds session-local memoization of the decision keyed on the diff content.

- `normalize_diff` (static helper) fingerprints a `diff` output using only the changed content lines (`<`, `>`, `---`), dropping the hunk headers (`5c5`, `10,12d9`). The fingerprint is therefore independent of line numbers and of the file name (the filename only appears in the prompt header, which is not part of the key).
- `accepted_diffs` is a dict local to `runIOTests`, so it lives only for the current run and is **never written to disk** -- no cross-session persistence.
- In the "existing reference file differs" branch, the normalized diff is looked up first. If it was already answered earlier in the session, the prior y/n decision is reused automatically (with an `AUTO` note in verbose mode) instead of re-prompting; otherwise the user is prompted as before and the answer is cached.

This layers on top of the existing per-basename `reviewed_file_names` mechanism and additionally catches identical diffs appearing across differently named files.

## Test plan
- [x] ast.parse -- module parses cleanly
- [x] Unit-checked normalize_diff: identical content at different line numbers matches; different content does not
- [ ] Manual interactive -U run on a test group that produces the same diff in multiple files, confirming the second file is auto-resolved

Generated with Claude Code

## Summary by Sourcery

Add session-local memoization of update decisions in IOTests based on normalized diff content to avoid repeatedly prompting for identical changes.

New Features:
- Introduce a normalize_diff helper to fingerprint diff outputs independent of file name and line numbers.
- Cache per-session user decisions for specific diffs so identical changes in other files automatically reuse the same answer during a -U run.
- Emit an AUTO marker in verbose mode when an update decision is auto-reused for an identical diff.

Enhancements:
- Preserve and extend the existing reviewed_file_names mechanism so basename-based reuse and diff-based reuse work together during IOTests.