### PR TITLE
Fix LHAPDF search-path registration so patched .info files are actually used

### DIFF
--- a/Template/Common/Source/PDF/pdf_lhapdf6.cc
+++ b/Template/Common/Source/PDF/pdf_lhapdf6.cc
@@ -203,11 +203,14 @@ extern "C" {
 
   /// Set PDF data path
   void setpdfpath_(const char* s, size_t len) {
-    /// @todo Works? Need to check C-string copying, null termination
-    char s2[1024];
-    s2[len] = '\0';
-    strncpy(s2, s, len);
-    LHAPDF::pathsPrepend(s2);
+    // The trailing blank padding of the Fortran string must be stripped:
+    // a padded path never matches an existing directory, so LHAPDF would
+    // silently ignore it and fall back to its global data directory.
+    string path(s, len);
+    const size_t last = path.find_last_not_of(' ');
+    if (last == string::npos) return;
+    path.erase(last+1);
+    LHAPDF::pathsPrepend(path);
   }
 
   /// Get PDF data path (colon-separated if there is more than one element)

--- a/Template/Common/Source/PDF/pdf_lhapdf62.cc
+++ b/Template/Common/Source/PDF/pdf_lhapdf62.cc
@@ -600,11 +600,12 @@ extern "C" {
 
   /// Set PDF data path
   void setpdfpath_(const char* s, size_t len) {
-    /// @todo Works? Need to check C-string copying, null termination
-    char s2[1024];
-    s2[len] = '\0';
-    strncpy(s2, s, len);
-    LHAPDF::pathsPrepend(s2);
+    // The trailing blank padding of the Fortran string must be stripped:
+    // a padded path never matches an existing directory, so LHAPDF would
+    // silently ignore it and fall back to its global data directory.
+    const string path = fstr_to_ccstr(s, len);
+    if (path.empty()) return;
+    LHAPDF::pathsPrepend(path);
   }
 
   /// Get PDF data path (colon-separated if there is more than one element)

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4691,7 +4691,11 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         f.write('\n')
                     f.write('\n'.join(extra) + '\n')
             except (OSError, IOError) as e:
-                logger.debug('Could not patch %s: %s', path, e)
+                logger.warning('Could not add %s to %s (%s). '
+                    'Recent LHAPDF versions can refuse to load this set '
+                    '(MetadataError). If this happens, add those keys to that '
+                    'file manually.',
+                    ', '.join(e2.split(':')[0] for e2 in extra), path, e)
 
 
     def copy_lhapdf_set(self, lhaid_list, pdfsets_dir, require_local=True):
@@ -4761,6 +4765,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     
                 os.environ["LHAPATH"] = [d for d in lhapdf_cluster_possibilities if os.path.exists(pjoin(d, pdfset))][0]
                 os.environ["CLUSTER_LHAPATH"] = os.environ["LHAPATH"]
+                self.patch_lhapdf_info_file(pjoin(os.environ["LHAPATH"], pdfset))
                 # no need to copy it
                 if os.path.exists(pjoin(pdfsets_dir, pdfset)):
                     try:
@@ -4772,6 +4777,7 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                         logger.debug('%s', error)
             if not require_local and (os.path.exists(pjoin(pdfsets_dir, pdfset)) or \
                                     os.path.isdir(pjoin(pdfsets_dir, pdfset))):
+                self.patch_lhapdf_info_file(pjoin(pdfsets_dir, pdfset))
                 continue
             if not require_local:
                 if 'LHAPDF_DATA_PATH' in os.environ:
@@ -4782,19 +4788,27 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                             found =True
                             break
                     if found:
+                        self.patch_lhapdf_info_file(pjoin(path, pdfset))
                         continue
-                    
-                    
+
+            # ensure that the set used at run time has the metadata required
+            # by recent LHAPDF versions: the code can read the global copy
+            # (in particular if the local one is not picked up), and the
+            # local copy is created from it.
+            self.patch_lhapdf_info_file(pjoin(pdfsets_dir, pdfset))
+
             #check that the pdfset is not already there
             if not os.path.exists(pjoin(self.me_dir, 'lib', 'PDFsets', pdfset)) and \
                not os.path.isdir(pjoin(self.me_dir, 'lib', 'PDFsets', pdfset)):
-    
+
                 if pdfset and not os.path.exists(pjoin(pdfsets_dir, pdfset)):
                     self.install_lhapdf_pdfset(pdfsets_dir, pdfset)
-    
+                    self.patch_lhapdf_info_file(pjoin(pdfsets_dir, pdfset))
+
                 if os.path.exists(pjoin(pdfsets_dir, pdfset)):
                     files.cp(pjoin(pdfsets_dir, pdfset), pjoin(self.me_dir, 'lib', 'PDFsets'))
                 elif os.path.exists(pjoin(os.path.dirname(pdfsets_dir), pdfset)):
+                    self.patch_lhapdf_info_file(pjoin(os.path.dirname(pdfsets_dir), pdfset))
                     files.cp(pjoin(os.path.dirname(pdfsets_dir), pdfset), pjoin(self.me_dir, 'lib', 'PDFsets'))
 
             self.patch_lhapdf_info_file(pjoin(self.me_dir, 'lib', 'PDFsets', pdfset))

--- a/madgraph/iolibs/template_files/pdf_wrap_emela.f
+++ b/madgraph/iolibs/template_files/pdf_wrap_emela.f
@@ -24,7 +24,9 @@ c-------------------
 
 c     initialize the pdf set
       call FindPDFPath(LHAPath)
-      CALL SetPDFPath(LHAPath)
+c     pass the path without its blank padding: some versions of the
+c     lhaglue interface keep the padding, making the path unusable
+      CALL SetPDFPath(trim(LHAPath))
       value(1)=lhaid
       parm(1)='DEFAULT'
       if (pdlabel.eq.'emela') then

--- a/madgraph/iolibs/template_files/pdf_wrap_lhapdf.f
+++ b/madgraph/iolibs/template_files/pdf_wrap_lhapdf.f
@@ -24,7 +24,9 @@ c-------------------
 
 c     initialize the pdf set
       call FindPDFPath(LHAPath)
-      CALL SetPDFPath(LHAPath)
+c     pass the path without its blank padding: some versions of the
+c     lhaglue interface keep the padding, making the path unusable
+      CALL SetPDFPath(trim(LHAPath))
       value(1)=lhaid
       parm(1)='DEFAULT'
       if (pdlabel.eq.'lhapdf') then

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -2319,7 +2319,9 @@ def import_python_lhapdf(lhapdfconfig):
                         import lhapdf
                         use_lhapdf=True
                         break
-                    except ImportError as  error:
+                    except (ImportError, SystemError) as  error:
+                        # SystemError: compiled lhapdf module incompatible
+                        # with the running python interpreter
                         sys.path.pop(0)
                         continue
             else:
@@ -2342,7 +2344,7 @@ def import_python_lhapdf(lhapdfconfig):
                         import lhapdf
                         use_lhapdf=True
                         break
-                    except ImportError as error:
+                    except (ImportError, SystemError) as error:
                         sys.path.pop(0)
                         continue
             else:
@@ -2352,7 +2354,7 @@ def import_python_lhapdf(lhapdfconfig):
             try:
                 import lhapdf
                 use_lhapdf=True
-            except ImportError:
+            except (ImportError, SystemError):
                 print('fail')
                 logger.warning("Failed to access python version of LHAPDF: "\
                                    "If the python interface to LHAPDF is available on your system, try "\

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -2322,6 +2322,8 @@ def import_python_lhapdf(lhapdfconfig):
                     except (ImportError, SystemError) as  error:
                         # SystemError: compiled lhapdf module incompatible
                         # with the running python interpreter
+                        logger.debug('fail to import lhapdf from %s: %s',
+                                     sys.path[0], error)
                         sys.path.pop(0)
                         continue
             else:
@@ -2345,6 +2347,8 @@ def import_python_lhapdf(lhapdfconfig):
                         use_lhapdf=True
                         break
                     except (ImportError, SystemError) as error:
+                        logger.debug('fail to import lhapdf from %s: %s',
+                                     sys.path[0], error)
                         sys.path.pop(0)
                         continue
             else:

--- a/tests/unit_tests/interface/test_madevent.py
+++ b/tests/unit_tests/interface/test_madevent.py
@@ -260,3 +260,87 @@ class TestDelphesFusion(unittest.TestCase):
         self.assertFalse(ok)
         final = pjoin(stub.me_dir, 'Events', 'run_01', 'tag_1_delphes_events.root')
         self.assertFalse(os.path.isfile(final))
+
+
+class TestLhapdfInfoPatch(unittest.TestCase):
+    """check that missing AlphaS_* metadata is added to the .info file of a
+    PDF set everywhere the run time can read it (global dir and local copy)"""
+
+    INFO_MISSING = """SetDesc: test set
+Format: lhagrid1
+FlavorScheme: variable
+NumFlavors: 5
+AlphaS_Type: ipol
+"""
+
+    def setUp(self):
+        import madgraph.interface.common_run_interface as common_run
+        self.common_run = common_run
+        self.tmpdir = tempfile.mkdtemp(prefix='mg5_lhapdf_test')
+        # a fake global lhapdf data directory with one set
+        self.pdfsets_dir = pjoin(self.tmpdir, 'share', 'LHAPDF')
+        os.makedirs(pjoin(self.pdfsets_dir, 'MYSET'))
+        with open(pjoin(self.pdfsets_dir, 'MYSET', 'MYSET.info'), 'w') as f:
+            f.write(self.INFO_MISSING)
+        # a fake process directory
+        self.me_dir = pjoin(self.tmpdir, 'PROC')
+        os.makedirs(pjoin(self.me_dir, 'lib', 'PDFsets'))
+        self.saved_datapath = os.environ.pop('LHAPDF_DATA_PATH', None)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        if self.saved_datapath is not None:
+            os.environ['LHAPDF_DATA_PATH'] = self.saved_datapath
+
+    def get_fake_cmd(self):
+        common_run = self.common_run
+        class FakeRunCmd(object):
+            patch_lhapdf_info_file = staticmethod(
+                          common_run.CommonRunCmd.patch_lhapdf_info_file)
+            copy_lhapdf_set = common_run.CommonRunCmd.copy_lhapdf_set
+        cmd = FakeRunCmd()
+        cmd.me_dir = self.me_dir
+        cmd.options = {'cluster_local_path': None, 'run_mode': 2}
+        cmd.lhapdf_pdfsets = {}
+        return cmd
+
+    def test_patch_lhapdf_info_file(self):
+        """missing AlphaS_* keys are mirrored from their base counterpart,
+        and the patching is idempotent"""
+
+        setdir = pjoin(self.pdfsets_dir, 'MYSET')
+        self.common_run.CommonRunCmd.patch_lhapdf_info_file(setdir)
+        content = open(pjoin(setdir, 'MYSET.info')).read()
+        self.assertIn('AlphaS_FlavorScheme: variable', content)
+        self.assertIn('AlphaS_NumFlavors: 5', content)
+        # calling it again should not duplicate the keys
+        self.common_run.CommonRunCmd.patch_lhapdf_info_file(setdir)
+        content = open(pjoin(setdir, 'MYSET.info')).read()
+        self.assertEqual(content.count('AlphaS_FlavorScheme'), 1)
+        self.assertEqual(content.count('AlphaS_NumFlavors'), 1)
+        # a non existing directory should simply be ignored
+        self.common_run.CommonRunCmd.patch_lhapdf_info_file(
+                                             pjoin(self.tmpdir, 'DOESNOTEXIST'))
+
+    def test_copy_lhapdf_set_patches_global_and_local(self):
+        """with require_local, both the global set and the local copy end up
+        with the required metadata"""
+
+        cmd = self.get_fake_cmd()
+        cmd.copy_lhapdf_set(['MYSET'], self.pdfsets_dir)
+        local_info = pjoin(self.me_dir, 'lib', 'PDFsets', 'MYSET', 'MYSET.info')
+        global_info = pjoin(self.pdfsets_dir, 'MYSET', 'MYSET.info')
+        self.assertTrue(os.path.isfile(local_info))
+        self.assertIn('AlphaS_FlavorScheme: variable', open(local_info).read())
+        self.assertIn('AlphaS_FlavorScheme: variable', open(global_info).read())
+
+    def test_copy_lhapdf_set_patches_global_without_local(self):
+        """without require_local the set stays global but is still patched"""
+
+        cmd = self.get_fake_cmd()
+        cmd.copy_lhapdf_set(['MYSET'], self.pdfsets_dir, require_local=False)
+        local_set = pjoin(self.me_dir, 'lib', 'PDFsets', 'MYSET')
+        global_info = pjoin(self.pdfsets_dir, 'MYSET', 'MYSET.info')
+        self.assertFalse(os.path.exists(local_set))
+        self.assertIn('AlphaS_FlavorScheme: variable', open(global_info).read())
+        self.assertIn('AlphaS_NumFlavors: 5', open(global_info).read())


### PR DESCRIPTION
## Problem

With `pdlabel=lhapdf` and an old PDF set (e.g. `lhaid 260000`, NNPDF30_nlo_as_0118), madevent aborts at PDF load time with recent LHAPDF builds:

```
==== LHAPDF6 USING DEFAULT-TYPE LHAGLUE INTERFACE ====
LHAPDF 6.5.5 loading .../share/LHAPDF/NNPDF30_nlo_as_0118/NNPDF30_nlo_as_0118_0000.dat
libc++abi: terminating due to uncaught exception of type LHAPDF::MetadataError: Metadata for key: AlphaS_FlavorScheme not found.
```

The existing workaround (0ad0fe268) that injects the missing `AlphaS_FlavorScheme`/`AlphaS_NumFlavors` keys did run, but only patched the copy in `lib/PDFsets` — and that copy was never read at run time (note the *global* path in the log above).

## Root cause

`setpdfpath_` in our copy of the lhaglue interface (`Template/Common/Source/PDF/pdf_lhapdf6.cc` and `pdf_lhapdf62.cc`) registers the path received from Fortran **with its trailing blank padding** (`character*150`). The padded path never matches an existing directory, so LHAPDF silently ignores `lib/PDFsets` and falls back to its global data directory, whose unpatched `.info` then triggers the `MetadataError` inside `mkAlphaS` (statically linked LHAPDF 6.5.5).

Verified with a minimal Fortran + glue reproducer: the untrimmed path loads the global file, the trimmed path loads the local patched copy.

## Fix (defense in depth)

- `pdf_lhapdf62.cc` / `pdf_lhapdf6.cc`: strip the Fortran blank padding in `setpdfpath_` (also removes a potential buffer overflow for len >= 1024)
- `pdf_wrap_lhapdf.f` / `pdf_wrap_emela.f` templates: pass `trim(LHAPath)`, covering binaries linked against external lhaglue implementations with the same flaw
- `copy_lhapdf_set`: also patch the `.info` of the **global** set (before copying, so the local copy inherits the fix), and patch in the `require_local=False` / `LHAPDF_DATA_PATH` / cluster branches which previously skipped the patching entirely; a failed patch is now a warning instead of a debug message
- `import_python_lhapdf`: also catch `SystemError` (raised by a compiled lhapdf python module incompatible with the running interpreter, e.g. python 3.14; previously killed `generate_events` before the survey)
- new unit tests: `TestLhapdfInfoPatch` in `tests/unit_tests/interface/test_madevent.py`

## Verification

- Reproduced the crash end-to-end pre-fix (`g g > t t~`, `set pdlabel lhapdf`, `set lhaid 260000`): survey jobs abort with the MetadataError, refine fails reading `results.dat`.
- Post-fix the same flow completes (397.5 +- 5 pb); the survey logs show `loading ../../../lib/PDFsets/NNPDF30_nlo_as_0118/...` (local patched copy finally used) and the global `.info` is patched automatically with an INFO message.
- `tests/test_manager.py -p U`: `TestLhapdfInfoPatch` (3/3), `test_madevent` (8), `test_misc`, `test_edit_card` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure LHAPDF uses patched PDF set metadata by correctly registering search paths and consistently patching .info files in both global and local locations.

Bug Fixes:
- Strip Fortran string padding when registering LHAPDF data paths so local PDF set directories are correctly detected and used.
- Patch LHAPDF .info metadata in all code paths (cluster, global-only, and local-copy installs) to prevent AlphaS_* MetadataError crashes.
- Treat failures to patch LHAPDF .info files as warnings instead of silent debug messages, making misconfigured sets visible to users.
- Handle SystemError when importing the Python LHAPDF module to avoid crashes with incompatible compiled extensions.

Enhancements:
- Add trimming of LHAPath in Fortran PDF wrapper templates to work around flawed external lhaglue implementations that keep blank padding.
- Introduce unit tests covering LHAPDF .info patching behavior for global and local PDF set copies.

Tests:
- Add TestLhapdfInfoPatch in test_madevent to verify that missing AlphaS_* metadata is added and kept consistent between global and local PDF sets.