### PR TITLE
Add P1TR/P1TL single-helicity propagators for massive vectors

### DIFF
--- a/aloha/aloha_writers.py
+++ b/aloha/aloha_writers.py
@@ -654,7 +654,7 @@ class ALOHAWriterForFortran(WriteALOHA):
             if self.declaration.is_used('P%s' % self.outgoing):
                 self.get_one_momenta_def(self.outgoing, out)
 
-            if "P1T" in self.tag or "P1L" in self.tag:
+            if any(t in self.tag for t in ("P1T","P1TR","P1TL","P1L")):
                 for i in range(1,4):
                     P = "P%s" % (self.outgoing)
                     value = ["1d-30", "0d0", "1d-15"]
@@ -2419,12 +2419,21 @@ class ALOHAWriterForPython(WriteALOHA):
                                              ''.join(p) % dict_energy))
             
             self.get_one_momenta_def(self.outgoing, out)
-            if "P1T" in self.tag or "P1L" in self.tag:
+            if any(t in self.tag for t in ("P1T","P1TR","P1TL","P1L")):
                 for i, value in zip(range(1,4), ("1e-30", "0.0", "1e-15")):
                     out.write("    if abs(P%(P)s[0])*1e-10 > abs(P%(P)s[%(i)s]): P%(P)s[%(i)s] = %(val)s\n"
                               % {"P": self.outgoing, "i": i, "val": value})
 
-               
+            i = self.outgoing
+            if self.declaration.is_used('Tnorm%s' % i):
+                out.write("    Tnorm{0} = (P{0}[1]*P{0}[1]+P{0}[2]*P{0}[2]+P{0}[3]*P{0}[3])**0.5\n".format(i))
+            if self.declaration.is_used('TnormZ%s' % i):
+                out.write("    TnormZ{0} = Tnorm{0} - P{0}[3]\n".format(i))
+            if self.declaration.is_used('FWP%s' % i):
+                out.write("    FWP{0} = (-P{0}[0] + Tnorm{0})**0.5\n".format(i))
+            if self.declaration.is_used('FWM%s' % i):
+                out.write("    FWM{0} = (-P{0}[0] - Tnorm{0})**0.5\n".format(i))
+
         # Returning result
         return out.getvalue()
 

--- a/aloha/create_aloha.py
+++ b/aloha/create_aloha.py
@@ -469,6 +469,16 @@ in presence of majorana particle/flow violation"""
         elif propa == "1T": # (pol=-1,1) transverse = -metric + -Theta
             numerator = "-1*PVec(-2,id)*PVec(-2,id) * EPST2(1,id)*EPST2(2,id) + EPST1(1,id)*EPST1(2,id)"
             denominator = "PVec(-2,id)*PVec(-2,id) * PT(-3,id)*PT(-3,id) * " + basicPole
+        elif propa == "1TR": # (pol=1) transverse helicity +1 = eps(+1) x eps(+1)*
+            # P1T = P1TR + P1TL ; the two circular helicities differ by the
+            # antisymmetric (imaginary) piece i*|p|*(EPST2 x EPST1 - EPST1 x EPST2)
+            numerator = "0.5*(-1*PVec(-2,id)*PVec(-2,id) * EPST2(1,id)*EPST2(2,id) + EPST1(1,id)*EPST1(2,id)" \
+            " + complex(0,1)*Tnorm(id)*(EPST2(1,id)*EPST1(2,id) - EPST1(1,id)*EPST2(2,id)))"
+            denominator = "PVec(-2,id)*PVec(-2,id) * PT(-3,id)*PT(-3,id) * " + basicPole
+        elif propa == "1TL": # (pol=-1) transverse helicity -1 = eps(-1) x eps(-1)*
+            numerator = "0.5*(-1*PVec(-2,id)*PVec(-2,id) * EPST2(1,id)*EPST2(2,id) + EPST1(1,id)*EPST1(2,id)" \
+            " - complex(0,1)*Tnorm(id)*(EPST2(1,id)*EPST1(2,id) - EPST1(1,id)*EPST2(2,id)))"
+            denominator = "PVec(-2,id)*PVec(-2,id) * PT(-3,id)*PT(-3,id) * " + basicPole
         elif propa == "1A": # (pol=99) auxiliary
             numerator = "(P(-2,id)*P(-2,id) - Mass(id)**2) * P(1,id) * P(2,id)"
             denominator = "P(-2,id)*P(-2,id) * Mass(id)**2 * " + basicPole
@@ -920,7 +930,7 @@ class AbstractALOHAModel(dict):
                                 new_props.append(['P0']) 
                             # routine for polarised production
                             if part.spin == 3: # vector
-                                new_props += [['P1L'], ['P1T'], ['P1A']]
+                                new_props += [['P1L'], ['P1T'], ['P1TR'], ['P1TL'], ['P1A']]
                                 if part.mass.name.lower() == 'zero':
                                     new_props.append(['P1PS']) # phase-space gauge 
                             elif part.spin == 2: #fermion

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1643,13 +1643,19 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 output['propa'] = 'P1S'
 
             elif self.get('polarization') == [1]:
-                if self.get('spin') != 2:
+                if self.get('spin') == 2:
+                    output['propa'] = 'P1P'
+                elif self.get('spin') == 3:
+                    output['propa'] = 'P1TR'
+                else:
                     raise InvalidCmd( 'polarization not supported for decay particle')
-                output['propa'] = 'P1P'
             elif self.get('polarization') == [-1]:
-                if self.get('spin') != 2:
-                    raise InvalidCmd( 'Left polarization not supported for decay particle for spin (2s+1=%s) particles' % self.get('spin')) 
-                output['propa'] = 'P1M'
+                if self.get('spin') == 2:
+                    output['propa'] = 'P1M'
+                elif self.get('spin') == 3:
+                    output['propa'] = 'P1TL'
+                else:
+                    raise InvalidCmd( 'Left polarization not supported for decay particle for spin (2s+1=%s) particles' % self.get('spin'))
             else:            
                 raise InvalidCmd( 'polarization not supported for decay particle')
             
@@ -1875,9 +1881,11 @@ class HelasWavefunction(base_objects.PhysicsObject):
             elif self.get('polarization') == [99]:
                 tags.append('P1A')
             elif self.get('polarization') == [1]:
-                tags.append('P1P')
+                # helicity +1: transverse projector for a vector, u-spinor for a fermion
+                tags.append('P1TR' if self.get('spin') == 3 else 'P1P')
             elif self.get('polarization') == [-1]:
-                tags.append('P1M')
+                # helicity -1: transverse projector for a vector, v-spinor for a fermion
+                tags.append('P1TL' if self.get('spin') == 3 else 'P1M')
             elif sorted(self.get('polarization')) == [0,9]: # = 0+9
                 tags.append('P1LS')
             elif self.get('polarization') == [4]: # = T-5


### PR DESCRIPTION
## Summary

ALOHA has a dedicated transverse propagator `P1T` for massive spin-1 bosons, but no way to select a **single** transverse helicity. As noted, the `P1T` numerator is exactly the sum of the two circular helicities:

```
P1T  =  eps(+1) ⊗ eps(+1)*  +  eps(-1) ⊗ eps(-1)*
```

This PR adds the two individual projectors `P1TR` (+1) and `P1TL` (-1) and wires them into the mg5 polarization syntax.

The two helicities share the **same denominator** as `P1T` and differ only by the antisymmetric (imaginary) piece:

```
P1T{R,L}  numerator = ½ · [ P1T numerator  ±  i·|p⃗|·(EPST2⊗EPST1 − EPST1⊗EPST2) ]
```

where `|p⃗|` is `Tnorm`. The cross-term cancels in the sum, recovering `P1T`. (See the comment thread for the full derivation.)

## Changes

- **`aloha/create_aloha.py`** — define the `1TR`/`1TL` propagators in `get_custom_propa`, and register them for spin-3 routine generation.
- **`madgraph/core/helas_objects.py`** — make the polarization→propagator mapping spin-aware in **both** `get_helas_call_dict` and `get_aloha_info`: for a **vector** (spin 3), `[1]→P1TR` and `[-1]→P1TL`; fermions keep `P1P`/`P1M`.
- **`aloha/aloha_writers.py`** — recognise the new tags for the small-momentum protection, and emit `Tnorm`/`TnormZ`/`FWP`/`FWM` in the Python writer (previously missing — this also fixes the pre-existing `P1P`/`P1M` fermion propagators in Python/standalone output).

## mg5 syntax

The `{R}`/`{L}`/`{T}` labels already exist; they now produce meaningful routines for massive vectors:

```
u u~ > z{R} z{L}, (z > e+ e-)    # z{R} = +1 (P1TR), z{L} = -1 (P1TL), z{T} = both (P1T)
```

For a massive vector, `{L}` (previously an error) now correctly means *left transverse* (−1); MG5 already warns to distinguish it from longitudinal `{0}`.

## Validation

- `P1TR + P1TL = P1T` element-wise to ~1e-20 through the actual generated ALOHA routines (Python and Fortran).
- Full `output standalone` of `u u~ > z{R} z{L}, (z > e+ e-)` generates and **compiles** the `FFV*P1TR/P1TL` routines; the matrix element evaluates to a finite physical value (no NaN), unchanged across renames.
- `test_helas_objects.py` (44 tests) passes — no regression.

### Cross-section closure (`p p > Z j, Z > e+ e-`)

Run at 13 TeV with `nn23lo1`, identical settings across all runs (same seed, cuts `ptj>20`, `ptl>10`, systematics off):

| Process | σ (pb) |
|---|---|
| `p p > Z j` (full) | **391.9 ± 1.2** |
| `p p > Z{0} j` (longitudinal) | 67.59 ± 0.26 |
| `p p > Z{R} j` (helicity +1, P1TR) | 186.1 ± 0.45 |
| `p p > Z{L} j` (helicity −1, P1TL) | 139.3 ± 0.43 |
| `p p > Z{T} j` (transverse, P1T) | 326.3 ± 0.97 |

**Transverse = (+1) + (−1):** σ(R) + σ(L) = 325.4 ± 0.62  vs  σ(T) = 326.3 ± 0.97  →  Δ ≈ 0.8σ ✓

**Full = longitudinal + transverse:** σ(0) + σ(R) + σ(L) = 393.0 ± 0.68  vs  σ(full) = 391.9 ± 1.2  →  Δ ≈ 0.8σ ✓

Both closures hold within Monte-Carlo uncertainties. Note σ(R) ≠ σ(L) (186 vs 139 pb): the +1/−1 asymmetry — driven by the parity-violating Z couplings — is real and was inaccessible before (only the sum `{T}` existed), yet it correctly sums back to `{T}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)