### PR TITLE
CI: run the unit and acceptance tests that no workflow triggered

### DIFF
--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -1040,8 +1040,9 @@ jobs:
 
       - name: run the test
         run: |
-            #./tests/test_manager.py test_contur_from_file test_rivet_from_file -pA -t0 -l INFO 
-            PYTHONPATH=$PYTHONPATH:/home/runner/.cache/HEPtools/contur/python3.10:/home/runner/.cache/HEPTools/rivet/local/lib/python3.10/dist-packages/:/home/runner/.cache/HEPTools/yoda/local/lib/python3.10/dist-packages/ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/.cache/HEPTools/lib ./tests/test_manager.py  test_rivet_from_file -pA -t0 -l INFO  
+            # test_contur_from_file disabled: needs the mg5 contur_path option pointing to a full contur install (conturenv.sh), not available on the runner
+            #./tests/test_manager.py test_contur_from_file test_rivet_from_file -pA -t0 -l INFO
+            PYTHONPATH=$PYTHONPATH:/home/runner/.cache/HEPtools/contur/python3.10:/home/runner/.cache/HEPTools/rivet/local/lib/python3.10/dist-packages/:/home/runner/.cache/HEPTools/yoda/local/lib/python3.10/dist-packages/ LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/runner/.cache/HEPTools/lib ./tests/test_manager.py  test_rivet_from_file -pA -t0 -l INFO
             
   acceptancetest_contur2:
     # The type of runner that the job will run on
@@ -1485,23 +1486,23 @@ jobs:
             ./tests/test_manager.py test_check_singletop_fastjet -pA -t0 -l INFO
 
 
-            #  acceptancetest_85:
-            #    # The type of runner that the job will run on
-            #    runs-on: ubuntu-22.04
-            #
-            #    # Steps represent a sequence of tasks that will be executed as part of the job
-            #    steps:
-            #      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            #      - uses: actions/checkout@v4
-            #      - uses: ./.github/actions/checkout_mg5 
-            #      - uses: ./.github/actions/restore-pip-cache
-            #
-            #      # Runs a set of commands using the runners shell
-            #      - name: test one of the test test_gen_evt_onlygen
-            #        run: |
-            #            cd $GITHUB_WORKSPACE
-            #            ./tests/test_manager.py test_gen_evt_onlygen -pA -t0 -l INFO
-            #
+  acceptancetest_85:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore_all
+
+      # Runs a set of commands using the runners shell
+      - name: test one of the test test_gen_evt_onlygen
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_gen_evt_onlygen -pA -t0 -l INFO
 
 
   acceptancetest_emela:
@@ -1590,42 +1591,42 @@ jobs:
 
 
 
-            #  acceptancetest_91:
-            #    # The type of runner that the job will run on
-            #    runs-on: ubuntu-22.04
-            #
-            #    # Steps represent a sequence of tasks that will be executed as part of the job
-            #    steps:
-            #      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            #      - uses: actions/checkout@v4
-            #      - uses: ./.github/actions/checkout_mg5 
-            #      - uses: ./.github/actions/restore-pip-cache
-            #
-            #      # Runs a set of commands using the runners shell
-            #      - name: test one of the test test_generate_events_lo_hw6_stdhep
-            #        run: |
-            #            cd $GITHUB_WORKSPACE
-            #            ./tests/test_manager.py test_generate_events_lo_hw6_stdhep -pA -t0 -l INFO
-            #
+  acceptancetest_91:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore_all
+
+      # Runs a set of commands using the runners shell
+      - name: test one of the test test_generate_events_lo_hw6_stdhep
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_generate_events_lo_hw6_stdhep -pA -t0 -l INFO
 
 
-            #  acceptancetest_92:
-            #    # The type of runner that the job will run on
-            #    runs-on: ubuntu-22.04
-            #
-            #    # Steps represent a sequence of tasks that will be executed as part of the job
-            #    steps:
-            #      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            #      - uses: actions/checkout@v4
-            #      - uses: ./.github/actions/checkout_mg5 
-            #      - uses: ./.github/actions/restore-pip-cache
-            #
-            #      # Runs a set of commands using the runners shell
-            #      - name: test one of the test test_generate_events_lo_py6_stdhep
-            #        run: |
-            #            cd $GITHUB_WORKSPACE
-            #            ./tests/test_manager.py test_generate_events_lo_py6_stdhep -pA -t0 -l INFO
-            #
+  acceptancetest_92:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore_all
+
+      # Runs a set of commands using the runners shell
+      - name: test one of the test test_generate_events_lo_py6_stdhep
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_generate_events_lo_py6_stdhep -pA -t0 -l INFO
 
 
   acceptancetest_93:
@@ -1668,23 +1669,23 @@ jobs:
 
 
 
-            #  acceptancetest_95:
-            #    # The type of runner that the job will run on
-            #    runs-on: ubuntu-22.04
-            #
-            #    # Steps represent a sequence of tasks that will be executed as part of the job
-            #    steps:
-            #      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-            #      - uses: actions/checkout@v4
-            #      - uses: ./.github/actions/checkout_mg5 
-            #      - uses: ./.github/actions/restore-pip-cache
-            #
-            #      # Runs a set of commands using the runners shell
-            #      - name: test one of the test test_madspin_LOonly
-            #        run: |
-            #            cd $GITHUB_WORKSPACE
-            #            ./tests/test_manager.py test_madspin_LOonly -pA -t0 -l INFO
-            #
+  acceptancetest_95:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore_all
+
+      # Runs a set of commands using the runners shell
+      - name: test one of the test test_madspin_LOonly
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_madspin_LOonly -pA -t0 -l INFO
 
 
   acceptancetest_96:
@@ -1946,3 +1947,57 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             ./tests/test_manager.py test_pythia8_delphes_parallel -pA -t0 -l INFO
+
+
+  acceptancetest_check_gauge:
+    # gauge/lorentz check commands that were not listed in any workflow (CI coverage audit)
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore-pip-cache
+      - name: test the check gauge/full acceptance tests
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_check_gauge_epem_aa_includes_axial -pA -t0 -l INFO
+            ./tests/test_manager.py test_check_gauge_epem_vevex_wpwm -pA -t0 -l INFO
+            ./tests/test_manager.py test_check_gauge_pp_wpwm -pA -t0 -l INFO
+            ./tests/test_manager.py test_check_pp_wpwm -pA -t0 -l INFO
+
+
+  acceptancetest_decay_chain_outoforder:
+    # decay chain with identical particles out of order (CI coverage audit)
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore-pip-cache
+      - name: test test_decay_chain_identical_particle_outoforder
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_decay_chain_identical_particle_outoforder -pA -t0 -l INFO
+
+
+  acceptancetest_dy3j_mlm:
+    # DY+3j with MLM matching (CI coverage audit)
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore-pip-cache
+      - name: test test_madevent_dy3j_mlm
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_madevent_dy3j_mlm -pA -t0 -l INFO
+
+
+  # test_ieva_collision and test_eva_oldrelease_collision are not run: they
+  # assert run_card defaults (evaorder=1, eva_xcut=0) that do not match the
+  # current ones, and test_ieva_collision uses an undefined variable
+  # (err1 = results['error']) after the run

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -48,23 +48,6 @@ jobs:
             cd $GITHUB_WORKSPACE
             ./tests/test_manager.py -v2 -t0 testIO_modification_to_cuts -e .github/workflows/unittest.yml 
 
-#  test_excluded2:
-#    # excluded due to side effect
-#    # The type of runner that the job will run on
-#    runs-on: ubuntu-latest#
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-#      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - uses: actions/checkout@v5#
-#
-#      # Runs a set of commands using the runners shell
-#      - name: test one of the test test_short_mssm_subset_creation
-#        run: |
-#            cd $GITHUB_WORKSPACE
-#            ./tests/test_manager.py -t0  test_write_model    #excluded from fast unittest
-
-
   unittest_0:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -636,5 +619,34 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             ./tests/test_manager.py test_q_polynomial test_hepmc_parser -t0
+
+
+  unittest_uncovered:
+    # unit tests that were not listed in any workflow (CI coverage audit).
+    # test_fks_ppzz_in_RS is left out: the RS UFO model is still python2 only.
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: run the previously untriggered unit tests
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_CF_simple test_cf_computation test_generate_ewsud_ttbar test_generate_ewsud_ww test_generate_ewsud_zz testIO_test_pptt_ewsudakovSA testIO_test_ppzz_ewsudakov testIO_test_ppw_fksall testIO_Loop_sqso_uux_ddx test_check_import_model test_schedular test_dummy_fcts test_UFO_Python_helas_call_writer_fd test_get_symmetric_color test_get_symmetric_lorentz test_remove_interactions2 test_remove_interactions3 test_fd_python_value_matches_unitary_fixed_point test_shower_card_write -t0
+
+
+  unittest_write_model:
+    # runs alone: excluded from the shared unittest jobs due to side effects
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: run test_write_model (usermod)
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_write_model -t0
 
 

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -1687,10 +1687,11 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
                     return "%id0/%id0" % (frac.numerator, frac.denominator)
             elif frac.real == frac:
                 #misc.sprint(frac.real, frac)
-                return ('%.15e' % frac.real).replace('e','d')
+                # +0.0 drops the sign of negative zeros, which depends on the python version
+                return ('%.15e' % (frac.real + 0.0)).replace('e','d')
                 #str(float(frac.real)).replace('e','d')
             else:
-                return ('(%.15e,%.15e)' % (frac.real, frac.imag)).replace('e','d')
+                return ('(%.15e,%.15e)' % (frac.real + 0.0, frac.imag + 0.0)).replace('e','d')
                 #str(frac).replace('e','d').replace('j','*imag1')
                 
         

--- a/tests/acceptance_tests/test_cmd_amcatnlo.py
+++ b/tests/acceptance_tests/test_cmd_amcatnlo.py
@@ -647,20 +647,20 @@ class MECmdShell(IOTests.IOTestManager):
         #self.do('generate_events LO -f')        
         
         # test the lhe event file exists
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/events.lhe.gz' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/summary.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/run_01_LO_tag_1_banner.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/res_0.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/res_1.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_0.html' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_1.html' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_2.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/events.lhe.gz' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/summary.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/run_01_tag_1_banner.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/res_0.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/res_1.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_0.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_1.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_2.html' % self.path))
         # test the hep event file exists
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/events_HERWIG6_0.hep.gz' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/events_HERWIG6_0.hep.gz' % self.path))
         # sanity check on the size
         self.assertGreater(
-            os.path.getsize('%s/Events/run_01_LO/events_HERWIG6_0.hep.gz' % self.path),
-            os.path.getsize('%s/Events/run_01_LO/events.lhe.gz' % self.path)
+            os.path.getsize('%s/Events/run_01/events_HERWIG6_0.hep.gz' % self.path),
+            os.path.getsize('%s/Events/run_01/events.lhe.gz' % self.path)
         )
         
 
@@ -676,20 +676,20 @@ class MECmdShell(IOTests.IOTestManager):
         self.do('generate_events aMC@LO -f')        
         
         # test the lhe event file exists
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/events.lhe.gz' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/summary.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/run_01_LO_tag_1_banner.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/res_0.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/res_1.txt' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_0.html' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_1.html' % self.path))
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/alllogs_2.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/events.lhe.gz' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/summary.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/run_01_tag_1_banner.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/res_0.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/res_1.txt' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_0.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_1.html' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/alllogs_2.html' % self.path))
         # test the hep event file exists
-        self.assertTrue(os.path.exists('%s/Events/run_01_LO/events_PYTHIA6Q_0.hep.gz' % self.path))
+        self.assertTrue(os.path.exists('%s/Events/run_01/events_PYTHIA6Q_0.hep.gz' % self.path))
         # sanity check on the size
         self.assertGreater(
-            os.path.getsize('%s/Events/run_01_LO/events_PYTHIA6Q_0.hep.gz' % self.path),
-            os.path.getsize('%s/Events/run_01_LO/events.lhe.gz' % self.path)
+            os.path.getsize('%s/Events/run_01/events_PYTHIA6Q_0.hep.gz' % self.path),
+            os.path.getsize('%s/Events/run_01/events.lhe.gz' % self.path)
         )
 
 

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_gg_ttx%matrix_1.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_pptt_fksreal/%SubProcesses%P0_gg_ttx%matrix_1.f
@@ -349,13 +349,13 @@ C     JAMPs contributing to orders QCD=3 QED=0
       TMP_JAMP(1) = AMP(12) - AMP(17)  ! used 4 times
       TMP_JAMP(9) = TMP_JAMP(3) + ((0.000000000000000D+00,
      $ -1.000000000000000D+00)) * AMP(8)  ! used 2 times
-      TMP_JAMP(8) = TMP_JAMP(3) + ((-0.000000000000000D+00
+      TMP_JAMP(8) = TMP_JAMP(3) + ((0.000000000000000D+00
      $ ,1.000000000000000D+00)) * AMP(5)  ! used 2 times
-      TMP_JAMP(7) = TMP_JAMP(2) + ((-0.000000000000000D+00
+      TMP_JAMP(7) = TMP_JAMP(2) + ((0.000000000000000D+00
      $ ,1.000000000000000D+00)) * AMP(2)  ! used 2 times
       TMP_JAMP(6) = TMP_JAMP(2) + ((0.000000000000000D+00,
      $ -1.000000000000000D+00)) * AMP(3)  ! used 2 times
-      TMP_JAMP(5) = TMP_JAMP(1) + ((-0.000000000000000D+00
+      TMP_JAMP(5) = TMP_JAMP(1) + ((0.000000000000000D+00
      $ ,1.000000000000000D+00)) * AMP(11)  ! used 2 times
       TMP_JAMP(4) = TMP_JAMP(1) + ((0.000000000000000D+00,
      $ -1.000000000000000D+00)) * AMP(10)  ! used 2 times

--- a/tests/unit_tests/various/test_import_ufo.py
+++ b/tests/unit_tests/various/test_import_ufo.py
@@ -92,8 +92,11 @@ class TestImportUFO(unittest.TestCase):
         self.assertEqual(new_lor.structure, 'Metric(1,2)')
 
         # here flip Scalar and Vector
+        # the exact index is not checked: the UFO module is global to the
+        # process, so an equivalent SSVV lorentz can already exist (and be
+        # returned) if another test did convert the sm model before this one
         new_lor = ufo2mg5_converter.get_symmetric_lorentz('VVSS1', {0: 3, 1:2,2: 1, 3:0}, change_number=True)
-        self.assertEqual(new_lor.name, 'SSVV2')
+        self.assertRegex(new_lor.name, r'^SSVV\d+$')
         self.assertEqual(new_lor.structure, 'Metric(4,3)')
 
     def test_get_symmetric_color(self):

--- a/tests/unit_tests/various/test_usermod.py
+++ b/tests/unit_tests/various/test_usermod.py
@@ -354,7 +354,10 @@ class TestModUFO(unittest.TestCase):
         self.assertEqual(11, 
                 len([1 for name in os.listdir(output) if name.endswith('.py')]))
 
+        # the model dir itself must be in the path since UFO models use
+        # implicit relative imports (import particles) inside __init__.py
         sys.path.insert(0, os.path.dirname(output))
+        sys.path.insert(0, output)
         import usrmod
 
 


### PR DESCRIPTION
## Summary

Port to `3.7.3` of the CI coverage audit validated on 3.x (branch `claude/untriggered-test-functions-cf1868`, all workflows green there). Every CI job lists its tests explicitly, and an audit of the workflows against the test suite showed that a number of unit and acceptance tests were listed nowhere, so they never ran.

### unittest.yml
- new `unittest_uncovered` job with 19 previously untriggered unit tests (color algebra, EW sudakov generation + IOTests, `testIO_test_ppw_fksall`, `testIO_Loop_sqso_uux_ddx`, import_ufo symmetric color/lorentz, restrict model, process checks, shower card, ...)
- new `unittest_write_model` job: `test_write_model` runs isolated — it only passes when no other test has loaded a UFO model first (the known "side effect" that had it excluded)
- `test_fks_ppzz_in_RS` stays out: the RS UFO model is still python2-only

### acceptancetest.yml
- re-enabled the commented-out jobs for `test_gen_evt_onlygen`, `test_generate_events_lo_hw6_stdhep`, `test_generate_events_lo_py6_stdhep` and `test_madspin_LOonly` (now with `restore_all`)
- new jobs for the four `check gauge`/`check full` tests, `test_decay_chain_identical_particle_outoforder` and `test_madevent_dy3j_mlm`
- still excluded, documented in place: `test_contur_from_file` (needs a configured `contur_path` on the runner), the two eva tests (assert run_card defaults that do not match the current ones; `test_ieva_collision` also uses an undefined variable), and the madweight tests (excluded on request)

### Fixes required for the above to pass (all validated on the 3.x run)
- **export_v4**: normalise negative zeros when writing JAMP coefficients — python 3.14's C99 complex semantics make the sign of a zero version-dependent — and update the `test_pptt_fksreal` reference accordingly
- `test_write_model`: add the model directory itself to `sys.path` (UFO models use implicit relative imports)
- `test_get_symmetric_lorentz`: don't require the exact SSVV index; the process-global UFO module can already contain an equivalent lorentz which is legitimately reused
- stdhep tests: `generate_events aMC@LO` names the run `run_01`; the `_LO` suffix only applies to fixed-order LO mode

Note: the PA-decay/wj-madspin tests and the density jobs exist only on 3.x (madspin work) and are not part of this port; they reach 3.7.x whenever 3.x is merged.

## Test plan
- [x] the 19-test `unittest_uncovered` batch, `test_write_model` and `testIO_test_pptt_fksreal` pass locally on this branch (3.7.3 base, python 3.14)
- [x] the same content is fully green on 3.x (unittest, acceptance, aloha, parallel workflows)
- [ ] CI on this PR (acceptance jobs need warm HEPTools caches — if many jobs fail within seconds, check for "Cache not found" and re-run after warming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand CI coverage to run previously untriggered unit and acceptance tests and make small fixes so they pass across supported Python versions.

Enhancements:
- Add unittest jobs to run uncovered tests and isolate the side-effectful test_write_model case.
- Re-enable and add acceptance test jobs for stdhep event generation, madspin, gauge/full checks, decay-chain ordering and DY+3j MLM matching, with appropriate cache restores and conditions.
- Document and keep disabled acceptance tests that require unavailable external tools or rely on outdated run_card defaults.
- Normalize complex-number formatting in export_v4 to avoid Python-version-dependent negative zeros and update the corresponding reference matrix file.
- Relax UFO symmetric Lorentz structure assertions and adjust write_model imports to work with shared global UFO modules and implicit relative imports.
- Align stdhep acceptance tests with the actual run directory naming used by aMC@LO event generation.