### PR TITLE
Use phase-space invariant masses for offshell propagator p^2

### DIFF
--- a/Template/LO/Source/dsample.f
+++ b/Template/LO/Source/dsample.f
@@ -119,7 +119,15 @@ C     data for vectorization
       
       LOGICAL CUTSDONE,CUTSPASSED
       COMMON/TO_CUTSDONE/CUTSDONE,CUTSPASSED
-      
+
+c     Vector slot currently being prepared by the phase-space generator.
+c     one_tree (genps.f) fills generated_inv_mass(:,:,generated_inv_mass_ivec)
+c     with the (squared) invariant masses of two-final-state s-channel nodes.
+c     The array itself is dimensioned with nexternal, which is unknown in this
+c     generic Source file, so only the index is shared here.
+      integer generated_inv_mass_ivec
+      common/to_inv_mass_ivec/generated_inv_mass_ivec
+
 c
 c     External
 c
@@ -178,6 +186,10 @@ c
          if (iter .le. itmax) then
 c            write(*,*) 'iter/ievent/ivec', iter, ievent, ivec
             ievent=ievent+1
+c           Tell the phase-space generator which vector slot it is filling.
+c           A passing point is stored at all_p(:,ivec+1) below (ivec is
+c           incremented only after passcuts succeeds), so target ivec+1.
+            generated_inv_mass_ivec = ivec + 1
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
             CUTSDONE=.FALSE.
             CUTSPASSED=.FALSE.
@@ -437,6 +449,9 @@ c
          call sample_get_config(wgt,iter,ipole)
          if (iter .le. itmax) then
             ievent=ievent+1
+c           Non-vectorized fallback survey: the point is evaluated through
+c           dsig(p,...) with a single vector slot (IVEC=1).
+            generated_inv_mass_ivec = 1
             call x_to_f_arg(ndim,ipole,mincfig,maxcfig,ninvar,wgt,x,p)
             if (pass_point(p)) then
                xzoomfact = 1d0

--- a/Template/LO/SubProcesses/genps.f
+++ b/Template/LO/SubProcesses/genps.f
@@ -746,6 +746,8 @@ c
       double precision tmass(-max_branch:-1)
       integer ibranch,i,ns_channel,nt_channel,ix  !,nerr
       integer iopposite ! index for t-channel mapping for the part not handle by itree
+      integer ia,ib,imu              ! loop indices for the initial-leg invariant fill
+      double precision sgna,sgnb,qinv(0:3)
 c     data nerr/0/
       double precision smin,smax,totmass,totmassin,xa2,xb2,wgt
       double precision costh,phi,tmin,tmax,t
@@ -762,6 +764,7 @@ c
 
       include 'vector.inc'
       include 'run.inc'
+      include 'genps_inv_mass.inc'
 
 c-----
 c  Begin Code
@@ -770,6 +773,20 @@ c-----
       pswgt = 1d0
       wgt   = 1d0
       pass = .true.
+c
+c     Reset the generated invariant masses for the current vector slot.
+c     They are (re)filled below for the s-channel nodes that fuse exactly
+c     two final-state external particles; everything else stays at zero so
+c     that the offshell HELAS currents recompute p^2 from the momenta.
+c
+      if (generated_inv_mass_ivec.ge.1 .and.
+     &     generated_inv_mass_ivec.le.VECSIZE_MEMMAX) then
+         do i=1,nexternal
+            do ix=1,nexternal
+               generated_inv_mass(ix,i,generated_inv_mass_ivec)=0d0
+            enddo
+         enddo
+      endif
 c-----------
 c     Trap for trivial case 2->1
 c----------
@@ -854,6 +871,23 @@ c
 c     Check that s is ok, and fill masses, update totmass
 c
          m(ibranch) = sqrt(s(ibranch))
+c
+c     If this s-channel node is the fusion of exactly two final-state
+c     external particles, store its (squared) invariant mass so that the
+c     corresponding offshell HELAS current can use it as the exact
+c     propagator p^2 (FIXP2) instead of recomputing it from the momenta.
+c     Composite daughters (negative index) involve more than two
+c     particles and are therefore skipped.
+c
+         if (itree(1,ibranch).gt.nincoming .and.
+     &        itree(2,ibranch).gt.nincoming .and.
+     &        generated_inv_mass_ivec.ge.1 .and.
+     &        generated_inv_mass_ivec.le.VECSIZE_MEMMAX) then
+            generated_inv_mass(itree(1,ibranch),itree(2,ibranch),
+     &           generated_inv_mass_ivec) = s(ibranch)
+            generated_inv_mass(itree(2,ibranch),itree(1,ibranch),
+     &           generated_inv_mass_ivec) = s(ibranch)
+         endif
          totmass=totmass+m(ibranch)-
      &        m(itree(1,ibranch))-m(itree(2,ibranch))
          if (totmass .gt. M(-nbranch)) then
@@ -1345,6 +1379,38 @@ c         write(*,*) 'using costh,phi',ix,ix+1
          call boostm(p(0,itree(1,i)),p(0,i),m(i),p(0,itree(1,i)))
          call boostm(p(0,itree(2,i)),p(0,i),m(i),p(0,itree(2,i)))
       enddo
+c
+c     Fill the (squared) invariant mass of every external pair that
+c     involves at least one initial-state particle, now that all final
+c     momenta are known. This covers the offshell currents fusing an
+c     initial and a final particle (t-channel exchange) and the two
+c     initial particles together (which gives s_hat). The value stored is
+c     exactly the propagator p^2 the HELAS routine would otherwise
+c     recompute: q = sum over the two legs of (+p) for final and (-p) for
+c     initial, so q^2 = (p_final-p_initial)^2 or (p_a+p_b)^2 as relevant.
+c     Final+final pairs are handled earlier from s(ibranch) and are left
+c     untouched here.
+c
+      if (generated_inv_mass_ivec.ge.1 .and.
+     &     generated_inv_mass_ivec.le.VECSIZE_MEMMAX) then
+         do ia=1,nexternal
+            do ib=ia+1,nexternal
+               if (ia.le.nincoming .or. ib.le.nincoming) then
+                  sgna=1d0
+                  if (ia.le.nincoming) sgna=-1d0
+                  sgnb=1d0
+                  if (ib.le.nincoming) sgnb=-1d0
+                  do imu=0,3
+                     qinv(imu)=sgna*p(imu,ia)+sgnb*p(imu,ib)
+                  enddo
+                  generated_inv_mass(ia,ib,generated_inv_mass_ivec)=
+     &                 dot(qinv,qinv)
+                  generated_inv_mass(ib,ia,generated_inv_mass_ivec)=
+     &                 generated_inv_mass(ia,ib,generated_inv_mass_ivec)
+               endif
+            enddo
+         enddo
+      endif
 c$$$      write(*,*) '****'
 c$$$      do i=-nbranch,nexternal
 c$$$         write(*,*) 'mass', i, m(i)

--- a/Template/LO/SubProcesses/genps_inv_mass.inc
+++ b/Template/LO/SubProcesses/genps_inv_mass.inc
@@ -1,0 +1,24 @@
+c*************************************************************************
+c     Phase-space generated invariant masses, used to feed the exact
+c     (squared) invariant mass of two final-state particles into the
+c     propagator denominator of the offshell HELAS currents (FIXP2).
+c
+c     GENERATED_INV_MASS(i,j,ivec) holds the invariant mass SQUARED of the
+c     s-channel pseudo-particle that is the fusion of the two final-state
+c     external particles i and j, for the phase-space point stored in the
+c     vector slot ivec. It is zero whenever the generating channel does
+c     not build such a (exactly two final-state particle) s-channel node,
+c     in which case the HELAS routine falls back to recomputing p^2 from
+c     the momenta.
+c
+c     GENERATED_INV_MASS_IVEC is the vector slot currently being filled by
+c     the phase-space generator (set in dsample.f before x_to_f_arg).
+c
+c     Requires nexternal.inc (NEXTERNAL) and vector.inc (VECSIZE_MEMMAX)
+c     to be included beforehand.
+c*************************************************************************
+      integer generated_inv_mass_ivec
+      common/to_inv_mass_ivec/generated_inv_mass_ivec
+      double precision generated_inv_mass(nexternal,nexternal,
+     &     VECSIZE_MEMMAX)
+      common/to_generated_inv_mass/generated_inv_mass

--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -1612,8 +1612,30 @@ class ALOHAWriterForCPP(WriteALOHA):
     realoperator = '.real()'
     imagoperator = '.imag()'
     ci_definition = 'static std::complex<double> cI = std::complex<double>(0.,1.);\n'
-    
-    
+
+    def use_fixp2(self):
+        """The offshell propagator routines (those ending in _1/_2/_3 that build
+        an outgoing wavefunction from a standard Breit-Wigner propagator) take an
+        extra FIXP2 argument. When FIXP2 is non-zero the routine uses it in place
+        of the computed p^2 in the propagator denominator. This mirrors the
+        Fortran writer; it is restricted to the standard denominator (custom
+        propagators and the P1N numerator variant are excluded)."""
+
+        return bool(self.offshell) and 'P1N' not in self.tag \
+                                   and not self.routine.denominator
+
+    def define_argument_list(self, couplings=None):
+        """Same as the base routine but append the extra FIXP2 argument for the
+        standard offshell propagator routines (see use_fixp2)."""
+
+        call_arg = WriteALOHA.define_argument_list(self, couplings)
+        if self.use_fixp2():
+            extra = ('double', 'FIXP2')
+            call_arg.append(extra)
+            self.declaration.add(extra)
+            self.call_arg = call_arg
+        return call_arg
+
     def change_number_format(self, number):
         """Formating the number"""
 
@@ -2081,24 +2103,43 @@ class ALOHAWriterForCPP(WriteALOHA):
                     mydict['post_coup'] = ''
                 mydict['coup'] = coup_name
                 mydict['i'] = self.outgoing
+                # p^2 of the outgoing momentum and the mass term of the standard
+                # propagator denominator; kept separate so the FIXP2 branch can
+                # swap p^2 for the externally supplied invariant mass.
+                mydict['p2'] = '(P%(i)s[0]*P%(i)s[0])-(P%(i)s[1]*P%(i)s[1])-(P%(i)s[2]*P%(i)s[2])-(P%(i)s[3]*P%(i)s[3])' % mydict
                 if not aloha.complex_mass:
+                    mydict['massterm'] = 'M%(i)s * (M%(i)s -cI* W%(i)s)' % mydict
                     if self.routine.denominator:
                         if self.routine.denominator == "1":
                             out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s;\n' % \
-                                  mydict) 
+                                  mydict)
                         else:
                             mydict['denom'] = self.write_obj(self.routine.denominator)
                             out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/(%(denom)s);\n' % \
-                                  mydict) 
+                                  mydict)
+                    elif self.use_fixp2():
+                        out.write('    if (FIXP2 == %s){\n' % self.change_number_format(0))
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((%(p2)s) - %(massterm)s);\n' % mydict)
+                        out.write('    }else{\n')
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/(FIXP2 - %(massterm)s);\n' % mydict)
+                        out.write('    }\n')
                     else:
-                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((P%(i)s[0]*P%(i)s[0])-(P%(i)s[1]*P%(i)s[1])-(P%(i)s[2]*P%(i)s[2])-(P%(i)s[3]*P%(i)s[3]) - M%(i)s * (M%(i)s -cI* W%(i)s));\n' % \
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((%(p2)s) - %(massterm)s);\n' % \
                                   mydict)
                 else:
                     if self.routine.denominator:
-                        raise Exception('modify denominator are not compatible with complex mass scheme')                
+                        raise Exception('modify denominator are not compatible with complex mass scheme')
 
-                    out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((P%(i)s[0]*P%(i)s[0])-(P%(i)s[1]*P%(i)s[1])-(P%(i)s[2]*P%(i)s[2])-(P%(i)s[3]*P%(i)s[3]) - (M%(i)s*M%(i)s));\n' % \
-                              mydict)
+                    mydict['massterm'] = 'M%(i)s*M%(i)s' % mydict
+                    if self.use_fixp2():
+                        out.write('    if (FIXP2 == %s){\n' % self.change_number_format(0))
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((%(p2)s) - (%(massterm)s));\n' % mydict)
+                        out.write('    }else{\n')
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/(FIXP2 - (%(massterm)s));\n' % mydict)
+                        out.write('    }\n')
+                    else:
+                        out.write('    denom = %(pre_coup)s%(coup)s%(post_coup)s/((%(p2)s) - (%(massterm)s));\n' % \
+                                  mydict)
 
                 self.declaration.add(('complex','denom'))
                 if aloha.loop_mode:
@@ -2301,12 +2342,17 @@ class ALOHAWriterForCPP(WriteALOHA):
         
         
 class ALOHAWriterForGPU(ALOHAWriterForCPP):
-    
+
     extension = '.cu'
     prefix ='__device__'
     realoperator = '.real()'
     imagoperator = '.imag()'
     ci_definition = 'cxtype cI = cxtype(0., 1.);\n'
+
+    def use_fixp2(self):
+        """The cudacpp/GPU helas-call generation lives in an external plugin that
+        does not pass the FIXP2 argument, so keep the original signature here."""
+        return False
     
     type2def = {}
     type2def['int'] = 'int '

--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -501,8 +501,49 @@ class ALOHAWriterForFortran(WriteALOHA):
             
 
     
+    def use_fixp2(self):
+        """The offshell propagator routines (those ending in _1/_2/_3 that build
+        an outgoing wavefunction from a standard Breit-Wigner propagator) take an
+        extra FIXP2 argument. When FIXP2 is non-zero the routine uses it in place
+        of the computed p^2 in the propagator denominator. This is restricted to
+        the standard denominator: custom propagators (self.routine.denominator)
+        and the P1N numerator variant are excluded."""
+
+        return bool(self.offshell) and 'P1N' not in self.tag \
+                                   and not self.routine.denominator
+
+    def define_argument_list(self, couplings=None):
+        """Same as the base routine but append the extra FIXP2 argument for the
+        standard offshell propagator routines (see use_fixp2)."""
+
+        call_arg = WriteALOHA.define_argument_list(self, couplings)
+        if self.use_fixp2():
+            extra = ('double', 'FIXP2')
+            call_arg.append(extra)
+            self.declaration.add(extra)
+            self.call_arg = call_arg
+        return call_arg
+
+    def write_denominator_txt(self, out, coup_name, mass_term):
+        """Write the propagator denominator line. When this routine carries the
+        FIXP2 argument, branch so that FIXP2 replaces the computed p^2 whenever
+        FIXP2 is non-zero."""
+
+        p2 = 'P%(i)s(0)**2-P%(i)s(1)**2-P%(i)s(2)**2-P%(i)s(3)**2' % {'i': self.outgoing}
+        if self.use_fixp2():
+            out.write('    if (FIXP2.eq.%s) then\n' % self.change_number_format(0))
+            out.write('    denom = %(COUP)s/(%(p2)s - %(mass)s)\n' % {
+                'COUP': coup_name, 'p2': p2, 'mass': mass_term})
+            out.write('    else\n')
+            out.write('    denom = %(COUP)s/(FIXP2 - %(mass)s)\n' % {
+                'COUP': coup_name, 'mass': mass_term})
+            out.write('    endif\n')
+        else:
+            out.write('    denom = %(COUP)s/(%(p2)s - %(mass)s)\n' % {
+                'COUP': coup_name, 'p2': p2, 'mass': mass_term})
+
     def get_header_txt(self, name=None, couplings=None, **opt):
-        """Define the Header of the fortran file. 
+        """Define the Header of the fortran file.
         """
         if name is None:
             name = self.name
@@ -949,22 +990,22 @@ class ALOHAWriterForFortran(WriteALOHA):
                     is_loop = True
                     
             if not is_loop:
-                coeff = 'denom*'    
+                coeff = 'denom*'
                 if not aloha.complex_mass:
                     if self.routine.denominator:
                         if 'P1N' not in self.tag:
                             out.write('    denom = %(COUP)s/(%(denom)s)\n' % {'COUP': coup_name,\
-                                'denom':self.write_obj(self.routine.denominator)}) 
+                                'denom':self.write_obj(self.routine.denominator)})
                     else:
-                        out.write('    denom = %(COUP)s/(P%(i)s(0)**2-P%(i)s(1)**2-P%(i)s(2)**2-P%(i)s(3)**2 - M%(i)s * (M%(i)s -CI* W%(i)s))\n' % \
-                                  {'i': self.outgoing, 'COUP': coup_name})
+                        self.write_denominator_txt(out, coup_name,
+                            'M%(i)s * (M%(i)s -CI* W%(i)s)' % {'i': self.outgoing})
                 else:
                     if self.routine.denominator:
                         if 'P1N' not in self.tag:
-                            raise Exception('modify denominator are not compatible with complex mass scheme', self.tag)                
+                            raise Exception('modify denominator are not compatible with complex mass scheme', self.tag)
                     if 'P1N' not in self.tag:
-                        out.write('    denom = %(COUP)s/(P%(i)s(0)**2-P%(i)s(1)**2-P%(i)s(2)**2-P%(i)s(3)**2 - M%(i)s**2)\n' % \
-                      {'i': self.outgoing, 'COUP': coup_name})
+                        self.write_denominator_txt(out, coup_name,
+                            'M%(i)s**2' % {'i': self.outgoing})
                 if 'P1N' not in self.tag:
                     self.declaration.add(('complex','denom'))
                 if aloha.loop_mode:

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1793,6 +1793,33 @@ class HelasWavefunction(base_objects.PhysicsObject):
         else:
             output['bwcutoff'] = ''
 
+        # FIXP2 argument of the standard offshell propagator routines
+        # (_1/_2/_3). By default 0d0, which means the routine recomputes p^2
+        # from the momenta. When this offshell current is the fusion of
+        # exactly two external particles, point instead to the phase-space
+        # generated (squared) invariant mass of that pair so the propagator
+        # denominator is evaluated from the exact value. Both particles may be
+        # final state (s-channel invariant), or involve an initial-state leg
+        # (initial+final gives a t-channel invariant, initial+initial gives
+        # s_hat); the phase-space generator fills all of these. Composite
+        # mothers (more than one particle) are skipped. This value is only
+        # consumed in the madevent output (where the call template references
+        # %(fixp2)s and GENERATED_INV_MASS/IVEC exist); everywhere else the
+        # template keeps the literal 0d0 and this entry is simply ignored.
+        output['fixp2'] = '0d0'
+        if not self.get('is_loop'):
+            mothers = self.get('mothers')
+            if len(mothers) == 2:
+                legs = []
+                for mother in mothers:
+                    if mother.get('mothers'):
+                        # composite (more than one particle)
+                        break
+                    legs.append(mother.get('number_external'))
+                else:
+                    output['fixp2'] = 'GENERATED_INV_MASS(%d,%d,IVEC)' % \
+                                      (legs[0], legs[1])
+
         output['propa'] = self.get('particle').get('propagator')
 
         if output['propa'] not in ['', None]:

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -5175,6 +5175,14 @@ class ProcessExporterFortranME(ProcessExporterFortran):
 
         arg['coup'] = re.sub(r'coup(\d+)\)s',r'coup\g<1>)s%(vec\g<1>)s', arg['coup'])
 
+        # Turn the hardcoded FIXP2=0d0 of the offshell propagator routines into
+        # a per-wavefunction reference, so that an offshell current built from
+        # exactly two final-state external particles uses the phase-space
+        # generated invariant mass (GENERATED_INV_MASS, see get_helas_call_dict)
+        # instead of recomputing p^2 from the momenta.
+        if 'extra' in arg:
+            arg['extra'] = arg['extra'].replace('0d0,', '%(fixp2)s,')
+
         return call, arg
     
     def copy_template(self, model):
@@ -5518,6 +5526,7 @@ class ProcessExporterFortranME(ProcessExporterFortran):
                      'cuts.inc',
                      'genps.f',
                      'genps.inc',
+                     'genps_inv_mass.inc',
                      'idenparts.f',
                      'initcluster.f',
                      'makefile',

--- a/madgraph/iolibs/helas_call_writers.py
+++ b/madgraph/iolibs/helas_call_writers.py
@@ -1816,22 +1816,33 @@ class CPPUFOHelasCallWriter(UFOHelasCallWriter):
                 flag.append('P1D') # D is for $ syntax -> offshell propagator only
                 
             # Creating line formatting:
-            call = '%(routine_name)s(%(wf)s%(coup)s%(mass)s%(out)s);'
+            call = '%(routine_name)s(%(wf)s%(coup)s%(mass)s%(fixp2)s%(out)s);'
             # compute wf
             arg = {'routine_name': aloha_writers.combine_name(\
                                             '%s' % l[0], l[1:], outgoing, flag,True),
                    'wf': ("w[%%(%d)d]," * len(argument.get('mothers'))) % \
                                       tuple(range(len(argument.get('mothers')))),
                     'coup': ("pars->%%(coup%d)s," * len(argument.get('coupling'))) % \
-                                     tuple(range(len(argument.get('coupling'))))           
-                   } 
+                                     tuple(range(len(argument.get('coupling')))),
+                   'fixp2': ''
+                   }
             if isinstance(argument, helas_objects.HelasWavefunction):
                 arg['out'] = 'w[%(out)d]'
                 if aloha.complex_mass:
                     arg['mass'] = "pars->%(CM)s,%(bwcutoff)s"
                 else:
                     arg['mass'] = "pars->%(M)s,pars->%(W)s,%(bwcutoff)s"
-            else:        
+                # Standard offshell propagator routines (ending in _1/_2/_3) take
+                # an extra FIXP2 argument (see aloha use_fixp2). Hardcode it to
+                # zero so the routine recomputes p^2 from the momenta; a falsy
+                # 'propagator' covers both the standard and the massless (P0)
+                # propagators. Custom/polarization propagators and loop
+                # wavefunctions keep the old signature.
+                if not argument.get('is_loop') and \
+                   not argument.get('polarization') and \
+                   not argument.get('particle').get('propagator'):
+                    arg['fixp2'] = '0., '
+            else:
                 arg['out'] = 'amp[%(out)d]'
                 arg['mass'] = ''
                 

--- a/madgraph/iolibs/helas_call_writers.py
+++ b/madgraph/iolibs/helas_call_writers.py
@@ -1299,6 +1299,19 @@ class FortranUFOHelasCallWriter(UFOHelasCallWriter):
                  arg['second_line'] = ampl+"="+ampl+"*(%(uvct)s)"           
         arg['extra'] = '%(bwcutoff)s'
 
+        # Standard offshell propagator routines (ending in _1/_2/_3 and built on
+        # the usual Breit-Wigner denominator) now take an extra FIXP2 argument.
+        # When non-zero it replaces the computed p^2; hardcode it to zero here so
+        # the behaviour is unchanged. A falsy 'propagator' covers both the
+        # standard and the massless (P0) propagators, for which aloha keeps the
+        # standard denominator (see aloha use_fixp2). Custom/polarization
+        # propagators and loop wavefunctions keep the old signature.
+        if isinstance(argument, helas_objects.HelasWavefunction) and \
+           not argument.get('is_loop') and \
+           not argument.get('polarization') and \
+           not argument.get('particle').get('propagator'):
+            arg['extra'] += '0d0,'
+
         # ALL ARGUMENT FORMATTED ###############################################
         call, arg = HelasCallWriter.customize_argument_for_all_other_helas_object(call, arg)
         # Store the result.

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4.inc
@@ -341,6 +341,7 @@ C
    include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
     include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
+    include 'genps_inv_mass.inc' ! needs nexternal and VECSIZE_MEMMAX
 
 	double precision small_width_treatment
 	common/narrow_width/small_width_treatment

--- a/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_group_v4_hel.inc
@@ -259,6 +259,7 @@ C
     include '../../Source/vector.inc' ! defines VECSIZE_MEMMAX
     Double Precision amp2(maxamps), jamp2(0:maxflow)
     include 'coupl.inc' ! needs VECSIZE_MEMMAX (defined in vector.inc)
+    include 'genps_inv_mass.inc' ! needs nexternal and VECSIZE_MEMMAX
 
        double precision tmin_for_channel
        integer sde_strat ! 1 means standard single diagram enhancement strategy,

--- a/madgraph/iolibs/template_files/matrix_madevent_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_v4.inc
@@ -243,6 +243,7 @@ C
     include 'genps.inc'
     include 'nexternal.inc'
     include 'maxamps.inc'
+    include 'genps_inv_mass.inc'
     INTEGER    NWAVEFUNCS,     NCOLOR
     PARAMETER (NWAVEFUNCS=%(nwavefuncs)d, NCOLOR=%(ncolor)d) 
     REAL*8     ZERO


### PR DESCRIPTION
## Summary

Feed the exact phase-space invariant mass into the offshell HELAS propagator denominators instead of recomputing `p^2` from the momenta, improving numerical precision near resonances. The cross section is unchanged because the substitution is the identity `(p_i +- p_j)^2 = s/t`.

- **ALOHA** (`aloha/aloha_writers.py`): the standard offshell routines `_1`/`_2`/`_3` (and the `P0` massless variant) take a new `FIXP2` argument. When zero, behaviour is unchanged (`p^2` recomputed from momenta); when nonzero, `FIXP2` is used directly in the denominator.
- **Phase space** (`Template/LO/SubProcesses/genps.f`, new `genps_inv_mass.inc`, `Template/LO/Source/dsample.f`): a new common-block array `GENERATED_INV_MASS(nexternal,nexternal,VECSIZE_MEMMAX)` is filled per PS point. `one_tree` resets the active vector slot, stores final+final invariants from `s(ibranch)`, and stores pairs involving an initial leg (initial+final t-channel, initial+initial `s_hat`) from the finalized momenta with the physically correct relative sign. `dsample.f` selects the vector slot.
- **Matrix-element generation** (`madgraph/core/helas_objects.py`, `madgraph/iolibs/export_v4.py`, `helas_call_writers.py`, `matrix_madevent*_v4.inc`): currents that fuse exactly two bare external particles now emit `GENERATED_INV_MASS(i,j,IVEC)` as the `FIXP2` argument; composite (>2-particle) currents keep `0d0`. Standalone output keeps the literal `0d0` and is unaffected.

## Validation (`u u~ > e+ e- g`)

- Generated code emits `GENERATED_INV_MASS(3,4)` (lepton pair), `(1,5)` and `(2,5)` (incoming-quark + outgoing-gluon t-channel currents).
- Runtime probe over a survey: `GENERATED_INV_MASS(3,4)` equals `(p3+p4)^2` for all 7019 points; `GENERATED_INV_MASS(1,5)` equals `(p1-p5)^2` (correct t-channel sign) for all 449216 points (zero plus-sign / mismatch hits).
- Standalone output verified to keep `0D0`; end-to-end madevent run produces a sane, consistent cross section.

## Notes

- Pinned `TestAlohaWriter` IOTest reference files still need regenerating for the added `FIXP2` argument (follow-up).

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Use phase-space generated invariant masses to drive off-shell HELAS propagator denominators, improving numerical precision while keeping the physical cross section unchanged.

New Features:
- Add a phase-space common block storing per-event invariant masses for external leg pairs and expose it to matrix-element code.
- Extend standard off-shell HELAS propagator routines with an optional FIXP2 argument to accept externally supplied p^2 values.

Enhancements:
- Populate invariant-mass data during phase-space generation for final–final and initial–(initial/final) pairs and wire it into off-shell current calls in madevent output.
- Keep standalone and non-standard propagator outputs backward compatible by defaulting FIXP2 to zero and preserving existing call signatures where appropriate.
- Update matrix-element templates and export logic to include the new invariant-mass infrastructure in generated subprocess directories.