### PR TITLE
Auto-convert py2-only UFO models at download time; re-add test_fks_ppzz_in_RS to CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -623,7 +623,8 @@ jobs:
 
   unittest_uncovered:
     # unit tests that were not listed in any workflow (CI coverage audit).
-    # test_fks_ppzz_in_RS is left out: the RS UFO model is still python2 only.
+    # test_fks_ppzz_in_RS auto-downloads the RS UFO model (python2 only) which
+    # is now converted to python3 on the fly at download time.
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
 
@@ -633,7 +634,7 @@ jobs:
       - name: run the previously untriggered unit tests
         run: |
             cd $GITHUB_WORKSPACE
-            ./tests/test_manager.py test_CF_simple test_cf_computation test_generate_ewsud_ttbar test_generate_ewsud_ww test_generate_ewsud_zz testIO_test_pptt_ewsudakovSA testIO_test_ppzz_ewsudakov testIO_test_ppw_fksall testIO_Loop_sqso_uux_ddx test_check_import_model test_schedular test_dummy_fcts test_UFO_Python_helas_call_writer_fd test_get_symmetric_color test_get_symmetric_lorentz test_remove_interactions2 test_remove_interactions3 test_fd_python_value_matches_unitary_fixed_point test_shower_card_write -t0
+            ./tests/test_manager.py test_CF_simple test_cf_computation test_generate_ewsud_ttbar test_generate_ewsud_ww test_generate_ewsud_zz testIO_test_pptt_ewsudakovSA testIO_test_ppzz_ewsudakov testIO_test_ppw_fksall testIO_Loop_sqso_uux_ddx test_check_import_model test_schedular test_dummy_fcts test_UFO_Python_helas_call_writer_fd test_get_symmetric_color test_get_symmetric_lorentz test_remove_interactions2 test_remove_interactions3 test_fd_python_value_matches_unitary_fixed_point test_shower_card_write test_fks_ppzz_in_RS -t0
 
 
   unittest_write_model:

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -3494,32 +3494,9 @@ This implies that with decay chains:
             answer = self.ask('model conversion to support both py2 and py3 are done in place.\n They are NO guarantee of success.\n It can make the model to stop working under PY2 as well.\n Do you want to proceed?',
                      'y', ['y','n'])
             if answer != 'y':
-                return 
-        
-        #Object_library 
-        text = open(pjoin(model_dir, 'object_library.py')).read()
-        #(.iteritems() -> .items())
-        text = text.replace('.iteritems()', '.items()')
-        # raise UFOError, "" -> raise UFOError()
-        text = re.sub('raise (\\w+)\\s*,\\s*["\']([^"]+)["\']',
-                      r'raise \g<1>("\g<2>")', text)
-        text = open(pjoin(model_dir, 'object_library.py'),'w').write(text)
-        
-        # write_param_card.dat -> copy the one of the sm model
-        files.cp(pjoin(MG5DIR, 'models','sm','write_param_card.py'),
-                 pjoin(model_dir, 'write_param_card.py'))
-        
-        # __init__.py check that function_library and object_library are imported
-        text = open(pjoin(model_dir, '__init__.py')).read()
-        mod = False
-        to_check =  ['object_library', 'function_library']
-        for lib in to_check:
-            if 'import %s' % lib in text:
-                continue
-            mod = True
-            text = "import %s \n" % lib + text  
-        if mod:
-            open(pjoin(model_dir, '__init__.py'),'w').write(text)
+                return
+
+        import_ufo.convert_model_py2_to_py3(model_dir, force=True)
         
         
         

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -196,6 +196,53 @@ def import_model_from_db(model_name, local_dir=False):
             proc = misc.call('tar -xzpvf tmp.tgz', shell=True, cwd=target)#, stdout=devnull, stderr=devnull)
     if proc:
         raise Exception("Impossible to unpack the model. Please install it manually")
+
+    # some models of the database are still written for python2 only.
+    # convert them (in place) such that the model can be loaded directly.
+    model_dir = pjoin(target, model_name)
+    if os.path.isdir(model_dir):
+        convert_model_py2_to_py3(model_dir)
+    return True
+
+py2_raise_pattern = re.compile('raise (\\w+)\\s*,\\s*["\']([^"]+)["\']')
+def convert_model_py2_to_py3(model_dir, force=False):
+    """modify (in place) a python2-only UFO model to make it compatible with
+    both python2 and python3. Returns True if the model was modified.
+    Without the force option, models which look already python3 compatible
+    are left untouched."""
+
+    obj_lib = pjoin(model_dir, 'object_library.py')
+    if not os.path.exists(obj_lib):
+        return False
+    text = open(obj_lib).read()
+    if not force and '.iteritems()' not in text and not py2_raise_pattern.search(text):
+        return False
+    logger.info("model %s is python2 only. Converting it to be python3 compatible (in place)", model_dir)
+
+    #Object_library
+    #(.iteritems() -> .items())
+    text = text.replace('.iteritems()', '.items()')
+    # raise UFOError, "" -> raise UFOError("")
+    text = py2_raise_pattern.sub(r'raise \g<1>("\g<2>")', text)
+    open(obj_lib, 'w').write(text)
+
+    # write_param_card.dat -> copy the one of the sm model
+    files.cp(pjoin(MG5DIR, 'models','sm','write_param_card.py'),
+             pjoin(model_dir, 'write_param_card.py'))
+
+    # __init__.py check that function_library and object_library are imported
+    text = open(pjoin(model_dir, '__init__.py')).read()
+    mod = False
+    # import function_library
+    # from . import function_library
+    to_check =  ['object_library', 'function_library']
+    for lib in to_check:
+        if 'import %s' % lib in text:
+            continue
+        mod = True
+        text = "import %s \n" % lib + text
+    if mod:
+        open(pjoin(model_dir, '__init__.py'),'w').write(text)
     return True
 
 def get_path_restrict(model_name, restrict=True):

--- a/models/import_ufo.py
+++ b/models/import_ufo.py
@@ -217,7 +217,10 @@ def convert_model_py2_to_py3(model_dir, force=False):
     text = open(obj_lib).read()
     if not force and '.iteritems()' not in text and not py2_raise_pattern.search(text):
         return False
-    logger.info("model %s is python2 only. Converting it to be python3 compatible (in place)", model_dir)
+    if force:
+        logger.info("Applying in-place py2→py3 compatibility transforms to model %s", model_dir)
+    else:
+        logger.info("model %s is python2 only. Converting it to be python3 compatible (in place)", model_dir)
 
     #Object_library
     #(.iteritems() -> .items())


### PR DESCRIPTION
## Summary

`test_fks_ppzz_in_RS` was excluded from the `unittest_uncovered` job because the RS UFO model (auto-downloaded from the online database) is still python2 only and fails to load with `UFOError: 'dict' object has no attribute 'iteritems'`.

The repo already has a py2->py3 UFO conversion, but it only triggers from the interface `do_import` error path (`auto_convert_model` option). Direct calls to `import_ufo.import_model()` — as done by the unit tests and the scripting API — bypass it entirely.

## Changes

- **models/import_ufo.py**: new reusable `convert_model_py2_to_py3(model_dir, force=False)` carrying the same transforms as the old inline code in `do_convert_model` (`.iteritems()` -> `.items()`, py2 `raise X, "msg"` rewrite, copy of the sm `write_param_card.py`, `__init__.py` import check). It is now called automatically after `import_model_from_db` unpacks a freshly downloaded model; models that already look python3 compatible are left untouched.
- **madgraph/interface/madgraph_interface.py**: `do_convert_model` keeps its consent logic but delegates the file editing to the new function (removes the duplicated code). The `auto_convert_model` option semantics are unchanged for pre-existing user models.
- **.github/workflows/unittest.yml**: `test_fks_ppzz_in_RS` re-added to the `unittest_uncovered` job.

## Validation

- `./tests/test_manager.py test_fks_ppzz_in_RS -t0` passes (was failing with the iteritems error)
- Simulated the CI path: fresh `import_model_from_db` download of RS into an empty directory auto-converts and the model loads (44 particles, 165 vertices); a second conversion call is a no-op
- The interactive `convert model <path>` command still works on a pristine py2 copy of RS
- Regression batch green: `test_check_import_model test_ImportUFONoSideEffectLO test_ImportUFONoSideEffectNLO test_ImportUFOcheckgoldstone test_import_from_cmd test_simple_import test_full_import` (8 tests OK including the RS one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Auto-convert downloaded Python 2–only UFO models to be Python 3 compatible and re-enable the previously skipped RS-related unit test in CI.

Bug Fixes:
- Ensure UFO models downloaded from the online database are converted from Python 2 to Python 3 so they can be imported without iteritems-related failures.
- Re-enable the RS-based test_fks_ppzz_in_RS unit test in the CI unittest_uncovered job by making its model load correctly.

Enhancements:
- Extract UFO Python 2-to-3 conversion into a reusable utility used both at download time and by the interactive convert model command.

CI:
- Include test_fks_ppzz_in_RS in the unittest_uncovered workflow test suite.