### PR TITLE
change MadSpin defaults: spinmode=madspin, density_keep_jacobian=True…

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -64,7 +64,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('ms_dir', '')
         self.add_param('max_running_process', 100)
         self.add_param('onlyhelicity', False)
-        self.add_param('spinmode', "PA", allowed=['full', 'madspin', 'none', 'onshell', 'PA', 'madspin_v1', 'onshell_v1'])
+        self.add_param('spinmode', "madspin", allowed=['full', 'madspin', 'none', 'onshell', 'PA', 'madspin_v1', 'onshell_v1'])
         self.add_param('use_old_dir', False, comment='should be use only for faster debugging')
         self.add_param('run_card', '' , comment='define cut for decay_events (in onshell frame). Path to run_card to use')
         self.add_param('fixed_order', False, comment='to activate fixed order handling of counter-event')
@@ -80,8 +80,11 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
         self.add_param('nb_core', 0, comment='Number of cores for the MadSpin parallel unweighting (0 = use the global MG5 nb_core). nb_core>1 enables the process-parallel unweighting path.')
-        self.add_param('density_keep_jacobian', False, comment='PA spinmode only: fold the offshell-reshuffling phase-space jacobian into the accept/reject weight instead of applying the reshuffle as a post-acceptance kinematic dressing. Ignored by the madspin/full spinmodes, which always include that jacobian.')
-        self.add_param('sequential_decay', False, comment='accept/reject one decaying particle at a time instead of the full set at once (density mode). Exact and much cheaper when several particles decay; set to False for the historical joint accept/reject.')
+        self.add_param('density_keep_jacobian', True, comment='PA spinmode only: fold the offshell-reshuffling phase-space jacobian into the accept/reject weight (default) instead of applying the reshuffle as a post-acceptance kinematic dressing (False). Ignored by the madspin/full spinmodes, which always include that jacobian.')
+        self.add_param('sequential_decay', False, comment='accept/reject one decaying particle at a time instead of the full set at once (density mode). Exact and much cheaper when several particles decay. Default is auto: True for the PA/onshell spinmodes, False (joint accept/reject) for madspin/full.')
+        # default is 'auto': resolved at run time by _sequential_active --
+        # sequential for PA/onshell, joint for madspin/full
+        self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
 
     ############################################################################
@@ -2136,11 +2139,15 @@ class MadSpinInterface(extended_cmd.Cmd):
         Density mode only -- the whole scheme is expressed in terms of the
         production density matrix. ``fixed_order`` keeps the joint test: its
         counter-events ride along with the decays and have not been thought
-        through here. ``sequential_decay`` is the opt-out.
+        through here. ``sequential_decay`` defaults to 'auto': sequential for
+        the PA/onshell pole approximations, joint for madspin/full.
         """
         if not density_method:
             return False
-        if not self.options['sequential_decay']:
+        sequential = self.options['sequential_decay']
+        if sequential == 'auto':
+            sequential = self.options['spinmode'] in ['PA', 'onshell']
+        if not sequential:
             return False
         if self.options['fixed_order']:
             logger.info("MadSpin: fixed_order is on, keeping the joint "
@@ -3797,7 +3804,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         draw_mass = (self.options['spinmode'] == 'PA' and nb_prod_final > 1)
         # Whether the production reshuffling jacobian enters the accept/reject
         # weight. Follows the joint path (interface_madspin.py, get_onshell PA
-        # block): off by default -- the reshuffle is then a post-acceptance
+        # block): on by default -- when off the reshuffle is a post-acceptance
         # kinematic dressing and only the Breit-Wigner sampling jacobian is in
         # the weight. The feasibility of the mass set is still checked either
         # way, to trigger the whole-set restart.

--- a/Template/Common/Cards/madspin_card_default.dat
+++ b/Template/Common/Cards/madspin_card_default.dat
@@ -18,8 +18,8 @@
 # set BW_cut 15                 # cut on how far the particle can be off-shell
 # set spinmode XXXXX      # Use one of the madspin special modes
 #         allowed spinmode:
-#         - PA : Default: Pole approximation -- onshell matrix-element + reshuffling.
-#         - madspin/full: density method with offshell matrix-elements.
+#         - PA : Pole approximation -- onshell matrix-element + reshuffling.
+#         - madspin/full: Default: density method with offshell matrix-elements.
 #         - onshell : not breit-wigner reshuffling
 #         - none : no spin correlation and no finite width effect
 #         legacy modes:

--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -80,8 +80,8 @@ SpinModeConfig = collections.namedtuple(
 #  - madspin_v1 : old default, mass smearing, no 3-body, identical part. only
 #  - onshell_v1 : traditional onshell decay chain
 #  - onshell    : "PA without reshuffling" (pure onshell kinematics, density ME)
-#  - madspin    : off-shell ME + density (BW shape from ME)
-#  - PA         : PA reshuffling with BW + density ME (new MadSpin default)
+#  - madspin    : off-shell ME + density (BW shape from ME) (new MadSpin default)
+#  - PA         : PA reshuffling with BW + density ME
 DEFAULT_MODES = [
     SpinModeConfig('full_decay_chain',    'madspin_v1'),  
     SpinModeConfig('onshell_decay_chain', 'onshell_v1'),

--- a/tests/parallel_tests/test_madspin_factory.py
+++ b/tests/parallel_tests/test_madspin_factory.py
@@ -283,7 +283,7 @@ class MadSpinFactoryTest(unittest.TestCase):
                             'vl': 've vm'},
             extra_run_card={'ebeam1': 6500, 'ebeam2': 6500},
         )
-        # Same default (PA) mode, same production events, serial vs multi-core.
+        # Same (PA) mode, same production events, serial vs multi-core.
         cfg = SpinModeConfig('PA_density', 'PA')
         serial = factory.run_mode(cfg, extra_settings={'nb_core': 1},
                                   run_tag='serial')

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1283,6 +1283,31 @@ class TestSequentialPoolLadder(unittest.TestCase):
         # onshell is supported just like PA
         self.assertTrue(self._stub({6: 2}, spinmode='onshell')._sequential_active(True))
 
+    def test_sequential_active_auto(self):
+        """'auto' (the default) resolves per spinmode: sequential for the
+        PA/onshell pole approximations, joint for madspin/full."""
+        for mode, expected in [('PA', True), ('onshell', True),
+                               ('madspin', False), ('full', False),
+                               ('none', False)]:
+            stub = self._stub({6: 2}, sequential_decay='auto', spinmode=mode)
+            self.assertEqual(stub._sequential_active(True), expected,
+                             'auto + spinmode=%s' % mode)
+        # fixed_order still forces the joint test
+        stub = self._stub({6: 2}, sequential_decay='auto', fixed_order=True)
+        self.assertFalse(stub._sequential_active(True))
+
+    def test_madspin_option_defaults(self):
+        """The shipped defaults: spinmode=madspin, jacobian in the weight,
+        sequential_decay on auto (and switchable off/back by the user)."""
+        options = interface_madspin.MadSpinOptions()
+        self.assertEqual(options['spinmode'], 'madspin')
+        self.assertEqual(options['density_keep_jacobian'], True)
+        self.assertEqual(options['sequential_decay'], 'auto')
+        options['sequential_decay'] = 'False'
+        self.assertEqual(options['sequential_decay'], False)
+        options['sequential_decay'] = 'auto'
+        self.assertEqual(options['sequential_decay'], 'auto')
+
 
 class TestScanMaxwgtDecomposition(unittest.TestCase):
     """The parallel max-weight scan splits the probe events across workers and


### PR DESCRIPTION
…, sequential_decay=auto

- spinmode default goes back to 'madspin' (now the density off-shell implementation) instead of 'PA'.
- density_keep_jacobian defaults to True: the PA reshuffling jacobian is folded into the accept/reject weight instead of being applied as a post-acceptance kinematic dressing.
- sequential_decay defaults to 'auto' (via the ConfigFile auto mechanism): resolved at run time to sequential accept/reject for the PA/onshell pole approximations and to the joint test for madspin/full. fixed_order and unsupported spinmodes still force the joint test.
- update the default madspin card and stale comments, add unit tests for the auto gate and the new defaults.

## Summary by Sourcery

Update MadSpin defaults and configuration handling for spin mode, jacobian treatment, and sequential decay behaviour.

New Features:
- Introduce an automatic sequential_decay mode that selects sequential or joint accept/reject based on the chosen spinmode.

Enhancements:
- Change the default spinmode to madspin to use the off-shell matrix element plus density configuration.
- Enable density_keep_jacobian by default so the reshuffling jacobian is included in the accept/reject weight instead of applied as a post-acceptance kinematic dressing.
- Make sequential_decay default to the auto configuration via the ConfigFile mechanism, with fixed_order continuing to enforce the joint test.
- Refresh the default MadSpin card comments to reflect the new spinmode and jacobian defaults.

Tests:
- Add unit coverage for the sequential_decay auto gate across spinmodes and fixed_order, and for the new MadSpin option defaults.
- Adjust parallel test expectations and comments to align with the updated default spinmode behaviour.