### PR TITLE
Fix plugin search paths and plugin launch interface in bin/madevent

### DIFF
--- a/Template/LO/bin/madevent
+++ b/Template/LO/bin/madevent
@@ -160,16 +160,17 @@ try:
 except:
     pass
 import internal.madevent_interface as cmd_interface
+import internal.misc as misc
 
 # check for plugin customization of the launch command
 launch_interface = cmd_interface.MadEventCmdShell
-if os.path.exists(pjoin(root_path, 'bin','internal', 'launch_plugin.py')):
+if os.path.exists(pjoin(root_path, 'internal', 'launch_plugin.py')):
     with  misc.TMP_variable(sys, 'path', sys.path + [pjoin(root_path, 'bin', 'internal')]):
         from importlib import reload
         try:
-            reload('launch_plugin')
+            reload('internal.launch_plugin')
         except Exception as error:
-            import launch_plugin
+            import internal.launch_plugin as launch_plugin
     launch_interface =  launch_plugin.MEINTERFACE
 
 
@@ -234,7 +235,7 @@ try:
                 cmd_line = cmd_interface.MadEventCmd(force_run=True)
                 cmd_line.cmdloop()
             else:
-                cmd_line = cmd_interface.MadEventCmdShell(force_run=True)
+                cmd_line = launch_interface(force_run=True)
                 cmd_line.cmdloop()
 except KeyboardInterrupt:
     print( 'writting history and directory and quit on KeyboardInterrupt' )


### PR DESCRIPTION
Bug found when trying to run `bin/madevent` when generating the process using CUDACPP.

Search paths for the `launch_plugin.py` module were wrong, and, if a plugin interface is picked up, now it will be called correctly.

## Summary by Sourcery

Correct plugin search paths and plugin launch handling in bin/madevent when using CUDACPP-generated processes.

Bug Fixes:
- Fix incorrect search paths for the launch_plugin.py module so plugins are discoverable by bin/madevent.
- Ensure detected plugin interfaces are invoked correctly by bin/madevent during event generation.