### PR TITLE
MadSpin sequential: restore the offshell rate factor in the mass-set …

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -894,6 +894,59 @@ error model below is wrong or that implementation is; the combination is
 reachable in the code but should not be used until the weight-identity check
 settles it.
 
+#### The option: one knob, four schemes
+
+`sequential_decay`, `sequential_exact` and `sequential_joint_angles` are replaced
+by a single enumerated option -- the schemes are mutually exclusive alternatives,
+not independent switches, and after variant B was dropped the three booleans no
+longer spanned a clean 2x2:
+
+    set unweighting auto | joint | two_stage | sequential | sequential_global_retry
+
+    mode                     mass stage   angle test              a rejection redraws
+    joint                    --           everything at once      everything
+    two_stage                yes          all angles, one bound   the angles only
+    sequential               yes          per particle            that particle
+    sequential_global_retry  yes          per particle            the virtualities too
+
+`sequential_decay` survives as a deprecated alias (`True` -> sequential,
+`False` -> joint, warning once), so cards written against the earlier revisions
+of this branch keep working. `sequential_spin_order` and `sequential_debug` keep
+their names: an ordering and a check, not modes.
+
+**`sequential_exact` was renamed, not kept.** "Exact" advertised a distinction of
+~0.001 GeV on the top lineshape -- the tabulated factor is good to ~0.5%, and the
+lineshape sensitivity is 0.25 GeV per unit fractional slope error -- inside a pole
+approximation whose own error is of order `Gamma/m` ~ 0.9%, three orders of
+magnitude larger. The name would have pushed users to a 2-3x slower scheme for a
+difference nobody can measure. `sequential_global_retry` says what the mode does
+and leaves the accuracy statement to the documentation, where it can carry the
+numbers.
+
+**`auto`** resolves once per run, from the number of decaying particles counted
+where `to_decay` is built -- not per event, since the modes carry different
+bounds and one that changed event to event would be testing against the wrong
+ones:
+
+- **one decaying particle -> `joint`**, in every spinmode. Every split
+  degenerates there: the per-particle test *is* the joint test (section 3), and
+  the mass/angle one only moves the same factors between two stages. Nothing to
+  win, so the identity machinery is pure cost.
+- **PA/onshell -> `sequential`**. `two_stage` and `sequential_global_retry` split
+  the accept/reject at the up-front mass draw, which those modes do not have;
+  asked for explicitly they log why and fall back to `sequential`.
+- **madspin/full -> `two_stage` for two, `sequential` from three.** One bound
+  over all the angles is tighter than the product of per-particle bounds, while
+  testing each particle as it is drawn lets a rejection skip the decays not yet
+  drawn. The first wins while there is little to skip, the second as the chain
+  lengthens.
+
+That last line makes `auto` non-joint for madspin/full, where `two_stage` is
+faster than the joint test (3.25 production densities and 5.74 decay MEs per
+event against 4.46 and 8.92) and agrees with it at +0.23 sigma over eight
+replicas. An explicit setting is always honoured, including the degenerate
+single-particle case, so any of the four stays available as a cross-check.
+
 #### How to compare these numbers (measurement notes, learned the hard way)
 
 **Wall clocks are only comparable within one campaign.** The per-slot scheme

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -998,10 +998,42 @@ the error bar before any comparison is made -- and the two error models
 Any future claim at the few-hundredths-of-a-GeV level needs either many more
 replicas or, better, the deterministic check below.
 
-**The check worth doing anyway.** For one (production, mass set, decay set),
-`w_mass * prod_k (w_k/Z_hat_k)` must equal
-`prod_i n_i * |M_prod|^2_on * wgt_joint` up to floating point -- the same
-deterministic identity that verified the decay-reshuffling jacobian to 1.5e-7.
-It settles exactness for every variant at once, with no error model to argue
-about, and it is the only way to separate a residual `Z_hat` effect from an
-implementation bug in a scheme like variant B.
+**Done: the weight identity holds (`sequential_debug`).** New option, offshell
+only: on every accepted chain, recompute the joint weight with the joint code --
+on copies, for the same production event, the same virtualities and the same
+decays -- and compare with the product of the stage weights.
+
+The weights compared are the ones taken *before* any `Z_hat` division, since
+`Z_hat` cancels between the mass stage and the angle stage. What is tested is
+therefore the decomposition itself, not the table. And what is tested is
+*proportionality*, not equality: the two differ by a constant -- the number of
+helicity states, and the normalisation the density path applies to the decay
+matrix elements relative to `calculate_matrix_element` -- which the bounds
+absorb. A constant ratio is the identity, whatever its value; a scheme sampling
+the wrong distribution has a ratio that varies chain to chain.
+
+Measured over 2000 accepted chains each:
+
+    variant A            spread 1.71e-07   ratio 1108198261
+    sequential per-slot  spread 1.55e-07   ratio 1108198255
+    variant B            spread 1.54e-07   ratio 1108198258
+
+The spread is float32 epsilon (1.19e-7) -- the density matrices are
+`complex64`, so that is the floor of the arithmetic and not physics -- and the
+three schemes agree on the constant to nine significant figures. The threshold
+is `density_tolerance`, for the same reason `density_debug` uses it: two
+evaluation routes through single-precision matrix elements cannot agree better
+than that.
+
+**What this settles, and what it does not.** It settles the *weight algebra* in
+all three schemes: no missing jacobian, no wrong normalisation, no mis-assigned
+factor. That is the class of bug a lineshape comparison detects only indirectly
+and that no amount of Monte Carlo could have excluded.
+
+It does not settle the *sampling*, which additionally requires that nothing
+self-normalising is left uncompensated -- the `Z_hat ~ Z` requirement for
+variant A and the per-slot scheme (measured at ~0.5%, far inside the ~12%
+tolerance), automatic for the restart schemes. So variant B's -0.034 GeV is not
+a broken weight. With the weights verified and the error models in the state
+described above, the honest summary is: weights correct, deviation unexplained,
+dropped because it is slower than variant A anyway.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -481,7 +481,9 @@ The whole point of the flag is A/B, so the plan is measurement-first:
 5. **Efficiency** — log per-slot acceptance and total decay events consumed per
    production event, both modes. That is the number that justifies the feature
    and calibrates the ladder.
-6. `density_debug` must still pass in joint mode (unchanged code path).
+6. ~~`density_debug` must still pass in joint mode (unchanged code path).~~
+   **`density_debug` is itself broken** and cannot be used as a validation
+   instrument -- see the note at the end of section 10.
 
 ---
 

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -954,23 +954,54 @@ Variant A is now faster than joint on n = 2 and correct as far as the statistics
 can tell, so that default is worth revisiting -- but not before the residual
 below is understood.
 
-**Open: all the tabulated schemes sit low.** Over four replicas each, against
-joint at 173.1818 +- 0.0024 (replica scatter):
+**Resolved: the residual is statistical, and Z_hat is not the limiting factor.**
+Earlier revisions of this section recorded that every tabulated scheme sat below
+joint with the same sign in all twelve replicas, and flagged a possible `Z_hat`
+inaccuracy. Tested directly by raising `max_weight_ps_point` from 500 to 2500,
+i.e. 187500 probe samples per slot instead of 37500:
 
-    variant A            173.1704 +- 0.0101   -0.011   (-1.1 sigma)
-    sequential per-slot  173.1703 +- 0.0062   -0.012   (-1.7 sigma)
-    variant B (dropped)  173.1478 +- 0.0076   -0.034   (-4.3 sigma)
+    Z table         Z(150.6)      Z(195.4)     bin/fit deviation
+    1x probe      0.527 / 0.529  1.705/1.710      1.8% / 0.8%
+    5x probe      0.524 / 0.524  1.707/1.705      0.4% / 0.6%
+    analytic          0.5245        1.7036
 
-Each is within its errors on the conservative model and marginal on the
-optimistic one, but the sign is the same in all twelve replicas. That is what a
-small `Z_hat` inaccuracy would look like -- and variant A and the per-slot
-scheme are exposed to it, while variant B is not, which makes variant B's
-being the *worst* the thing to explain first.
+The table is already converged at the default statistics: five times the samples
+move its endpoints by under 1%, the bin-to-fit deviation falls like 1/sqrt(N)
+(so it was statistical, not a wrong fit form), and the deep table reproduces the
+narrow-width `(m/M) Gamma(m)/Gamma(M)` to 0.1-0.2%. Against a lineshape
+sensitivity of 0.25 GeV per unit fractional error in the slope of `ln Z`, the
+observed residual would have needed a ~4.4% slope error -- an order of magnitude
+more than the table's ~0.5%.
 
-**Next step: check the weight identity, not more statistics.** For one
-(production, mass set, decay set), `w_mass * prod_k (w_k/Z_hat_k)` must equal
+And the lineshape moved the wrong way for a systematic, over four replicas each:
+
+    variant A, 1x probe   173.1704 +- 0.0101    -0.011 +- 0.010   (-1.1 sigma)
+    variant A, 5x probe   173.1985 +- 0.0182    +0.017 +- 0.018   (+0.9 sigma)
+    joint                 173.1818 +- 0.0024
+
+-- it flipped sign rather than shrinking, and three of the four deep-probe
+replicas sit *above* joint, which retires the "same sign every time" pattern.
+Pooling all eight variant A replicas gives **173.1844 +- 0.0110 against joint's
+173.1818, i.e. +0.003 +- 0.011 (+0.23 sigma)**. Variant A agrees with the joint
+accept/reject.
+
+`max_weight_ps_point = 500` is therefore sufficient for the Z table; the deeper
+probe costs 169 s against 76 s per 10000-event run (the probe is fixed setup, so
+it amortises on larger samples) and buys nothing.
+
+**What this leaves open.** Variant B's -0.034 GeV was quoted at "-4.3 sigma" on
+the replica-scatter error model; that significance is not trustworthy. The
+replica scatter itself ranges from 0.005 (joint) to 0.036 (variant A, deep
+probe) across schemes estimated from four points each -- a ~40% uncertainty on
+the error bar before any comparison is made -- and the two error models
+(naive per-run MC error, and replica scatter) disagree by a factor of three.
+Any future claim at the few-hundredths-of-a-GeV level needs either many more
+replicas or, better, the deterministic check below.
+
+**The check worth doing anyway.** For one (production, mass set, decay set),
+`w_mass * prod_k (w_k/Z_hat_k)` must equal
 `prod_i n_i * |M_prod|^2_on * wgt_joint` up to floating point -- the same
-deterministic check that verified the decay-reshuffling jacobian to 1.5e-7. It
-settles exactness for every variant at once, with no error model to argue about,
-and it is the only way to separate a `Z_hat` inaccuracy from an implementation
-bug.
+deterministic identity that verified the decay-reshuffling jacobian to 1.5e-7.
+It settles exactness for every variant at once, with no error model to argue
+about, and it is the only way to separate a residual `Z_hat` effect from an
+implementation bug in a scheme like variant B.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -639,7 +639,185 @@ joint and sequential, and orthogonal to the per-particle factorisation: it hits
 `w+ > all all` regardless of which accept/reject is used. For resonant decays
 the density mode is efficient and the sequential version improves on it.
 
-**madspin/full are enabled** in `_sequential_active`. The open item is the
+**madspin/full are reachable but not the default** in `_sequential_active`:
+`sequential_decay = auto` resolves to sequential for PA/onshell and to the joint
+test for madspin/full, and the wall-time measurement below says it should stay
+that way. The open item is the
 `w+ > all all` non-resonant blow-up in the density-madspin *weight* (BW_cut too
 wide for unweighting the reshuffle? reweighting normalisation? keep those
 channels weighted?), which would help the default joint madspin too.
+
+### Fixed (measured): the mass-set stage missed the per-slot normalisation
+
+The claim above that the un-drawn-slot identity "keeps whatever per-particle
+constant (the offshell/onshell rate ratio) it carries; that is absorbed into
+C_k" is **wrong when that ratio depends on the sampled virtuality**, which is
+the madspin case. The per-angle loop redraws until it accepts, so slot k's
+accepted angles are distributed as `p_pool * w_k / Z_k` with
+
+    Z_k(m) = Integral p_pool(Omega) w_k(Omega, m) dOmega ~ Gamma_k(m)/Gamma_k(on)
+
+Redrawing-until-accept divides `Z_k` out, so the accepted *mass sets* are
+missing `prod_k Z_k(m_k)` relative to the joint weight -- the running-width
+factor. For PA/onshell this cannot happen: fact (b) makes `Z_k == 1`. For
+madspin it is a real bias of the two-stage (mass set, then angles) split.
+
+Measured on `p p > t t~`, `t > w+ b, w+ > l+ vl`, 10000 events (probe-mode dump
+of `E[w_0 | m]`):
+
+    Z(155) = 0.61   Z(165) = 0.81   Z(173) = 1.00   Z(180) = 1.19   Z(190) = 1.49
+
+and the consequence on the reconstructed top lineshape:
+
+    sequential madspin  <m_top> = 172.937 +- 0.022
+    joint madspin       <m_top> = 173.185 +- 0.022     (-7.8 sigma)
+    sequential x Z(m_t)Z(m_tbar) = 173.190 +- 0.023    (closure, 0.14 sigma)
+
+i.e. the whole discrepancy is that one factor -- it is not the decay
+reshuffling jacobian (added since, and verified chain-by-chain: with it the
+sequential product equals `prod(n_i) * |M_prod|^2_on * wgt_joint` to 1.5e-7,
+against a 1.4% rms spread without it), and it is not max-weight truncation
+(doubling `C_mass` via `nb_sigma = 3` leaves the shift at -0.26 GeV). The mass
+distribution sequential madspin produces is the PA/Breit-Wigner one
+(`<m_top>` = 172.916 for PA joint), because the decay-side offshell
+reweighting of the virtuality is exactly what gets normalised away.
+
+#### What Z_k is, and why it can be tabulated
+
+Working the contraction through, the pool sampling density (proportional to
+`|M_dec|^2_on`) cancels the onshell denominator and rotational invariance in the
+parent rest frame turns the angular integral of `D^off` into the identity, so
+
+    Z_k(m) = Integral dPhi_off(m) |M_dec|^2 / Integral dPhi_on |M_dec|^2
+           = (m/M) * Gamma_k(m) / Gamma_k(M)
+
+-- the `m/M` because this ratio carries no `1/2m` flux factor. Three things drop
+out of it: the production event, the other slots' virtualities, and the angles
+already accepted. It is a smooth function of **that slot's virtuality alone**,
+which is what makes a one-dimensional table per slot the right object. The
+narrow-width formula for `t > W b` reproduces the measured values above to 1-2%
+(0.601 / 0.807 / 1 / 1.194 / 1.512 against 0.61 / 0.81 / 1.00 / 1.19 / 1.49).
+
+The same derivation gives a cheaper estimator than `w_k` itself: with
+`s_k = jac_dec * Tr(D^off) / |M_dec|^2_on`, `E[s_k|m] = E[w_k|m] = Z_k(m)`
+exactly -- the density ratio `N_k/N_{k-1}` averages to one at fixed m -- so the
+table is built from `s_k`, which carries no polarisation modulation and hence
+less variance.
+
+#### An imperfect Z_hat does *not* cancel
+
+The per-angle stage is **invariant** under any rescaling of `w_k` by a factor
+that does not depend on the angles: `w_k -> w_k / Z_hat_k` changes its
+normalisation to `Z_k / Z_hat_k` and leaves the accepted angles alone. So
+whatever weight it is given, it still divides out the *true* `Z_k`, and the
+residual bias of a tabulated scheme is exactly `Z_hat / Z`. Accuracy is
+therefore a requirement, not a nicety -- unless the per-angle stage is stopped
+from normalising at all, which is what `sequential_exact` does.
+
+How accurate: the full factor moves `<m_top>` by 0.248 GeV, so a fractional
+error `eps` in the slope of `ln Z` leaves `0.25 * eps` GeV behind. Against the
+0.031 GeV combined MC error of a 10000-event A/B that is `eps < 12%` -- loose,
+and about ten times looser than what the probe delivers.
+
+#### Implementation
+
+`_zhat` / `_build_z_tables` / `_z_slot_keys` (interface_madspin.py). The samples
+are free: the max-weight probe already draws `Nevents_for_max_weight *
+max_weight_ps_point` = 75 * 500 chains, each giving one `(m_k, s_k)` pair per
+slot, so `sequential_accept_reject` records them in probe mode
+(`probe_extra`) and `get_sequential_maxwgt` fits the table before combining the
+bounds. The fit is a weighted quadratic in `ln(m/pole)` through the *bin means*
+(Z is an expectation, so the mean estimates it and the mean of the logarithms
+would not), held constant outside the probed range and reported in the log
+against the running width it estimates. `C_mass` is then derived from the
+completed weights `w_mass * prod_k Z_hat_k` (`_complete_offshell_probe`), which
+is why the probe now keeps its chains instead of maxing them online.
+
+Two related points fell out:
+
+- **`jac_dec == 0` is a rejection, not a restart.** The offshell branch used to
+  trash the whole mass set when a drawn decay could not be reshuffled onto its
+  virtuality. That is a *second* mass-dependent normalisation -- the set then
+  survives slot k with probability `Z_k / (Z_k + q_k C_k)`, not `Z_k` -- which
+  would defeat the correction near a threshold (it is invisible on `t > W b`,
+  where `m_t > M_W + M_b` always). A zero-weight candidate is an ordinary
+  rejection; counting it as one makes `Z_k`, which includes those zeros, the
+  exact correction again. A virtuality no pool decay can reach is killed by the
+  table itself (`zero_below`), with a 200-draw fail-safe behind it.
+- The `max_wgt_sequential` cache splits: the offshell bounds travel with their
+  tables (and depend on `sequential_exact`), so they get their own file name and
+  a JSON format.
+
+#### `sequential_exact`: the escape hatch
+
+New option, offshell spinmodes only. The mass stage pays `Z_hat_k`, each slot
+divides it back out, and a **rejected decay trashes the mass set** instead of
+being redrawn. The chain is then accepted with probability proportional to
+`w_mass * prod_k w_k` -- the joint weight -- so `Z_hat` cancels identically and
+is reduced to an efficiency preconditioner: exact whatever the table says, or
+even with no table at all. The price is that the per-angle stage no longer
+recovers from a rejection, so the acceptance falls back towards the joint one
+and only the early-exit saving survives (worth little at n=2, more at n>=3). Use
+it to bound the residual bias of the tabulated path without needing the joint
+run as the yardstick.
+
+#### A/B after the fix
+
+Same 10000 production events, `p p > t t~`, `t > w+ b, w+ > l+ vl`, seed 42,
+`nb_core 1`, joint madspin as the reference:
+
+                        <m(l+ v b)>          <m(l- v~ b~)>        lineshape
+    joint            173.2024 +- 0.0318   173.1681 +- 0.0318      --
+    sequential + Z   173.1278 +- 0.0319   173.1554 +- 0.0318      chi2/ndf 19.0/22
+    sequential_exact 173.1914 +- 0.0323   173.1906 +- 0.0323      chi2/ndf 10.4/22
+
+Over both resonances that is a shift of -0.044 +- 0.032 GeV for the tabulated
+path and +0.006 +- 0.032 GeV for the exact one, against **-0.248 GeV (-7.8
+sigma)** and chi2/ndf 75.8/22 before the fix. `m(l+ vl)` and `dphi(l+,l-)`, the
+no-regression checks, stay within 0.3-0.6 and 1.0-1.9 sigma.
+
+The -1.66 sigma on `m(l+ v b)` alone is a fluctuation, not a residual. Four
+sequential replicas over the same production events with independent MadSpin
+seeds (42, 43, 44, 45) average both resonances to 173.1416, 173.1527, 173.2167
+and 173.1453 -- 173.1641 +- 0.0177 -- against two joint replicas at 173.1853 and
+173.1867. That is a residual of **-0.022 +- 0.024 GeV**, a tenth of what was
+there before and consistent with zero.
+
+The joint-vs-joint replica is the control that makes the rest readable: it comes
+out at chi2/ndf 21.7/22 on the lineshape and 2.1 sigma on `m(l+ vl)`, i.e. the
+scatter between two runs of the *same* scheme is as large as anything the
+sequential replicas show (14.8, 18.9, 23.1 on the lineshape; 1.2-2.5 sigma on
+`m(l+ vl)`, whose naive standard error is optimistic because the Breit-Wigner
+tail reaches 15 widths). Sequential-vs-joint is now indistinguishable from
+joint-vs-joint.
+
+(Replicating needs a *fresh factory per seed*: MadSpin seeds its RNG on the
+first `set seed` of the card and ignores every later one, so an extra `set seed`
+appended to the card silently reproduces the same run.)
+
+The tabulated `Z` is accurate far beyond what is needed: the fit reports
+`Z(150.7) = 0.53`, `Z(173) = 1`, `Z(195.4) = 1.71` with bin-to-fit deviations
+under 2%, against the narrow-width `(m/M) Gamma(m)/Gamma(M)` values 0.525 and
+1.704 -- i.e. under 0.5% on the shape, where 12% would do.
+
+#### Cost: the offshell path is *slower* than joint, and always was
+
+Decay-phase wall time for the same 10000 events: joint 14.4 s, sequential 28.7
+s, sequential_exact 83.9 s.
+
+The earlier "faster than the joint test" claim counted **decay**-ME evaluations
+only (5.6 vs 8.9 per event, and it still holds: 6.3 here). It missed the
+mass-set stage, which draws **26 virtuality sets per accepted event**, each one
+an `Event(str(production))` parse, a production reshuffling and a production
+density evaluation, against the joint test's 4.5 trials. The `Z_hat` factor is
+not the cause: it inflates `C_mass` from ~14 to ~17-19, i.e. about a third of
+the gap. `sequential_exact` costs a further 3x (104 mass sets per accepted
+event) because a rejected decay now throws the mass set away.
+
+So `sequential_decay = auto` should keep routing madspin/full to the joint
+accept/reject. What this fix buys is that the offshell path is *correct* when
+switched on explicitly, and a per-slot decomposition that pays off for n >= 3 --
+where the joint test's cost grows like n / prod eff_k while the mass-set stage's
+does not. Making the mass-set stage itself cheaper (its acceptance is 1/26, so
+`C_mass` is ~26x the mean weight -- the production reshuffling jacobian tail) is
+the next thing to look at if that path is to be the default anywhere.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -800,24 +800,65 @@ The tabulated `Z` is accurate far beyond what is needed: the fit reports
 under 2%, against the narrow-width `(m/M) Gamma(m)/Gamma(M)` values 0.525 and
 1.704 -- i.e. under 0.5% on the shape, where 12% would do.
 
-#### Cost: the offshell path is *slower* than joint, and always was
+#### The mass weight must be normalised by |M_prod|^2 on shell (Olivier)
 
-Decay-phase wall time for the same 10000 events: joint 14.4 s, sequential 28.7
-s, sequential_exact 83.9 s.
+The mass-set weight above was written `Tr(rho_off) * jac_reshuffle * prod jac_bw`
+-- an offshell production matrix element in the numerator with nothing under it,
+while the joint weight divides by the **onshell** one
+(`calculate_matrix_element_from_density`: `MEdenom_prod` is evaluated before
+`reshuffle_production` and returned as `prod_diag`). The missing denominator is
 
-The earlier "faster than the joint test" claim counted **decay**-ME evaluations
-only (5.6 vs 8.9 per event, and it still holds: 6.3 here). It missed the
-mass-set stage, which draws **26 virtuality sets per accepted event**, each one
-an `Event(str(production))` parse, a production reshuffling and a production
-density evaluation, against the joint test's 4.5 trials. The `Z_hat` factor is
-not the cause: it inflates `C_mass` from ~14 to ~17-19, i.e. about a third of
-the gap. `sequential_exact` costs a further 3x (104 mass sets per accepted
-event) because a rejected decay now throws the mass set away.
+    w_mass = [ Tr(rho_off) / |M_prod|^2_on ] * jac_reshuffle * prod_k jac_bw_k
+                                            * prod_k Z_hat_k(m_k)
+
+**It is not a bias.** `|M_prod|^2_on` depends on the production event alone, and
+the chain never redraws the production event -- the mass stage resamples
+virtualities, nothing else. A factor constant over everything the chain
+resamples cancels between the weight and its bound, and since every production
+event is kept and retried to acceptance it cannot reweight events against each
+other either. Which is why the A/B closed without it.
+
+**It is still wrong**, because `C_mass` is a single number shared by every
+production event. Left out, the absolute scale of `|M_prod|^2` rides inside
+`w_mass` and varies across the sample by orders of magnitude: the bound is set
+by the loudest kinematics, the quiet ones pay for it in acceptance, and the loud
+ones exceed it and are silently truncated. Both of the runs reported above did
+log the overflow CRITICAL -- 10 weights (sequential) and 28 (exact) -- and the
+per-slot lines carry no overflow annotation, so every one of them was at the
+mass stage.
+
+Measured, same 10000 events, before -> after normalising:
+
+    C_mass                       17.1  ->  3.09
+    mass sets / accepted event   26.2  ->  3.20     (sequential)
+                                104.5  -> 12.79     (sequential_exact)
+    weights above their bound      10  ->  1        (sequential)
+                                   28  ->  3        (sequential_exact)
+    decay phase                  28.7s -> 19.7s     (sequential)
+                                 83.9s -> 31.4s     (sequential_exact)
+
+with the lineshape unchanged, as the constancy argument requires: over both
+resonances the sequential mean moves from 173.1641 to 173.17 and the exact one
+sits at 173.1877 against joint's 173.1853. Cost: one onshell production matrix
+element per production event, cached under `me_wgt` -- the same attribute, and
+the same quantity, the joint path already caches there.
+
+#### Cost: the offshell path is still slower than joint on n = 2
+
+Decay-phase wall time for the same 10000 events: joint 14.4 s, sequential 19.7
+s, sequential_exact 31.4 s.
+
+The "faster than the joint test" claim counted **decay**-ME evaluations only
+(5.6 vs 8.9 per event, and it still holds: 6.3 here). Removing 88% of the
+mass-set draws bought only 31% of the wall time, which locates the rest on the
+**per-decay** side: each draw costs an onshell ME, an `Event(str(decay))` LHE
+round-trip, a reshuffle, a density and a contraction, and sequential does 6.3 of
+those against joint's 8.9 -- so per draw it is doing more work than the joint
+test does. That string round-trip, in both `_offshell_production` and the slot
+loop, is the first thing to profile if this path is to get faster.
 
 So `sequential_decay = auto` should keep routing madspin/full to the joint
-accept/reject. What this fix buys is that the offshell path is *correct* when
-switched on explicitly, and a per-slot decomposition that pays off for n >= 3 --
-where the joint test's cost grows like n / prod eff_k while the mass-set stage's
-does not. Making the mass-set stage itself cheaper (its acceptance is 1/26, so
-`C_mass` is ~26x the mean weight -- the production reshuffling jacobian tail) is
-the next thing to look at if that path is to be the default anywhere.
+accept/reject. What this buys is that the offshell path is *correct* when
+switched on explicitly, and a per-slot decomposition that pays off for n >= 3,
+where the joint test's cost grows like n / prod eff_k while neither the mass-set
+stage nor the per-slot draws do.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -843,22 +843,134 @@ sits at 173.1877 against joint's 173.1853. Cost: one onshell production matrix
 element per production event, cached under `me_wgt` -- the same attribute, and
 the same quantity, the joint path already caches there.
 
-#### Cost: the offshell path is still slower than joint on n = 2
+#### `sequential_joint_angles` (variant A): one bound over all the angles
 
-Decay-phase wall time for the same 10000 events: joint 14.4 s, sequential 19.7
-s, sequential_exact 31.4 s.
+Suggested by Olivier. Keep the mass-set stage, but replace the *per-slot*
+accept/reject by a single test on the product of every slot's weight, redrawing
+the whole angle set on a rejection and **keeping the mass set**:
 
-The "faster than the joint test" claim counted **decay**-ME evaluations only
-(5.6 vs 8.9 per event, and it still holds: 6.3 here). Removing 88% of the
-mass-set draws bought only 31% of the wall time, which locates the rest on the
-**per-decay** side: each draw costs an onshell ME, an `Event(str(decay))` LHE
-round-trip, a reshuffle, a density and a contraction, and sequential does 6.3 of
-those against joint's 8.9 -- so per draw it is doing more work than the joint
-test does. That string round-trip, in both `_offshell_production` and the slot
-loop, is the first thing to profile if this path is to get faster.
+    stage 1   w_mass  = [Tr(rho_off)/|M_prod|^2_on] * jac_reshuffle
+                        * prod_k jac_bw_k * prod_k Z_hat_k(m_k)
+    stage 2   w_angle = prod_k [ (N_k/N_{k-1}) * jac_dec_k
+                                 * Tr(D_k^off)/|M_k,dec|^2_on / Z_hat_k ]
 
-So `sequential_decay = auto` should keep routing madspin/full to the joint
-accept/reject. What this buys is that the offshell path is *correct* when
-switched on explicitly, and a per-slot decomposition that pays off for n >= 3,
-where the joint test's cost grows like n / prod eff_k while neither the mass-set
-stage nor the per-slot draws do.
+This is the same target distribution as the per-slot scheme -- same mass stage,
+same self-normalising angle stage, only the granularity of the test changes --
+and the measurement says so: over four replicas each, variant A gives
+173.1704 +- 0.0101 and the per-slot scheme 173.1703 +- 0.0062, agreeing to
+0.0001 GeV while their replica scatters are 0.010-0.012. It needs `Z_hat` for
+exactly the same reason the per-slot scheme does: stage 2 redraws to acceptance
+and so divides out its own normalisation.
+
+**What it buys is reuse.** With the mass set frozen across angle retries, the
+production reshuffling and the offshell production density are evaluated once
+per *accepted mass set* rather than once per trial -- which the joint test
+cannot do, because a rejection there redraws the virtualities too. Per event on
+ttbar: 3.25 mass sets and 5.74 decay-ME evaluations, against joint's 4.46 trials
+and 8.92.
+
+The `Z_hat` division in stage 2 is not needed for correctness (stage 2 is
+invariant under any rescaling by a function of the masses) but is kept for two
+reasons: it flattens the virtuality dependence out of `C_angle`, and it makes
+the bound estimated by the probe -- which samples masses from the prior, not
+from the accepted mass distribution -- closer to what the run actually tests.
+
+An infeasible decay kills the whole angle set rather than being redrawn in
+place. Redrawing one slot would propose from the *feasible* part of the pool,
+making the normalisation stage 2 divides out `Z_k/(1 - q_k(m))` instead of
+`Z_k` -- a different function of the virtuality than the tabulated one, so the
+mass stage's `Z_hat` would no longer compensate it. The same argument applies to
+`sequential_exact`, and both were fixed together.
+
+#### Variant B (`sequential_joint_angles` + `sequential_exact`): dropped
+
+The same single angle bound, but a rejected angle set trashes the mass set. That
+makes `Z_hat` cancel between the stages and the scheme exact whatever the table
+says, and it costs the reuse above (9.25 mass sets per accepted event instead of
+3.25). It was measured and **dropped**: over four replicas it sits 0.034 GeV
+below joint, which is the *largest* deviation of any scheme tried and in the
+scheme that should have been the most exact. That is not understood. Either the
+error model below is wrong or that implementation is; the combination is
+reachable in the code but should not be used until the weight-identity check
+settles it.
+
+#### How to compare these numbers (measurement notes, learned the hard way)
+
+**Wall clocks are only comparable within one campaign.** The per-slot scheme
+measured 19.74 s in one campaign and 13.33 s in another, with byte-identical
+counters (same bounds, same trial counts, same seed) -- a 48% swing from machine
+load alone. Several cost claims in earlier revisions of this document were built
+on cross-campaign timings and were wrong. Quote the counters (mass sets, decay
+evaluations, acceptances, overflows); quote wall time only from a single
+campaign, with joint as an anchor in it.
+
+**Most of the decay phase is not the accept/reject.** Counter differences of
+30-40% between schemes move the clock by about 10%, so a large per-event fixed
+cost -- reading the production event, `add_decays`, the final
+`reshuffle_production`, writing the LHE -- dominates. A three-point fit put it
+near 1.05 ms/event, but PA's total is *below* that, so the fit is
+ill-conditioned and the figure too high; what survives is the qualitative
+statement. Profile before optimising the accept/reject further.
+
+**Replicas share production events.** Replicas of one scheme (same production
+sample, different MadSpin seed) scatter by 0.005 (joint) to 0.020 (the
+sequential schemes) on `<m_top>` over both resonances, while the naive
+per-run MC error is 0.0225. The replicas are therefore strongly correlated and
+neither error is right for a scheme-to-scheme difference: the naive one is too
+conservative, the replica scatter probably too optimistic. This is unresolved,
+and it is why the residuals below are quoted with both.
+
+#### Speed, measured within one campaign
+
+Decay phase for the same 10000 production events, `p p > t t~`,
+`t > w+ b, w+ > l+ vl`, `nb_core 1`:
+
+    spinmode   scheme                 decay phase   per event
+    PA         joint                     9.17 s     3.14 trials -> 6.28 decay ME
+    PA         sequential (default)     11.19 s     1.88 + 3.13 -> 5.01 decay ME
+    madspin    variant A                13.55 s     3.25 mass sets, 5.74 decay ME
+    madspin    joint                    14.61 s     4.46 trials -> 8.92 decay ME
+
+So full offshell matrix elements with variant A cost about **1.5x PA-joint**,
+where madspin-joint costs 1.6x, and variant A is **7-9% faster than
+madspin-joint** (13.06-13.55 s against 14.43-14.61 s over two campaigns).
+
+Two observations about PA, both independent of this work:
+
+- **PA sequential is 22% slower than PA joint on this process**, despite drawing
+  fewer decay events (5.01 against 6.28). With `density_keep_jacobian` on, every
+  slot trial calls `_production_jacobian_for` -- an `Event(str(production))` copy
+  and a reshuffle -- so 5.01 production reshufflings per event against joint's
+  3.14. The per-slot decomposition is supposed to pay off as n grows; at n = 2 it
+  does not, and `sequential_decay = auto` makes sequential the default for PA.
+- **PA sequential logged 11 weight overflows** (9 at slot 0, 2 at slot 1) against
+  variant A's 1 and joint's 0. Its per-slot bounds are under-estimated here, so
+  that sample is slightly biased. Worth a look on its own.
+
+#### Where the offshell path stands
+
+`sequential_decay = auto` still routes madspin/full to the joint accept/reject.
+Variant A is now faster than joint on n = 2 and correct as far as the statistics
+can tell, so that default is worth revisiting -- but not before the residual
+below is understood.
+
+**Open: all the tabulated schemes sit low.** Over four replicas each, against
+joint at 173.1818 +- 0.0024 (replica scatter):
+
+    variant A            173.1704 +- 0.0101   -0.011   (-1.1 sigma)
+    sequential per-slot  173.1703 +- 0.0062   -0.012   (-1.7 sigma)
+    variant B (dropped)  173.1478 +- 0.0076   -0.034   (-4.3 sigma)
+
+Each is within its errors on the conservative model and marginal on the
+optimistic one, but the sign is the same in all twelve replicas. That is what a
+small `Z_hat` inaccuracy would look like -- and variant A and the per-slot
+scheme are exposed to it, while variant B is not, which makes variant B's
+being the *worst* the thing to explain first.
+
+**Next step: check the weight identity, not more statistics.** For one
+(production, mass set, decay set), `w_mass * prod_k (w_k/Z_hat_k)` must equal
+`prod_i n_i * |M_prod|^2_on * wgt_joint` up to floating point -- the same
+deterministic check that verified the decay-reshuffling jacobian to 1.5e-7. It
+settles exactness for every variant at once, with no error model to argue about,
+and it is the only way to separate a `Z_hat` inaccuracy from an implementation
+bug.

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -1054,7 +1054,15 @@ class AllMatrixElement(dict):
             pid =  leg.get('id')
             nb = leg.get('number')
             if pid in to_decay and leg.get('state'):
-                i, proc = to_decay[pid].pop()
+                # FIFO: pair the n-th leg of a given pid with the n-th decay
+                # branch written for that pid. pop() (LIFO) reverses that
+                # pairing whenever two or more final-state particles share a
+                # pid and carry *different* branches (p p > z z with
+                # 'decay z > e+ e-' / 'decay z > u u~'), so the branch used to
+                # build the spin-correlated weight is not the one whose decay
+                # products get attached to that leg. Single-branch pids (t/t~,
+                # w+/w-) are unaffected: the list holds one entry either way.
+                i, proc = to_decay[pid].pop(0)
                 decay_struct[nb] = dc_branch_from_me(proc)
                 identical = [me.get('decay_chains')[i] for me in me_list[1:]]
                 decay_struct[nb].add_decay_ids(identical)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -87,6 +87,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
         self.add_param('sequential_exact', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: reject the whole mass set when a decay is rejected, instead of redrawing that decay until it is accepted. Makes the scheme exact whatever the accuracy of the tabulated offshell rate factor, at a lower acceptance. Ignored by PA/onshell, which need no such factor.')
+        self.add_param('sequential_debug', False, comment='sequential_decay with an offshell spinmode: on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- Z_hat cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
         self.add_param('sequential_joint_angles', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: draw every decay and test their weights against a *single* bound instead of one per particle, rejecting the mass set on failure. This is the joint accept/reject with a mass-set stage in front of it: exact, and it trades the per-particle bounds (whose product is looser than one bound on the product) against losing the early exit when an early particle is rejected. Implies sequential_exact.')
 
     ############################################################################
@@ -2773,7 +2774,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                 seq_stats = collections.defaultdict(int)
                 decays = self.sequential_accept_reject(
                                 production, evt_decayfile, maxwgts,
-                                nb_event - curr_event, stats=seq_stats)
+                                nb_event - curr_event, stats=seq_stats,
+                                decay_dict=decay_dict)
                 if decays is None:
                     # nothing to decay in this production event
                     output_lhe.write_events(production)
@@ -2969,6 +2971,29 @@ class MadSpinInterface(extended_cmd.Cmd):
         if restarts:
             logger.info("MadSpin sequential: %d chains restarted on a mass set "
                         "the production could not reshuffle", restarts)
+        checks = merged.get('nb_identity_check', 0)
+        if checks:
+            mean = merged.get('identity_ratio_sum', 0.0) / checks
+            variance = (merged.get('identity_ratio_sqsum', 0.0) / checks
+                        - mean * mean)
+            spread = (math.sqrt(max(0.0, variance)) / abs(mean)
+                      if mean else float('inf'))
+            # density_tolerance, like density_debug: the two routes evaluate the
+            # same matrix elements through different code, and the density
+            # matrices are single precision, so agreement is bounded by float32
+            # epsilon (~1.2e-7) and not by the physics
+            if spread > self.options['density_tolerance']:
+                logger.critical(
+                    "MadSpin sequential: the weight identity FAILED on %d "
+                    "accepted chains -- the chain weight is not proportional "
+                    "to the joint weight (relative spread of the ratio %.3g, "
+                    "mean %.10g). This scheme is not sampling the joint "
+                    "distribution.", checks, spread, mean)
+            else:
+                logger.info("MadSpin sequential: weight identity verified on "
+                            "%d accepted chains -- chain weight / joint weight "
+                            "constant to %.3g (ratio %.10g)",
+                            checks, spread, mean)
         total_overflow = sum(v for k, v in merged.items()
                              if k.startswith('nb_overflow_'))
         if total_overflow:
@@ -4416,9 +4441,68 @@ class MadSpinInterface(extended_cmd.Cmd):
                         len(samples), len(points), 100 * residual)
         return tables
 
+    def _check_weight_identity(self, production, decays, decay_dict, w_seq,
+                               helicities, stats):
+        """sequential_debug: the identity the whole decomposition rests on,
+        checked on the accepted chain instead of inferred from a distribution.
+
+            w_mass_raw * prod_k w_k_raw  ==  prod_i n_i * wgt_joint
+
+        with w_mass_raw the mass-set weight *before* the tabulated Z_hat and
+        w_k_raw each slot's weight before it is divided back out -- Z_hat
+        cancels between the two stages, so this tests the decomposition itself
+        and not the quality of the table. ``wgt_joint`` is recomputed here by the
+        joint code, on copies, for the same production event, the same
+        virtualities and the same decays.
+
+        A statistical A/B can only bound a bias at the level its Monte Carlo
+        error allows, and needs an error model to say even that. This is
+        deterministic: any scheme whose per-chain weight product is not the
+        joint weight is wrong, whatever a lineshape comparison happens to show.
+        """
+        prod_copy = lhe_parser.Event(str(production))
+        decays_copy = collections.defaultdict(list)
+        jac_bw = 1.0
+        for pdg, decay_list in decays.items():
+            for decay in decay_list:
+                copy = lhe_parser.Event(str(decay))
+                copy[0].new_mass = decay[0].new_mass
+                copy[0].reshuffle_info = decay[0].reshuffle_info
+                decays_copy[pdg].append(copy)
+        # the Breit-Wigner sampling jacobians: the joint path folds them in
+        # itself when it draws the masses, and here the masses are given, so
+        # they are recomputed from the same (pole, width, window) the draw used
+        for pdg, decay_list in decays.items():
+            for decay in decay_list:
+                pole, width, min_mass, max_mass = decay[0].reshuffle_info
+                gap = math.atan((pole ** 2 - min_mass ** 2) / pole / width)
+                gap += math.atan((max_mass ** 2 - pole ** 2) / pole / width)
+                jac_bw *= gap / math.pi
+        full_me, _, prod_diag, dec_diag, jac_reshuffle = \
+            self.calculate_matrix_element_from_density(prod_copy, decays_copy,
+                                                       decay_dict)
+        w_joint = full_me / (prod_diag * dec_diag) * jac_reshuffle * jac_bw
+        nb_hel = 1
+        for hel in helicities:
+            nb_hel *= len(hel)
+        if not w_joint:
+            return
+        # What must hold is *proportionality*, not equality: the chain weight and
+        # the joint weight differ by a constant -- the number of helicity states,
+        # and whatever normalisation the density path applies to the decay matrix
+        # elements relative to calculate_matrix_element -- and any constant is
+        # absorbed by the bounds. So accumulate the ratio and let the report look
+        # at its spread: a constant ratio *is* the identity, whatever its value,
+        # while a scheme that samples the wrong distribution has a ratio that
+        # varies chain to chain.
+        ratio = w_seq / (nb_hel * w_joint)
+        stats['nb_identity_check'] += 1
+        stats['identity_ratio_sum'] += ratio
+        stats['identity_ratio_sqsum'] += ratio * ratio
+
     def sequential_accept_reject(self, production, evt_decayfile, maxwgts,
                                  nb_remain, stats=None, probe=None,
-                                 probe_extra=None):
+                                 probe_extra=None, decay_dict=None):
         """Accept/reject one decaying particle at a time, in density mode.
 
         Returns the accepted ``decays`` dict (pdg -> list of decay events, in
@@ -4580,6 +4664,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                 w_mass = density_prod.trace().real / me_prod_on * jac_reshuffle
                 for s in order:
                     w_mass *= slot_mass[s][2]
+                # before Z_hat, which cancels between the two stages:
+                # this is what the weight-identity check compares
+                w_mass_raw = w_mass
                 if probe is not None:
                     del probe[:]            # start this chain's probe vector
                     probe.append(float(w_mass))
@@ -4630,6 +4717,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 restart = False
                 w_angles = 1.0      # joint_angles: the product tested once, below
                 angle_dead = False  # a zero member: reject the set, stop drawing
+                w_slots = 1.0       # product of the raw per-slot weights
 
                 for position, slot in enumerate(order):
                     index = slot_to_index[slot]
@@ -4731,6 +4819,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                             # reshuffling jacobian are in w_mass.
                             rate = jac_dec * (density.trace().real / me_on)
                             wgt = (n_k / n_prev).real * rate
+                            wgt_raw = wgt        # before any Z_hat division
                             j_k, new_budget = j_prev, budget
                             if probe is not None:
                                 probe.append(float(wgt))
@@ -4765,6 +4854,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                             if accept:
                                 slot_decays[slot] = decay
                                 n_prev = n_k
+                                w_slots *= wgt_raw
                                 break
                             slot_densities.pop(slot, None)
                             if exact:
@@ -4893,6 +4983,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         decays = collections.defaultdict(list)
         for slot in range(len(order)):
             decays[particles[slot_to_index[slot]].pid].append(slot_decays[slot])
+        if (offshell and probe is None and decay_dict
+                and self.options['sequential_debug']):
+            self._check_weight_identity(production, decays, decay_dict,
+                                        w_mass_raw * w_slots, helicities, stats)
         return decays
 
     def get_onshell_evt_and_wgt(self, production, decays, decay_dict, prod_density_cached=None, build_event=True):

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -87,6 +87,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
         self.add_param('sequential_exact', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: reject the whole mass set when a decay is rejected, instead of redrawing that decay until it is accepted. Makes the scheme exact whatever the accuracy of the tabulated offshell rate factor, at a lower acceptance. Ignored by PA/onshell, which need no such factor.')
+        self.add_param('sequential_joint_angles', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: draw every decay and test their weights against a *single* bound instead of one per particle, rejecting the mass set on failure. This is the joint accept/reject with a mass-set stage in front of it: exact, and it trades the per-particle bounds (whose product is looser than one bound on the product) against losing the early exit when an early particle is rejected. Implies sequential_exact.')
 
     ############################################################################
     ##  Special post-processing of the options                                ## 
@@ -2919,11 +2920,27 @@ class MadSpinInterface(extended_cmd.Cmd):
         rejects = merged.get('nb_mass_reject', 0)
         restarts = merged.get('nb_production_restart', 0)
         exact_restarts = merged.get('nb_exact_restart', 0)
-        if rejects or exact_restarts:
+        angle_tries = merged.get('nb_angleset_try', 0)
+        if angle_tries:
+            # variant B: one bound over all the angles, a rejection costing the
+            # mass set
+            logger.info("MadSpin sequential angle stage: %.2f angle sets per "
+                        "accepted event (%d drawn, %d rejected)",
+                        float(angle_tries) / n_written if n_written
+                        else float('inf'), angle_tries,
+                        merged.get('nb_angle_reject', 0))
+        if rejects or exact_restarts or merged.get("nb_angle_reject", 0):
             # the offshell mass-set stage: how many virtuality sets (each one a
             # production reshuffling and a production density) are drawn per
             # accepted event
+            # An angle-set rejection costs a mass set only under the restart
+            # scheme (variant B); with sequential_joint_angles alone (variant A)
+            # the mass set is kept and only the decays are drawn again, which is
+            # the whole point of that variant -- counting those here would
+            # inflate the production-side work by the angle-stage rejections.
             drawn = rejects + restarts + exact_restarts + n_written
+            if self.options['sequential_exact']:
+                drawn += merged.get('nb_angle_reject', 0)
             logger.info("MadSpin sequential mass stage: %.2f mass sets per "
                         "accepted event (%d drawn, %d rejected%s)",
                         float(drawn) / n_written if n_written else float('inf'),
@@ -3752,9 +3769,14 @@ class MadSpinInterface(extended_cmd.Cmd):
             # sequential_exact, so they get a name (and a format) of their own --
             # a cache written for one cannot be read back for the other.
             if offshell:
+                if self.options['sequential_joint_angles']:
+                    variant = '_jointangles'
+                elif self.options['sequential_exact']:
+                    variant = '_exact'
+                else:
+                    variant = ''
                 cache = pjoin(self.options['ms_dir'],
-                              'max_wgt_sequential_offshell%s'
-                              % ('_exact' if self.options['sequential_exact'] else ''))
+                              'max_wgt_sequential_offshell%s' % variant)
                 cached = self._read_offshell_cache(cache)
                 if cached is not None:
                     self._z_tables = cached['z_tables']
@@ -3892,7 +3914,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         per-angle stage takes it back -- 1/Z_k into that slot's own weight.
         """
         keys, order = event['keys'], event['order']
-        exact = self.options['sequential_exact']
+        joint_angles = self.options['sequential_joint_angles']
+        # Both restart-on-reject (sequential_exact) and the single angle bound
+        # (sequential_joint_angles) test w_k/Z_hat_k rather than w_k: for the
+        # first because the mass stage has already paid Z_hat and the two must
+        # cancel, for the second because it flattens the virtuality dependence
+        # out of the bound. The probe has to be completed the same way or the
+        # bound and the weight it bounds are different quantities.
+        exact = self.options['sequential_exact'] or joint_angles
         best = None
         for weights, masses in event['chains']:
             zhat = [self._zhat(key, mass) for key, mass in zip(keys, masses)]
@@ -3903,6 +3932,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                 for position, slot in enumerate(order):
                     current[position + 1] = (weights[position + 1] / zhat[slot]
                                              if zhat[slot] > 0 else 0.0)
+            if joint_angles:
+                # one bound over the product, so the vector is [C_mass, C_angles]
+                product = 1.0
+                for value in current[1:]:
+                    product *= value
+                current = [current[0], product]
             best = current if best is None else \
                    [max(old, new) for old, new in zip(best, current)]
         return best
@@ -4461,6 +4496,13 @@ class MadSpinInterface(extended_cmd.Cmd):
         # Offshell only: reject the mass set on a rejected decay instead of
         # redrawing that decay, so the per-angle stage never normalises. See the
         # Z_k discussion above _z_slot_keys.
+        # One bound over all the angles instead of one per particle, the mass
+        # set paying for a rejection either way: the joint accept/reject with a
+        # mass-set stage in front of it. Exact for the same reason
+        # sequential_exact is -- nothing is redrawn in place, so no stage
+        # normalises itself -- and it keeps Z_hat only as a preconditioner,
+        # since it cancels between the two stages.
+        joint_angles = offshell and self.options['sequential_joint_angles']
         exact = offshell and self.options['sequential_exact']
         zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
         # |M_prod|^2 on shell: the denominator the joint offshell weight divides
@@ -4564,201 +4606,275 @@ class MadSpinInterface(extended_cmd.Cmd):
                         stats['nb_mass_reject'] += 1
                         continue            # redraw the whole mass set
 
-            slot_densities = {}
-            slot_decays = {}
-            slot_masses = {}
-            n_prev = self._partial_density_contraction(density_prod, helicities, {})
-            j_prev = 1.0
-            budget = production.sqrts
-            restart = False
+            # Angle stage. The mass set, the offshell production density and
+            # the reshuffled parents are all fixed above and are *reused* by
+            # every pass of this loop -- which is the whole point of drawing the
+            # virtualities first: the joint accept/reject pays a production
+            # reshuffling and a production density matrix on every trial,
+            # because a rejection there redraws the masses too.
+            #   sequential_joint_angles alone (variant A): a rejected angle set
+            #     is redrawn against the same mass set, so this loop is where
+            #     the reuse happens -- and, redrawing to acceptance, it
+            #     normalises itself, which is what the Z_hat factor in w_mass
+            #     compensates.
+            #   with sequential_exact (variant B): a rejected angle set costs
+            #     the mass set, which makes Z_hat cancel and the scheme exact,
+            #     at the price of throwing that reuse away.
+            while True:
+                slot_densities = {}
+                slot_decays = {}
+                slot_masses = {}
+                n_prev = self._partial_density_contraction(density_prod, helicities, {})
+                j_prev = 1.0
+                budget = production.sqrts
+                restart = False
+                w_angles = 1.0      # joint_angles: the product tested once, below
+                angle_dead = False  # a zero member: reject the set, stop drawing
 
-            for position, slot in enumerate(order):
-                index = slot_to_index[slot]
-                particle = particles[index]
-                # offshell reserves maxwgts[0] for the mass set, so the per-slot
-                # bounds start at index 1
-                wpos = position + 1 if offshell else position
-                if maxwgts:
-                    maxwgt = maxwgts[wpos] if wpos < len(maxwgts) \
-                                           else maxwgts[-1]
-                else:
-                    maxwgt = None
-                nb_infeasible = 0
-                while True:
-                    stats['nb_try_%d' % position] += 1
-                    decay = self._draw_one_decay(particle, index, ids,
-                                                 evt_decayfile, nb_remain)
+                for position, slot in enumerate(order):
+                    index = slot_to_index[slot]
+                    particle = particles[index]
+                    # offshell reserves maxwgts[0] for the mass set, so the per-slot
+                    # bounds start at index 1
+                    wpos = position + 1 if offshell else position
+                    if joint_angles:
+                        # every slot contributes to the single angle weight, tested
+                        # once the last one has been drawn
+                        maxwgt = None
+                    elif maxwgts:
+                        maxwgt = maxwgts[wpos] if wpos < len(maxwgts) \
+                                               else maxwgts[-1]
+                    else:
+                        maxwgt = None
+                    nb_infeasible = 0
+                    while True:
+                        stats['nb_try_%d' % position] += 1
+                        decay = self._draw_one_decay(particle, index, ids,
+                                                     evt_decayfile, nb_remain)
 
-                    if offshell:
-                        # madspin/full: offshell numerator over onshell
-                        # denominator. The mass was drawn up front, so the
-                        # decay is reshuffled to it.
-                        me_on = self.calculate_matrix_element(decay)   # |M_dec|^2_on
-                        decay[0].new_mass, decay[0].reshuffle_info = \
-                            slot_mass[slot][0], slot_mass[slot][1]
-                        # The offshell density is taken on a copy: the drawn
-                        # decay must stay in its onshell rest frame (only tagged
-                        # with new_mass) so the final add_decays + a single
-                        # reshuffle_production rebuild consistent kinematics.
-                        # Reshuffling/boosting it in place leaves it on the
-                        # offshell parent and add_decays then rejects it.
-                        dcopy = lhe_parser.Event(str(decay))
-                        dcopy[0].new_mass = slot_mass[slot][0]
-                        dcopy[0].reshuffle_info = slot_mass[slot][1]
-                        # jac_dec_k: the decay reshuffling jacobian. Joint
-                        # madspin has it (calculate_matrix_element_from_density,
-                        # 'jac *= dec.reshuffle_decayevt()'), so it belongs in
-                        # the per-slot weight here -- it depends on this slot's
-                        # decay only, hence no telescoping ratio.
-                        jac_dec = dcopy.reshuffle_decayevt()
-                        if jac_dec in (0, -1):
-                            # This decay cannot be mapped onto the sampled
-                            # virtuality (its products do not fit). That is a
-                            # zero-weight candidate, i.e. an ordinary rejection
-                            # of *this decay*, not of the mass set: a zero is
-                            # part of Z_k, so counting it as a rejection here is
-                            # what makes the tabulated Z_k the exact correction
-                            # near a threshold. It is recorded as such in the
-                            # probe. The fail-safe covers a virtuality no decay
-                            # in the pool can reach -- with the table in place
-                            # the mass stage rejects those outright, since Z_k
-                            # vanishes there.
-                            stats['nb_infeasible_%d' % position] += 1
+                        if offshell:
+                            # madspin/full: offshell numerator over onshell
+                            # denominator. The mass was drawn up front, so the
+                            # decay is reshuffled to it.
+                            me_on = self.calculate_matrix_element(decay)   # |M_dec|^2_on
+                            decay[0].new_mass, decay[0].reshuffle_info = \
+                                slot_mass[slot][0], slot_mass[slot][1]
+                            # The offshell density is taken on a copy: the drawn
+                            # decay must stay in its onshell rest frame (only tagged
+                            # with new_mass) so the final add_decays + a single
+                            # reshuffle_production rebuild consistent kinematics.
+                            # Reshuffling/boosting it in place leaves it on the
+                            # offshell parent and add_decays then rejects it.
+                            dcopy = lhe_parser.Event(str(decay))
+                            dcopy[0].new_mass = slot_mass[slot][0]
+                            dcopy[0].reshuffle_info = slot_mass[slot][1]
+                            # jac_dec_k: the decay reshuffling jacobian. Joint
+                            # madspin has it (calculate_matrix_element_from_density,
+                            # 'jac *= dec.reshuffle_decayevt()'), so it belongs in
+                            # the per-slot weight here -- it depends on this slot's
+                            # decay only, hence no telescoping ratio.
+                            jac_dec = dcopy.reshuffle_decayevt()
+                            if jac_dec in (0, -1):
+                                # This decay cannot be mapped onto the sampled
+                                # virtuality (its products do not fit). That is a
+                                # zero-weight candidate, i.e. an ordinary rejection
+                                # of *this decay*, not of the mass set: a zero is
+                                # part of Z_k, so counting it as a rejection here is
+                                # what makes the tabulated Z_k the exact correction
+                                # near a threshold. It is recorded as such in the
+                                # probe. The fail-safe covers a virtuality no decay
+                                # in the pool can reach -- with the table in place
+                                # the mass stage rejects those outright, since Z_k
+                                # vanishes there.
+                                stats['nb_infeasible_%d' % position] += 1
+                                if probe is not None:
+                                    probe_extra['z'].append(
+                                        (zkeys[slot], slot_mass[slot][0], 0.0))
+                                elif joint_angles:
+                                    # A zero anywhere makes the whole angle set
+                                    # weight zero, so the set is rejected: stop
+                                    # drawing the remaining slots. Redrawing
+                                    # just this slot instead would propose from
+                                    # the *feasible* part of the pool, and the
+                                    # normalisation the mass stage compensates
+                                    # for would become Z_k/(1 - q_k(m)) -- a
+                                    # different function of the virtuality than
+                                    # the tabulated one.
+                                    w_angles = 0.0
+                                    angle_dead = True
+                                    break
+                                elif exact:
+                                    # Same argument for the per-slot restart
+                                    # scheme: a zero-weight decay has to reject
+                                    # the mass set rather than be redrawn here,
+                                    # or the feasible fraction 1 - q_k(m) is
+                                    # divided out of the accepted mass sets --
+                                    # the same class of bias as Z_k itself, and
+                                    # it would survive precisely where Z_k is
+                                    # supposed to vanish.
+                                    stats['nb_exact_restart'] += 1
+                                    restart = True
+                                    break
+                                nb_infeasible += 1
+                                if nb_infeasible < 200:
+                                    continue
+                                stats['nb_production_restart'] += 1
+                                restart = True
+                                break
+                            density = self._slot_density(dcopy, parents[slot],
+                                                         helicities[slot])
+                            slot_densities[slot] = density
+                            n_k = self._partial_density_contraction(
+                                            density_prod, helicities, slot_densities)
+                            # per-angle factor only: (N_k/N_{k-1}) * jac_dec_k *
+                            # Tr(D_off)/|M_dec|^2_on. jac_bw and the *production*
+                            # reshuffling jacobian are in w_mass.
+                            rate = jac_dec * (density.trace().real / me_on)
+                            wgt = (n_k / n_prev).real * rate
+                            j_k, new_budget = j_prev, budget
                             if probe is not None:
+                                probe.append(float(wgt))
+                                # E[rate | m] = E[w_k | m] = Z_k(m) -- the same
+                                # expectation, without the polarisation modulation
+                                # of the density ratio, so it is the tighter
+                                # estimator of the two.
                                 probe_extra['z'].append(
-                                    (zkeys[slot], slot_mass[slot][0], 0.0))
-                            nb_infeasible += 1
-                            if nb_infeasible < 200:
-                                continue
-                            stats['nb_production_restart'] += 1
-                            restart = True
-                            break
-                        density = self._slot_density(dcopy, parents[slot],
-                                                     helicities[slot])
-                        slot_densities[slot] = density
-                        n_k = self._partial_density_contraction(
-                                        density_prod, helicities, slot_densities)
-                        # per-angle factor only: (N_k/N_{k-1}) * jac_dec_k *
-                        # Tr(D_off)/|M_dec|^2_on. jac_bw and the *production*
-                        # reshuffling jacobian are in w_mass.
-                        rate = jac_dec * (density.trace().real / me_on)
-                        wgt = (n_k / n_prev).real * rate
-                        j_k, new_budget = j_prev, budget
+                                    (zkeys[slot], slot_mass[slot][0], float(rate)))
+                                accept = True
+                            elif joint_angles:
+                                # no test here: every slot feeds the single angle
+                                # weight, tested once the last decay is drawn
+                                zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
+                                w_angles *= wgt / zhat if zhat > 0 else 0.0
+                                accept = True
+                            elif maxwgt is None:
+                                accept = True
+                            else:
+                                if exact:
+                                    # the mass stage already paid Z_hat_k, so the
+                                    # bound this is tested against is the one of
+                                    # w_k/Z_hat_k -- flat in the virtuality, and the
+                                    # two factors cancel over the chain
+                                    zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
+                                    wgt = wgt / zhat if zhat > 0 else 0.0
+                                if wgt > maxwgt:
+                                    stats['nb_overflow_%d' % position] += 1
+                                    logger.debug('sequential: slot %s weight %s above'
+                                                 ' its max %s', position, wgt, maxwgt)
+                                accept = random.random() * maxwgt < wgt
+                            if accept:
+                                slot_decays[slot] = decay
+                                n_prev = n_k
+                                break
+                            slot_densities.pop(slot, None)
+                            if exact:
+                                # Redrawing this decay until it is accepted would
+                                # normalise the per-angle stage and divide Z_k(m)
+                                # out of the accepted mass sets. Rejecting the mass
+                                # set instead keeps the chain acceptance
+                                # proportional to the joint weight -- exact whatever
+                                # Z_hat is, at the cost of throwing the slots
+                                # already accepted away.
+                                stats['nb_exact_restart'] += 1
+                                restart = True
+                                break
+                            continue
+
+                        jac_bw = 1.0        # Breit-Wigner *sampling* jacobian
+                        jac_dec = 1.0       # decay *reshuffling* jacobian
+                        new_budget = budget
+                        if draw_mass:
+                            # decay-side failure is local to this slot: redraw its
+                            # mass, keep every slot already accepted
+                            while True:
+                                new_budget, jac_bw = self._draw_offshell_mass(
+                                                    particle.pdg, decay, budget)
+                                jac_dec = self._decay_reshuffle_jacobian(decay)
+                                if jac_dec not in (0, -1):
+                                    break
+                                stats['nb_mass_redraw_%d' % position] += 1
+                            slot_masses[slot] = (decay[0].new_mass,
+                                                 getattr(decay[0], 'reshuffle_info', None))
+                            if not keep_jac:
+                                # joint PA bundles jac_dec with J_prod: both come out
+                                # of the single reshuffle_production, which under
+                                # density_keep_jacobian = False runs only after the
+                                # event is accepted and so enters no weight. Mirror
+                                # that here, or the two schemes stop matching.
+                                jac_dec = 1.0
+
+                        # The production reshuffling jacobian only enters the
+                        # weight under density_keep_jacobian; then it is needed per
+                        # trial. Otherwise its sole use is spotting a mass set the
+                        # production cannot reshuffle, and that depends on the whole
+                        # set, so it is checked once after the chain is complete --
+                        # not here, where the reshuffle-on-a-copy dominated the cost.
+                        j_k = j_prev
+                        if keep_jac:
+                            j_probe = self._production_jacobian_for(production,
+                                                                   slot_to_index,
+                                                                   slot_masses)
+                            if j_probe in (0, -1):
+                                stats['nb_production_restart'] += 1
+                                restart = True
+                                break
+                            j_k = j_probe
+
+                        # accepted slots reuse their stored (already normalised)
+                        # density; only this slot's decay is evaluated here
+                        slot_densities[slot] = self._slot_density(
+                                        decay, init_part[slot], helicities[slot])
+                        n_k = self._partial_density_contraction(density_prod, helicities,
+                                                                slot_densities)
+                        # jac_dec is this slot's own factor (it depends on this
+                        # decay only), so unlike J it enters without a ratio -- the
+                        # product over slots is what the joint reshuffle_production
+                        # multiplies in.
+                        wgt = (n_k / n_prev).real * jac_bw * jac_dec * (j_k / j_prev)
                         if probe is not None:
+                            # python float: these are marshalled as JSON when the
+                            # scan runs across forked workers
                             probe.append(float(wgt))
-                            # E[rate | m] = E[w_k | m] = Z_k(m) -- the same
-                            # expectation, without the polarisation modulation
-                            # of the density ratio, so it is the tighter
-                            # estimator of the two.
-                            probe_extra['z'].append(
-                                (zkeys[slot], slot_mass[slot][0], float(rate)))
-                            accept = True
-                        elif maxwgt is None:
                             accept = True
                         else:
-                            if exact:
-                                # the mass stage already paid Z_hat_k, so the
-                                # bound this is tested against is the one of
-                                # w_k/Z_hat_k -- flat in the virtuality, and the
-                                # two factors cancel over the chain
-                                zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
-                                wgt = wgt / zhat if zhat > 0 else 0.0
                             if wgt > maxwgt:
+                                # the bound was under-estimated: this biases
+                                # silently, so it has to be visible
                                 stats['nb_overflow_%d' % position] += 1
-                                logger.debug('sequential: slot %s weight %s above'
-                                             ' its max %s', position, wgt, maxwgt)
+                                logger.debug('sequential: slot %s weight %s above '
+                                             'its max %s', position, wgt, maxwgt)
                             accept = random.random() * maxwgt < wgt
                         if accept:
                             slot_decays[slot] = decay
-                            n_prev = n_k
+                            n_prev, j_prev, budget = n_k, j_k, new_budget
                             break
+                        # rejected: this slot only, drop what it contributed
                         slot_densities.pop(slot, None)
-                        if exact:
-                            # Redrawing this decay until it is accepted would
-                            # normalise the per-angle stage and divide Z_k(m)
-                            # out of the accepted mass sets. Rejecting the mass
-                            # set instead keeps the chain acceptance
-                            # proportional to the joint weight -- exact whatever
-                            # Z_hat is, at the cost of throwing the slots
-                            # already accepted away.
-                            stats['nb_exact_restart'] += 1
-                            restart = True
-                            break
-                        continue
-
-                    jac_bw = 1.0        # Breit-Wigner *sampling* jacobian
-                    jac_dec = 1.0       # decay *reshuffling* jacobian
-                    new_budget = budget
-                    if draw_mass:
-                        # decay-side failure is local to this slot: redraw its
-                        # mass, keep every slot already accepted
-                        while True:
-                            new_budget, jac_bw = self._draw_offshell_mass(
-                                                particle.pdg, decay, budget)
-                            jac_dec = self._decay_reshuffle_jacobian(decay)
-                            if jac_dec not in (0, -1):
-                                break
-                            stats['nb_mass_redraw_%d' % position] += 1
-                        slot_masses[slot] = (decay[0].new_mass,
-                                             getattr(decay[0], 'reshuffle_info', None))
-                        if not keep_jac:
-                            # joint PA bundles jac_dec with J_prod: both come out
-                            # of the single reshuffle_production, which under
-                            # density_keep_jacobian = False runs only after the
-                            # event is accepted and so enters no weight. Mirror
-                            # that here, or the two schemes stop matching.
-                            jac_dec = 1.0
-
-                    # The production reshuffling jacobian only enters the
-                    # weight under density_keep_jacobian; then it is needed per
-                    # trial. Otherwise its sole use is spotting a mass set the
-                    # production cannot reshuffle, and that depends on the whole
-                    # set, so it is checked once after the chain is complete --
-                    # not here, where the reshuffle-on-a-copy dominated the cost.
-                    j_k = j_prev
-                    if keep_jac:
-                        j_probe = self._production_jacobian_for(production,
-                                                               slot_to_index,
-                                                               slot_masses)
-                        if j_probe in (0, -1):
-                            stats['nb_production_restart'] += 1
-                            restart = True
-                            break
-                        j_k = j_probe
-
-                    # accepted slots reuse their stored (already normalised)
-                    # density; only this slot's decay is evaluated here
-                    slot_densities[slot] = self._slot_density(
-                                    decay, init_part[slot], helicities[slot])
-                    n_k = self._partial_density_contraction(density_prod, helicities,
-                                                            slot_densities)
-                    # jac_dec is this slot's own factor (it depends on this
-                    # decay only), so unlike J it enters without a ratio -- the
-                    # product over slots is what the joint reshuffle_production
-                    # multiplies in.
-                    wgt = (n_k / n_prev).real * jac_bw * jac_dec * (j_k / j_prev)
-                    if probe is not None:
-                        # python float: these are marshalled as JSON when the
-                        # scan runs across forked workers
-                        probe.append(float(wgt))
-                        accept = True
-                    else:
-                        if wgt > maxwgt:
-                            # the bound was under-estimated: this biases
-                            # silently, so it has to be visible
-                            stats['nb_overflow_%d' % position] += 1
-                            logger.debug('sequential: slot %s weight %s above '
-                                         'its max %s', position, wgt, maxwgt)
-                        accept = random.random() * maxwgt < wgt
-                    if accept:
-                        slot_decays[slot] = decay
-                        n_prev, j_prev, budget = n_k, j_k, new_budget
+                        slot_masses.pop(slot, None)
+                    if restart or angle_dead:
                         break
-                    # rejected: this slot only, drop what it contributed
-                    slot_densities.pop(slot, None)
-                    slot_masses.pop(slot, None)
-                if restart:
-                    break
+                if joint_angles and not restart and probe is None and maxwgts:
+                    # One bound over the product of every slot's weight, instead
+                    # of one bound per slot: the per-slot bounds' product is
+                    # looser than a single bound on the product, and this buys
+                    # that back at the price of the early exit a per-slot test
+                    # gets when the first particle is rejected.
+                    stats['nb_angleset_try'] += 1
+                    c_angles = maxwgts[1] if len(maxwgts) > 1 else maxwgts[-1]
+                    if w_angles > c_angles:
+                        stats['nb_overflow_angles'] += 1
+                        logger.debug('sequential: angle weight %s above its max %s',
+                                     w_angles, c_angles)
+                    if random.random() * c_angles >= w_angles:
+                        stats['nb_angle_reject'] += 1
+                        if exact:
+                            restart = True      # variant B: the mass set pays
+                        else:
+                            # variant A: keep the mass set, and with it the
+                            # reshuffled production and its density matrix --
+                            # only the decays are drawn again
+                            continue
+                break
             if not restart and draw_mass and not keep_jac and probe is None:
                 # feasibility of the complete mass set: one reshuffle for the
                 # whole chain instead of one per trial

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -2272,7 +2272,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         """
         if not density_method:
             return 'joint'
-        mode = self.options['unweighting']
+        asked = mode = self.options['unweighting']
         if mode == 'auto':
             nb_decaying = getattr(self, '_nb_decaying', 2)
             if nb_decaying <= 1:
@@ -2290,17 +2290,17 @@ class MadSpinInterface(extended_cmd.Cmd):
             else:
                 mode = 'sequential'
         if mode == 'joint':
-            return 'joint'
+            return self._announce_mode('joint', asked)
         if self.options['fixed_order']:
             self._log_once('fixed_order',
                            "MadSpin: fixed_order is on, keeping the joint "
                            "accept/reject (unweighting ignored)")
-            return 'joint'
+            return self._announce_mode('joint', asked)
         if self.options['spinmode'] not in ['PA', 'onshell', 'madspin', 'full']:
             self._log_once('spinmode',
                            "MadSpin: spinmode=%s keeps the joint accept/reject "
                            "(unweighting ignored)", self.options['spinmode'])
-            return 'joint'
+            return self._announce_mode('joint', asked)
         if (mode in ('two_stage', 'sequential_global_retry')
                 and self.options['spinmode'] in ['PA', 'onshell']):
             self._log_once('offshell_only',
@@ -2308,7 +2308,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "(it splits the accept/reject at the up-front mass "
                            "draw, which PA/onshell do not have); using "
                            "sequential instead", mode)
-            return 'sequential'
+            return self._announce_mode('sequential', asked)
+        return self._announce_mode(mode, asked)
+
+    def _announce_mode(self, mode, asked):
+        """Say once which scheme the run uses. Worth a line because the card no
+        longer answers it: 'auto' resolves on the process."""
+        self._log_once('mode', "MadSpin: unweighting = %s (%s)", mode,
+                       'auto, %s decaying particle(s)'
+                       % getattr(self, '_nb_decaying', '?')
+                       if asked == 'auto' else 'set explicitly')
         return mode
 
     def _sequential_active(self, density_method):

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -86,6 +86,7 @@ class MadSpinOptions(banner.ConfigFile):
         # sequential for PA/onshell, joint for madspin/full
         self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
+        self.add_param('sequential_exact', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: reject the whole mass set when a decay is rejected, instead of redrawing that decay until it is accepted. Makes the scheme exact whatever the accuracy of the tabulated offshell rate factor, at a lower acceptance. Ignored by PA/onshell, which need no such factor.')
 
     ############################################################################
     ##  Special post-processing of the options                                ## 
@@ -2915,6 +2916,20 @@ class MadSpinInterface(extended_cmd.Cmd):
                 merged[key] += value
         if not merged:
             return
+        rejects = merged.get('nb_mass_reject', 0)
+        restarts = merged.get('nb_production_restart', 0)
+        exact_restarts = merged.get('nb_exact_restart', 0)
+        if rejects or exact_restarts:
+            # the offshell mass-set stage: how many virtuality sets (each one a
+            # production reshuffling and a production density) are drawn per
+            # accepted event
+            drawn = rejects + restarts + exact_restarts + n_written
+            logger.info("MadSpin sequential mass stage: %.2f mass sets per "
+                        "accepted event (%d drawn, %d rejected%s)",
+                        float(drawn) / n_written if n_written else float('inf'),
+                        drawn, rejects,
+                        ', %d dropped by a rejected decay' % exact_restarts
+                        if exact_restarts else '')
         positions = sorted(int(k.rsplit('_', 1)[1]) for k in merged
                            if k.startswith('nb_try_'))
         for position in positions:
@@ -2923,6 +2938,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             redraws = merged.get('nb_mass_redraw_%d' % position, 0)
             if redraws:
                 extra.append('%d mass redraws' % redraws)
+            infeasible = merged.get('nb_infeasible_%d' % position, 0)
+            if infeasible:
+                extra.append('%d decays that could not be reshuffled' % infeasible)
             overflows = merged.get('nb_overflow_%d' % position, 0)
             if overflows:
                 extra.append('%d ABOVE the maximum weight' % overflows)
@@ -2931,7 +2949,6 @@ class MadSpinInterface(extended_cmd.Cmd):
                 " (%d drawn)%s", position,
                 float(tries) / n_written if n_written else float('inf'), tries,
                 (' [%s]' % ', '.join(extra)) if extra else '')
-        restarts = merged.get('nb_production_restart', 0)
         if restarts:
             logger.info("MadSpin sequential: %d chains restarted on a mass set "
                         "the production could not reshuffle", restarts)
@@ -3464,7 +3481,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                                   nevents, nb_ps_point)
         else:
             logger.info("MadSpin: probing the maximum weight on %s cores", nb_core)
-            all_maxwgt = self._scan_maxwgt_parallel(
+            all_maxwgt, _ = self._scan_maxwgt_parallel(
                 orig_lhe, events, evt_decayfile, nb_core,
                 self._joint_maxwgt_shard_entry, (decay_dict, nevents, nb_ps_point))
 
@@ -3475,14 +3492,25 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     def _scan_maxwgt_range(self, events, start, stop, evt_decayfile,
                            nevents, nb_ps_point):
-        """Per-event maximum-weight vectors for ``events[start:stop]``: one
-        vector per event holding, for each ordering position, the largest w_k
-        seen over ``nb_ps_point`` probe chains. Returns None as soon as a
+        """Per-event probe data for ``events[start:stop]``, and the samples of
+        the offshell rate factor collected along the way.
+
+        Returns ``(per_event, z_samples)``, or ``(None, {})`` as soon as a
         production event turns out to have nothing to decay (the caller then
-        falls back to the joint bound)."""
+        falls back to the joint bound).
+
+        For PA/onshell ``per_event`` is one max-weight vector per event, holding
+        for each ordering position the largest w_k over ``nb_ps_point`` chains --
+        all the bound needs. The offshell branch keeps every chain instead: its
+        mass-set weight is only complete once Z_k is known, and Z_k is fitted
+        from ``z_samples``, which this same probe produces. Taking the maximum
+        there is deferred to the caller, over the completed weights.
+        """
         self.efficiency = 1. / nb_ps_point
+        offshell = self._sequential_offshell()
         t0 = time.time()
         per_event = []
+        z_samples = collections.defaultdict(list)
         for i in range(start, stop):
             if (i - start) % 5 == 1 and getattr(self, '_shard_tag', None) in (None, 0):
                 # only one worker prints scan progress
@@ -3495,19 +3523,31 @@ class MadSpinInterface(extended_cmd.Cmd):
             # refill nb_core times too many decays (900k instead of ~60k).
             nb_remain = stop - i
             best = None
+            chains = []
+            extra = {}
             for _ in range(nb_ps_point):
                 probe = []
                 out = self.sequential_accept_reject(base_event, evt_decayfile,
-                                                    None, nb_remain, probe=probe)
+                                                    None, nb_remain, probe=probe,
+                                                    probe_extra=extra)
                 if out is None:
-                    return None
-                if best is None:
+                    return None, {}
+                if offshell:
+                    chains.append([list(probe), list(extra['mass'])])
+                    for key, mass, value in extra.pop('z', ()):
+                        z_samples[key].append((mass, value))
+                elif best is None:
                     best = list(probe)
                 else:
                     best = [max(old, new) for old, new in zip(best, probe)]
-            if best:
+            if offshell:
+                if chains:
+                    per_event.append({'keys': extra['keys'],
+                                      'order': extra['order'],
+                                      'chains': chains})
+            elif best:
                 per_event.append(best)
-        return per_event
+        return per_event, dict(z_samples)
 
     def _scan_maxwgt_shard_entry(self, shard_id, nb_core, events, start, stop,
                                  evt_decayfile, nevents, nb_ps_point, out_path):
@@ -3524,10 +3564,10 @@ class MadSpinInterface(extended_cmd.Cmd):
             self._pool_gen = {}
             self._init_owner_refill(evt_decayfile, self.seed)
             local_pool = self._reopen_decay_pool(evt_decayfile, shard_id, nb_core)
-            per_event = self._scan_maxwgt_range(events, start, stop, local_pool,
-                                                nevents, nb_ps_point)
+            per_event, z_samples = self._scan_maxwgt_range(
+                            events, start, stop, local_pool, nevents, nb_ps_point)
             with open(out_path, 'w') as f:
-                json.dump({'per_event': per_event}, f)
+                json.dump({'per_event': per_event, 'z_samples': z_samples}, f)
         except Exception as exc:
             import traceback
             try:
@@ -3665,6 +3705,7 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         per_event = []
         result = per_event
+        z_samples = collections.defaultdict(list)
         for sid, outp in enumerate(out_paths):
             if not os.path.exists(outp):
                 raise Exception("MadSpin max-weight worker %s produced no result "
@@ -3678,12 +3719,15 @@ class MadSpinInterface(extended_cmd.Cmd):
                 result = None   # nothing to decay: fall back to the joint bound
             elif result is not None:
                 result.extend(r['per_event'])
+            for key, samples in (r.get('z_samples') or {}).items():
+                # json turns the (mass, value) pairs into lists
+                z_samples[key].extend((s[0], s[1]) for s in samples)
         for outp in out_paths:
             try:
                 os.remove(outp)
             except OSError:
                 pass
-        return result
+        return result, dict(z_samples)
 
     def get_sequential_maxwgt(self, orig_lhe, evt_decayfile):
         """One bound C_k per position of the decay ordering, for the sequential
@@ -3700,12 +3744,27 @@ class MadSpinInterface(extended_cmd.Cmd):
         with which the tail is explored differs, which is why the margins are
         kept and the accept/reject counts its overflows.
         """
+        offshell = self._sequential_offshell()
         cache = None
         if self.options['ms_dir']:
-            # a distinct name: the joint bound is a single float, this is a list
-            cache = pjoin(self.options['ms_dir'], 'max_wgt_sequential')
-            if os.path.exists(cache):
-                return [float(x) for x in open(cache).read().split()]
+            # a distinct name: the joint bound is a single float, this is a list.
+            # The offshell bounds come with the Z_k tables and depend on
+            # sequential_exact, so they get a name (and a format) of their own --
+            # a cache written for one cannot be read back for the other.
+            if offshell:
+                cache = pjoin(self.options['ms_dir'],
+                              'max_wgt_sequential_offshell%s'
+                              % ('_exact' if self.options['sequential_exact'] else ''))
+                if os.path.exists(cache):
+                    import json
+                    with open(cache) as f:
+                        cached = json.load(f)
+                    self._z_tables = cached['z_tables']
+                    return cached['maxwgts']
+            else:
+                cache = pjoin(self.options['ms_dir'], 'max_wgt_sequential')
+                if os.path.exists(cache):
+                    return [float(x) for x in open(cache).read().split()]
 
         nevents = self.options['Nevents_for_max_weight']
         if nevents == 0:
@@ -3745,11 +3804,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         nb_core = self._resolve_nb_core()
         nb_core = max(1, min(nb_core, len(events)))
         if nb_core == 1:
-            per_event = self._scan_maxwgt_range(events, 0, len(events),
-                                                evt_decayfile, nevents, nb_ps_point)
+            per_event, z_samples = self._scan_maxwgt_range(
+                events, 0, len(events), evt_decayfile, nevents, nb_ps_point)
         else:
             logger.info("MadSpin: probing the maximum weight on %s cores", nb_core)
-            per_event = self._scan_maxwgt_parallel(
+            per_event, z_samples = self._scan_maxwgt_parallel(
                 orig_lhe, events, evt_decayfile, nb_core,
                 self._scan_maxwgt_shard_entry, (nevents, nb_ps_point))
 
@@ -3759,13 +3818,45 @@ class MadSpinInterface(extended_cmd.Cmd):
             # _combine_maxwgt needs a spread to work with
             return []
 
+        if offshell:
+            self._z_tables = self._build_z_tables(z_samples)
+            per_event = [self._complete_offshell_probe(event)
+                         for event in per_event]
+
         maxwgts = [self._combine_maxwgt([event[slot] for event in per_event])
                    for slot in range(len(per_event[0]))]
         logger.info("Sequential maximum weights: %s",
                     ' '.join('%.4g' % w for w in maxwgts))
-        if cache:
+        if cache and offshell:
+            import json
+            with open(cache, 'w') as f:
+                json.dump({'maxwgts': maxwgts, 'z_tables': self._z_tables}, f)
+        elif cache:
             open(cache, 'w').write(' '.join(repr(w) for w in maxwgts))
         return maxwgts
+
+    def _complete_offshell_probe(self, event):
+        """The per-event maximum-weight vector of the offshell probe, over the
+        chains it recorded and with the Z_k factors the loop could not apply
+        while they were still being measured: Z_k(m_k) into the mass-set weight,
+        and -- under sequential_exact, where the mass stage pays it and the
+        per-angle stage takes it back -- 1/Z_k into that slot's own weight.
+        """
+        keys, order = event['keys'], event['order']
+        exact = self.options['sequential_exact']
+        best = None
+        for weights, masses in event['chains']:
+            zhat = [self._zhat(key, mass) for key, mass in zip(keys, masses)]
+            current = list(weights)
+            for z in zhat:
+                current[0] *= z
+            if exact:
+                for position, slot in enumerate(order):
+                    current[position + 1] = (weights[position + 1] / zhat[slot]
+                                             if zhat[slot] > 0 else 0.0)
+            best = current if best is None else \
+                   [max(old, new) for old, new in zip(best, current)]
+        return best
 
     def _combine_maxwgt(self, all_maxwgt):
         """Turn the per-production-event maxima of a probe into the bound the
@@ -3959,20 +4050,26 @@ class MadSpinInterface(extended_cmd.Cmd):
                 density_dec = density_dec.tensor_product(density)
         return density_dec.scalar_multiplication(density_prod)
 
-    def _decay_mass_is_feasible(self, decay):
-        """Can this decay's products be put on the virtuality just sampled for
-        it? ``t > b j j`` with a top below MW+Mb cannot.
+    def _decay_reshuffle_jacobian(self, decay):
+        """jac_dec: the jacobian of mapping this decay onto the virtuality just
+        sampled for its parent. 0 when that is kinematically impossible --
+        ``t > b j j`` with a top below MW+Mb -- which is also what tells the
+        caller to draw the mass again.
 
         Probed on a copy: the real reshuffling of the decay still happens once,
-        with the production, exactly as it does today. This only decides whether
-        the sampled mass has to be drawn again."""
+        with the production, exactly as it does today. The value is the same
+        either way -- ``mass_shuffle`` boosts to the parent rest frame before it
+        builds the jacobian, and ``reshuffle_decay``'s ``new_incoming`` only
+        feeds the Lorentz map applied afterwards -- so this probe is what enters
+        the accept/reject weight and the final ``reshuffle_production`` merely
+        recomputes it."""
         probe = lhe_parser.Event(str(decay))
         probe[0].new_mass = decay[0].new_mass
         probe[0].reshuffle_info = decay[0].reshuffle_info
         try:
-            return bool(probe.reshuffle_decayevt())
+            return probe.reshuffle_decayevt()
         except Exception:
-            return False
+            return 0
 
     def _slot_density(self, decay, parent, hel):
         """The decay density matrix of one slot, in the lab frame of its parent."""
@@ -4059,8 +4156,172 @@ class MadSpinInterface(extended_cmd.Cmd):
         parents = {slot: finals[slot_to_index[slot]] for slot in order}
         return rho_off, jac_reshuffle, slot_mass, parents
 
+    def _sequential_offshell(self):
+        """Whether the sequential accept/reject runs its offshell (madspin/full)
+        branch: the production density is evaluated at reshuffled momenta, so the
+        virtualities are drawn up front and rho is fixed per chain."""
+        return self.options['spinmode'] not in ['PA', 'onshell']
+
+    # ------------------------------------------------------------------
+    # Z_k(m): the offshell rate factor of one slot (madspin/full only)
+    # ------------------------------------------------------------------
+    # The offshell chain is unweighted in two stages -- the mass set first, then
+    # each slot's decay angles -- and the per-angle stage redraws until it
+    # accepts. That divides its own normalisation
+    #
+    #     Z_k(m) = Integral p_pool(Omega) w_k(Omega, m) dOmega
+    #            = Integral dPhi_off(m) |M_dec|^2 / Integral dPhi_on |M_dec|^2
+    #
+    # out of the accepted sample, so without a compensating factor in the
+    # mass-set weight the accepted virtualities follow the Breit-Wigner instead
+    # of the offshell one -- the resonance lineshape comes out PA-shaped. Z_k is
+    # the running partial width (times m/M, there being no 1/2m flux factor
+    # here), a smooth function of that slot's virtuality *alone*: the production
+    # event, the other slots' masses and the angles already accepted all cancel
+    # out of it, which is what makes it tabulable. See MADSPIN_SEQUENTIAL_PLAN.md
+    # section 10.
+    #
+    # A *wrong* Z_hat does not cancel: the per-angle stage divides out the true
+    # Z_k whatever weight it is given (rescaling w_k by anything that does not
+    # depend on the angles leaves its accepted distribution unchanged), so the
+    # residual bias of the tabulated scheme is exactly Z_hat/Z. That is why
+    # sequential_exact exists -- it stops the per-angle stage from normalising at
+    # all, and then Z_hat cancels identically and only sets the efficiency.
+
+    @staticmethod
+    def _z_slot_keys(particles, slot_to_index):
+        """Table key of each slot: its pdg and which occurrence of that pdg it
+        is. Slots of one pdg are consecutive and in production order, which is
+        also how _draw_one_decay picks a decay file when there is one file per
+        identical parent -- so the two agree on which slot draws from what."""
+        keys = []
+        seen = collections.defaultdict(int)
+        for index in slot_to_index:
+            pdg = particles[index].pid
+            keys.append('%s_%s' % (pdg, seen[pdg]))
+            seen[pdg] += 1
+        return keys
+
+    def _zhat(self, key, mass):
+        """The tabulated Z_k at a sampled virtuality. 1 when no table has been
+        built (the max-weight probe itself, which is what measures it, and every
+        non-offshell mode)."""
+        table = (getattr(self, '_z_tables', None) or {}).get(key)
+        if not table:
+            return 1.0
+        if mass < table['zero_below']:
+            return 0.0
+        lo, hi = table['range']
+        # held constant outside the probed range rather than extrapolated: the
+        # fit is only constrained where the Breit-Wigner put samples
+        u = math.log(min(max(mass, lo), hi) / table['pole'])
+        c = table['coeff']
+        return math.exp(c[0] + u * (c[1] + u * c[2]))
+
+    @staticmethod
+    def _weighted_polyfit2(xs, ys, ws):
+        """Weighted least-squares quadratic y = c0 + c1 x + c2 x^2, by the normal
+        equations. Returns None when the system is degenerate (too few distinct
+        points). Small and self contained -- numpy is not imported here."""
+        n = len(xs)
+        if n < 3:
+            return None
+        # symmetric 3x3 normal matrix, moments of x up to 4
+        moment = [sum(w * x ** k for x, w in zip(xs, ws)) for k in range(5)]
+        rhs = [sum(w * y * x ** k for x, y, w in zip(xs, ys, ws)) for k in range(3)]
+        mat = [[moment[i + j] for j in range(3)] + [rhs[i]] for i in range(3)]
+        for col in range(3):       # gaussian elimination with partial pivoting
+            pivot = max(range(col, 3), key=lambda r: abs(mat[r][col]))
+            if abs(mat[pivot][col]) < 1e-30:
+                return None
+            mat[col], mat[pivot] = mat[pivot], mat[col]
+            for row in range(3):
+                if row == col:
+                    continue
+                factor = mat[row][col] / mat[col][col]
+                for k in range(col, 4):
+                    mat[row][k] -= factor * mat[col][k]
+        return [mat[i][3] / mat[i][i] for i in range(3)]
+
+    def _build_z_tables(self, z_samples, nb_bin=20, min_per_bin=20):
+        """Fit ln Z_k(m) from the (virtuality, rate factor) pairs the max-weight
+        probe collected, one table per slot key.
+
+        The samples are binned in m and *averaged* -- Z_k is an expectation, so
+        the mean of the samples estimates it while their logarithm would not --
+        then a quadratic in ln(m/pole) is fitted through the bin means, weighted
+        by their counts. The fit is what smooths the tails, where the
+        Breit-Wigner leaves few samples; the accepted lineshape is sensitive to
+        the *slope* of ln Z, and a fractional error there survives as the same
+        fractional error on the shift it corrects.
+
+        Bins whose mean is zero sit below the decay threshold (no pool event can
+        be reshuffled onto that virtuality): they are excluded from the fit and
+        recorded as ``zero_below``, which then makes the mass-set stage reject
+        those virtualities outright.
+        """
+        tables = {}
+        for key, samples in sorted(z_samples.items()):
+            if len(samples) < 4 * min_per_bin:
+                logger.warning("MadSpin sequential: only %d probe samples for "
+                               "slot %s, not tabulating its offshell rate "
+                               "factor", len(samples), key)
+                continue
+            pole = self.banner.get('param', 'mass',
+                                   abs(int(key.split('_')[0]))).value
+            samples = sorted(samples)
+            lo, hi = samples[0][0], samples[-1][0]
+            if not pole or hi <= lo:
+                continue
+            width = (hi - lo) / float(nb_bin)
+            bins = [[0, 0.0, 0.0] for _ in range(nb_bin)]   # count, sum m, sum s
+            for mass, value in samples:
+                index = min(nb_bin - 1, int((mass - lo) / width))
+                bins[index][0] += 1
+                bins[index][1] += mass
+                bins[index][2] += value
+            zero_below = 0.0
+            points = []
+            for count, sum_mass, sum_value in bins:
+                if count < min_per_bin:
+                    continue
+                mean_mass = sum_mass / count
+                mean_value = sum_value / count
+                if mean_value <= 0:
+                    # entirely below threshold: everything up to here is dead
+                    zero_below = max(zero_below, mean_mass)
+                    points = []
+                    continue
+                points.append((math.log(mean_mass / pole),
+                               math.log(mean_value), count))
+            coeff = self._weighted_polyfit2([p[0] for p in points],
+                                            [p[1] for p in points],
+                                            [float(p[2]) for p in points])
+            if coeff is None:
+                logger.warning("MadSpin sequential: could not fit the offshell "
+                               "rate factor of slot %s (%d usable bins)",
+                               key, len(points))
+                continue
+            fit = lambda u: math.exp(coeff[0] + u * (coeff[1] + u * coeff[2]))
+            residual = max(abs(math.exp(y) / fit(u) - 1) for u, y, _ in points)
+            # normalise to 1 at the pole: a constant multiplies every mass set
+            # alike, so it is absorbed by the maximum weight, and it makes the
+            # table readable against the running width it estimates
+            coeff[0] = 0.0      # ``fit`` closes over coeff: normalised from here
+            tables[key] = {'pole': pole, 'coeff': coeff,
+                           'zero_below': zero_below,
+                           'range': (max(lo, zero_below), hi)}
+            logger.info("MadSpin sequential: slot %s offshell rate factor "
+                        "Z(%.5g)=%.3f  Z(%.5g)=1  Z(%.5g)=%.3f "
+                        "(%d samples, %d bins, bin/fit deviation up to %.1f%%)",
+                        key, lo, fit(math.log(max(lo, zero_below) / pole)),
+                        pole, hi, fit(math.log(hi / pole)),
+                        len(samples), len(points), 100 * residual)
+        return tables
+
     def sequential_accept_reject(self, production, evt_decayfile, maxwgts,
-                                 nb_remain, stats=None, probe=None):
+                                 nb_remain, stats=None, probe=None,
+                                 probe_extra=None):
         """Accept/reject one decaying particle at a time, in density mode.
 
         Returns the accepted ``decays`` dict (pdg -> list of decay events, in
@@ -4069,21 +4330,41 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         Exactness: slot k is accepted with probability w_k / C_k where
 
-            w_k = (N_k / N_{k-1}) * jac_k^decay * (J_k / J_{k-1})
+            w_k = (N_k / N_{k-1}) * jac_bw_k * jac_dec_k * (J_k / J_{k-1})
 
-        and every factor telescopes over the chain, so the product reproduces
-        the joint weight. On a reject only *that* slot is redrawn; the slots
-        already accepted are kept. See MADSPIN_SEQUENTIAL_PLAN.md.
+        with jac_bw_k the Breit-Wigner sampling jacobian of slot k's virtuality,
+        jac_dec_k the jacobian of reshuffling slot k's decay onto it, and J_k the
+        production reshuffling jacobian with the slots drawn so far offshell. The
+        N and J factors telescope and the per-slot ones multiply out, so the
+        product reproduces the joint weight (which gets jac_dec_k from the same
+        reshuffle_production call that gives it J). On a reject only *that* slot
+        is redrawn; the slots already accepted are kept. See
+        MADSPIN_SEQUENTIAL_PLAN.md.
 
-        Failure handling follows the scope of the failure: a mass its own decay
-        products cannot accommodate is redrawn on the spot, while a mass *set*
-        the production cannot reshuffle is only knowable once every slot has a
-        mass, so it trashes the whole set and restarts the chain.
+        Failure handling follows the scope of the failure. In PA, where slot k
+        draws its own mass, a mass its decay products cannot accommodate is
+        redrawn on the spot; a mass *set* the production cannot reshuffle is only
+        knowable once every slot has a mass, so it trashes the whole set and
+        restarts the chain. Offshell the mass set is fixed before the loop, so
+        the same decay-side failure is a rejection of that decay instead.
+
+        The offshell (madspin/full) branch splits this in two: a mass-set
+        accept/reject first, then the per-angle loop above. The per-angle loop
+        redraws until it accepts and so divides out its own normalisation
+        Z_k(m), which is a function of the sampled virtuality -- hence the
+        tabulated ``_zhat`` factor in the mass-set weight, without which the
+        accepted resonance lineshape is the Breit-Wigner one. Under
+        ``sequential_exact`` a rejected decay instead trashes the mass set, the
+        per-angle stage stops normalising, and Z_hat cancels from the chain
+        (leaving it a pure efficiency preconditioner).
 
         ``probe``: when a list is given nothing is ever rejected and each slot's
         w_k is appended to it instead. That is how the max-weight scan measures
         the bounds -- on exactly the weights this loop will later test, since it
-        is this same code computing them.
+        is this same code computing them. The weights are recorded *before*
+        ``_zhat`` is applied (the probe is what measures it, so it does not
+        exist yet); ``probe_extra`` carries the virtualities and the rate-factor
+        samples the scan needs to build it.
         """
         decays_key = self._decaying_pdgs(production, evt_decayfile)
         if not decays_key:
@@ -4114,7 +4395,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         # momenta that couple all decay masses, so rho is drawn per chain (after
         # the up-front reshuffle) rather than once at onshell. PA/onshell keep a
         # fixed onshell rho, cached on the production event.
-        offshell = self.options['spinmode'] not in ['PA', 'onshell']
+        offshell = self._sequential_offshell()
+        # Offshell only: reject the mass set on a rejected decay instead of
+        # redrawing that decay, so the per-angle stage never normalises. See the
+        # Z_k discussion above _z_slot_keys.
+        exact = offshell and self.options['sequential_exact']
+        zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
         density_prod = None
         if not offshell:
             density_prod = getattr(production, '_ms_density_prod', None)
@@ -4139,6 +4425,8 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         if stats is None:
             stats = collections.defaultdict(int)
+        if probe is not None and probe_extra is None:
+            probe_extra = {}
 
         while True:     # restart point: an impossible/rejected production mass set
             parents = init_part
@@ -4165,7 +4453,23 @@ class MadSpinInterface(extended_cmd.Cmd):
                 if probe is not None:
                     del probe[:]            # start this chain's probe vector
                     probe.append(float(w_mass))
-                elif maxwgts:
+                    probe_extra['keys'] = zkeys
+                    probe_extra['order'] = list(order)
+                    probe_extra['mass'] = [slot_mass[s][0]
+                                           for s in range(len(order))]
+                    # not reset with the rest: a chain that ends up restarting
+                    # still drew valid (virtuality, rate factor) pairs, and Z_k
+                    # wants every one of them -- including the zeros of a
+                    # virtuality below threshold, which is precisely where
+                    # dropping them would bias the table upwards
+                    probe_extra.setdefault('z', [])
+                else:
+                    # Z_k(m_k): what the per-angle stage will divide out again.
+                    # Without it the accepted virtualities are Breit-Wigner
+                    # distributed instead of offshell distributed.
+                    for s in order:
+                        w_mass *= self._zhat(zkeys[s], slot_mass[s][0])
+                if probe is None and maxwgts:
                     if w_mass > maxwgts[0]:
                         stats['nb_overflow_mass'] += 1
                     if random.random() * maxwgts[0] >= w_mass:
@@ -4191,6 +4495,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                            else maxwgts[-1]
                 else:
                     maxwgt = None
+                nb_infeasible = 0
                 while True:
                     stats['nb_try_%d' % position] += 1
                     decay = self._draw_one_decay(particle, index, ids,
@@ -4199,9 +4504,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     if offshell:
                         # madspin/full: offshell numerator over onshell
                         # denominator. The mass was drawn up front, so the
-                        # decay is reshuffled to it; on failure the whole set
-                        # restarts (the mass cannot be redrawn for one slot
-                        # without invalidating the fixed rho).
+                        # decay is reshuffled to it.
                         me_on = self.calculate_matrix_element(decay)   # |M_dec|^2_on
                         decay[0].new_mass, decay[0].reshuffle_info = \
                             slot_mass[slot][0], slot_mass[slot][1]
@@ -4214,7 +4517,31 @@ class MadSpinInterface(extended_cmd.Cmd):
                         dcopy = lhe_parser.Event(str(decay))
                         dcopy[0].new_mass = slot_mass[slot][0]
                         dcopy[0].reshuffle_info = slot_mass[slot][1]
-                        if dcopy.reshuffle_decayevt() in (0, -1):
+                        # jac_dec_k: the decay reshuffling jacobian. Joint
+                        # madspin has it (calculate_matrix_element_from_density,
+                        # 'jac *= dec.reshuffle_decayevt()'), so it belongs in
+                        # the per-slot weight here -- it depends on this slot's
+                        # decay only, hence no telescoping ratio.
+                        jac_dec = dcopy.reshuffle_decayevt()
+                        if jac_dec in (0, -1):
+                            # This decay cannot be mapped onto the sampled
+                            # virtuality (its products do not fit). That is a
+                            # zero-weight candidate, i.e. an ordinary rejection
+                            # of *this decay*, not of the mass set: a zero is
+                            # part of Z_k, so counting it as a rejection here is
+                            # what makes the tabulated Z_k the exact correction
+                            # near a threshold. It is recorded as such in the
+                            # probe. The fail-safe covers a virtuality no decay
+                            # in the pool can reach -- with the table in place
+                            # the mass stage rejects those outright, since Z_k
+                            # vanishes there.
+                            stats['nb_infeasible_%d' % position] += 1
+                            if probe is not None:
+                                probe_extra['z'].append(
+                                    (zkeys[slot], slot_mass[slot][0], 0.0))
+                            nb_infeasible += 1
+                            if nb_infeasible < 200:
+                                continue
                             stats['nb_production_restart'] += 1
                             restart = True
                             break
@@ -4223,16 +4550,31 @@ class MadSpinInterface(extended_cmd.Cmd):
                         slot_densities[slot] = density
                         n_k = self._partial_density_contraction(
                                         density_prod, helicities, slot_densities)
-                        # per-angle factor only: (N_k/N_{k-1}) * Tr(D_off)/
-                        # |M_dec|^2_on. jac_bw and jac_reshuffle are in w_mass.
-                        wgt = (n_k / n_prev).real * (density.trace().real / me_on)
+                        # per-angle factor only: (N_k/N_{k-1}) * jac_dec_k *
+                        # Tr(D_off)/|M_dec|^2_on. jac_bw and the *production*
+                        # reshuffling jacobian are in w_mass.
+                        rate = jac_dec * (density.trace().real / me_on)
+                        wgt = (n_k / n_prev).real * rate
                         j_k, new_budget = j_prev, budget
                         if probe is not None:
                             probe.append(float(wgt))
+                            # E[rate | m] = E[w_k | m] = Z_k(m) -- the same
+                            # expectation, without the polarisation modulation
+                            # of the density ratio, so it is the tighter
+                            # estimator of the two.
+                            probe_extra['z'].append(
+                                (zkeys[slot], slot_mass[slot][0], float(rate)))
                             accept = True
                         elif maxwgt is None:
                             accept = True
                         else:
+                            if exact:
+                                # the mass stage already paid Z_hat_k, so the
+                                # bound this is tested against is the one of
+                                # w_k/Z_hat_k -- flat in the virtuality, and the
+                                # two factors cancel over the chain
+                                zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
+                                wgt = wgt / zhat if zhat > 0 else 0.0
                             if wgt > maxwgt:
                                 stats['nb_overflow_%d' % position] += 1
                                 logger.debug('sequential: slot %s weight %s above'
@@ -4243,21 +4585,41 @@ class MadSpinInterface(extended_cmd.Cmd):
                             n_prev = n_k
                             break
                         slot_densities.pop(slot, None)
+                        if exact:
+                            # Redrawing this decay until it is accepted would
+                            # normalise the per-angle stage and divide Z_k(m)
+                            # out of the accepted mass sets. Rejecting the mass
+                            # set instead keeps the chain acceptance
+                            # proportional to the joint weight -- exact whatever
+                            # Z_hat is, at the cost of throwing the slots
+                            # already accepted away.
+                            stats['nb_exact_restart'] += 1
+                            restart = True
+                            break
                         continue
 
-                    jac_dec = 1.0
+                    jac_bw = 1.0        # Breit-Wigner *sampling* jacobian
+                    jac_dec = 1.0       # decay *reshuffling* jacobian
                     new_budget = budget
                     if draw_mass:
                         # decay-side failure is local to this slot: redraw its
                         # mass, keep every slot already accepted
                         while True:
-                            new_budget, jac_dec = self._draw_offshell_mass(
+                            new_budget, jac_bw = self._draw_offshell_mass(
                                                 particle.pdg, decay, budget)
-                            if self._decay_mass_is_feasible(decay):
+                            jac_dec = self._decay_reshuffle_jacobian(decay)
+                            if jac_dec not in (0, -1):
                                 break
                             stats['nb_mass_redraw_%d' % position] += 1
                         slot_masses[slot] = (decay[0].new_mass,
                                              getattr(decay[0], 'reshuffle_info', None))
+                        if not keep_jac:
+                            # joint PA bundles jac_dec with J_prod: both come out
+                            # of the single reshuffle_production, which under
+                            # density_keep_jacobian = False runs only after the
+                            # event is accepted and so enters no weight. Mirror
+                            # that here, or the two schemes stop matching.
+                            jac_dec = 1.0
 
                     # The production reshuffling jacobian only enters the
                     # weight under density_keep_jacobian; then it is needed per
@@ -4282,7 +4644,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                                     decay, init_part[slot], helicities[slot])
                     n_k = self._partial_density_contraction(density_prod, helicities,
                                                             slot_densities)
-                    wgt = (n_k / n_prev).real * jac_dec * (j_k / j_prev)
+                    # jac_dec is this slot's own factor (it depends on this
+                    # decay only), so unlike J it enters without a ratio -- the
+                    # product over slots is what the joint reshuffle_production
+                    # multiplies in.
+                    wgt = (n_k / n_prev).real * jac_bw * jac_dec * (j_k / j_prev)
                     if probe is not None:
                         # python float: these are marshalled as JSON when the
                         # scan runs across forked workers

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -3755,10 +3755,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                 cache = pjoin(self.options['ms_dir'],
                               'max_wgt_sequential_offshell%s'
                               % ('_exact' if self.options['sequential_exact'] else ''))
-                if os.path.exists(cache):
-                    import json
-                    with open(cache) as f:
-                        cached = json.load(f)
+                cached = self._read_offshell_cache(cache)
+                if cached is not None:
                     self._z_tables = cached['z_tables']
                     return cached['maxwgts']
             else:
@@ -3830,10 +3828,59 @@ class MadSpinInterface(extended_cmd.Cmd):
         if cache and offshell:
             import json
             with open(cache, 'w') as f:
-                json.dump({'maxwgts': maxwgts, 'z_tables': self._z_tables}, f)
+                json.dump({'format': self._OFFSHELL_CACHE_FORMAT,
+                           'maxwgts': maxwgts, 'z_tables': self._z_tables}, f)
         elif cache:
             open(cache, 'w').write(' '.join(repr(w) for w in maxwgts))
         return maxwgts
+
+    # Bumped whenever the offshell cache's *meaning* changes: another entry in
+    # the bound vector, a different fit variable or degree, another key in a
+    # table. The file name already separates sequential_exact from the default,
+    # and PA/onshell from both; this separates one version of this code from the
+    # next, which a name cannot.
+    _OFFSHELL_CACHE_FORMAT = 1
+
+    def _read_offshell_cache(self, path):
+        """The cached offshell bounds and Z_k tables, or None if there is
+        nothing usable there.
+
+        A cache that does not match what this code writes is *ignored*, not
+        repaired and not raised on: the scan that produced it is reproducible,
+        so paying for it again is always an option, whereas a table read under
+        the wrong schema would either crash deep inside the accept/reject or --
+        worse -- silently weight the virtualities with somebody else's fit.
+        Hence a format tag, and a structural check of every field the
+        accept/reject will dereference.
+        """
+        if not path or not os.path.exists(path):
+            return None
+        import json
+        try:
+            with open(path) as f:
+                cached = json.load(f)
+            if cached.get('format') != self._OFFSHELL_CACHE_FORMAT:
+                raise ValueError('format %s, expected %s'
+                                 % (cached.get('format'),
+                                    self._OFFSHELL_CACHE_FORMAT))
+            maxwgts = [float(w) for w in cached['maxwgts']]
+            if not maxwgts:
+                raise ValueError('no bounds')
+            tables = cached['z_tables']
+            for key, table in tables.items():
+                missing = {'pole', 'coeff', 'zero_below',
+                           'range'} - set(table)
+                if missing:
+                    raise ValueError('slot %s is missing %s'
+                                     % (key, ', '.join(sorted(missing))))
+                if len(table['coeff']) != 3 or len(table['range']) != 2:
+                    raise ValueError('slot %s has a malformed fit' % key)
+        except Exception as error:
+            logger.warning("MadSpin: ignoring the cached sequential maximum "
+                           "weights in %s (%s); they will be measured again.",
+                           path, error)
+            return None
+        return {'maxwgts': maxwgts, 'z_tables': tables}
 
     def _complete_offshell_probe(self, event):
         """The per-event maximum-weight vector of the offshell probe, over the
@@ -4221,8 +4268,20 @@ class MadSpinInterface(extended_cmd.Cmd):
     @staticmethod
     def _weighted_polyfit2(xs, ys, ws):
         """Weighted least-squares quadratic y = c0 + c1 x + c2 x^2, by the normal
-        equations. Returns None when the system is degenerate (too few distinct
-        points). Small and self contained -- numpy is not imported here."""
+        equations. Returns None when the system is too close to degenerate to
+        solve meaningfully. Small and self contained -- numpy is not imported
+        here, and this runs once per slot at the end of the max-weight scan, so
+        a 3x3 solve in plain python costs nothing worth optimising.
+
+        The pivot tolerance is *relative* to the size of the matrix: the fit
+        variable is ln(m/pole), which spans about +-0.13 over a Breit-Wigner
+        window, so the moments of x^4 are ~1e-4 of the moments of x^0 and an
+        absolute threshold would mean something different for every resonance.
+        A relative one rejects exactly the case that matters -- every bin at the
+        same virtuality, where the quadratic is not determined -- and accepts
+        the normal conditioning of this fit (~3e4, which double precision
+        handles with ten digits to spare).
+        """
         n = len(xs)
         if n < 3:
             return None
@@ -4230,9 +4289,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         moment = [sum(w * x ** k for x, w in zip(xs, ws)) for k in range(5)]
         rhs = [sum(w * y * x ** k for x, y, w in zip(xs, ys, ws)) for k in range(3)]
         mat = [[moment[i + j] for j in range(3)] + [rhs[i]] for i in range(3)]
+        tolerance = 1e-12 * max(abs(value) for row in mat for value in row[:3])
         for col in range(3):       # gaussian elimination with partial pivoting
             pivot = max(range(col, 3), key=lambda r: abs(mat[r][col]))
-            if abs(mat[pivot][col]) < 1e-30:
+            if abs(mat[pivot][col]) <= tolerance:
                 return None
             mat[col], mat[pivot] = mat[pivot], mat[col]
             for row in range(3):

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -88,7 +88,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
         self.add_param('sequential_exact', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: reject the whole mass set when a decay is rejected, instead of redrawing that decay until it is accepted. Makes the scheme exact whatever the accuracy of the tabulated offshell rate factor, at a lower acceptance. Ignored by PA/onshell, which need no such factor.')
         self.add_param('sequential_debug', False, comment='sequential_decay with an offshell spinmode: on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- Z_hat cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
-        self.add_param('sequential_joint_angles', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: draw every decay and test their weights against a *single* bound instead of one per particle, rejecting the mass set on failure. This is the joint accept/reject with a mass-set stage in front of it: exact, and it trades the per-particle bounds (whose product is looser than one bound on the product) against losing the early exit when an early particle is rejected. Implies sequential_exact.')
+        self.add_param('sequential_joint_angles', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: draw every decay and test their weights against a *single* bound instead of one per particle, redrawing the whole set against the same virtualities on failure. The production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial, which the joint accept/reject cannot do. Takes precedence over sequential_exact.')
 
     ############################################################################
     ##  Special post-processing of the options                                ## 
@@ -2924,8 +2924,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         exact_restarts = merged.get('nb_exact_restart', 0)
         angle_tries = merged.get('nb_angleset_try', 0)
         if angle_tries:
-            # variant B: one bound over all the angles, a rejection costing the
-            # mass set
+            # sequential_joint_angles: one bound over all the angles
             logger.info("MadSpin sequential angle stage: %.2f angle sets per "
                         "accepted event (%d drawn, %d rejected)",
                         float(angle_tries) / n_written if n_written
@@ -2935,14 +2934,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             # the offshell mass-set stage: how many virtuality sets (each one a
             # production reshuffling and a production density) are drawn per
             # accepted event
-            # An angle-set rejection costs a mass set only under the restart
-            # scheme (variant B); with sequential_joint_angles alone (variant A)
-            # the mass set is kept and only the decays are drawn again, which is
-            # the whole point of that variant -- counting those here would
-            # inflate the production-side work by the angle-stage rejections.
+            # An angle-set rejection does not cost a mass set: the set is kept
+            # and only the decays are drawn again, which is the whole point of
+            # sequential_joint_angles. Counting those here would inflate the
+            # production-side work by the angle-stage rejections.
             drawn = rejects + restarts + exact_restarts + n_written
-            if self.options['sequential_exact']:
-                drawn += merged.get('nb_angle_reject', 0)
             logger.info("MadSpin sequential mass stage: %.2f mass sets per "
                         "accepted event (%d drawn, %d rejected%s)",
                         float(drawn) / n_written if n_written else float('inf'),
@@ -4587,7 +4583,18 @@ class MadSpinInterface(extended_cmd.Cmd):
         # normalises itself -- and it keeps Z_hat only as a preconditioner,
         # since it cancels between the two stages.
         joint_angles = offshell and self.options['sequential_joint_angles']
-        exact = offshell and self.options['sequential_exact']
+        # The two never combine: testing every angle against one bound *and*
+        # making a rejection cost the mass set was measured (as "variant B") and
+        # dropped -- it throws away the reuse that motivates the single bound,
+        # and it landed further from the joint accept/reject than either
+        # surviving scheme without the weight identity explaining why.
+        exact = offshell and self.options['sequential_exact'] and not joint_angles
+        if (joint_angles and self.options['sequential_exact']
+                and not getattr(self, '_warned_joint_exact', False)):
+            self._warned_joint_exact = True     # once per run, not per event
+            logger.warning("MadSpin: sequential_joint_angles takes precedence "
+                           "over sequential_exact; a rejected angle set is "
+                           "redrawn against the same mass set.")
         zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
         # |M_prod|^2 on shell: the denominator the joint offshell weight divides
         # by (calculate_matrix_element_from_density evaluates it *before*
@@ -4699,14 +4706,13 @@ class MadSpinInterface(extended_cmd.Cmd):
             # virtualities first: the joint accept/reject pays a production
             # reshuffling and a production density matrix on every trial,
             # because a rejection there redraws the masses too.
-            #   sequential_joint_angles alone (variant A): a rejected angle set
-            #     is redrawn against the same mass set, so this loop is where
-            #     the reuse happens -- and, redrawing to acceptance, it
-            #     normalises itself, which is what the Z_hat factor in w_mass
-            #     compensates.
-            #   with sequential_exact (variant B): a rejected angle set costs
-            #     the mass set, which makes Z_hat cancel and the scheme exact,
-            #     at the price of throwing that reuse away.
+            #   sequential_joint_angles: a rejected angle set is redrawn
+            #     against the same mass set, so this loop is where the reuse
+            #     happens -- and, redrawing to acceptance, it normalises itself,
+            #     which is what the Z_hat factor in w_mass compensates.
+            #   sequential_exact: a rejected *decay* costs the mass set, which
+            #     makes Z_hat cancel and that scheme exact whatever the table
+            #     says, at the price of the reuse.
             while True:
                 slot_densities = {}
                 slot_decays = {}
@@ -4957,13 +4963,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                                      w_angles, c_angles)
                     if random.random() * c_angles >= w_angles:
                         stats['nb_angle_reject'] += 1
-                        if exact:
-                            restart = True      # variant B: the mass set pays
-                        else:
-                            # variant A: keep the mass set, and with it the
-                            # reshuffled production and its density matrix --
-                            # only the decays are drawn again
-                            continue
+                        # keep the mass set, and with it the reshuffled
+                        # production and its density matrix: only the decays are
+                        # drawn again. That reuse is the point of this scheme.
+                        continue
                 break
             if not restart and draw_mass and not keep_jac and probe is None:
                 # feasibility of the complete mass set: one reshuffle for the

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -3839,7 +3839,9 @@ class MadSpinInterface(extended_cmd.Cmd):
     # table. The file name already separates sequential_exact from the default,
     # and PA/onshell from both; this separates one version of this code from the
     # next, which a name cannot.
-    _OFFSHELL_CACHE_FORMAT = 1
+    # 2: the mass-set weight is normalised by |M_prod|^2 on shell, so every
+    #    bound in the vector changed scale.
+    _OFFSHELL_CACHE_FORMAT = 2
 
     def _read_offshell_cache(self, path):
         """The cached offshell bounds and Z_k tables, or None if there is
@@ -4461,6 +4463,27 @@ class MadSpinInterface(extended_cmd.Cmd):
         # Z_k discussion above _z_slot_keys.
         exact = offshell and self.options['sequential_exact']
         zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
+        # |M_prod|^2 on shell: the denominator the joint offshell weight divides
+        # by (calculate_matrix_element_from_density evaluates it *before*
+        # reshuffle_production and returns it as prod_diag). It depends on the
+        # production event only -- which the chain never redraws -- so leaving it
+        # out would not bias anything, but it would leave the absolute scale of
+        # the production matrix element inside the mass-set weight while its
+        # bound is a single number shared by every production event: the loud
+        # kinematics would set the bound and then overflow it, the quiet ones
+        # would pay for it in acceptance. Cached on the event under the name the
+        # joint path already uses for the same quantity.
+        me_prod_on = 1.0
+        if offshell:
+            me_prod_on = getattr(production, 'me_wgt', None)
+            if not me_prod_on:
+                me_prod_on = self.calculate_matrix_element(production)
+                production.me_wgt = me_prod_on
+            if not me_prod_on:
+                # a production event with no matrix element cannot be normalised
+                # to itself; leave the weight unscaled rather than divide by zero
+                logger.debug('sequential: |M_prod|^2 = 0, mass weight unscaled')
+                me_prod_on = 1.0
         density_prod = None
         if not offshell:
             density_prod = getattr(production, '_ms_density_prod', None)
@@ -4507,7 +4530,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                 # jacobians, and the offshell production trace -- go here, so the
                 # per-angle loop no longer carries them (that bundling made slot
                 # 0's acceptance ~1/300). See MADSPIN_SEQUENTIAL_PLAN.md sec 10.
-                w_mass = density_prod.trace().real * jac_reshuffle
+                # Tr(rho_off)/|M_prod|^2_on -- the offshell production matrix
+                # element over the onshell one, which is what the joint weight
+                # carries. Applied in probe mode too, unlike Z_hat: it is known
+                # before the scan, so the bound is measured on the same quantity
+                # the accept/reject will test.
+                w_mass = density_prod.trace().real / me_prod_on * jac_reshuffle
                 for s in order:
                     w_mass *= slot_mass[s][2]
                 if probe is not None:

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -90,7 +90,7 @@ class MadSpinOptions(banner.ConfigFile):
                        "sequential: as two_stage but one test per decaying particle, redrawing only the particle that was rejected. "
                        "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
                        "two_stage and sequential need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
-                       "auto: two_stage for up to two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are), or sequential under PA/onshell. "
+                       "auto: joint when a single particle decays (every split degenerates there), two_stage for two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are), or sequential under PA/onshell. "
                        "two_stage and sequential_global_retry need an offshell spinmode and fall back to sequential elsewhere.")
         self.add_param('sequential_decay', 'auto',
                        comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
@@ -2251,8 +2251,11 @@ class MadSpinInterface(extended_cmd.Cmd):
           sequential_global_retry  as sequential, but a rejected decay redraws
                                    the virtualities as well.
 
-        ``auto`` picks by the number of decaying particles, because the two
-        splits trade off against each other: one bound over all the angles is
+        ``auto`` picks by the number of decaying particles. With one, it takes
+        ``joint``: every split degenerates there -- the per-particle test is the
+        joint test, and the mass/angle one only moves the same factors between
+        two stages -- so there is nothing to win and the identity machinery is
+        pure cost. Beyond one, the two splits trade off against each other: one bound over all the angles is
         tighter than the product of per-particle bounds, while testing each
         particle as it is drawn lets a rejection skip the decays not yet drawn.
         The first wins while there is little to skip and the second as the
@@ -2271,11 +2274,18 @@ class MadSpinInterface(extended_cmd.Cmd):
             return 'joint'
         mode = self.options['unweighting']
         if mode == 'auto':
-            if self.options['spinmode'] in ['PA', 'onshell']:
+            nb_decaying = getattr(self, '_nb_decaying', 2)
+            if nb_decaying <= 1:
+                # with a single decaying particle every split degenerates: the
+                # per-particle test *is* the joint test, and the mass/angle one
+                # only moves the same factors between two stages. Nothing to
+                # win, so do not pay for the identity machinery.
+                mode = 'joint'
+            elif self.options['spinmode'] in ['PA', 'onshell']:
                 # two_stage and sequential_global_retry need the up-front mass
                 # draw, which these modes do not have
                 mode = 'sequential'
-            elif getattr(self, '_nb_decaying', 2) <= 2:
+            elif nb_decaying <= 2:
                 mode = 'two_stage'
             else:
                 mode = 'sequential'

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -81,14 +81,22 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
         self.add_param('nb_core', 0, comment='Number of cores for the MadSpin parallel unweighting (0 = use the global MG5 nb_core). nb_core>1 enables the process-parallel unweighting path.')
         self.add_param('density_keep_jacobian', True, comment='PA spinmode only: fold the offshell-reshuffling phase-space jacobian into the accept/reject weight (default) instead of applying the reshuffle as a post-acceptance kinematic dressing (False). Ignored by the madspin/full spinmodes, which always include that jacobian.')
-        self.add_param('sequential_decay', False, comment='accept/reject one decaying particle at a time instead of the full set at once (density mode). Exact and much cheaper when several particles decay. Default is auto: True for the PA/onshell spinmodes, False (joint accept/reject) for madspin/full.')
-        # default is 'auto': resolved at run time by _sequential_active --
-        # sequential for PA/onshell, joint for madspin/full
+        self.add_param('unweighting', 'auto',
+                       allowed=['auto', 'joint', 'two_stage', 'sequential',
+                                'sequential_global_retry'],
+                       comment="how the accept/reject is organised (density modes). "
+                       "joint: one test over the virtualities and every decay at once, the historical scheme. "
+                       "two_stage: unweight the set of virtualities first, then every decay against a single bound, redrawing only the decays on a rejection -- the production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial. "
+                       "sequential: as two_stage but one test per decaying particle, redrawing only the particle that was rejected. "
+                       "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
+                       "two_stage and sequential need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
+                       "auto: two_stage for up to two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are), or sequential under PA/onshell. "
+                       "two_stage and sequential_global_retry need an offshell spinmode and fall back to sequential elsewhere.")
+        self.add_param('sequential_decay', 'auto',
+                       comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
         self.auto_set.add('sequential_decay')
-        self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in sequential_decay: default fermions, then vectors, then scalars (which can never be rejected).')
-        self.add_param('sequential_exact', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: reject the whole mass set when a decay is rejected, instead of redrawing that decay until it is accepted. Makes the scheme exact whatever the accuracy of the tabulated offshell rate factor, at a lower acceptance. Ignored by PA/onshell, which need no such factor.')
-        self.add_param('sequential_debug', False, comment='sequential_decay with an offshell spinmode: on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- Z_hat cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
-        self.add_param('sequential_joint_angles', False, comment='sequential_decay with an offshell spinmode (madspin/full) only: draw every decay and test their weights against a *single* bound instead of one per particle, redrawing the whole set against the same virtualities on failure. The production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial, which the joint accept/reject cannot do. Takes precedence over sequential_exact.')
+        self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in the sequential unweighting modes: default fermions, then vectors, then scalars (which can never be rejected).')
+        self.add_param('sequential_debug', False, comment='offshell spinmodes with a non-joint unweighting: on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
 
     ############################################################################
     ##  Special post-processing of the options                                ## 
@@ -105,6 +113,20 @@ class MadSpinOptions(banner.ConfigFile):
         if not hasattr(random, 'mg_seedset'):
             random.seed(self['seed'])  
             random.mg_seedset = self['seed']  
+
+    def post_set_sequential_decay(self, value, change_userdefine, raiseerror, *opts):
+        """Deprecated alias for 'unweighting'. True/False were the only values
+        it ever had beyond 'auto', so they map onto the two modes that existed
+        then."""
+        if value in ('auto', None):
+            mode = 'auto'
+        elif value in (True, 'True', 'true', 1, '1'):
+            mode = 'sequential'
+        else:
+            mode = 'joint'
+        logger.warning("MadSpin: 'sequential_decay' is deprecated; "
+                       "use 'set unweighting %s'", mode)
+        self['unweighting'] = mode
 
     ############################################################################        
     def post_set_run_card(self, value, change_userdefine, raiseerror, *opts):
@@ -1812,6 +1834,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                     spin = self.model.get_particle(particle.pdg).get('spin')
                     decay_dict[particle.pdg] = [width, mass, color, spin]
         #print(f"to_decay = {to_decay}")
+        # How many particles decay in one event -- the same multiplicity the
+        # pool ladder counts. It decides which unweighting scheme 'auto' picks,
+        # so it is resolved once here rather than per event: the modes have
+        # different bounds, and a mode that changed event to event would be
+        # testing against somebody else's.
+        self._nb_decaying = sum(max(1, int(nb) // int(nb_event))
+                                for nb in to_decay.values()) if nb_event else 0
                 	
         with misc.MuteLogger(["madgraph", "madevent", "ALOHA", "cmdprint"], [50,50,50,50]):
             mg5 = self.mg5cmd
@@ -2191,31 +2220,91 @@ class MadSpinInterface(extended_cmd.Cmd):
             position += multiplicity
         return ladder
 
-    def _sequential_active(self, density_method):
-        """Whether to accept/reject one decaying particle at a time.
+    def _log_once(self, key, message, *args):
+        """Log a resolution message the first time only: these are decided per
+        production event but say something about the run."""
+        seen = getattr(self, '_logged_once', None)
+        if seen is None:
+            seen = self._logged_once = set()
+        if key not in seen:
+            seen.add(key)
+            logger.info(message, *args)
 
-        Density mode only -- the whole scheme is expressed in terms of the
-        production density matrix. ``fixed_order`` keeps the joint test: its
-        counter-events ride along with the decays and have not been thought
-        through here. ``sequential_decay`` defaults to 'auto': sequential for
-        the PA/onshell pole approximations, joint for madspin/full.
+    def _unweighting_mode(self, density_method=True):
+        """Which accept/reject scheme this run uses: one of 'joint',
+        'two_stage', 'sequential', 'sequential_global_retry'.
+
+        All of them sample the same distribution; they differ in how the test is
+        split and in what a rejection redraws.
+
+          joint                    one test over the virtualities and every
+                                   decay at once -- the historical scheme, and
+                                   the only one available outside density mode.
+          two_stage                the set of virtualities is unweighted first,
+                                   then every decay against a single bound; a
+                                   rejection redraws the decays only, so the
+                                   production reshuffling and its density matrix
+                                   are reused across the retries.
+          sequential               as two_stage, but one test per decaying
+                                   particle, redrawing only the particle that
+                                   was rejected.
+          sequential_global_retry  as sequential, but a rejected decay redraws
+                                   the virtualities as well.
+
+        ``auto`` picks by the number of decaying particles, because the two
+        splits trade off against each other: one bound over all the angles is
+        tighter than the product of per-particle bounds, while testing each
+        particle as it is drawn lets a rejection skip the decays not yet drawn.
+        The first wins while there is little to skip and the second as the
+        chain gets longer, so auto takes ``two_stage`` up to two decaying
+        particles and ``sequential`` from three. Under PA/onshell it is always
+        ``sequential``, the other two needing an offshell spinmode.
+
+        ``fixed_order`` forces joint: its counter-events ride along with the
+        decays and have not been thought through here. ``two_stage`` and
+        ``sequential_global_retry`` need the offshell (madspin/full) spinmodes,
+        where the virtualities are drawn up front; under PA/onshell each slot
+        draws its own mass, there is no mass-set stage to hang them on, and they
+        fall back to ``sequential``.
         """
         if not density_method:
-            return False
-        sequential = self.options['sequential_decay']
-        if sequential == 'auto':
-            sequential = self.options['spinmode'] in ['PA', 'onshell']
-        if not sequential:
-            return False
+            return 'joint'
+        mode = self.options['unweighting']
+        if mode == 'auto':
+            if self.options['spinmode'] in ['PA', 'onshell']:
+                # two_stage and sequential_global_retry need the up-front mass
+                # draw, which these modes do not have
+                mode = 'sequential'
+            elif getattr(self, '_nb_decaying', 2) <= 2:
+                mode = 'two_stage'
+            else:
+                mode = 'sequential'
+        if mode == 'joint':
+            return 'joint'
         if self.options['fixed_order']:
-            logger.info("MadSpin: fixed_order is on, keeping the joint "
-                        "accept/reject (sequential_decay ignored)")
-            return False
+            self._log_once('fixed_order',
+                           "MadSpin: fixed_order is on, keeping the joint "
+                           "accept/reject (unweighting ignored)")
+            return 'joint'
         if self.options['spinmode'] not in ['PA', 'onshell', 'madspin', 'full']:
-            logger.info("MadSpin: spinmode=%s keeps the joint accept/reject "
-                        "(sequential_decay ignored)", self.options['spinmode'])
-            return False
-        return True
+            self._log_once('spinmode',
+                           "MadSpin: spinmode=%s keeps the joint accept/reject "
+                           "(unweighting ignored)", self.options['spinmode'])
+            return 'joint'
+        if (mode in ('two_stage', 'sequential_global_retry')
+                and self.options['spinmode'] in ['PA', 'onshell']):
+            self._log_once('offshell_only',
+                           "MadSpin: unweighting=%s needs an offshell spinmode "
+                           "(it splits the accept/reject at the up-front mass "
+                           "draw, which PA/onshell do not have); using "
+                           "sequential instead", mode)
+            return 'sequential'
+        return mode
+
+    def _sequential_active(self, density_method):
+        """Whether any of the per-particle / two-stage schemes is in use, i.e.
+        anything but the historical joint accept/reject."""
+        return self._unweighting_mode(density_method) != 'joint'
 
     def _sequential_spin_order(self):
         """The spin order (MG5 2S+1 convention) driving which particle is
@@ -2924,7 +3013,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         exact_restarts = merged.get('nb_exact_restart', 0)
         angle_tries = merged.get('nb_angleset_try', 0)
         if angle_tries:
-            # sequential_joint_angles: one bound over all the angles
+            # two_stage: one bound over all the angles
             logger.info("MadSpin sequential angle stage: %.2f angle sets per "
                         "accepted event (%d drawn, %d rejected)",
                         float(angle_tries) / n_written if n_written
@@ -2936,7 +3025,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             # accepted event
             # An angle-set rejection does not cost a mass set: the set is kept
             # and only the decays are drawn again, which is the whole point of
-            # sequential_joint_angles. Counting those here would inflate the
+            # two_stage. Counting those here would inflate the
             # production-side work by the angle-stage rejections.
             drawn = rejects + restarts + exact_restarts + n_written
             logger.info("MadSpin sequential mass stage: %.2f mass sets per "
@@ -2997,7 +3086,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 "MadSpin sequential: %d weights exceeded their per-particle "
                 "maximum. That bound is under-estimated and the sample is "
                 "biased: raise nb_sigma or Nevents_for_max_weight, or set "
-                "sequential_decay = False.", total_overflow)
+                "unweighting = joint.", total_overflow)
 
     def _apply_accounting(self, base_out, stats_list):
         """Post-loop accounting shared by the serial and parallel paths: the
@@ -3787,15 +3876,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         if self.options['ms_dir']:
             # a distinct name: the joint bound is a single float, this is a list.
             # The offshell bounds come with the Z_k tables and depend on
-            # sequential_exact, so they get a name (and a format) of their own --
+            # the unweighting mode, so they get a name (and a format) of their own --
             # a cache written for one cannot be read back for the other.
             if offshell:
-                if self.options['sequential_joint_angles']:
-                    variant = '_jointangles'
-                elif self.options['sequential_exact']:
-                    variant = '_exact'
-                else:
-                    variant = ''
+                mode = self._unweighting_mode()
+                variant = '' if mode == 'sequential' else '_%s' % mode
                 cache = pjoin(self.options['ms_dir'],
                               'max_wgt_sequential_offshell%s' % variant)
                 cached = self._read_offshell_cache(cache)
@@ -3879,7 +3964,7 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     # Bumped whenever the offshell cache's *meaning* changes: another entry in
     # the bound vector, a different fit variable or degree, another key in a
-    # table. The file name already separates sequential_exact from the default,
+    # table. The file name already separates the unweighting modes,
     # and PA/onshell from both; this separates one version of this code from the
     # next, which a name cannot.
     # 2: the mass-set weight is normalised by |M_prod|^2 on shell, so every
@@ -3931,18 +4016,18 @@ class MadSpinInterface(extended_cmd.Cmd):
         """The per-event maximum-weight vector of the offshell probe, over the
         chains it recorded and with the Z_k factors the loop could not apply
         while they were still being measured: Z_k(m_k) into the mass-set weight,
-        and -- under sequential_exact, where the mass stage pays it and the
+        and -- under sequential_global_retry, where the mass stage pays it and the
         per-angle stage takes it back -- 1/Z_k into that slot's own weight.
         """
         keys, order = event['keys'], event['order']
-        joint_angles = self.options['sequential_joint_angles']
-        # Both restart-on-reject (sequential_exact) and the single angle bound
-        # (sequential_joint_angles) test w_k/Z_hat_k rather than w_k: for the
-        # first because the mass stage has already paid Z_hat and the two must
-        # cancel, for the second because it flattens the virtuality dependence
-        # out of the bound. The probe has to be completed the same way or the
-        # bound and the weight it bounds are different quantities.
-        exact = self.options['sequential_exact'] or joint_angles
+        mode = self._unweighting_mode()
+        joint_angles = mode == 'two_stage'
+        # Both sequential_global_retry and two_stage test w_k/Z_hat_k rather
+        # than w_k: the first because the mass stage has already paid Z_hat and
+        # the two must cancel, the second because it flattens the virtuality
+        # dependence out of the bound. The probe has to be completed the same
+        # way or the bound and the weight it bounds are different quantities.
+        exact = joint_angles or mode == 'sequential_global_retry'
         best = None
         for weights, masses in event['chains']:
             zhat = [self._zhat(key, mass) for key, mass in zip(keys, masses)]
@@ -4290,7 +4375,7 @@ class MadSpinInterface(extended_cmd.Cmd):
     # Z_k whatever weight it is given (rescaling w_k by anything that does not
     # depend on the angles leaves its accepted distribution unchanged), so the
     # residual bias of the tabulated scheme is exactly Z_hat/Z. That is why
-    # sequential_exact exists -- it stops the per-angle stage from normalising at
+    # sequential_global_retry exists -- it stops the per-angle stage normalising at
     # all, and then Z_hat cancels identically and only sets the efficiency.
 
     @staticmethod
@@ -4531,7 +4616,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         Z_k(m), which is a function of the sampled virtuality -- hence the
         tabulated ``_zhat`` factor in the mass-set weight, without which the
         accepted resonance lineshape is the Breit-Wigner one. Under
-        ``sequential_exact`` a rejected decay instead trashes the mass set, the
+        ``sequential_global_retry`` a rejected decay trashes the mass set, the
         per-angle stage stops normalising, and Z_hat cancels from the chain
         (leaving it a pure efficiency preconditioner).
 
@@ -4579,22 +4664,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         # One bound over all the angles instead of one per particle, the mass
         # set paying for a rejection either way: the joint accept/reject with a
         # mass-set stage in front of it. Exact for the same reason
-        # sequential_exact is -- nothing is redrawn in place, so no stage
+        # sequential_global_retry is -- nothing is redrawn in place, so no stage
         # normalises itself -- and it keeps Z_hat only as a preconditioner,
         # since it cancels between the two stages.
-        joint_angles = offshell and self.options['sequential_joint_angles']
-        # The two never combine: testing every angle against one bound *and*
-        # making a rejection cost the mass set was measured (as "variant B") and
-        # dropped -- it throws away the reuse that motivates the single bound,
-        # and it landed further from the joint accept/reject than either
-        # surviving scheme without the weight identity explaining why.
-        exact = offshell and self.options['sequential_exact'] and not joint_angles
-        if (joint_angles and self.options['sequential_exact']
-                and not getattr(self, '_warned_joint_exact', False)):
-            self._warned_joint_exact = True     # once per run, not per event
-            logger.warning("MadSpin: sequential_joint_angles takes precedence "
-                           "over sequential_exact; a rejected angle set is "
-                           "redrawn against the same mass set.")
+        mode = self._unweighting_mode()
+        joint_angles = offshell and mode == 'two_stage'
+        exact = offshell and mode == 'sequential_global_retry'
         zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
         # |M_prod|^2 on shell: the denominator the joint offshell weight divides
         # by (calculate_matrix_element_from_density evaluates it *before*
@@ -4706,11 +4781,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             # virtualities first: the joint accept/reject pays a production
             # reshuffling and a production density matrix on every trial,
             # because a rejection there redraws the masses too.
-            #   sequential_joint_angles: a rejected angle set is redrawn
+            #   two_stage: a rejected angle set is redrawn
             #     against the same mass set, so this loop is where the reuse
             #     happens -- and, redrawing to acceptance, it normalises itself,
             #     which is what the Z_hat factor in w_mass compensates.
-            #   sequential_exact: a rejected *decay* costs the mass set, which
+            #   sequential_global_retry: a rejected *decay* costs the mass set, which
             #     makes Z_hat cancel and that scheme exact whatever the table
             #     says, at the price of the reuse.
             while True:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1142,9 +1142,11 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _decay_slot_order = interface._decay_slot_order
             sequential_accept_reject = interface.sequential_accept_reject
             _scan_maxwgt_range = interface._scan_maxwgt_range
+            _sequential_offshell = interface._sequential_offshell
             def __init__(self):
                 self.options = {'spinmode': 'onshell',
-                                'sequential_spin_order': '2 3 1'}
+                                'sequential_spin_order': '2 3 1',
+                                'sequential_exact': False}
             def _density_basis(self, production, decays_key):
                 particles, slots = interface._sequential_slots(production, decays_key)
                 return {'decays_key': decays_key, 'helicities': hels,
@@ -1335,11 +1337,11 @@ class TestScanMaxwgtDecomposition(unittest.TestCase):
         stub, events, evt_decayfile = self._fixture()
 
         random.seed(5)
-        whole = stub._scan_maxwgt_range(events, 0, 6, evt_decayfile, 6, 30)
+        whole, _ = stub._scan_maxwgt_range(events, 0, 6, evt_decayfile, 6, 30)
 
         random.seed(5)
-        first = stub._scan_maxwgt_range(events, 0, 2, evt_decayfile, 6, 30)
-        second = stub._scan_maxwgt_range(events, 2, 6, evt_decayfile, 6, 30)
+        first, _ = stub._scan_maxwgt_range(events, 0, 2, evt_decayfile, 6, 30)
+        second, _ = stub._scan_maxwgt_range(events, 2, 6, evt_decayfile, 6, 30)
 
         self.assertEqual(len(whole), 6)
         self.assertEqual(first + second, whole)
@@ -1349,8 +1351,269 @@ class TestScanMaxwgtDecomposition(unittest.TestCase):
         import random
         random.seed(1)
         #Ignore the message "Error while creating the f2py modules for the production/decay part"
-        per_event = stub._scan_maxwgt_range(events, 0, 6, evt_decayfile, 6, 20)
+        per_event, _ = stub._scan_maxwgt_range(events, 0, 6, evt_decayfile, 6, 20)
         self.assertEqual(len(per_event), 6)
         for vec in per_event:
             self.assertEqual(len(vec), 2)          # two decaying particles
             self.assertTrue(all(w >= 0 for w in vec))
+
+
+class TestOffshellRateFactor(unittest.TestCase):
+    """Z_k(m): the normalisation the per-angle stage of the offshell sequential
+    accept/reject divides out, and which therefore has to be put back into the
+    mass-set weight.
+
+    Z_k is the offshell decay rate at the sampled virtuality over the onshell
+    one -- for a two-body decay of a spin-1/2 parent it is (m/M) Gamma(m)/Gamma(M),
+    a smooth function of that slot's virtuality alone. These tests check that the
+    tabulation recovers a known one from the samples the max-weight probe
+    collects, that it interpolates and clips as advertised, and that it lands in
+    the two weights the way sequential_exact needs.
+    """
+
+    class _Val(object):
+        def __init__(self, value):
+            self.value = value
+
+    class _Banner(object):
+        def get(self, card, kind, pdg):
+            return TestOffshellRateFactor._Val(173.0)
+
+    class _Stub(object):
+        _build_z_tables = interface_madspin.MadSpinInterface._build_z_tables
+        _weighted_polyfit2 = staticmethod(
+                        interface_madspin.MadSpinInterface._weighted_polyfit2)
+        _z_slot_keys = staticmethod(
+                        interface_madspin.MadSpinInterface._z_slot_keys)
+        _zhat = interface_madspin.MadSpinInterface._zhat
+        _complete_offshell_probe = \
+                        interface_madspin.MadSpinInterface._complete_offshell_probe
+        def __init__(self, exact=False):
+            self.banner = TestOffshellRateFactor._Banner()
+            self.options = {'sequential_exact': exact}
+            self._z_tables = {}
+
+    @staticmethod
+    def _truth(mass):
+        """A stand-in running width: (m/M) Gamma(m)/Gamma(M) for t > W b."""
+        pole, mw = 173.0, 80.419
+        def rate(m):
+            x = (mw / m) ** 2
+            return m ** 4 * (1 - x) ** 2 * (1 + 2 * x)
+        return rate(mass) / rate(pole)
+
+    def _samples(self, nb=20000, seed=3, spread=1.0, threshold=0.0):
+        """(virtuality, rate factor) pairs as the probe records them: one draw
+        each, the rate factor fluctuating around Z(m) with a large spread -- the
+        table is an average, not a fit through clean points."""
+        import random
+        rng = random.Random(seed)
+        out = []
+        for _ in range(nb):
+            mass = rng.uniform(150.0, 196.0)
+            if mass < threshold:
+                out.append((mass, 0.0))
+                continue
+            # lognormal noise, mean one: E[value | m] = Z(m)
+            noise = math.exp(rng.gauss(0, spread) - 0.5 * spread ** 2)
+            out.append((mass, self._truth(mass) * noise))
+        return out
+
+    def test_polyfit_recovers_a_quadratic(self):
+        xs = [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0]
+        ys = [0.5 - 2 * x + 3 * x ** 2 for x in xs]
+        coeff = self._Stub()._weighted_polyfit2(xs, ys, [1.0] * len(xs))
+        for got, want in zip(coeff, [0.5, -2.0, 3.0]):
+            self.assertAlmostEqual(got, want, places=6)
+
+    def test_polyfit_is_degenerate_below_three_points(self):
+        stub = self._Stub()
+        self.assertIsNone(stub._weighted_polyfit2([1.0, 2.0], [1.0, 2.0], [1, 1]))
+        self.assertIsNone(stub._weighted_polyfit2([1.0] * 4, [1.0] * 4, [1] * 4))
+
+    def test_tabulation_recovers_the_running_width(self):
+        """The whole point: an average over noisy per-draw samples reproduces
+        the underlying Z(m) across the Breit-Wigner range.
+
+        The tolerance that matters is on the *slope* of ln Z -- a fractional
+        error there survives as the same fractional error on the lineshape shift
+        the factor corrects -- so it is checked directly, and much more tightly
+        than the 10% the physics needs.
+        """
+        stub = self._Stub()
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples()})
+        self.assertIn('6_0', stub._z_tables)
+        for mass in (152.0, 160.0, 173.0, 185.0, 195.0):
+            self.assertLess(abs(stub._zhat('6_0', mass) / self._truth(mass) - 1),
+                            0.05, 'Z(%s) off' % mass)
+        slope = ((math.log(stub._zhat('6_0', 190.0) / stub._zhat('6_0', 156.0)))
+                 / (math.log(self._truth(190.0) / self._truth(156.0))))
+        self.assertLess(abs(slope - 1), 0.05)
+
+    def test_normalised_at_the_pole(self):
+        stub = self._Stub()
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples()})
+        self.assertAlmostEqual(stub._zhat('6_0', 173.0), 1.0, places=6)
+
+    def test_held_constant_outside_the_probed_range(self):
+        """Beyond the samples the fit is unconstrained, so it is frozen at the
+        edge rather than extrapolated."""
+        stub = self._Stub()
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples()})
+        self.assertEqual(stub._zhat('6_0', 400.0), stub._zhat('6_0', 196.0))
+        self.assertEqual(stub._zhat('6_0', 100.0), stub._zhat('6_0', 150.0))
+
+    def test_threshold_is_recorded_as_a_hard_zero(self):
+        """Virtualities no decay of the pool can be reshuffled onto give a rate
+        factor of exactly zero, and the mass-set stage must reject them: Z there
+        is 0, not the low edge of the fit."""
+        stub = self._Stub()
+        stub._z_tables = stub._build_z_tables(
+                            {'6_0': self._samples(threshold=165.0)})
+        self.assertEqual(stub._zhat('6_0', 160.0), 0.0)
+        self.assertGreater(stub._zhat('6_0', 180.0), 0.0)
+
+    def test_no_table_is_a_factor_one(self):
+        """The max-weight probe itself runs before any table exists, and every
+        non-offshell mode never builds one."""
+        stub = self._Stub()
+        self.assertEqual(stub._zhat('6_0', 160.0), 1.0)
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples(nb=10)})
+        self.assertEqual(stub._z_tables, {})
+        self.assertEqual(stub._zhat('6_0', 160.0), 1.0)
+
+    def test_slot_keys_separate_identical_parents(self):
+        Part = TestSequentialAcceptReject._Part
+        particles = [Part(6), Part(-6), Part(6)]
+        keys = self._Stub()._z_slot_keys(particles, [0, 2, 1])
+        self.assertEqual(keys, ['6_0', '6_1', '-6_0'])
+
+    def _probe_event(self):
+        return {'keys': ['6_0', '-6_0'], 'order': [1, 0],
+                'chains': [[[2.0, 3.0, 5.0], [160.0, 180.0]],
+                           [[1.0, 7.0, 4.0], [173.0, 173.0]]]}
+
+    def test_probe_completion_puts_z_in_the_mass_weight(self):
+        """The probe records the mass-set weight before Z exists; completing it
+        multiplies in one Z per slot, and leaves the per-angle weights alone."""
+        stub = self._Stub()
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
+                                               '-6_0': self._samples(seed=9)})
+        z0, z1 = stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)
+        best = stub._complete_offshell_probe(self._probe_event())
+        self.assertAlmostEqual(best[0], max(2.0 * z0 * z1, 1.0), places=10)
+        self.assertEqual(best[1], 7.0)      # position 0 = slot 1
+        self.assertEqual(best[2], 5.0)
+
+    def test_probe_completion_divides_z_out_per_slot_when_exact(self):
+        """Under sequential_exact the mass stage pays Z and the slot takes it
+        back, so the bound each slot is tested against is the one of w_k/Z_k --
+        mapped through the ordering, not the slot order."""
+        stub = self._Stub(exact=True)
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
+                                               '-6_0': self._samples(seed=9)})
+        z_by_slot = [stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)]
+        best = stub._complete_offshell_probe(self._probe_event())
+        # order [1, 0]: probe position 0 is slot 1, position 1 is slot 0
+        self.assertAlmostEqual(best[1], max(3.0 / z_by_slot[1], 7.0), places=10)
+        self.assertAlmostEqual(best[2], max(5.0 / z_by_slot[0], 4.0), places=10)
+
+
+class TestTwoStageMassDistribution(unittest.TestCase):
+    """The bias the Z_k factor exists to remove, and the two cures, on a model
+    of the offshell chain small enough to solve exactly.
+
+    The chain is: draw a virtuality m from a prior, accept the mass set with
+    probability w_mass(m) Z_hat(m) / C, then draw decay angles until one is
+    accepted with probability w(m, angle) / C_ang. The target -- what the joint
+    accept/reject samples -- is p(m) w_mass(m) E_angle[w(m, .)]. Because the
+    per-angle stage redraws until it accepts, it divides its own normalisation
+    Z(m) = E_angle[w(m, .)] out again, so with Z_hat = 1 the accepted
+    virtualities come out proportional to p(m) w_mass(m) instead: the
+    Breit-Wigner shape rather than the offshell one. This is the measured
+    ttbar bias in miniature.
+    """
+
+    ANGLES = [0.3, 0.8, 1.6, 2.5]      # the decay "pool"
+    MASSES = [160.0, 170.0, 180.0, 190.0]
+
+    def _w(self, mass, angle):
+        """Per-angle weight; its angle average rises steeply with the mass, as
+        the offshell rate factor does."""
+        return (mass / 170.0) ** 6 * angle
+
+    def _w_mass(self, mass):
+        return 1.0 + (mass - 160.0) / 100.0
+
+    def _z(self, mass):
+        return sum(self._w(mass, a) for a in self.ANGLES) / len(self.ANGLES)
+
+    def _target(self):
+        raw = {m: self._w_mass(m) * self._z(m) for m in self.MASSES}
+        total = sum(raw.values())
+        return {m: v / total for m, v in raw.items()}
+
+    def _run(self, zhat, exact, nb=200000, seed=7):
+        """The two-stage chain, mirroring sequential_accept_reject's offshell
+        branch: mass-set accept/reject, then one slot redrawn to acceptance
+        (or, under ``exact``, a rejected angle killing the mass set)."""
+        import random
+        rng = random.Random(seed)
+        c_mass = max(self._w_mass(m) * zhat(m) for m in self.MASSES) * 1.01
+        c_ang = max(self._w(m, a) / zhat(m)
+                    for m in self.MASSES for a in self.ANGLES) * 1.01
+        counts = collections.Counter()
+        for _ in range(nb):
+            while True:
+                mass = rng.choice(self.MASSES)
+                if rng.random() * c_mass >= self._w_mass(mass) * zhat(mass):
+                    continue
+                restart = False
+                while True:
+                    angle = rng.choice(self.ANGLES)
+                    if rng.random() * c_ang < self._w(mass, angle) / zhat(mass):
+                        break
+                    if exact:
+                        restart = True
+                        break
+                if not restart:
+                    break
+            counts[mass] += 1
+        return {m: counts[m] / float(nb) for m in self.MASSES}
+
+    def _assert_close(self, got, want, tolerance):
+        for mass in self.MASSES:
+            self.assertLess(abs(got[mass] / want[mass] - 1), tolerance,
+                            'mass %s: got %.4f, want %.4f' % (mass, got[mass],
+                                                              want[mass]))
+
+    def test_without_the_factor_the_mass_distribution_is_biased(self):
+        """The bug: the accepted virtualities follow p(m) w_mass(m), the shape
+        the per-angle stage was supposed to reweight."""
+        got = self._run(lambda m: 1.0, exact=False)
+        prior = {m: self._w_mass(m) for m in self.MASSES}
+        total = sum(prior.values())
+        self._assert_close(got, {m: v / total for m, v in prior.items()}, 0.03)
+        self.assertGreater(abs(got[190.0] / self._target()[190.0] - 1), 0.3)
+
+    def test_the_exact_factor_restores_the_target(self):
+        self._assert_close(self._run(self._z, exact=False), self._target(), 0.03)
+
+    def test_a_wrong_factor_biases_by_exactly_its_error(self):
+        """Why the tabulation has to be accurate: the per-angle stage divides
+        out the true Z whatever weight it is given, so the residual bias is
+        Z_hat/Z -- it does not cancel."""
+        skew = lambda m: self._z(m) * (m / 170.0) ** 2
+        got = self._run(skew, exact=False)
+        want = {m: v * (m / 170.0) ** 2 for m, v in self._target().items()}
+        total = sum(want.values())
+        self._assert_close(got, {m: v / total for m, v in want.items()}, 0.03)
+
+    def test_sequential_exact_is_right_for_any_factor(self):
+        """And why the switch exists: rejecting the mass set instead of
+        redrawing the angle stops the per-angle stage from normalising, so
+        Z_hat cancels from the chain and only sets the efficiency."""
+        for zhat in (lambda m: 1.0,
+                     lambda m: self._z(m),
+                     lambda m: self._z(m) * (m / 170.0) ** 2):
+            self._assert_close(self._run(zhat, exact=True), self._target(), 0.03)

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1143,10 +1143,13 @@ class TestSequentialAcceptReject(unittest.TestCase):
             sequential_accept_reject = interface.sequential_accept_reject
             _scan_maxwgt_range = interface._scan_maxwgt_range
             _sequential_offshell = interface._sequential_offshell
+            _unweighting_mode = interface._unweighting_mode
+            _log_once = interface._log_once
             def __init__(self):
                 self.options = {'spinmode': 'onshell',
                                 'sequential_spin_order': '2 3 1',
-                                'sequential_exact': False}
+                                'unweighting': 'sequential',
+                                'fixed_order': False}
             def _density_basis(self, production, decays_key):
                 particles, slots = interface._sequential_slots(production, decays_key)
                 return {'decays_key': decays_key, 'helicities': hels,
@@ -1233,11 +1236,13 @@ class TestSequentialPoolLadder(unittest.TestCase):
         class Stub(object):
             _sequential_pool_ladder = interface._sequential_pool_ladder
             _sequential_active = interface._sequential_active
+            _unweighting_mode = interface._unweighting_mode
+            _log_once = interface._log_once
             _sequential_spin_order = interface._sequential_spin_order
             _decay_pool_ladder = staticmethod(interface._decay_pool_ladder)
         stub = Stub()
         stub.model = self._Model(spins)
-        stub.options = {'sequential_decay': True, 'fixed_order': False,
+        stub.options = {'unweighting': 'sequential', 'fixed_order': False,
                         'spinmode': 'PA', 'sequential_spin_order': '2 3 1'}
         stub.options.update(options)
         return stub
@@ -1266,7 +1271,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
         spins = {6: 2, -6: 2}
         pools = {6: self.NB, -6: self.NB}
         # opted out
-        self.assertEqual(self._stub(spins, sequential_decay=False)
+        self.assertEqual(self._stub(spins, unweighting='joint')
                              ._sequential_pool_ladder(pools, self.NB, True), {})
         # not density mode
         self.assertEqual(self._stub(spins)
@@ -1286,29 +1291,69 @@ class TestSequentialPoolLadder(unittest.TestCase):
         self.assertTrue(self._stub({6: 2}, spinmode='onshell')._sequential_active(True))
 
     def test_sequential_active_auto(self):
-        """'auto' (the default) resolves per spinmode: sequential for the
-        PA/onshell pole approximations, joint for madspin/full."""
+        """'auto' resolves per spinmode: a per-particle or two-stage scheme
+        everywhere it is supported, joint outside the density modes."""
         for mode, expected in [('PA', True), ('onshell', True),
-                               ('madspin', False), ('full', False),
+                               ('madspin', True), ('full', True),
                                ('none', False)]:
-            stub = self._stub({6: 2}, sequential_decay='auto', spinmode=mode)
+            stub = self._stub({6: 2}, unweighting='auto', spinmode=mode)
             self.assertEqual(stub._sequential_active(True), expected,
                              'auto + spinmode=%s' % mode)
         # fixed_order still forces the joint test
-        stub = self._stub({6: 2}, sequential_decay='auto', fixed_order=True)
+        stub = self._stub({6: 2}, unweighting='auto', fixed_order=True)
         self.assertFalse(stub._sequential_active(True))
+        self.assertEqual(stub._unweighting_mode(True), 'joint')
+
+    def test_auto_picks_the_scheme_by_the_number_of_decays(self):
+        """One bound over all the angles is tighter than the product of
+        per-particle bounds, while a per-particle test lets a rejection skip the
+        decays not yet drawn. The first wins while there is little to skip, so
+        auto takes two_stage up to two decaying particles and sequential from
+        three -- offshell only, since the other modes have no mass-set stage to
+        split at."""
+        for nb, expected in [(1, 'two_stage'), (2, 'two_stage'),
+                             (3, 'sequential'), (6, 'sequential')]:
+            stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin')
+            stub._nb_decaying = nb
+            self.assertEqual(stub._unweighting_mode(True), expected,
+                             '%d decaying particles' % nb)
+        # PA has no up-front mass draw: always per particle, whatever n is
+        for nb in (1, 2, 5):
+            stub = self._stub({6: 2}, unweighting='auto', spinmode='PA')
+            stub._nb_decaying = nb
+            self.assertEqual(stub._unweighting_mode(True), 'sequential')
+
+    def test_offshell_only_modes_fall_back_under_pa(self):
+        """Asked for explicitly under PA/onshell, the two modes that need the
+        up-front mass draw say so and use sequential."""
+        for mode in ('two_stage', 'sequential_global_retry'):
+            stub = self._stub({6: 2}, unweighting=mode, spinmode='PA')
+            self.assertEqual(stub._unweighting_mode(True), 'sequential')
+            stub = self._stub({6: 2}, unweighting=mode, spinmode='madspin')
+            self.assertEqual(stub._unweighting_mode(True), mode)
 
     def test_madspin_option_defaults(self):
         """The shipped defaults: spinmode=madspin, jacobian in the weight,
-        sequential_decay on auto (and switchable off/back by the user)."""
+        unweighting on auto, and the deprecated alias still understood."""
         options = interface_madspin.MadSpinOptions()
         self.assertEqual(options['spinmode'], 'madspin')
         self.assertEqual(options['density_keep_jacobian'], True)
-        self.assertEqual(options['sequential_decay'], 'auto')
+        self.assertEqual(options['unweighting'], 'auto')
+        for value in ('joint', 'two_stage', 'sequential',
+                      'sequential_global_retry'):
+            options['unweighting'] = value
+            self.assertEqual(options['unweighting'], value)
+
+    def test_deprecated_sequential_decay_alias(self):
+        """sequential_decay is gone as a knob but still understood: the two
+        values it ever had map onto the two modes that existed then."""
+        options = interface_madspin.MadSpinOptions()
+        options['sequential_decay'] = 'True'
+        self.assertEqual(options['unweighting'], 'sequential')
         options['sequential_decay'] = 'False'
-        self.assertEqual(options['sequential_decay'], False)
+        self.assertEqual(options['unweighting'], 'joint')
         options['sequential_decay'] = 'auto'
-        self.assertEqual(options['sequential_decay'], 'auto')
+        self.assertEqual(options['unweighting'], 'auto')
 
 
 class TestScanMaxwgtDecomposition(unittest.TestCase):
@@ -1380,6 +1425,8 @@ class TestOffshellRateFactor(unittest.TestCase):
             return TestOffshellRateFactor._Val(173.0)
 
     class _Stub(object):
+        _unweighting_mode = interface_madspin.MadSpinInterface._unweighting_mode
+        _log_once = interface_madspin.MadSpinInterface._log_once
         _build_z_tables = interface_madspin.MadSpinInterface._build_z_tables
         _weighted_polyfit2 = staticmethod(
                         interface_madspin.MadSpinInterface._weighted_polyfit2)
@@ -1390,8 +1437,13 @@ class TestOffshellRateFactor(unittest.TestCase):
                         interface_madspin.MadSpinInterface._complete_offshell_probe
         def __init__(self, exact=False, joint_angles=False):
             self.banner = TestOffshellRateFactor._Banner()
-            self.options = {'sequential_exact': exact,
-                            'sequential_joint_angles': joint_angles}
+            mode = 'sequential'
+            if joint_angles:
+                mode = 'two_stage'
+            elif exact:
+                mode = 'sequential_global_retry'
+            self.options = {'unweighting': mode, 'fixed_order': False,
+                            'spinmode': 'madspin'}
             self._z_tables = {}
 
     @staticmethod

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1144,6 +1144,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _scan_maxwgt_range = interface._scan_maxwgt_range
             _sequential_offshell = interface._sequential_offshell
             _unweighting_mode = interface._unweighting_mode
+            _announce_mode = interface._announce_mode
             _log_once = interface._log_once
             def __init__(self):
                 self.options = {'spinmode': 'onshell',
@@ -1237,6 +1238,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
             _sequential_pool_ladder = interface._sequential_pool_ladder
             _sequential_active = interface._sequential_active
             _unweighting_mode = interface._unweighting_mode
+            _announce_mode = interface._announce_mode
             _log_once = interface._log_once
             _sequential_spin_order = interface._sequential_spin_order
             _decay_pool_ladder = staticmethod(interface._decay_pool_ladder)
@@ -1441,6 +1443,7 @@ class TestOffshellRateFactor(unittest.TestCase):
 
     class _Stub(object):
         _unweighting_mode = interface_madspin.MadSpinInterface._unweighting_mode
+        _announce_mode = interface_madspin.MadSpinInterface._announce_mode
         _log_once = interface_madspin.MadSpinInterface._log_once
         _build_z_tables = interface_madspin.MadSpinInterface._build_z_tables
         _weighted_polyfit2 = staticmethod(

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1311,17 +1311,32 @@ class TestSequentialPoolLadder(unittest.TestCase):
         auto takes two_stage up to two decaying particles and sequential from
         three -- offshell only, since the other modes have no mass-set stage to
         split at."""
-        for nb, expected in [(1, 'two_stage'), (2, 'two_stage'),
+        for nb, expected in [(1, 'joint'), (2, 'two_stage'),
                              (3, 'sequential'), (6, 'sequential')]:
             stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin')
             stub._nb_decaying = nb
             self.assertEqual(stub._unweighting_mode(True), expected,
                              '%d decaying particles' % nb)
-        # PA has no up-front mass draw: always per particle, whatever n is
-        for nb in (1, 2, 5):
+        # PA has no up-front mass draw: per particle whenever there is a
+        # decomposition to make at all
+        for nb in (2, 5):
             stub = self._stub({6: 2}, unweighting='auto', spinmode='PA')
             stub._nb_decaying = nb
             self.assertEqual(stub._unweighting_mode(True), 'sequential')
+
+    def test_auto_is_joint_for_a_single_decaying_particle(self):
+        """One decaying particle: the per-particle test is the joint test and
+        the mass/angle split only moves the same factors between two stages, so
+        auto pays for neither -- in every spinmode."""
+        for spinmode in ('PA', 'onshell', 'madspin', 'full'):
+            stub = self._stub({6: 1}, unweighting='auto', spinmode=spinmode)
+            stub._nb_decaying = 1
+            self.assertEqual(stub._unweighting_mode(True), 'joint', spinmode)
+            self.assertFalse(stub._sequential_active(True))
+        # asked for explicitly it is still honoured, for cross-checks
+        stub = self._stub({6: 1}, unweighting='sequential', spinmode='madspin')
+        stub._nb_decaying = 1
+        self.assertEqual(stub._unweighting_mode(True), 'sequential')
 
     def test_offshell_only_modes_fall_back_under_pa(self):
         """Asked for explicitly under PA/onshell, the two modes that need the

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1388,9 +1388,10 @@ class TestOffshellRateFactor(unittest.TestCase):
         _zhat = interface_madspin.MadSpinInterface._zhat
         _complete_offshell_probe = \
                         interface_madspin.MadSpinInterface._complete_offshell_probe
-        def __init__(self, exact=False):
+        def __init__(self, exact=False, joint_angles=False):
             self.banner = TestOffshellRateFactor._Banner()
-            self.options = {'sequential_exact': exact}
+            self.options = {'sequential_exact': exact,
+                            'sequential_joint_angles': joint_angles}
             self._z_tables = {}
 
     @staticmethod
@@ -1517,6 +1518,24 @@ class TestOffshellRateFactor(unittest.TestCase):
         # order [1, 0]: probe position 0 is slot 1, position 1 is slot 0
         self.assertAlmostEqual(best[1], max(3.0 / z_by_slot[1], 7.0), places=10)
         self.assertAlmostEqual(best[2], max(5.0 / z_by_slot[0], 4.0), places=10)
+
+    def test_probe_completion_collapses_to_two_bounds_when_joint(self):
+        """Variant B tests every angle against one bound, so the probe vector
+        collapses to [C_mass, C_angles] and the second entry is the *product*
+        over slots of w_k/Z_k -- maxed chain by chain, not per slot, since the
+        chain is what is accepted or rejected."""
+        stub = self._Stub(joint_angles=True)
+        stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
+                                               '-6_0': self._samples(seed=9)})
+        z = [stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)]
+        best = stub._complete_offshell_probe(self._probe_event())
+        self.assertEqual(len(best), 2)
+        # chain 1: masses (160, 180), weights w_slot1 = 3.0, w_slot0 = 5.0
+        # chain 2: masses (173, 173) where Z = 1, weights 7.0 and 4.0
+        self.assertAlmostEqual(best[0], max(2.0 * z[0] * z[1], 1.0), places=10)
+        self.assertAlmostEqual(best[1],
+                               max((3.0 / z[1]) * (5.0 / z[0]), 7.0 * 4.0),
+                               places=10)
 
 
 class TestTwoStageMassDistribution(unittest.TestCase):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1617,3 +1617,117 @@ class TestTwoStageMassDistribution(unittest.TestCase):
                      lambda m: self._z(m),
                      lambda m: self._z(m) * (m / 170.0) ** 2):
             self._assert_close(self._run(zhat, exact=True), self._target(), 0.03)
+
+
+class TestOffshellCache(unittest.TestCase):
+    """The offshell sequential bounds travel with the Z_k tables that complete
+    them, so the cache holds two coupled objects and must not be read back under
+    a schema it was not written with.  A mismatch is ignored rather than raised
+    on: the scan is reproducible, so re-measuring is always available, whereas a
+    table dereferenced under the wrong schema would either crash inside the
+    accept/reject or silently weight the virtualities with the wrong fit.
+    """
+
+    class _Stub(object):
+        _OFFSHELL_CACHE_FORMAT = \
+            interface_madspin.MadSpinInterface._OFFSHELL_CACHE_FORMAT
+        _read_offshell_cache = \
+            interface_madspin.MadSpinInterface._read_offshell_cache
+
+    def _write(self, payload):
+        import json, tempfile
+        handle, path = tempfile.mkstemp(suffix='.json')
+        with os.fdopen(handle, 'w') as f:
+            json.dump(payload, f)
+        self.addCleanup(os.remove, path)
+        return path
+
+    def _good(self):
+        return {'format': self._Stub._OFFSHELL_CACHE_FORMAT,
+                'maxwgts': [17.0, 2.3, 3.9],
+                'z_tables': {'6_0': {'pole': 173.0, 'coeff': [0.0, 2.0, -1.0],
+                                     'zero_below': 0.0, 'range': [150.0, 195.0]}}}
+
+    def test_round_trip(self):
+        got = self._Stub()._read_offshell_cache(self._write(self._good()))
+        self.assertEqual(got['maxwgts'], [17.0, 2.3, 3.9])
+        self.assertEqual(got['z_tables']['6_0']['pole'], 173.0)
+
+    def test_missing_file_is_not_an_error(self):
+        self.assertIsNone(self._Stub()._read_offshell_cache('/no/such/file'))
+        self.assertIsNone(self._Stub()._read_offshell_cache(''))
+
+    def test_every_malformed_shape_is_ignored(self):
+        """Each of these would otherwise surface as a KeyError, an IndexError or
+        a wrong weight somewhere inside the unweighting loop."""
+        cases = {}
+        cases['no format tag'] = {k: v for k, v in self._good().items()
+                                  if k != 'format'}
+        cases['older format'] = dict(self._good(), format=0)
+        cases['no bounds'] = dict(self._good(), maxwgts=[])
+        cases['no tables'] = {k: v for k, v in self._good().items()
+                              if k != 'z_tables'}
+        short = self._good()
+        short['z_tables']['6_0'].pop('zero_below')
+        cases['table missing a field'] = short
+        degree = self._good()
+        degree['z_tables']['6_0']['coeff'] = [0.0, 2.0, -1.0, 0.5]
+        cases['a cubic fit'] = degree
+        window = self._good()
+        window['z_tables']['6_0']['range'] = [150.0]
+        cases['a malformed range'] = window
+        for name, payload in cases.items():
+            self.assertIsNone(
+                self._Stub()._read_offshell_cache(self._write(payload)), name)
+
+    def test_garbage_is_ignored(self):
+        import tempfile
+        handle, path = tempfile.mkstemp(suffix='.json')
+        with os.fdopen(handle, 'w') as f:
+            f.write('not json at all')
+        self.addCleanup(os.remove, path)
+        self.assertIsNone(self._Stub()._read_offshell_cache(path))
+
+
+class TestPolyfitConditioning(unittest.TestCase):
+    """_weighted_polyfit2 solves the normal equations of a fit in
+    u = ln(m/pole), which spans about +-0.13 over a Breit-Wigner window.  The
+    moments therefore range over four orders of magnitude before any data is
+    seen, which is why the degeneracy test has to be relative to the size of the
+    matrix rather than an absolute floor.
+    """
+
+    def _fit(self, xs, ys, ws=None):
+        return interface_madspin.MadSpinInterface._weighted_polyfit2(
+                        xs, ys, ws or [1.0] * len(xs))
+
+    def _window(self, pole=173.0, lo=150.7, hi=195.4, nb=20):
+        return [math.log((lo + i * (hi - lo) / (nb - 1)) / pole)
+                for i in range(nb)]
+
+    def test_recovers_a_quadratic_on_the_real_fit_variable(self):
+        """Exact data over the actual window, with the actual weights (bin
+        counts in the thousands): the conditioning of this fit is ~3e4, so
+        double precision must return the coefficients essentially exactly."""
+        xs = self._window()
+        ys = [0.3 + 2.0 * x - 1.0 * x ** 2 for x in xs]
+        got = self._fit(xs, ys, [1000.0] * len(xs))
+        for value, want in zip(got, [0.3, 2.0, -1.0]):
+            self.assertAlmostEqual(value, want, places=8)
+
+    def test_all_bins_at_one_virtuality_is_degenerate(self):
+        """The case the tolerance exists for.  An absolute floor of 1e-30 would
+        let this through -- the moments are O(n) -- and return a quadratic
+        fitted to nothing."""
+        self.assertIsNone(self._fit([0.1] * 6, [1.0, 2.0, 1.5, 1.2, 1.8, 1.4]))
+
+    def test_a_needle_narrow_window_is_degenerate(self):
+        """A resonance whose samples all land within rounding of each other:
+        the moments are tiny in absolute terms but the matrix is still
+        singular relative to itself."""
+        xs = [1e-13 * i for i in range(6)]
+        self.assertIsNone(self._fit(xs, [1.0, 2.0, 1.5, 1.2, 1.8, 1.4],
+                                    [1000.0] * 6))
+
+    def test_two_distinct_points_cannot_fix_a_quadratic(self):
+        self.assertIsNone(self._fit([0.0, 0.0, 0.1, 0.1], [1.0, 1.0, 2.0, 2.0]))


### PR DESCRIPTION
…weight

The offshell (madspin/full) sequential accept/reject unweights in two stages: the mass set first, then each slot's decay angles. The per-angle stage redraws until it accepts and so divides out its own normalisation

    Z_k(m) = Int dPhi_off(m) |M_dec|^2 / Int dPhi_on |M_dec|^2 = (m/M) Gamma(m)/Gamma(M)

which is a strong function of the sampled virtuality. The accepted mass sets were therefore missing prod_k Z_k(m_k) and the reconstructed resonance lineshape came out Breit-Wigner (PA) shaped instead of offshell: on p p > t t~, t > w+ b, w+ > l+ vl, <m(l+ v b)> sat -0.248 GeV (-7.8 sigma) from the joint accept/reject, chi2/ndf 75.8/22 over a +-8 GeV window.

Z_k is a function of that slot's virtuality alone -- the production event, the other slots' masses and the angles already accepted all cancel out of it -- so it is tabulated per slot and multiplied into the mass-set weight. The samples are free: the max-weight probe already draws Nevents_for_max_weight * max_weight_ps_point chains, each giving one (m_k, s_k) pair per slot with s_k = jac_dec * Tr(D^off)/|M_dec|^2_on, which has the same conditional expectation as w_k without its polarisation modulation. The table is a weighted quadratic in ln(m/pole) through binned means (Z_k is an expectation, so the mean estimates it and the mean of the logarithms would not), and C_mass is derived afterwards from the completed weights -- hence the probe now keeps its chains instead of maxing them online.

An imperfect Z_hat does not cancel: the per-angle stage divides out the true Z_k whatever weight it is given, so the residual bias is exactly Z_hat/Z. Hence also the new sequential_exact option, where the mass stage pays Z_hat, each slot divides it back out and a rejected decay trashes the mass set. The chain is then accepted with probability proportional to the joint weight, so Z_hat cancels identically and is reduced to an efficiency preconditioner -- exact whatever the table says, at roughly 3x the cost.

Also: a decay that cannot be reshuffled onto its virtuality (jac_dec = 0) is now an ordinary rejection of that decay rather than a restart of the whole chain. The restart was a second, C_k-dependent mass-dependent normalisation (the set survived slot k with probability Z_k/(Z_k + q_k C_k), not Z_k) which would have defeated the correction near a decay threshold; it is invisible on t > W b, where m_t > M_W + M_b always. Counting those zeros as rejections is what makes the tabulated Z_k the exact correction there.

PA/onshell are untouched: every new line is inside an offshell branch, and neither the random-number stream nor any arithmetic on that path changes.

Validation (10000 events, seed 42, nb_core 1, same production sample):
- the fitted table reproduces the narrow-width (m/M) Gamma(m)/Gamma(M) to under 0.5%: Z(150.7) = 0.53, Z(173) = 1, Z(195.4) = 1.71;
- four sequential replicas with independent MadSpin seeds average both resonances to 173.1641 +- 0.0177 against two joint replicas at 173.1853 and 173.1867 -- a residual of -0.022 +- 0.024 GeV, consistent with zero;
- lineshape chi2/ndf 19.0/22, against 21.7/22 for a joint-vs-joint control;
- sequential_exact lands at +0.006 +- 0.032 GeV, chi2/ndf 10.4/22.

Cost, measured on the same runs: the offshell sequential path is ~2x slower than the joint test (28.7 s vs 14.4 s of decay-phase wall time), which the earlier per-event decay-ME count missed -- the mass-set stage draws 26 virtuality sets per accepted event, each an Event parse, a production reshuffle and a production density. Z_hat accounts for about a third of that gap (C_mass 14 -> 17-19). So sequential_decay = auto keeps routing madspin/full to the joint accept/reject; what this buys is that the offshell path is correct when switched on explicitly.

The decay-reshuffling jacobian this builds on (_decay_reshuffle_jacobian and the jac_dec factors in both branches) was already in the working tree, uncommitted, and is included here.

## Summary by Sourcery

Tabulate and apply per-slot offshell decay rate factors in MadSpin's sequential offshell unweighting, add an exact sequential mode, and adjust handling, statistics, caching, and tests accordingly to restore the correct resonance lineshape and provide validation of the scheme.

Enhancements:
- Introduce an offshell rate-factor tabulation pipeline (Z_k tables) from max-weight probe samples and use it to correct sequential mass-set weights in offshell spin modes.
- Add a sequential_exact option that rejects entire mass sets on decay rejection so the scheme is exact regardless of Z_k accuracy, and adjust logging and statistics for mass-stage performance and infeasible decays.
- Refine offshell sequential decay handling by treating infeasible decay reshuffles as local rejections, propagating decay reshuffling Jacobians into weights, and sharing BW and decay Jacobians consistently with the joint scheme.
- Extend max-weight scanning and caching to handle offshell sequential data, including storing Z_k tables alongside slot bounds and completing offshell probes post-fit.

Documentation:
- Expand MADSPIN_SEQUENTIAL_PLAN.md with a detailed discussion of the missing offshell normalisation issue, Z_k derivation and implementation, the sequential_exact mode, performance measurements, and updated validation results.

Tests:
- Add unit tests for Z_k(tabulated offshell rate factor) construction, interpolation, threshold handling, and its integration into probe completion, and for a toy model demonstrating bias removal and correctness of the sequential_exact mode.
- Update existing sequential max-weight tests to account for the new return shape of _scan_maxwgt_range and ensure range-split behaviour remains consistent.