### PR TITLE
MadSpin: honour me_frame and beampol in the density spinmodes

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2370,7 +2370,7 @@ class decay_all_events(object):
             nb_mc_masses=len(indices_for_mc_masses)
 
             p, p_str=self.curr_event.give_momenta(event_map)
-            stdin_text=' %s %s %s %s %s %s %s \n' % ('2', self.options['BW_cut'], self.Ecollider, decay_me['max_weight'], self.options['frame_id'], self.options['beampol'][0], self.options['beampol'][1]) 
+            stdin_text=' %s %s %s %s %s %s %s \n' % ('2', self.options['BW_cut'], self.Ecollider, decay_me['max_weight'], self.options['frame_id'], self.options.beampol_me()[0], self.options.beampol_me()[1]) 
             stdin_text+=p_str
             # here I also need to specify the Monte Carlo Masses
             stdin_text+=" %s \n" % nb_mc_masses
@@ -2503,7 +2503,7 @@ class decay_all_events(object):
         except KeyError:
             frameid = 6
         try:
-            beampol = self.options['beampol']
+            beampol = self.options.beampol_me()
         except KeyError:
             beampol = (1.0,1.0)
 
@@ -3447,7 +3447,7 @@ class decay_all_events(object):
         """return the max. weight associated with me decay['path']"""
 
         p, p_str=self.curr_event.give_momenta(event_map)
-        std_in=" %s  %s %s %s %s %s %s \n" % ("1",BWcut, self.Ecollider, nbpoints, self.options['frame_id'], self.options['beampol'][0], self.options['beampol'][1])
+        std_in=" %s  %s %s %s %s %s %s \n" % ("1",BWcut, self.Ecollider, nbpoints, self.options['frame_id'], self.options.beampol_me()[0], self.options.beampol_me()[1])
         std_in+=p_str
         max_weight = self.loadfortran('maxweight',
                                path, std_in)

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2505,7 +2505,7 @@ class decay_all_events(object):
         try:
             beampol = self.options['beampol']
         except KeyError:
-            beampol = (0.5,0.5)
+            beampol = (1.0,1.0)
 
         stdin_text=' %s %s %s %s %s %s %s\n' % ('2', self.options['BW_cut'], self.Ecollider, 1.0, frameid, beampol[0], beampol[1])
         stdin_text+=p_str

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -114,6 +114,16 @@ class MadSpinOptions(banner.ConfigFile):
             random.seed(self['seed'])  
             random.mg_seedset = self['seed']  
 
+    def post_set_beampol(self, value, change_userdefine, raiseerror, *opts):
+        """Two values or none: one number is ambiguous (which beam?) and would
+        otherwise only surface as an IndexError once the run reaches a matrix
+        element, long after the card was read."""
+        if value and len(value) != 2:
+            raise banner.InvalidCmd(
+                "beampol takes the polarisation of *both* beams, in percent: "
+                "'set beampol [%s, 0]' for the first beam only. Got %s value(s)."
+                % (value[0] if value else 0, len(value)))
+
     def beampol_me(self):
         """The beam polarisations in the convention the matrix elements use.
 
@@ -126,7 +136,7 @@ class MadSpinOptions(banner.ConfigFile):
         here rather than at parse time keeps the stored option equal to what the
         user typed, and keeps one convention in the cards and one in Fortran.
         """
-        pol = self['beampol'] or [0., 0.]
+        pol = self['beampol'] or [0., 0.]      # unset / [] is unpolarised
         out = []
         for value in (pol[0], pol[1]):
             value = float(value)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -75,7 +75,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('frame_id', 6)
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
-        self.add_param('beampol', [0.5, 0.5], comment='beam polarization')
+        self.add_param('beampol', [1.0, 1.0], comment='beam polarization, in the /to_polarization/ convention of madevent: 1 is unpolarized, |beampol| grows to 2 for a fully polarized beam and its sign selects the favoured helicity. Set from the run_card polbeam1/polbeam2 when there is one.')
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -397,6 +397,29 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.prod_branches = ''
         self.final_state = set()
 
+    @staticmethod
+    def polbeam_to_beampol(polbeam):
+        """Map a run_card ``polbeam1``/``polbeam2`` (a polarisation in percent,
+        -100 .. 100) onto the ``beampol`` the matrix elements expect.
+
+        The matrix-element side -- ``/to_beampol/`` in the v1 driver's msP/msF
+        SMATRIX and now in GET_DENSITY -- is a verbatim copy of madevent's
+        ``/to_polarization/`` reweighting, so it wants madevent's convention for
+        the value too (Template/LO/Source/setrun.f)::
+
+            beampol = sign(1 + |polbeam|/100, polbeam)
+
+        i.e. 1 for an unpolarised beam, +2 for a beam fully polarised along +1
+        helicity, -2 for one fully polarised along -1. That is what makes the
+        two branches of the reweighting come out as they should: at |beampol|=1
+        both are 1, and at |beampol|=2 the favoured helicity gets 2 and the
+        other 0.
+        """
+        polbeam = float(polbeam)
+        if not polbeam:
+            return 1.
+        return math.copysign(1 + abs(polbeam) / 100., polbeam)
+
     def _load_f2py_matrix_module(self, sp_path, menum=2):
         """Load the freshly-compiled ``all_matrix<menum>py`` extension under
         ``sp_path``.
@@ -544,14 +567,20 @@ class MadSpinInterface(extended_cmd.Cmd):
             
             if isinstance(run_card, banner.RunCardLO):
                 run_card.update_system_parameter_for_include()
-                self.options['frame_id'] = run_card['frame_id']
-                beampol = [.5,.5]
-                beampol[0] =  (-1./200)* run_card['polbeam1'] + 0.5
-                beampol[1] =  (-1./200)* run_card['polbeam2'] + 0.5
-                self.options['beampol'] = beampol
+                # The run_card of the production is the default source for both,
+                # but an explicit "set frame_id"/"set beampol" in the MadSpin
+                # card wins -- otherwise neither option could be set from the
+                # card the rest of the MadSpin options live in.
+                if 'frame_id' not in self.options.user_set:
+                    self.options['frame_id'] = run_card['frame_id']
+                if 'beampol' not in self.options.user_set:
+                    self.options['beampol'] = [self.polbeam_to_beampol(run_card['polbeam1']),
+                                               self.polbeam_to_beampol(run_card['polbeam2'])]
             else:
-                self.options['frame_id'] = 6
-                self.options['beampol'] = [.5,.5]
+                if 'frame_id' not in self.options.user_set:
+                    self.options['frame_id'] = 6
+                if 'beampol' not in self.options.user_set:
+                    self.options['beampol'] = [1., 1.]
 
         else:
             if not self.options['Nevents_for_max_weight']:
@@ -786,6 +815,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.check_set(args)
 
         self.options[args[0]] = ' '.join(args[1:])
+        # ConfigFile only fills user_set through its own set(); record it here
+        # so options that are otherwise taken from the production run_card
+        # (frame_id, beampol) can still be overridden from the MadSpin card.
+        self.options.user_set.add(args[0].strip().lower())
         
 
     def complete_set(self,  text, line, begidx, endidx):
@@ -4280,13 +4313,19 @@ class MadSpinInterface(extended_cmd.Cmd):
         except Exception:
             return 0
 
-    def _slot_density(self, decay, parent, hel):
-        """The decay density matrix of one slot, in the lab frame of its parent."""
+    def _slot_density(self, decay, parent, hel, frame_boost=None):
+        """The decay density matrix of one slot, in the lab frame of its parent
+        (and then in the ``frame_id`` frame, when there is one -- see
+        ``get_density``)."""
+        rest_leg = None
+        if frame_boost is not None:
+            rest_leg = self._decay_frame_rest_leg(parent, frame_boost)
         boost = -1 * lhe_parser.FourMomentum(parent)
         boost.E *= -1
         decay.boost(boost)
         return self.get_density(decay, position=[1], allow_hel=hel,
-                                ncomb=len(hel), dimension=len(hel))
+                                ncomb=len(hel), dimension=len(hel),
+                                frame_boost=frame_boost, frame_rest_leg=rest_leg)
 
     def _draw_mass_value(self, pdg, budget):
         """Sample one resonance virtuality from its Breit-Wigner, capped at the
@@ -4333,7 +4372,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         and what madspin does not give for free (see MADSPIN_SEQUENTIAL_PLAN.md
         section 10).
 
-        Returns ``(rho_off, jac_reshuffle, slot_mass, parents)`` or None if the
+        Returns ``(rho_off, jac_reshuffle, slot_mass, parents, frame_boost)`` or None if the
         mass set cannot be reshuffled (the caller redraws the whole set):
         - ``slot_mass[slot]`` = (mass, reshuffle_info, jac_bw);
         - ``parents[slot]``   = the reshuffled (offshell) production particle to
@@ -4359,11 +4398,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         jac_reshuffle = prod_off.reshuffle_production(_allow_retry=False)
         if jac_reshuffle in (0, -1):
             return None
+        # the frame is derived from the *reshuffled* production, since that is
+        # the event rho_off is evaluated at; the decays are contracted against
+        # it, so they have to be boosted with this same momentum
+        frame_boost = self._frame_boost(prod_off)
         rho_off = self.get_density(prod_off, prod_static['position'],
                                    prod_static['allowed_hel'],
-                                   prod_static['ncomb'], prod_static['dimension'])
+                                   prod_static['ncomb'], prod_static['dimension'],
+                                   frame_boost=frame_boost)
         parents = {slot: finals[slot_to_index[slot]] for slot in order}
-        return rho_off, jac_reshuffle, slot_mass, parents
+        return rho_off, jac_reshuffle, slot_mass, parents, frame_boost
 
     def _sequential_offshell(self):
         """Whether the sequential accept/reject runs its offshell (madspin/full)
@@ -4700,6 +4744,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         # kinematics would set the bound and then overflow it, the quiet ones
         # would pay for it in acceptance. Cached on the event under the name the
         # joint path already uses for the same quantity.
+        # frame the helicity basis is defined in (run_card me_frame), shared by
+        # the production density and by every decay contracted against it. The
+        # offshell branch gets its own from _offshell_production, derived from
+        # the reshuffled production rho is evaluated at.
+        frame_boost = None
         me_prod_on = 1.0
         if offshell:
             me_prod_on = getattr(production, 'me_wgt', None)
@@ -4715,10 +4764,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         if not offshell:
             density_prod = getattr(production, '_ms_density_prod', None)
             if density_prod is None:
+                frame_boost = self._frame_boost(production)
                 density_prod = self.get_density(production, prod_static['position'],
                                                 prod_static['allowed_hel'],
                                                 prod_static['ncomb'],
-                                                prod_static['dimension'])
+                                                prod_static['dimension'],
+                                                frame_boost=frame_boost)
                 production._ms_density_prod = density_prod
 
         # PA samples a virtuality per resonance; onshell does not. 2 -> 1
@@ -4749,7 +4800,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 if setup is None:
                     stats['nb_production_restart'] += 1
                     continue
-                density_prod, jac_reshuffle, slot_mass, parents = setup
+                density_prod, jac_reshuffle, slot_mass, parents, frame_boost = setup
 
                 # Mass-set accept/reject, before the per-angle loop. All the
                 # factors that depend on the mass set but not the decay angles --
@@ -4910,7 +4961,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 restart = True
                                 break
                             density = self._slot_density(dcopy, parents[slot],
-                                                         helicities[slot])
+                                                         helicities[slot],
+                                                         frame_boost=frame_boost)
                             slot_densities[slot] = density
                             n_k = self._partial_density_contraction(
                                             density_prod, helicities, slot_densities)
@@ -5013,7 +5065,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                         # accepted slots reuse their stored (already normalised)
                         # density; only this slot's decay is evaluated here
                         slot_densities[slot] = self._slot_density(
-                                        decay, init_part[slot], helicities[slot])
+                                        decay, init_part[slot], helicities[slot],
+                                        frame_boost=frame_boost)
                         n_k = self._partial_density_contraction(density_prod, helicities,
                                                                 slot_densities)
                         # jac_dec is this slot's own factor (it depends on this
@@ -5248,6 +5301,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                 os.replace(_ml_tmp, _ml_dat)
                 mymod.set_madloop_path(MadLoopCardPath)
 
+        # the beam polarisation is constant over a run, so it is pushed into
+        # the library once per module rather than passed on every call
+        self._set_f2py_beampol(mymod)
+
 
     def create_f2py_module(self, sp_path, prod_or_decay, all_prefix, all_pdg, all_procid):
         """ Load the density-matrix f2py extensions and build the pdg -> prefix
@@ -5442,11 +5499,18 @@ class MadSpinInterface(extended_cmd.Cmd):
         density_iden_prod = iden_p * sym_factor_prod_ident
         density_iden_decay = 1
 
+        # frame the helicity basis is defined in (run_card me_frame); shared by
+        # the production and by every decay, otherwise the two sides of the
+        # contraction below would not be in the same basis. None unless the
+        # beams are polarised -- see the comment above _beampol.
+        frame_boost = self._frame_boost(production)
+
         density_prod = self.get_density(production,
                                         position,
                                         allowed_hel,
                                         ncomb,
-                                        dimension) \
+                                        dimension,
+                                        frame_boost=frame_boost) \
             if prod_density_cached is None else prod_density_cached
 
         # ------------------------------------------------------------------
@@ -5513,7 +5577,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                     position=[1],
                     allow_hel=helicities[decaying_idx + i_decay_event],
                     ncomb=len(helicities[decaying_idx + i_decay_event]),
-                    dimension=len(helicities[decaying_idx + i_decay_event])
+                    dimension=len(helicities[decaying_idx + i_decay_event]),
+                    frame_boost=frame_boost,
+                    frame_rest_leg=None if frame_boost is None
+                                   else self._decay_frame_rest_leg(part, frame_boost)
                 )
 
                 if density_dec is None:
@@ -5587,7 +5654,127 @@ class MadSpinInterface(extended_cmd.Cmd):
         self._allowed_hel_cache[key] = out
         return out  
 
-    def get_density(self, event, position, allow_hel, ncomb, dimension):
+    def _beampol(self):
+        """The (pol1, pol2) actually in force, or None for unpolarised beams.
+
+        |beampol| runs from 1 (unpolarised) to 2 (fully polarised), so anything
+        at or below 1 means no polarisation -- the same test the matrix elements
+        make, so that an out-of-range value cannot switch on the frame boost
+        here while the Fortran ignores it.
+        """
+        beampol = self.options['beampol']
+        if not beampol:
+            return None
+        pol = (float(beampol[0]), float(beampol[1]))
+        if abs(pol[0]) <= 1. and abs(pol[1]) <= 1.:
+            return None
+        return pol
+
+    def _set_f2py_beampol(self, mymod):
+        """Push the beam polarisation into the matrix-element library once per
+        module. The value is constant over a run and ``get_density`` is on the
+        hot path, so this is a setter rather than a per-call argument."""
+        pol = self._beampol()
+        if pol is None:
+            # the library defaults to unpolarised (BLOCK DATA BEAMPOL_DEFAULT)
+            return
+        if not hasattr(mymod, 'py_set_beampol'):
+            logger.warning('The matrix elements of this MadSpin run predate the '
+                           'beam-polarisation support of the density modes; '
+                           'beampol=%s will be ignored. Regenerate the process '
+                           'directory to enable it.', list(pol))
+            return
+        mymod.py_set_beampol(pol[0], pol[1])
+
+    def _frame_boost(self, event):
+        """The 4-momentum whose rest frame ``frame_id`` selects for ``event``,
+        or None when the frame machinery cannot change anything.
+
+        ``frame_id`` is the bitmask the run_card builds as
+        ``sum(2**n for n in me_frame)``, so external leg n (counted from 1, in
+        the matrix element's own ordering) is selected by bit n -- the same
+        convention ``mapid`` uncompresses with ``btest(id, i)``. The returned
+        momentum is the sum of the selected legs, ready to be handed to
+        ``Event.boost`` / ``_boost_momenta``, which negate the spatial part
+        themselves (HELAS ``boostx``, exactly what ``boost_to_frame`` does in
+        driver.f).
+        """
+        if self._beampol() is None:
+            return None
+        frame_id = int(self.options['frame_id'])
+        if frame_id <= 0:
+            return None
+        _, orig_order, _, _ = self.get_pdir(event)
+        momenta = event.get_momenta(orig_order)
+        selected = [n for n in range(1, len(momenta) + 1) if frame_id >> n & 1]
+        if not selected:
+            return None
+        pboost = lhe_parser.FourMomentum()
+        for n in selected:
+            pboost += lhe_parser.FourMomentum(momenta[n - 1])
+        # A single selected leg has to end up exactly at rest: vxxxxx branches
+        # on pp.eq.rZero and takes the frame z axis as quantisation axis there,
+        # so a residual 1d-14 three-momentum left by the boost arithmetic would
+        # silently pick a different polarisation state (see the same fix in
+        # boost_to_frame, Template/LO/SubProcesses/genps.f).
+        if len(selected) == 1:
+            pboost.rest_leg = selected[0]
+            mom = momenta[selected[0] - 1]
+            pboost.rest_leg_mom = (mom[0], mom[1], mom[2], mom[3])
+        else:
+            pboost.rest_leg = None
+            pboost.rest_leg_mom = None
+        return pboost
+
+    @staticmethod
+    def _decay_frame_rest_leg(parent, frame_boost):
+        """1 when ``frame_id`` selects exactly this resonance, so leg 1 of its
+        decay matrix element has to be forced to zero three-momentum; None
+        otherwise. Same rounding argument as in ``_frame_boost``."""
+        rest_mom = getattr(frame_boost, 'rest_leg_mom', None)
+        if rest_mom == (parent.E, parent.px, parent.py, parent.pz):
+            return 1
+        return None
+
+    @staticmethod
+    def _boost_momenta(momenta, pboost, rest_leg=-1):
+        """``boost_to_frame``: every momentum of ``momenta`` into the rest frame
+        of ``pboost``, as (E, px, py, pz) tuples.
+
+        This works on the momenta rather than on the event, so a decay event
+        stays where the rest of MadSpin needs it -- in the lab, which is what
+        ``add_decays`` and the reshuffling assume. ``rest_leg`` (1-based, -1 to
+        take it from ``pboost``) is the leg the frame is built from when it is a
+        single one, forced exactly at rest.
+        """
+        neg = lhe_parser.FourMomentum(pboost.E, -pboost.px, -pboost.py, -pboost.pz)
+        out = []
+        for mom in momenta:
+            new = lhe_parser.FourMomentum(mom).boost(neg)
+            out.append((new.E, new.px, new.py, new.pz))
+        if rest_leg == -1:
+            rest_leg = getattr(pboost, 'rest_leg', None)
+        if rest_leg is not None and rest_leg <= len(out):
+            out[rest_leg - 1] = (out[rest_leg - 1][0], 0., 0., 0.)
+        return out
+
+    def get_density(self, event, position, allow_hel, ncomb, dimension,
+                    frame_boost=None, frame_rest_leg=-1):
+        """``frame_boost`` is the momentum whose rest frame ``frame_id`` picks
+        (see ``_frame_boost``); the momenta are boosted there before the matrix
+        element sees them, which is what defines the axis the initial-state
+        helicities -- the ones ``beampol`` reweights -- are quantised along.
+
+        The *same* momentum is used for the production and for every decay
+        contracted against it. A decay event reaches this point already boosted
+        into the lab (by its parent's momentum), so applying the frame boost to
+        its momenta here composes the two in the right order and leaves both
+        sides of the contraction in one helicity basis. ``frame_rest_leg``
+        names the leg to force exactly at rest; the default takes it from
+        ``frame_boost``, which is right for a production event, and the decay
+        callers pass ``_decay_frame_rest_leg``'s answer instead.
+        """
+
         orig_order = getattr(event, '_ms_orig_order_for_density', None)
         if orig_order is None:
             _, orig_order, _, _, tag = self.get_pdir(event)
@@ -5604,6 +5791,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             all_p = event.get_all_momenta(orig_order)
             assert len(all_p) == 1, "Error: get_density can only be called for a single phase-space point"
             p = all_p[0]
+        if frame_boost is not None:
+            p = self._boost_momenta(p, frame_boost, rest_leg=frame_rest_leg)
         P = rwgt_interface.ReweightInterface.invert_momenta(p) 
         pdgs =list(orig_order[0])+list(orig_order[1])
         n_changing = len(position)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -75,7 +75,7 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('frame_id', 6)
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
-        self.add_param('beampol', [1.0, 1.0], comment='beam polarization, in the /to_polarization/ convention of madevent: 1 is unpolarized, |beampol| grows to 2 for a fully polarized beam and its sign selects the favoured helicity. Set from the run_card polbeam1/polbeam2 when there is one.')
+        self.add_param('beampol', [0., 0.], comment='beam polarisation of each beam in percent, -100 .. 100, exactly as the run_card polbeam1/polbeam2 (0 is unpolarised). Taken from the run_card of the production when it has one.')
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -113,6 +113,26 @@ class MadSpinOptions(banner.ConfigFile):
         if not hasattr(random, 'mg_seedset'):
             random.seed(self['seed'])  
             random.mg_seedset = self['seed']  
+
+    def beampol_me(self):
+        """The beam polarisations in the convention the matrix elements use.
+
+        The card and the run_card both speak percent (-100 .. 100, 0 for an
+        unpolarised beam). ``/to_beampol/`` -- the v1 driver's msP/msF SMATRIX
+        and GET_DENSITY -- is a verbatim copy of madevent's
+        ``/to_polarization/`` reweighting, so it wants madevent's *internal*
+        value, ``sign(1 + |polbeam|/100, polbeam)``: 1 unpolarised, +2 fully
+        polarised along +1 helicity, -2 fully polarised along -1. Converting
+        here rather than at parse time keeps the stored option equal to what the
+        user typed, and keeps one convention in the cards and one in Fortran.
+        """
+        pol = self['beampol'] or [0., 0.]
+        out = []
+        for value in (pol[0], pol[1]):
+            value = float(value)
+            out.append(1. if not value
+                       else math.copysign(1 + abs(value) / 100., value))
+        return tuple(out)
 
     def post_set_sequential_decay(self, value, change_userdefine, raiseerror, *opts):
         """Deprecated alias for 'unweighting'. True/False were the only values
@@ -397,29 +417,6 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.prod_branches = ''
         self.final_state = set()
 
-    @staticmethod
-    def polbeam_to_beampol(polbeam):
-        """Map a run_card ``polbeam1``/``polbeam2`` (a polarisation in percent,
-        -100 .. 100) onto the ``beampol`` the matrix elements expect.
-
-        The matrix-element side -- ``/to_beampol/`` in the v1 driver's msP/msF
-        SMATRIX and now in GET_DENSITY -- is a verbatim copy of madevent's
-        ``/to_polarization/`` reweighting, so it wants madevent's convention for
-        the value too (Template/LO/Source/setrun.f)::
-
-            beampol = sign(1 + |polbeam|/100, polbeam)
-
-        i.e. 1 for an unpolarised beam, +2 for a beam fully polarised along +1
-        helicity, -2 for one fully polarised along -1. That is what makes the
-        two branches of the reweighting come out as they should: at |beampol|=1
-        both are 1, and at |beampol|=2 the favoured helicity gets 2 and the
-        other 0.
-        """
-        polbeam = float(polbeam)
-        if not polbeam:
-            return 1.
-        return math.copysign(1 + abs(polbeam) / 100., polbeam)
-
     def _load_f2py_matrix_module(self, sp_path, menum=2):
         """Load the freshly-compiled ``all_matrix<menum>py`` extension under
         ``sp_path``.
@@ -574,13 +571,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                 if 'frame_id' not in self.options.user_set:
                     self.options['frame_id'] = run_card['frame_id']
                 if 'beampol' not in self.options.user_set:
-                    self.options['beampol'] = [self.polbeam_to_beampol(run_card['polbeam1']),
-                                               self.polbeam_to_beampol(run_card['polbeam2'])]
+                    self.options['beampol'] = [run_card['polbeam1'],
+                                               run_card['polbeam2']]
             else:
                 if 'frame_id' not in self.options.user_set:
                     self.options['frame_id'] = 6
                 if 'beampol' not in self.options.user_set:
-                    self.options['beampol'] = [1., 1.]
+                    self.options['beampol'] = [0., 0.]
 
         else:
             if not self.options['Nevents_for_max_weight']:
@@ -5662,10 +5659,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         make, so that an out-of-range value cannot switch on the frame boost
         here while the Fortran ignores it.
         """
-        beampol = self.options['beampol']
-        if not beampol:
-            return None
-        pol = (float(beampol[0]), float(beampol[1]))
+        pol = self.options.beampol_me()
         if abs(pol[0]) <= 1. and abs(pol[1]) <= 1.:
             return None
         return pol

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -5,6 +5,40 @@ ANNOUNCEMENT:
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
 3.7.2 (XX/XX/XX):
+    OM: MadSpin: the run_card me_frame and polbeam1/polbeam2 are now honoured by the
+        density-based spinmodes (onshell/PA/madspin/full) and no longer only by the
+        legacy madspin_v1/onshell_v1 paths.
+        - beampol reweights the initial-state helicity sum inside the density matrix,
+          through a new PY_SET_BEAMPOL entry point of the matrix-element library;
+        - me_frame boosts the momenta of the production and of every decay into the
+          selected frame before the matrix element sees them, which is what defines
+          the axis those helicities are quantised along. The boost is skipped for
+          unpolarised beams, so unpolarised runs are unchanged bit-for-bit. Note
+          that -- in the density modes as in the v1 path -- the frame turns out not
+          to change any observable: the initial-state legs are massless, so their
+          helicity labels and each fixed-helicity |M|^2 with them are boost
+          invariant, and so is the reweighted sum. What the boost does change is the
+          basis the individual density-matrix elements are written in, which is why
+          the production and every decay have to be boosted with the same momentum.
+        - "set frame_id"/"set beampol" in the MadSpin card now override the run_card
+          values instead of being silently discarded.
+    OM: Two MadSpin bug fixes in the beam-polarisation support of the legacy
+        madspin_v1/onshell_v1 paths (both since it was added in 3.6.3):
+        - the run_card polbeam1/polbeam2 were converted to the [0,1] left-handed-
+          fraction convention of the EVA PDF and then fed to a matrix-element
+          reweighting that expects madevent's /to_polarization/ convention. As a
+          result an *unpolarised* run (polbeam=0 -> beampol=0.5) applied a spurious
+          factor 0.5 to one initial-state helicity and 1.5 to the other, while a
+          fully polarised beam (polbeam=-100 -> beampol=1) applied nothing at all,
+          and the sign of the polarisation was flipped. The mapping is now
+          sign(1+|polbeam|/100, polbeam), as in setrun.f;
+        - in matrix_standalone_msF_v4.inc the reweighting was applied after the
+          helicity sum rather than before it, so only HELAMP was polarised and the
+          full matrix element -- the numerator of the MadSpin decay weight, and the
+          only place the polarisation can reach the decay angles -- stayed
+          unpolarised. The decay distribution of the v1 path was therefore
+          insensitive to any partial beam polarisation (100% happened to work by
+          accident, through the GOODHEL filter zeroing the disfavoured helicities).
     RF: Fixed the writing of LHE files in fixed-order computations that was broken since previous release (3.7.1).
 
 3.7.1 (29/04/26):

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -27,7 +27,7 @@ ANNOUNCEMENT:
         - the run_card polbeam1/polbeam2 were converted to the [0,1] left-handed-
           fraction convention of the EVA PDF and then fed to a matrix-element
           reweighting that expects madevent's /to_polarization/ convention. As a
-          result an *unpolarised* run (polbeam=0 -> beampol=0.5) applied a spurious
+          result, an *unpolarised* run (polbeam=0 -> beampol=0.5) applied a spurious
           factor 0.5 to one initial-state helicity and 1.5 to the other, while a
           fully polarised beam (polbeam=-100 -> beampol=1) applied nothing at all,
           and the sign of the polarisation was flipped. The mapping is now

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -3930,6 +3930,7 @@ class ProcessExporterFortranMW(ProcessExporterFortran):
         # Extract number of external particles
         (nexternal, ninitial) = matrix_element.get_nexternal_ninitial()
         replace_dict['nexternal'] = nexternal
+        replace_dict['nincoming'] = ninitial
 
         # Extract ncomb
         ncomb = matrix_element.get_helicity_combinations()

--- a/madgraph/iolibs/template_files/f2py_splitter.py
+++ b/madgraph/iolibs/template_files/f2py_splitter.py
@@ -98,6 +98,33 @@ CF2PY INTENT(IN) :: PATH
       CALL SETPARA(PATH)  !first call to setup the paramaters
       RETURN
       END
+
+
+      BLOCK DATA %(f2py_prefix)sBEAMPOL_DEFAULT
+C     Unpolarised beams unless PY_SET_BEAMPOL says otherwise. This has
+C     to be a default rather than something the caller is trusted to
+C     set: the GET_DENSITY routines read /to_beampol/ unconditionally,
+C     and a zero-filled common block would be read as a fully polarised
+C     beam of the wrong handedness.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
+      DATA BEAMPOL/1D0,1D0/
+      END
+
+
+      SUBROUTINE %(f2py_prefix)sf77_set_beampol(POL1, POL2)
+C     Fill /to_beampol/ on this side of the shared-library boundary --
+C     the f2py wrapper and the matrix elements do not share common
+C     blocks, which is why the nhel bookkeeping copies rather than
+C     aliases them. See PY_SET_BEAMPOL for the convention.
+      IMPLICIT NONE
+      DOUBLE PRECISION POL1, POL2
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
+      BEAMPOL(1) = POL1
+      BEAMPOL(2) = POL2
+      RETURN
+      END
       
       
       subroutine %(f2py_prefix)sf77_CHANGE_PARA(name, value)

--- a/madgraph/iolibs/template_files/f2py_wrapper_all.inc
+++ b/madgraph/iolibs/template_files/f2py_wrapper_all.inc
@@ -89,6 +89,23 @@ CF2PY INTENT(IN) :: PATH
       END
 
 
+      SUBROUTINE %(f2py_prefix)sPY_SET_BEAMPOL(POL1, POL2)
+C     ROUTINE FOR F2PY to set the beam polarisation of the density
+C     matrix evaluation. POL1/POL2 follow the convention of the
+C     /to_polarization/ common block of madevent (and of the v1 MadSpin
+C     driver): 1 is an unpolarised beam and |POL| grows to 2 for a fully
+C     polarised one, the sign of POL giving the favoured helicity.
+C     The value is constant over a run, so this is called once at module
+C     initialisation rather than passed to every PY_GET_DENSITY call.
+      IMPLICIT NONE
+CF2PY DOUBLE PRECISION, INTENT(IN) :: POL1
+CF2PY DOUBLE PRECISION, INTENT(IN) :: POL2
+      DOUBLE PRECISION POL1, POL2
+      CALL %(f2py_prefix)sf77_set_beampol(POL1, POL2)
+      RETURN
+      END
+
+
       SUBROUTINE %(f2py_prefix)sCHANGE_PARA(NAME, VALUE)
       IMPLICIT NONE
 CF2PY intent(in) :: name

--- a/madgraph/iolibs/template_files/loop/all_matrix.f
+++ b/madgraph/iolibs/template_files/loop/all_matrix.f
@@ -10,6 +10,32 @@ CF2PY INTENT(IN) :: PATH
       RETURN
       END
 
+
+      BLOCK DATA BEAMPOL_DEFAULT
+C     Unpolarised beams unless PY_SET_BEAMPOL says otherwise. This has
+C     to be a default rather than something the caller is trusted to
+C     set: the GET_DENSITY routines read /to_beampol/ unconditionally,
+C     and a zero-filled common block would be read as a fully polarised
+C     beam of the wrong handedness.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
+      DATA BEAMPOL/1D0,1D0/
+      END
+
+
+      SUBROUTINE f77_SET_BEAMPOL(POL1, POL2)
+C     Fill /to_beampol/ on this side of the shared-library boundary --
+C     the f2py wrapper and the matrix elements do not share common
+C     blocks. See PY_SET_BEAMPOL for the convention.
+      IMPLICIT NONE
+      DOUBLE PRECISION POL1, POL2
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
+      BEAMPOL(1) = POL1
+      BEAMPOL(2) = POL2
+      RETURN
+      END
+
       subroutine f77_CHANGE_PARA(name, value)
       implicit none
 CF2PY intent(in) :: name

--- a/madgraph/iolibs/template_files/loop/f2py_wrapper_subproccesses.f
+++ b/madgraph/iolibs/template_files/loop/f2py_wrapper_subproccesses.f
@@ -30,6 +30,21 @@ CF2PY intent(in) :: value
       END
 
 
+      SUBROUTINE PY_SET_BEAMPOL(POL1, POL2)
+C     ROUTINE FOR F2PY to set the beam polarisation of the density
+C     matrix evaluation. POL1/POL2 follow the convention of the
+C     /to_polarization/ common block of madevent (and of the v1 MadSpin
+C     driver): 1 is an unpolarised beam and |POL| grows to 2 for a fully
+C     polarised one, the sign of POL giving the favoured helicity.
+      IMPLICIT NONE
+CF2PY DOUBLE PRECISION, INTENT(IN) :: POL1
+CF2PY DOUBLE PRECISION, INTENT(IN) :: POL2
+      DOUBLE PRECISION POL1, POL2
+      CALL F77_SET_BEAMPOL(POL1, POL2)
+      RETURN
+      END
+
+
       SUBROUTINE SET_MADLOOP_PATH(PATH)
 C     Routine to set the path of the folder 'MadLoop5_resources' to
 C      MadLoop

--- a/madgraph/iolibs/template_files/loop_optimized/compute_color_flows.inc
+++ b/madgraph/iolibs/template_files/loop_optimized/compute_color_flows.inc
@@ -1227,10 +1227,19 @@ C
       COMMON/%(proc_prefix)sHELCONFIGS/HELC
       REAL*8 AUX(0:3,0:AUX_DIMENSION)
 
-C     
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=%(nincoming)d)
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
+
+C
 C     local
-C     
-      INTEGER I, IHEL, IPART
+C
+      INTEGER I, IHEL, IPART, JJ
+      DOUBLE PRECISION POLFACT
 
 c     Maybe should be a .or. ?
       IF ((ALPHAS.ne.0D0).and.(SCALE2.ne.0D0)) THEN
@@ -1249,9 +1258,30 @@ c     Maybe should be a .or. ?
             if(THISNHEL(POS(IPART)).NE.ALLOW_HEL(IPART)) GOTO 10 !BYPASS COMPUTATION FOR HELICITY
         ENDDO
         call %(proc_prefix)sGET_ALL_INTER(JAMPL_ALL, THISNHEL, POS, N_CHANGING, ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         do I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I, 0)
-        enddo 
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I, 0)
+        enddo
  10   enddo
         
 c      CALL %(proc_prefix)sNORMALISE_RHO(INTER, N_COMB, RHO_NORM)

--- a/madgraph/iolibs/template_files/matrix_standalone_msF_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_standalone_msF_v4.inc
@@ -53,9 +53,14 @@ C ----------
       ANS = 0D0
           DO IHEL=1,NCOMB
              IF (GOODHEL(IHEL) .OR. NTRY .LT. 100) THEN
-                 T=MATRIX(P ,NHEL(1,IHEL),JC(1))            
-               ANS=ANS+T
-C HANDLE POLARISED BEAM               
+                 T=MATRIX(P ,NHEL(1,IHEL),JC(1))
+C HANDLE POLARISED BEAM
+C The reweighting has to come *before* the sum: ANS is the full matrix
+C element MadSpin divides by the production one to get the decay weight,
+C so it is the only place the polarisation can reach the decay angles.
+C Weighting HELAMP alone (as this did) left the decay distribution of the
+C v1 path exactly unpolarised while SMATRIX_PROD, which weights in the
+C right order, polarised the denominator.
               DO JJ=1,NINCOMING
                 IF(BEAMPOL(JJ).NE.1D0.AND.NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
                   T=T*ABS(BEAMPOL(JJ))
@@ -63,6 +68,7 @@ C HANDLE POLARISED BEAM
                   T=T*(2D0-ABS(BEAMPOL(JJ)))
                 ENDIF
               ENDDO
+               ANS=ANS+T
 
                  HELAMP(IHEL)=T
                IF (T .NE. 0D0) THEN

--- a/madgraph/iolibs/template_files/matrix_standalone_splitOrders_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_standalone_splitOrders_v4.inc
@@ -138,7 +138,10 @@ C LOCAL VARIABLES
 C
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/%(beamone_helavgfactor)d,%(beamtwo_helavgfactor)d/
@@ -208,6 +211,21 @@ C     For this reason, we simply remove the filterin when there is only three ex
                 CYCLE
               ENDIF
               CALL %(proc_prefix)sMATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C Support for polarised beam, see matrix_standalone_v4.inc
+              IF (NINITIAL.EQ.2) THEN
+                DO JJ=1,NINITIAL
+                  IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                  IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                    DO I=1,NSQAMPSO
+                      T(I)=T(I)*ABS(BEAMPOL(JJ))
+                    ENDDO
+                  ELSE
+                    DO I=1,NSQAMPSO
+                      T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                    ENDDO
+                  ENDIF
+                ENDDO
+              ENDIF
               BUFF=0D0
               DO I=1,NSQAMPSO
                 IF(POLARIZATIONS(0,0).eq.-1.or.%(proc_prefix)sIS_BORN_HEL_SELECTED(IHEL)) THEN
@@ -540,15 +558,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=%(nincoming)d)
 c LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C
 C     GLOBAL
 C
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/%(proc_prefix)sCHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -579,10 +605,31 @@ C
         ENDDO
         TMP_INTER(:,:) = 0
         call  %(proc_prefix)sGET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         do J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             do I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             enddo
           endif
         enddo

--- a/madgraph/iolibs/template_files/matrix_standalone_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_standalone_v4.inc
@@ -70,7 +70,15 @@ C  put in common block to expose this variable to python interface
       COMMON/%(proc_prefix)sPROCESS_NHEL/NHEL 
       REAL*8 T
       REAL*8 %(proc_prefix)sMATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/%(beamone_helavgfactor)d,%(beamtwo_helavgfactor)d/
@@ -139,6 +147,23 @@ C     For this reason, we simply remove the filterin when there is only three ex
                     ENDIF
                     
                     T=%(proc_prefix)sMATRIX(P ,NHEL(1,IHEL),JC(1))
+C Support for polarised beam. Same reweighting of the initial-state
+C helicity sum as madevent's matrix.f and as the v1 MadSpin msP/msF
+C templates. Inert (and skipped) unless /to_beampol/ has been filled:
+C |BEAMPOL| runs from 1 (unpolarised) to 2 (fully polarised), so
+C anything at or below 1 -- including a zero-filled common block --
+C means "no polarisation". 1 -> N matrix elements are left alone: their
+C leg 1 is a decaying resonance, not a beam.
+      IF (NINITIAL.EQ.2) THEN
+        DO JJ=1,NINITIAL
+          IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+          IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+            T=T*ABS(BEAMPOL(JJ))
+          ELSE
+            T=T*(2D0-ABS(BEAMPOL(JJ)))
+          ENDIF
+        ENDDO
+      ENDIF
                     IF(POLARIZATIONS(0,0).eq.-1.or.%(proc_prefix)sIS_BORN_HEL_SELECTED(IHEL)) THEN
                         ANS=ANS+T
                     ENDIF
@@ -434,13 +459,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=%(ncomb)d)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=%(nincoming)d)
 c LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/%(proc_prefix)sPROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C
 C     include coupling definition to update the value of alphas
 C
@@ -466,10 +501,31 @@ C
         ENDDO
         TMP_INTER(:) = 0
         call  %(proc_prefix)sGET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         do I = 1, N_COMB*(N_COMB+1)/2
-           INTER(I) = INTER(I) + TMP_INTER(I)
-        enddo 
- 10   enddo 
+           INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
+        enddo
+ 10   enddo
       return 
       deallocate(TMP_INTER)
       end

--- a/madgraph/various/lhe_parser.py
+++ b/madgraph/various/lhe_parser.py
@@ -4128,7 +4128,14 @@ class FourMomentum(object):
                            py=self.py + mom.py * lf,
                            pz=self.pz + mom.pz * lf)
         else:
-            return FourMomentum(mom)
+            # ``mom`` has no spatial part, so the transformation is the
+            # identity and the momentum is returned untouched. This is the
+            # ``qq.eq.rZero`` branch of the HELAS boostx this routine copies
+            # (aloha/template_files/aloha_functions.f); returning ``mom`` here
+            # instead would replace every boosted momentum by the boost itself.
+            # It is reached whenever the selected system is already at rest --
+            # e.g. boosting to the partonic CMS of a lepton-collider event.
+            return FourMomentum(self)
 
     def zboost(self, pboost=None, E=0, pz=0):
         """Both momenta should be in the same frame. 

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_dxu_wp%V0_dxu_wp%born_matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_dxu_wp%V0_dxu_wp%born_matrix.f
@@ -141,7 +141,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -229,6 +232,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -592,15 +610,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -632,10 +658,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_udx_wp%V0_udx_wp%born_matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_ppw_fksall/%SubProcesses%P0_udx_wp%V0_udx_wp%born_matrix.f
@@ -141,7 +141,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -229,6 +232,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -592,15 +610,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -632,10 +658,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_dxu_veep%V0_dxu_veep%born_matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_dxu_veep%V0_dxu_veep%born_matrix.f
@@ -141,7 +141,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -233,6 +236,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -602,15 +620,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -642,10 +668,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_udx_veep%V0_udx_veep%born_matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportFKSTest/test_wprod_fksew/%SubProcesses%P0_udx_veep%V0_udx_veep%born_matrix.f
@@ -141,7 +141,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -233,6 +236,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -602,15 +620,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -642,10 +668,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_standalone/matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_standalone/matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -179,6 +187,29 @@ C      only three external particles.
             ENDIF
 
             T=MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL))
      $        THEN
               ANS=ANS+T
@@ -543,13 +574,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=32)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -576,8 +617,29 @@ C
         TMP_INTER(:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/MadLoop_output_from_the_interface/TIR_output/%ggttx_IOTest%SubProcesses%P0_gg_ttx%born_matrix.f
+++ b/tests/input_files/IOTestsComparison/MadLoop_output_from_the_interface/TIR_output/%ggttx_IOTest%SubProcesses%P0_gg_ttx%born_matrix.f
@@ -140,7 +140,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -232,6 +235,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.
@@ -609,15 +627,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/ML5_0_CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -649,10 +675,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_NoSQSO.f
+++ b/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_NoSQSO.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -211,6 +219,29 @@ C      only three external particles.
             ENDIF
 
             T=MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL))
      $        THEN
               ANS=ANS+T
@@ -816,13 +847,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=64)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -849,8 +890,29 @@ C
         TMP_INTER(:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_QCDsq_le_6.f
+++ b/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_QCDsq_le_6.f
@@ -140,7 +140,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -280,6 +283,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -922,15 +940,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -962,10 +988,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_ampOrderQED2_eq_2_WGTsq_le_14_QCDsq_gt_4.f
+++ b/tests/input_files/IOTestsComparison/SquaredOrder_IOTest/sqso_uux_uuxuuxx/matrix_ampOrderQED2_eq_2_WGTsq_le_14_QCDsq_gt_4.f
@@ -140,7 +140,10 @@ C     LOCAL VARIABLES
 C     
       INTEGER NTRY
       REAL*8 T(NSQAMPSO), BUFF
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation, see the same block in matrix_standalone_v4.inc
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -280,6 +283,21 @@ C      only three external particles.
               CYCLE
             ENDIF
             CALL MATRIX(P ,NHEL(1,IHEL),JC(1), T)
+C           Support for polarised beam, see matrix_standalone_v4.inc
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*ABS(BEAMPOL(JJ))
+                  ENDDO
+                ELSE
+                  DO I=1,NSQAMPSO
+                    T(I)=T(I)*(2D0-ABS(BEAMPOL(JJ)))
+                  ENDDO
+                ENDIF
+              ENDDO
+            ENDIF
             BUFF=0D0
             DO I=1,NSQAMPSO
               IF(POLARIZATIONS(0,0).EQ.-1.OR.IS_BORN_HEL_SELECTED(IHEL)
@@ -922,15 +940,23 @@ C
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:,:)
       DOUBLE PRECISION ALPHAS, MU_R2
       DOUBLE COMPLEX INTER_SUM(*)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       INTEGER J
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
 C     GLOBAL
 C     
       LOGICAL CHOSEN_SO_CONFIGS(NSQAMPSO)
       COMMON/CHOSEN_BORN_SQSO/CHOSEN_SO_CONFIGS
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF).
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 
       INTEGER NHEL(NEXTERNAL,NB_NHEL),NTRY
 C     put in common block to expose this variable to python interface
@@ -962,10 +988,31 @@ C
         TMP_INTER(:,:) = 0
         CALL  GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING, ALLOW_HEL,
      $    N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO J =1, NSQAMPSO
           IF (CHOSEN_SO_CONFIGS(J)) THEN
             DO I = 1, N_COMB*(N_COMB+1)/2
-              INTER_SUM(I) = INTER_SUM(I) + TMP_INTER(J,I)
+              INTER_SUM(I) = INTER_SUM(I) + POLFACT*TMP_INTER(J,I)
             ENDDO
           ENDIF
         ENDDO

--- a/tests/input_files/IOTestsComparison/long_ML_SMQCD_default/dux_mumvmxg/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/long_ML_SMQCD_default/dux_mumvmxg/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -179,6 +187,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -531,13 +562,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=32)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -564,8 +605,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/long_ML_SMQCD_default/gg_wmtbx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/long_ML_SMQCD_default/gg_wmtbx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -195,6 +203,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -586,13 +617,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=48)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -619,8 +660,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/long_ML_SMQCD_optimized/dux_mumvmxg/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/long_ML_SMQCD_optimized/dux_mumvmxg/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -179,6 +187,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -531,13 +562,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=32)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -564,8 +605,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/long_ML_SMQCD_optimized/gg_wmtbx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/long_ML_SMQCD_optimized/gg_wmtbx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -195,6 +203,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -586,13 +617,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=48)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -619,8 +660,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/short_ML_SMQCD_default/ddx_ttx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/short_ML_SMQCD_default/ddx_ttx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -163,6 +171,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -496,13 +527,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=16)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -529,8 +570,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/short_ML_SMQCD_default/gg_ttx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/short_ML_SMQCD_default/gg_ttx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -163,6 +171,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -504,13 +535,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=16)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -537,8 +578,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/short_ML_SMQCD_optimized/ddx_ttx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/short_ML_SMQCD_optimized/ddx_ttx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -163,6 +171,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -496,13 +527,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=16)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -529,8 +570,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/input_files/IOTestsComparison/short_ML_SMQCD_optimized/gg_ttx/born_matrix.f
+++ b/tests/input_files/IOTestsComparison/short_ML_SMQCD_optimized/gg_ttx/born_matrix.f
@@ -72,7 +72,15 @@ C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
       REAL*8 T
       REAL*8 ML5_0_MATRIX
-      INTEGER IHEL,IDEN, I, J
+      INTEGER IHEL,IDEN, I, J, JJ
+C     beam polarisation. Unpolarised unless something fills
+C     /to_beampol/: PY_SET_BEAMPOL for the MadSpin density
+C     modes, the driver's stdin for the v1 path. Convention as
+C     in madevent's /to_polarization/: 1 is unpolarised,
+C     |BEAMPOL| grows to 2 for a fully polarised beam and its
+C     sign gives the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     For a 1>N process, them BEAMTWO_HELAVGFACTOR would be set to 1.
       INTEGER BEAMS_HELAVGFACTOR(2)
       DATA (BEAMS_HELAVGFACTOR(I),I=1,2)/2,2/
@@ -163,6 +171,29 @@ C      only three external particles.
             ENDIF
 
             T=ML5_0_MATRIX(P ,NHEL(1,IHEL),JC(1))
+C           Support for polarised beam. Same reweighting of the
+C            initial-state
+C           helicity sum as madevent's matrix.f and as the v1 MadSpin
+C            msP/msF
+C           templates. Inert (and skipped) unless /to_beampol/ has
+C            been filled:
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C            polarised), so
+C           anything at or below 1 -- including a zero-filled common
+C            block --
+C           means "no polarisation". 1 -> N matrix elements are left
+C            alone: their
+C           leg 1 is a decaying resonance, not a beam.
+            IF (NINITIAL.EQ.2) THEN
+              DO JJ=1,NINITIAL
+                IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+                IF (NHEL(JJ,IHEL).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+                  T=T*ABS(BEAMPOL(JJ))
+                ELSE
+                  T=T*(2D0-ABS(BEAMPOL(JJ)))
+                ENDIF
+              ENDDO
+            ENDIF
             IF(POLARIZATIONS(0,0).EQ.
      $       -1.OR.ML5_0_IS_BORN_HEL_SELECTED(IHEL)) THEN
               ANS=ANS+T
@@ -504,13 +535,23 @@ C
       INTEGER NB_NHEL
       DOUBLE COMPLEX, ALLOCATABLE :: TMP_INTER(:)
       PARAMETER (NB_NHEL=16)
+      INTEGER    NINITIAL
+      PARAMETER (NINITIAL=2)
 C     LOCAL
-      INTEGER I,IHEL,IPART
+      INTEGER I,IHEL,IPART,JJ
       DOUBLE PRECISION PI
+      DOUBLE PRECISION POLFACT
 C     
       INTEGER NHEL(NEXTERNAL,NB_NHEL)
 C     put in common block to expose this variable to python interface
       COMMON/ML5_0_PROCESS_NHEL/NHEL
+C     beam polarisation, filled from python through PY_SET_BEAMPOL.
+C     Same common block and same convention as the v1 MadSpin path
+C     (matrix_standalone_msP_v4.inc / msF): BEAMPOL = 1 is unpolarised
+C     and |BEAMPOL| runs up to 2 for a fully polarised beam, its sign
+C     giving the favoured helicity.
+      DOUBLE PRECISION BEAMPOL(2)
+      COMMON/TO_BEAMPOL/BEAMPOL
 C     
 C     include coupling definition to update the value of alphas
 C     
@@ -537,8 +578,29 @@ C
         TMP_INTER(:) = 0
         CALL  ML5_0_GET_ALL_INTER(P, THISNHEL, POS, N_CHANGING,
      $    ALLOW_HEL, N_COMB, TMP_INTER)
+C       Support for polarised beam: reweight the initial-state helicity
+C       sum exactly as SMATRIX_PROD does in the v1 path. Skipped unless
+C       the process has two incoming legs -- the same shared library
+C       also holds the 1 -> N decay matrix elements, whose leg 1 is the
+C       decaying resonance and not a beam.
+        POLFACT = 1D0
+        IF (NINITIAL.EQ.2) THEN
+          DO JJ=1,NINITIAL
+C           |BEAMPOL| runs from 1 (unpolarised) to 2 (fully
+C           polarised), so anything at or below 1 means "no
+C           polarisation" -- including the zero-filled common
+C           block of an output whose link line does not pull
+C           in BLOCK DATA BEAMPOL_DEFAULT.
+            IF (ABS(BEAMPOL(JJ)).LE.1D0) CYCLE
+            IF (THISNHEL(JJ).EQ.INT(SIGN(1D0,BEAMPOL(JJ)))) THEN
+              POLFACT = POLFACT*ABS(BEAMPOL(JJ))
+            ELSE
+              POLFACT = POLFACT*(2D0-ABS(BEAMPOL(JJ)))
+            ENDIF
+          ENDDO
+        ENDIF
         DO I = 1, N_COMB*(N_COMB+1)/2
-          INTER(I) = INTER(I) + TMP_INTER(I)
+          INTER(I) = INTER(I) + POLFACT*TMP_INTER(I)
         ENDDO
  10   ENDDO
       RETURN

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -243,6 +243,151 @@ class TestDensity(unittest.TestCase):
         nb_false = len([True for key in out if not out[key][0]])
         self.assertEqual(nb_false, 6)
 
+
+class _FrameStub(object):
+    """Just enough of MadSpinInterface for the frame/beampol helpers: they only
+    need the options and the matrix-element ordering of the event."""
+
+    def __init__(self, frame_id, beampol):
+        self.options = {'frame_id': frame_id, 'beampol': beampol}
+
+    def get_pdir(self, event):
+        return None, None, None, None
+
+    _beampol = interface_madspin.MadSpinInterface._beampol
+    _frame_boost = interface_madspin.MadSpinInterface._frame_boost
+    _boost_momenta = staticmethod(interface_madspin.MadSpinInterface._boost_momenta)
+
+
+class _MomentaEvent(object):
+    """Stands in for the production event: get_density/_frame_boost only ever
+    ask it for its momenta in the matrix element's ordering."""
+
+    def __init__(self, momenta):
+        self.momenta = momenta
+
+    def get_momenta(self, orig_order):
+        return self.momenta
+
+
+class TestFrameBoost(unittest.TestCase):
+    """me_frame / frame_id and beampol support in the density modes."""
+
+    # 1 and 2 along +z/-z, 3 and 4 sharing the recoil
+    MOMENTA = [(500., 0., 0., 500.),
+               (200., 0., 0., -200.),
+               (300., 100., 50., -80.),
+               (400., -100., -50., 380.)]
+
+    def _stub(self, frame_id, beampol=(1.8, 1.)):
+        return _FrameStub(frame_id, beampol)
+
+    def test_polbeam_to_beampol(self):
+        """the run_card polbeam -> beampol map has to land on madevent's
+        /to_polarization/ convention, not on the [0,1] left-handed fraction the
+        eva PDF uses"""
+        fct = interface_madspin.MadSpinInterface.polbeam_to_beampol
+        self.assertEqual(fct(0), 1.)
+        self.assertEqual(fct(100), 2.)
+        self.assertEqual(fct(-100), -2.)
+        self.assertEqual(fct(50), 1.5)
+        self.assertEqual(fct(-50), -1.5)
+        # the two branches of the matrix-element reweighting, as written in
+        # matrix_standalone_msP_v4.inc: unpolarised leaves both helicities
+        # alone, +-100%% keeps one and kills the other
+        for polbeam, hel_plus, hel_minus in [(0, 1., 1.),
+                                             (100, 2., 0.),
+                                             (-100, 0., 2.),
+                                             (50, 1.5, 0.5)]:
+            pol = fct(polbeam)
+            if abs(pol) <= 1:
+                got = (1., 1.)
+            elif pol > 0:
+                got = (abs(pol), 2 - abs(pol))
+            else:
+                got = (2 - abs(pol), abs(pol))
+            self.assertEqual(got, (hel_plus, hel_minus))
+
+    def test_frame_inert_without_polarisation(self):
+        """the frame only changes the axis the initial-state helicities are
+        quantised along, so with unpolarised beams there is nothing to do"""
+        stub = self._stub(6, beampol=(1., 1.))
+        self.assertIsNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
+
+    def test_frame_id_bitmask(self):
+        """frame_id = sum(2**n over the selected legs), the convention mapid
+        uncompresses with btest(id, i)"""
+        # 6 = 2**1 + 2**2 -> the two initial legs
+        boost = self._stub(6)._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (700., 0., 0., 300.))
+        # 24 = 2**3 + 2**4 -> the two final legs; same frame, by momentum
+        # conservation
+        boost = self._stub(24)._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (700., 0., 0., 300.))
+        # 8 = 2**3 -> leg 3 alone
+        boost = self._stub(8)._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (300., 100., 50., -80.))
+        # a frame_id selecting nothing is not a frame
+        self.assertIsNone(self._stub(1)._frame_boost(_MomentaEvent(self.MOMENTA)))
+        self.assertIsNone(self._stub(0)._frame_boost(_MomentaEvent(self.MOMENTA)))
+
+    def test_boost_to_partonic_cms(self):
+        """frame_id = 6 on back-to-back beams is a pure z boost; check every leg
+        against the closed form"""
+        stub = self._stub(6)
+        boost = stub._frame_boost(_MomentaEvent(self.MOMENTA))
+        out = stub._boost_momenta(self.MOMENTA, boost)
+
+        mass = math.sqrt(700.**2 - 300.**2)
+        gamma, gammabeta = 700. / mass, 300. / mass
+        for mom, new in zip(self.MOMENTA, out):
+            E, px, py, pz = mom
+            self.assertAlmostEqual(new[0], gamma * E - gammabeta * pz, places=9)
+            self.assertAlmostEqual(new[1], px, places=9)
+            self.assertAlmostEqual(new[2], py, places=9)
+            self.assertAlmostEqual(new[3], gamma * pz - gammabeta * E, places=9)
+
+        # the frame is defined by legs 1+2, so their sum is at rest in it
+        self.assertAlmostEqual(out[0][3] + out[1][3], 0., places=9)
+        # and the boost is an invariance of the masses
+        for mom, new in zip(self.MOMENTA, out):
+            m2 = mom[0]**2 - mom[1]**2 - mom[2]**2 - mom[3]**2
+            n2 = new[0]**2 - new[1]**2 - new[2]**2 - new[3]**2
+            self.assertAlmostEqual(m2, n2, delta=1e-6 * abs(mom[0])**2)
+
+    def test_single_leg_frame_is_exactly_at_rest(self):
+        """with one selected leg that leg has to come out at exactly zero
+        three-momentum: vxxxxx branches on pp.eq.rZero and would otherwise pick
+        its quantisation axis from the rounding noise"""
+        stub = self._stub(8)
+        boost = stub._frame_boost(_MomentaEvent(self.MOMENTA))
+        out = stub._boost_momenta(self.MOMENTA, boost)
+        self.assertEqual(out[2][1:], (0., 0., 0.))
+        self.assertAlmostEqual(out[2][0], math.sqrt(300.**2 - 100.**2 - 50.**2 - 80.**2),
+                               places=9)
+        # two selected legs: no leg sits on that branch point, nothing is forced
+        boost = self._stub(6)._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertIsNone(boost.rest_leg)
+
+    def test_boost_of_a_system_already_at_rest(self):
+        """A lepton-collider event arrives in the partonic CMS, so frame_id = 6
+        asks for a boost with no spatial part. That is the identity, not an
+        excuse to replace every momentum by the boost (HELAS boostx's
+        qq.eq.rZero branch)."""
+        momenta = [(250., 0., 0., 250.),
+                   (250., 0., 0., -250.),
+                   (250., 100., 50., -80.),
+                   (250., -100., -50., 80.)]
+        stub = _FrameStub(6, (1.8, 1.))
+        boost = stub._frame_boost(_MomentaEvent(momenta))
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (500., 0., 0., 0.))
+        self.assertEqual(stub._boost_momenta(momenta, boost), momenta)
+
+
 class TestEvent(unittest.TestCase):
     """Test class for the reading of the lhe input file"""
     
@@ -1146,11 +1291,14 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _unweighting_mode = interface._unweighting_mode
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
+            _beampol = interface._beampol
+            _frame_boost = interface._frame_boost
             def __init__(self):
                 self.options = {'spinmode': 'onshell',
                                 'sequential_spin_order': '2 3 1',
                                 'unweighting': 'sequential',
-                                'fixed_order': False}
+                                'fixed_order': False,
+                                'beampol': [1., 1.], 'frame_id': 6}
             def _density_basis(self, production, decays_key):
                 particles, slots = interface._sequential_slots(production, decays_key)
                 return {'decays_key': decays_key, 'helicities': hels,
@@ -1164,7 +1312,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             def _draw_one_decay(self, particle, index, ids, evt_decayfile, nb_remain):
                 import random
                 return ('cand', self._slot_of[index], random.randrange(pool))
-            def _slot_density(self, decay, parent, hel):
+            def _slot_density(self, decay, parent, hel, frame_boost=None):
                 return pools[decay[1]][decay[2]]
         return Stub()
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -322,6 +322,17 @@ class TestFrameBoost(unittest.TestCase):
                 got = (2 - abs(pol), abs(pol))
             self.assertEqual(got, (hel_plus, hel_minus))
 
+    def test_beampol_needs_both_beams(self):
+        """One number is ambiguous -- which beam? -- and used to surface only as
+        an IndexError once the run reached a matrix element. It is refused when
+        the card is read instead."""
+        options = interface_madspin.MadSpinOptions()
+        for bad in ('50', '[50]'):
+            self.assertRaises(Exception, options.__setitem__, 'beampol', bad)
+        # unset stays legal and means unpolarised
+        options['beampol'] = '[]'
+        self.assertEqual(options.beampol_me(), (1., 1.))
+
     def test_frame_inert_without_polarisation(self):
         """the frame only changes the axis the initial-state helicities are
         quantised along, so with unpolarised beams there is nothing to do"""

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -244,12 +244,19 @@ class TestDensity(unittest.TestCase):
         self.assertEqual(nb_false, 6)
 
 
+class _StubOptions(dict):
+    """A plain options dict plus the one method the interface calls on it."""
+    beampol_me = interface_madspin.MadSpinOptions.beampol_me
+
+
 class _FrameStub(object):
     """Just enough of MadSpinInterface for the frame/beampol helpers: they only
     need the options and the matrix-element ordering of the event."""
 
     def __init__(self, frame_id, beampol):
-        self.options = {'frame_id': frame_id, 'beampol': beampol}
+        self.options = interface_madspin.MadSpinOptions()
+        self.options['frame_id'] = frame_id
+        self.options['beampol'] = list(beampol)
 
     def get_pdir(self, event):
         return None, None, None, None
@@ -279,19 +286,26 @@ class TestFrameBoost(unittest.TestCase):
                (300., 100., 50., -80.),
                (400., -100., -50., 380.)]
 
-    def _stub(self, frame_id, beampol=(1.8, 1.)):
+    def _stub(self, frame_id, beampol=(80., 0.)):
         return _FrameStub(frame_id, beampol)
 
     def test_polbeam_to_beampol(self):
-        """the run_card polbeam -> beampol map has to land on madevent's
-        /to_polarization/ convention, not on the [0,1] left-handed fraction the
-        eva PDF uses"""
-        fct = interface_madspin.MadSpinInterface.polbeam_to_beampol
+        """the card speaks percent, like the run_card polbeam1/polbeam2, and
+        beampol_me lands it on madevent's /to_polarization/ convention -- not on
+        the [0,1] left-handed fraction the eva PDF uses"""
+        def fct(polbeam):
+            options = interface_madspin.MadSpinOptions()
+            options['beampol'] = [polbeam, 0.]
+            return options.beampol_me()[0]
         self.assertEqual(fct(0), 1.)
         self.assertEqual(fct(100), 2.)
         self.assertEqual(fct(-100), -2.)
         self.assertEqual(fct(50), 1.5)
         self.assertEqual(fct(-50), -1.5)
+        # an unpolarised beam stays exactly 1, whichever slot it is in
+        options = interface_madspin.MadSpinOptions()
+        options['beampol'] = [60., 0.]
+        self.assertEqual(options.beampol_me(), (1.6, 1.))
         # the two branches of the matrix-element reweighting, as written in
         # matrix_standalone_msP_v4.inc: unpolarised leaves both helicities
         # alone, +-100%% keeps one and kills the other
@@ -311,7 +325,7 @@ class TestFrameBoost(unittest.TestCase):
     def test_frame_inert_without_polarisation(self):
         """the frame only changes the axis the initial-state helicities are
         quantised along, so with unpolarised beams there is nothing to do"""
-        stub = self._stub(6, beampol=(1., 1.))
+        stub = self._stub(6, beampol=(0., 0.))
         self.assertIsNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
 
     def test_frame_id_bitmask(self):
@@ -1294,11 +1308,12 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
             def __init__(self):
-                self.options = {'spinmode': 'onshell',
+                self.options = _StubOptions(
+                               {'spinmode': 'onshell',
                                 'sequential_spin_order': '2 3 1',
                                 'unweighting': 'sequential',
                                 'fixed_order': False,
-                                'beampol': [1., 1.], 'frame_id': 6}
+                                'beampol': [0., 0.], 'frame_id': 6})
             def _density_basis(self, production, decays_key):
                 particles, slots = interface._sequential_slots(production, decays_key)
                 return {'decays_key': decays_key, 'helicities': hels,

--- a/tests/unit_tests/various/test_lhe_parser.py
+++ b/tests/unit_tests/various/test_lhe_parser.py
@@ -741,6 +741,30 @@ class TestFourMomentum(unittest.TestCase):
         self.assertAlmostEqual(out.py, 0)
         self.assertAlmostEqual(out.pz, 0)
 
+    def test_boost_by_a_momentum_at_rest(self):
+        """boost() is a copy of the HELAS boostx, including its qq.eq.rZero
+        branch: a boost momentum with no spatial part is the identity, and must
+        leave the boosted momentum alone rather than overwrite it with the
+        boost. That branch is reached whenever the system defining the frame is
+        already at rest -- e.g. the initial-state pair of a lepton-collider
+        event, which arrives in the partonic CMS."""
+
+        p = FourMomentum(38.2494167715, 24.8053721987, 27.2397493528, -10.2814127749)
+        at_rest = FourMomentum(500., 0., 0., 0.)
+
+        out = p.boost(at_rest)
+        self.assertAlmostEqual(out.E, p.E)
+        self.assertAlmostEqual(out.px, p.px)
+        self.assertAlmostEqual(out.py, p.py)
+        self.assertAlmostEqual(out.pz, p.pz)
+
+        # and the limit is continuous: a nearly-at-rest boost gives nearly the
+        # same answer, which is what makes the branch the right one
+        almost = FourMomentum(500., 0., 0., 1e-9)
+        out = p.boost(almost)
+        self.assertAlmostEqual(out.E, p.E, places=6)
+        self.assertAlmostEqual(out.pz, p.pz, places=6)
+
     def test_y_eta_massless(self):
         """test that rapidity and pseudorapidity coincide for
         a massless particle. At 45 degrees, they both should be equal to .88"""


### PR DESCRIPTION
Rebase of `claude/hungry-stonebraker-e6ef3c` onto the landed #334, plus one follow-up on the polarisation convention. Original work by the me_frame/beampol session; I did the merge because their branch was based on a pre-#334 checkpoint and conflicted heavily with the sequential unweighting schemes.

## What it does

`frame_id` (me_frame) and `beampol` were honoured only by the legacy `madspin_v1` path — `decay.py` ships them on stdin to the Fortran driver, which reads them into `/to_me_frame/` and `/to_beampol/`. Every density spinmode (onshell / PA / madspin / full) ignored both, silently.

- **`frame_id` is handled in python.** It is pure kinematics: `frame_id` is the bitmask `sum(2**n)` over the legs whose sum defines the rest frame (the convention `mapid` uncompresses with `btest`), and the momenta are boosted there before the matrix element sees them. `_frame_boost` builds it, `_boost_momenta` applies it inside `get_density`, and the *same* momentum is used for the production density and for every decay contracted against it — otherwise the two sides of the contraction would not share a helicity basis.
- **`beampol` needs the Fortran.** It reweights the initial-state helicity sum, which happens inside the matrix element, so `PY_SET_BEAMPOL(POL1, POL2)` was added to the f2py wrapper and is pushed once per module at initialisation rather than passed on every `get_density` call.

## Two v1 bugs fixed in passing (these change `madspin_v1` output)

- `matrix_standalone_msF_v4.inc` applied the polarisation weight *after* the helicity sum, so the full matrix element stayed unpolarised while the denominator was polarised. No partial beam polarisation ever reached the decay distribution; exactly ±100% happened to work because there the disfavoured helicities get weight zero either way.
- the run_card `polbeam` → `beampol` map used the eva PDF's `[0,1]` left-handed-fraction convention while the Fortran wanted madevent's `/to_polarization/` one.

## One follow-up (ec811a378)

`beampol` was the one place a user met a third convention: the run_card asks for percent (`polbeam1 = 50`), the matrix elements want the internal `sign(1+|polbeam|/100, polbeam)`, and the MadSpin card was asking for that internal value — so `set beampol [1.5, 1.0]` meant a 50% polarised first beam. Since the previous MadSpin convention never worked (see the msF bug above), there is nothing to keep compatible with, so the card now speaks percent like the run_card and the conversion lives in one place, `MadSpinOptions.beampol_me()`, which the density path and all three v1 stdin sites go through.

## Also here

`FourMomentum.boost` returned the boost vector instead of the momentum unchanged when the boost had no three-momentum, where HELAS `boostx` copies. `Event.boost()` would then turn every particle into the boost vector. Reachable whenever the frame-defining system is already at rest — e.g. the `e+ e-` pair of a lepton-collider event — and shared with the joint density path, which boosts the same way. Unit test in `tests/unit_tests/various/test_lhe_parser.py`.

## Merge notes for review

The third commit is **hand-assembled, not a clean replay**, and deserves the closest look. Their branch was based on `a92634d05`, a pre-cherry-pick checkpoint of #334, and also predates madspin_density's `create_f2py_module` rework, so git matched the same changes twice under different hashes and produced misaligned hunks — at one point silently dropping two methods that exist only on the #334 side. I reset the file to the landed version and ported their twelve changes as explicit anchored edits, then verified each is present.

One design point I changed from their description: the frame boost for the offshell branch is computed **once per accepted mass set** inside `_offshell_production`, from the reshuffled production `rho_off` is evaluated at — not per slot. `two_stage` (the new default for two decaying particles) reuses that production density across angle retries, and a per-slot boost would have destroyed exactly the reuse that makes it faster than the joint test.

## Validation

- unpolarised is inert: a 400-event `p p > t t~` smoke reproduces the pre-merge joint result bit-for-bit (`m_top` 173.3373 ± 0.1624), which is the first thing that had to hold since both options default to no-ops;
- all three non-joint unweighting schemes still satisfy the weight identity on the merged tree (`sequential_debug`, ratio constant to 1.7e-07);
- 86 MadSpin unit tests and 298 `various` unit tests pass.

Polarised physics is validated on the original branch (density vs `madspin_v1`); see `UpdateNotes.txt` there.

## Summary by Sourcery

Honour beam polarisation and matrix-element rest-frame options in all MadSpin density modes and fix related polarisation handling bugs.

New Features:
- Add support for beam polarisation and frame_id-based rest-frame boosts in the MadSpin density path, shared consistently between production and decay.
- Expose beam polarisation to the f2py matrix-element libraries and reweight initial-state helicity sums in standalone and split-orders matrix templates.

Bug Fixes:
- Correct polarised-beam reweighting in madspin_v1 so the decay distribution is properly polarised rather than only the denominator.
- Fix FourMomentum.boost so boosting by a momentum at rest leaves the boosted momentum unchanged instead of overwriting it with the boost vector.
- Align beampol convention with the run_card percent-based polbeam settings and madevent’s internal /to_polarization/ representation.

Enhancements:
- Allow MadSpin card values for frame_id and beampol to override production run_card defaults and centralise beampol conversion via MadSpinOptions.beampol_me().
- Cache and reuse frame boosts per production event or accepted offshell mass set to keep production and decay densities in a common helicity basis.
- Extend tests to cover beam-polarisation conventions, frame_id bitmask handling, frame boosts, and boost behaviour for systems already at rest.

Documentation:
- Clarify documentation strings and comments around beam polarisation conventions, frame_id semantics, and their impact on helicity quantisation.