### PR TITLE
MadSpin: honour the '@' decay grouping tags in the density modes

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -4440,6 +4440,8 @@ class decay_all_events_onshell(decay_all_events):
         decay_text = []
         for decays in self.mscmd.list_branches.values():
             for decay in  decays:
+                # MadSpin's own '@' grouping tag, not something MG5 should see
+                decay = self.mscmd._split_group_tag(decay)[0]
                 if '=' not in decay:
                     decay += ' QCD=99'
                 if ',' in decay:
@@ -4459,6 +4461,8 @@ class decay_all_events_onshell(decay_all_events):
         decay_text = []
         for decays in self.mscmd.list_branches.values():
             for decay in  decays:
+                # MadSpin's own '@' grouping tag, not something MG5 should see
+                decay = self.mscmd._split_group_tag(decay)[0]
                 if '=' not in decay:
                     decay += ' QCD=99'
                 if ',' in decay:
@@ -4467,7 +4471,7 @@ class decay_all_events_onshell(decay_all_events):
                     decay_text.append(decay)
         decay_text = ', '.join(decay_text)
 #        commandline = ''
-        
+
         for proc in processes:
             if not proc.strip().startswith(('add','generate')):
                 proc = 'add process %s' % proc
@@ -4482,10 +4486,18 @@ class decay_all_events_onshell(decay_all_events):
         i=0
         for processes in self.list_branches.values():
             for proc in processes:
+                # Drop MadSpin's own '@' grouping tag first: this line appends a
+                # process number of its own, MG5 binds that at the top level and
+                # would absorb the user's as the process number of the
+                # *sub-decay*. Nothing would fail -- the amplitude is the same --
+                # but the tag is MadSpin bookkeeping and has no business
+                # reaching MG5. (madspin_v1 strips it the same way, decay.py
+                # get_all_ME step 6.)
+                proc = self.mscmd._split_group_tag(proc)[0]
                 newproc = "add process %s @%i --no_warning=duplicate --standalone;" % (proc,i)
-                commandline += self.adapt_decay(newproc) 
+                commandline += self.adapt_decay(newproc)
                 #commandline+="add process %s @%i --no_warning=duplicate --standalone;" % (proc,i)
-                i+=1 
+                i+=1
         return commandline
 
     def compile(self):

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4363,7 +4363,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         logger.info("*****************************")
         logger.info("Probing the first %s events with %s phase space points"
                     % (nevents, nb_ps_point))
-        # sequential_decay never reaches here with fixed_order (it falls back to
+        # a non-joint unweighting never reaches here with fixed_order (it falls back to
         # the joint accept/reject), so the events are plain, not event-groups.
         orig_lhe.seek(0)
         events = []

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -908,7 +908,107 @@ class MadSpinInterface(extended_cmd.Cmd):
     # *groups* meant to be used together -- the semi-leptonic ttbar idiom, where
     # only the two charge assignments exist and no fully leptonic or fully
     # hadronic event is produced.
-    _DECAY_GROUP_TAG = re.compile(r'@\s*\d+')
+    #
+    # The tag is kept inside the branch string rather than in a structure of its
+    # own: ``list_branches`` is renamed, pruned and handed to MG5 from several
+    # places, and index i of ``list_branches[name]`` is also the number of the
+    # ``decay_<pdg>_<i>`` pool, so a parallel list would be one more thing to
+    # keep in step. It is split off at the few points that need it.
+    _DECAY_GROUP_TAG = re.compile(r'@\s*(\d+)\s*$')
+
+    @classmethod
+    def _split_group_tag(cls, branch):
+        """``'t > w+ b, w+ > l+ vl @1'`` -> ``('t > w+ b, w+ > l+ vl', '1')``.
+
+        The tag is returned as a string: it names a group, it is not an integer
+        the code ever does arithmetic on. ``(branch, None)`` when untagged.
+        """
+        found = cls._DECAY_GROUP_TAG.search(branch)
+        if not found:
+            return branch, None
+        return branch[:found.start()].rstrip(), found.group(1)
+
+    def _decay_group_layout(self):
+        """Sort the decay lines into groups.
+
+        Returns ``(layout, reason)``. ``layout`` is None when the card declares
+        no group at all (``reason`` None too) or when the tags cannot be honoured
+        (``reason`` says why, for the warning). Otherwise::
+
+            {'tags':  ['1', '2'],                       # first-appearance order
+             'lines': {particle_name: {tag: [index into list_branches[name]]}}}
+
+        An *untagged* line belongs to every group -- the natural way to write a
+        third particle that decays the same way whatever the group is, and what
+        madspin_v1 does (it prepends the untagged branches to each group).
+
+        This is the half of the check that needs only the card. Whether each
+        group covers every decaying particle the right number of times needs the
+        production events too; see :meth:`_validate_decay_groups`.
+        """
+        tags = []
+        parsed = {}
+        for name, branches in self.list_branches.items():
+            parsed[name] = []
+            for branch in branches:
+                stripped, tag = self._split_group_tag(branch)
+                if '@' in stripped:
+                    # an '@' that is not a trailing group tag: refuse rather than
+                    # half-read it, since MG5 would take it as a process number
+                    return None, ("the decay line %r carries an '@' that is not "
+                                  "a group tag at the end of the line" % branch)
+                parsed[name].append(tag)
+                if tag is not None and tag not in tags:
+                    tags.append(tag)
+        if not tags:
+            return None, None
+        lines = {}
+        for name, name_tags in parsed.items():
+            lines[name] = dict((tag, []) for tag in tags)
+            for i, tag in enumerate(name_tags):
+                for target in (tags if tag is None else [tag]):
+                    lines[name][target].append(i)
+        return {'tags': tags, 'lines': lines}, None
+
+    def _validate_decay_groups(self, layout, to_decay, nb_event, name2pdg):
+        """Can this grouping be honoured for these production events?
+
+        Supported shape -- rectangular: every group gives exactly ``n_part``
+        lines for every decaying particle, ``n_part`` being how many of that
+        particle each event carries. ``n_part == 1`` is the semi-leptonic ttbar
+        idiom; ``n_part == 2`` is ``p p > t t~ t~ t``, where the group's two
+        lines for a pdg are handed to its two particles by the existing
+        positional rule.
+
+        Anything else is refused rather than approximated: the group would not
+        be a complete assignment, so neither its rate ``prod_k Gamma_k`` nor the
+        branching ratio is defined.
+
+        ``name2pdg`` maps a decay-line parent name to its pdg, or to None when
+        the name is a multiparticle (refused: one name would own several pools).
+
+        Returns ``(ok, reason)``.
+        """
+        for name, per_tag in layout['lines'].items():
+            pdg = name2pdg(name)
+            if pdg is None:
+                return False, ("%s is a multiparticle: grouping needs one "
+                               "decaying particle per decay line" % name)
+            if pdg not in to_decay or not nb_event:
+                continue            # never appears in the events; ignored anyway
+            if to_decay[pdg] % nb_event:
+                return False, ("the production events do not all carry the same "
+                               "number of %s, and a branching ratio per group "
+                               "cannot be defined then" % name)
+            nb_part = to_decay[pdg] // nb_event
+            for tag in layout['tags']:
+                got = len(per_tag.get(tag, ()))
+                if got != nb_part:
+                    return False, (
+                        "group @%s gives %d decay line(s) for %s but every event "
+                        "carries %d of them -- each group must decay every "
+                        "particle exactly once" % (tag, got, name, nb_part))
+        return True, None
 
     def _warn_ignored_decay_groups(self, spinmode):
         """Warn when the card carries @ grouping tags in a mode that ignores them.
@@ -933,10 +1033,13 @@ class MadSpinInterface(extended_cmd.Cmd):
         tags = []
         for name, branches in self.list_branches.items():
             for branch in branches:
-                found = self._DECAY_GROUP_TAG.search(branch)
-                if found:
-                    tags.append((name, branch,
-                                 found.group(0).replace(' ', '')))
+                stripped, tag = self._split_group_tag(branch)
+                if tag is not None:
+                    tags.append((name, branch, '@%s' % tag))
+                elif '@' in stripped:
+                    # not a trailing tag, so not a group -- but MG5 will still
+                    # read it as a process number, so it is worth the same line
+                    tags.append((name, branch, '@?'))
         if not tags:
             return []
         logger.warning(

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -1124,10 +1124,23 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     @staticmethod
     def _clamped_partial_width(pwidth, totwidth, pdg=None):
-        """A measured partial width, complained about and capped when it comes
-        out above the total width of the param_card. Only ever applied to *one*
-        channel's width (or to a sum over channels, which is still a width): a
-        product of several is not comparable with a single total."""
+        """A measured partial width, reconciled with the total width of the
+        param_card. Only ever applied to *one* channel's width (or to a sum over
+        channels, which is still a width): a product of several is not
+        comparable with a single total.
+
+        The two regimes are deliberate, and are the long-standing behaviour this
+        helper factors out of run_onshell rather than a new policy:
+
+        - up to 1% above the total, the excess is Monte Carlo noise in the width
+          measurement, so it is capped silently and the branching ratio stays at
+          most 1;
+        - more than 1% above, the param_card's total genuinely disagrees with
+          what was generated. That is warned about and the *measured* value is
+          used, because capping there would quietly reshape the normalisation to
+          match a card that is wrong, and hide the disagreement instead of
+          reporting it.
+        """
         if pwidth > 1.01 * totwidth:
             logger.warning('partial width (%s) larger than total width (%s) '
                            '--from param_card-- for pdg %s',

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -904,10 +904,59 @@ class MadSpinInterface(extended_cmd.Cmd):
         return self.parser_launch().parse_args(args)
         
 
+    # ``decay t > w+ b, w+ > l+ vl @1``: the @ suffix sorts the decay lines into
+    # *groups* meant to be used together -- the semi-leptonic ttbar idiom, where
+    # only the two charge assignments exist and no fully leptonic or fully
+    # hadronic event is produced.
+    _DECAY_GROUP_TAG = re.compile(r'@\s*\d+')
+
+    def _warn_ignored_decay_groups(self, spinmode):
+        """Warn when the card carries @ grouping tags in a mode that ignores them.
+
+        Only ``madspin_v1`` implements the grouping, and it does so by building
+        one decayed matrix element per group. Everywhere else there is no such
+        object: the decay pools are filled per particle and per channel and each
+        particle draws its channel independently at run time, so a cross-particle
+        correlation has nothing to act on.
+
+        Worse, the tag is swallowed in silence. The decay-matrix-element
+        generation appends an ``@`` process number of its own to every branch, so
+        MG5 sees two of them, binds its own at the top level and absorbs the
+        user's as the process number of the sub-decay. Nothing fails, the matrix
+        element that comes out is the correct *ungrouped* one, and without this
+        the card simply does not mean what it looks like it means.
+
+        Returns the (particle, branch, tag) triples found, for the tests.
+        """
+        if spinmode == 'madspin_v1':
+            return []
+        tags = []
+        for name, branches in self.list_branches.items():
+            for branch in branches:
+                found = self._DECAY_GROUP_TAG.search(branch)
+                if found:
+                    tags.append((name, branch,
+                                 found.group(0).replace(' ', '')))
+        if not tags:
+            return []
+        logger.warning(
+            "The decay lines carry '@' grouping tags (%s) but spinmode=%s does "
+            "not support grouping -- it is implemented only in madspin_v1, "
+            "which generates one decayed matrix element per group. Here every "
+            "particle draws its decay channel independently, so the tags change "
+            "nothing (MG5 reads them as an ordinary process number) and the "
+            "sample will contain EVERY combination of the channels listed, not "
+            "only the tagged ones. Generate one group per MadSpin run and merge "
+            "the outputs -- fixing the normalisation with 'set cross_section' if "
+            "the automatic branching ratio is not what you want -- or switch to "
+            "spinmode = madspin_v1.",
+            ', '.join(sorted(set(t[2] for t in tags))), spinmode)
+        return tags
+
     @misc.mute_logger()
     def do_launch(self, line):
         """end of the configuration launched the code"""
-        
+
         (options, args) = self.parse_launch(line)
         if getattr(lhe_parser, "_ENABLE_LHE_TIMERS", False):
             lhe_parser.reset_lhe_timers()
@@ -940,6 +989,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.options['spinmode'] = spinmode
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
+        self._warn_ignored_decay_groups(spinmode)
 
         if spinmode in ["none"]:
             out = self.run_bridge(line)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -372,6 +372,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.events_file = None
         self.decay_processes = {}
         self.list_branches = {}
+        # the resolved '@' decay grouping, or None when the card declares none
+        # (or declares one this run cannot honour). See _resolve_decay_groups.
+        self._decay_groups = None
         self.to_decay={}
         self.mg5cmd = master_interface.MasterCmd()
         self.seed = None
@@ -1010,26 +1013,21 @@ class MadSpinInterface(extended_cmd.Cmd):
                         "particle exactly once" % (tag, got, name, nb_part))
         return True, None
 
-    def _warn_ignored_decay_groups(self, spinmode):
-        """Warn when the card carries @ grouping tags in a mode that ignores them.
+    def _warn_ignored_decay_groups(self, spinmode, reason=None):
+        """Warn when the card carries @ grouping tags this run cannot honour.
 
-        Only ``madspin_v1`` implements the grouping, and it does so by building
-        one decayed matrix element per group. Everywhere else there is no such
-        object: the decay pools are filled per particle and per channel and each
-        particle draws its channel independently at run time, so a cross-particle
-        correlation has nothing to act on.
-
-        Worse, the tag is swallowed in silence. The decay-matrix-element
-        generation appends an ``@`` process number of its own to every branch, so
-        MG5 sees two of them, binds its own at the top level and absorbs the
-        user's as the process number of the sub-decay. Nothing fails, the matrix
-        element that comes out is the correct *ungrouped* one, and without this
-        the card simply does not mean what it looks like it means.
+        A tag that silently means nothing is the worst outcome: the
+        decay-matrix-element generation appends an ``@`` process number of its
+        own to every branch, so MG5 sees two of them, binds its own at the top
+        level and absorbs the user's as the process number of the sub-decay.
+        Nothing fails, the matrix element that comes out is the correct
+        *ungrouped* one, and without this the card simply does not mean what it
+        looks like it means.
 
         Returns the (particle, branch, tag) triples found, for the tests.
         """
         if spinmode == 'madspin_v1':
-            return []
+            return []                     # v1 implements the grouping itself
         tags = []
         for name, branches in self.list_branches.items():
             for branch in branches:
@@ -1043,18 +1041,179 @@ class MadSpinInterface(extended_cmd.Cmd):
         if not tags:
             return []
         logger.warning(
-            "The decay lines carry '@' grouping tags (%s) but spinmode=%s does "
-            "not support grouping -- it is implemented only in madspin_v1, "
-            "which generates one decayed matrix element per group. Here every "
-            "particle draws its decay channel independently, so the tags change "
-            "nothing (MG5 reads them as an ordinary process number) and the "
-            "sample will contain EVERY combination of the channels listed, not "
-            "only the tagged ones. Generate one group per MadSpin run and merge "
-            "the outputs -- fixing the normalisation with 'set cross_section' if "
-            "the automatic branching ratio is not what you want -- or switch to "
-            "spinmode = madspin_v1.",
-            ', '.join(sorted(set(t[2] for t in tags))), spinmode)
+            "The decay lines carry '@' grouping tags (%s) but this run cannot "
+            "honour them: %s. The tags therefore change nothing (MG5 reads them "
+            "as an ordinary process number) and the sample will contain EVERY "
+            "combination of the channels listed, not only the tagged ones. "
+            "Generate one group per MadSpin run and merge the outputs -- fixing "
+            "the normalisation with 'set cross_section' if the automatic "
+            "branching ratio is not what you want.",
+            ', '.join(sorted(set(t[2] for t in tags))),
+            reason or ("grouping is available in the density spin modes (PA, "
+                       "onshell, madspin/full) and in madspin_v1, and "
+                       "spinmode=%s is neither" % spinmode))
         return tags
+
+    # ------------------------------------------------------------------
+    # Resolved grouping: what the run-time draw and the branching ratio use
+    # ------------------------------------------------------------------
+    def _decay_group_pdgs(self):
+        """The pdgs whose decay lines are grouped (empty when they are not)."""
+        groups = getattr(self, '_decay_groups', None)
+        return () if not groups else groups['lines']
+
+    def _resolve_decay_groups(self, to_decay, nb_event, density_method):
+        """Turn the card's '@' tags into the grouping the run will use, or warn
+        and fall back to the ungrouped behaviour.
+
+        Sets (and returns) ``self._decay_groups``::
+
+            {'tags':  ['1', '2'],
+             'lines': {pdg: {tag: [decay pool number]}},
+             'prob':  None}                 # filled by _resolve_group_rates
+
+        None when the card declares no group, or when this run cannot honour the
+        one it declares. Must run before anything is generated: it decides how
+        many pools each particle gets, and it forces the joint accept/reject.
+        """
+        self._decay_groups = None
+        layout, reason = self._decay_group_layout()
+        if layout is None and reason is None:
+            return None                              # no tags at all
+
+        spinmode = self.options['spinmode']
+        if not reason and not density_method:
+            reason = ("spinmode=%s does not fill one decay pool per channel, "
+                      "which is what a group draws from" % spinmode)
+        if not reason and self.options['fixed_order']:
+            reason = ("fixed_order rides the counter-events along with the "
+                      "decays, and a group would have to be drawn once per "
+                      "event group")
+        if not reason:
+            ok, reason = self._validate_decay_groups(
+                layout, to_decay, nb_event, self._decay_parent_pdg)
+        if reason:
+            self._warn_ignored_decay_groups(spinmode, reason)
+            return None
+
+        lines = {}
+        for name, per_tag in layout['lines'].items():
+            pdg = self._decay_parent_pdg(name)
+            if pdg in to_decay:          # a species that never appears in the
+                lines[pdg] = per_tag     # events is dropped anyway
+        if not lines:
+            return None
+        self._decay_groups = {'tags': layout['tags'], 'lines': lines,
+                              'prob': None}
+        logger.info("MadSpin: %s decay groups (@%s); each event draws one group "
+                    "and every particle takes that group's channel",
+                    len(layout['tags']), ', @'.join(layout['tags']))
+        return self._decay_groups
+
+    def _decay_parent_pdg(self, name):
+        """pdg of a decay line's parent, or None when the name stands for more
+        than one particle (a multiparticle owning several pools at once is what
+        the grouping cannot express)."""
+        if name in self.mg5cmd._multiparticles:
+            pdgs = self.mg5cmd._multiparticles[name]
+            return pdgs[0] if len(pdgs) == 1 else None
+        try:
+            return self.mg5cmd._curr_model.get('name2pdg')[name]
+        except KeyError:
+            return None
+
+    @staticmethod
+    def _clamped_partial_width(pwidth, totwidth, pdg=None):
+        """A measured partial width, complained about and capped when it comes
+        out above the total width of the param_card. Only ever applied to *one*
+        channel's width (or to a sum over channels, which is still a width): a
+        product of several is not comparable with a single total."""
+        if pwidth > 1.01 * totwidth:
+            logger.warning('partial width (%s) larger than total width (%s) '
+                           '--from param_card-- for pdg %s',
+                           pwidth, totwidth, pdg)
+        elif pwidth > totwidth:
+            return totwidth
+        return pwidth
+
+    @classmethod
+    def _assignment_multiplicity(cls, branches):
+        """How many *distinct* ways this multiset of decay lines can be dealt to
+        that many identical parents: ``n! / prod_c m_c!``.
+
+        The positional rule generates one of those assignments and multiplies
+        the rate by their number. A plain ``n!`` is right only while the lines
+        are all different -- with two identical ones it counts the same final
+        state twice.
+        """
+        counts = collections.Counter(cls._split_group_tag(b)[0].strip()
+                                     for b in branches)
+        out = math.factorial(len(branches))
+        for repeat in counts.values():
+            out //= math.factorial(repeat)
+        return out
+
+    def _resolve_group_rates(self, gen_jobs, channel_widths):
+        """Branching ratio of the grouped particles, and each group's share.
+
+        A group is one complete assignment of channels to particles, so its rate
+        is a product over the particles::
+
+            br_g = prod_pdg  mult(g,pdg) * prod_{i in g} Gamma_i / Gamma_tot^n
+
+        with ``mult`` from :meth:`_assignment_multiplicity`. The groups are
+        alternatives, so ``br = sum_g br_g`` -- and the group to use is drawn
+        with ``p_g = br_g / br``, which is exactly the unpolarised factorisation
+        of its rate. Everything the polarisation adds on top is then carried by
+        the accept/reject weight, the same way the per-channel cross-section
+        draw already works for the ungrouped multi-channel case.
+        """
+        rates = []
+        for tag in self._decay_groups['tags']:
+            rate = 1.0
+            for pdg, per_tag in self._decay_groups['lines'].items():
+                if pdg not in gen_jobs:
+                    continue
+                indices = per_tag[tag]
+                widths = channel_widths.get(pdg) or {}
+                branches = self.list_branches[
+                    self.model.get_particle(pdg).get_name()]
+                for i in indices:
+                    rate *= self._clamped_partial_width(
+                        widths.get(i, 0.0), gen_jobs[pdg]['totwidth'], pdg)
+                rate *= self._assignment_multiplicity(
+                    [branches[i] for i in indices])
+                rate /= gen_jobs[pdg]['totwidth'] ** len(indices)
+            rates.append(rate)
+        total = sum(rates)
+        if total <= 0:
+            raise Exception("MadSpin: every decay group has a vanishing rate; "
+                            "check the decay lines and the param_card widths.")
+        self._decay_groups['prob'] = [r / total for r in rates]
+        logger.info("MadSpin: decay group rates %s (BR %.6g)",
+                    ', '.join('@%s=%.4f' % (tag, p) for tag, p in
+                              zip(self._decay_groups['tags'],
+                                  self._decay_groups['prob'])), total)
+        return total
+
+    def _draw_decay_group(self):
+        """The group this chain uses, or None when the card declares none.
+
+        Drawn afresh on every trial -- the caller is the top of the draw, which
+        the joint accept/reject re-enters on each rejection. That is what keeps
+        the group part of what is being unweighted, rather than something a
+        later stage could normalise away.
+        """
+        groups = getattr(self, '_decay_groups', None)
+        if not groups:
+            return None
+        r = random.random()
+        cumul = 0.0
+        for tag, prob in zip(groups['tags'], groups['prob']):
+            cumul += prob
+            if r < cumul:
+                return tag
+        return groups['tags'][-1]
 
     @misc.mute_logger()
     def do_launch(self, line):
@@ -1092,7 +1251,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.options['spinmode'] = spinmode
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
-        self._warn_ignored_decay_groups(spinmode)
+        # The density modes decide about the '@' grouping later, in run_onshell,
+        # where the production events say how many of each particle an event
+        # carries. These two never can, so say it now rather than after the
+        # generation.
+        if spinmode in ('none', 'onshell_v1'):
+            self._warn_ignored_decay_groups(spinmode)
 
         if spinmode in ["none"]:
             out = self.run_bridge(line)
@@ -1733,8 +1897,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         use_gridpack = bool(self.options['ms_dir'])
         if cumul:
             width = 0.
-        else:   
+        else:
             width = 1.
+        # channel number -> its own partial width. ``width`` above is the product
+        # (or the sum, under cumul) that the branching ratio has always been
+        # built from; the grouping needs each channel on its own, since a group
+        # takes one channel per particle and its rate is the product over *its*
+        # channels only.
+        channel_widths = {}
         part = self.model.get_particle(pdg)
         if not part:
             return {}# this particle is not defined in the current model so ignore it
@@ -1744,7 +1914,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         logger.info("generate %s decay event for particle %s" % (int(nb_event), name))
         if name not in self.list_branches:
             return out
-        for i,proc in enumerate(self.list_branches[name]):
+        for i,tagged_proc in enumerate(self.list_branches[name]):
+            # the '@' grouping tag is MadSpin's own bookkeeping: MG5 would read
+            # it as a process number (and the decay-ME generation appends one of
+            # its own), so it never reaches the generation
+            proc = self._split_group_tag(tagged_proc)[0]
             if restrict_file and i not in restrict_file:
                 continue
             decay_dir = pjoin(self.path_me, "decay_%s_%s" %(str(pdg).replace("-","x"),i))
@@ -1754,7 +1928,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                     for j,proc2 in enumerate(self.list_branches[name][1:]):
                         if restrict_file and j not in restrict_file:
                             raise Exception # Do not see how this can happen
-                        mg5.exec_cmd("add process %s" % proc2)
+                        mg5.exec_cmd("add process %s"
+                                     % self._split_group_tag(proc2)[0])
                     mg5.exec_cmd("output %s -f" % decay_dir)
                 else:
                     mg5.exec_cmd("generate %s" % proc)
@@ -1798,11 +1973,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # actually creation
                     me5_cmd.exec_cmd("generate_events run_01 -f")
                     if output_width:
+                        channel_widths[i] = me5_cmd.results.current['cross']
                         if cumul:
                             width += me5_cmd.results.current['cross']
                         else:
                             width *= me5_cmd.results.current['cross']
-                    me5_cmd.exec_cmd("exit")                        
+                    me5_cmd.exec_cmd("exit")
                     #remove pointless informat
                     if not os.path.exists(pjoin(decay_dir, 'run.sh')):
                         devnull = open('/dev/null','w')
@@ -1872,6 +2048,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 self.seed += 1
                 me5_cmd.exec_cmd("generate_events %s -f" % run_name)
                 if output_width:
+                    channel_widths[i] = me5_cmd.results.current['cross']
                     if cumul:
                         width += me5_cmd.results.current['cross']
                     else:
@@ -1916,7 +2093,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         if not output_width:
             return out
         else:
-            return out, width
+            return out, width, channel_widths
 
     def run_onshell(self, line, density_method=False):
         """Run the onshell Algorithm"""
@@ -2050,6 +2227,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             #    below so they overlap instead of running one particle after the
             #    other.
             gen_jobs = collections.OrderedDict()
+            # '@' grouping tags. Resolved before anything is generated: it
+            # decides how many pools each particle gets, and it forces the joint
+            # accept/reject, which _sequential_pool_ladder below already needs to
+            # know about.
+            self._resolve_decay_groups(to_decay, nb_event, density_method)
             # How many decay events one production event burns per decaying
             # particle. The joint accept/reject redraws the whole set on a
             # reject, so every pool is consumed at the same rate; the sequential
@@ -2070,7 +2252,24 @@ class MadSpinInterface(extended_cmd.Cmd):
                 totwidth = self.banner.get('param_card', 'decay', abs(pdg)).value
 
                 #check if a splitting is needed
-                if nb_needed == nb_event:
+                if pdg in self._decay_group_pdgs():
+                    # Grouped: one pool per decay *line*, whatever the
+                    # multiplicity -- a group hands each of its lines to one
+                    # particle, so a line is never mixed with another one in a
+                    # single pool the way `simple`/`mult_cumul` mix them.
+                    #
+                    # Every pool is sized as if its group were drawn on every
+                    # event. The exact size would be that times the group's
+                    # share p_g, but p_g is only known once the partial widths
+                    # have been measured, i.e. once this generation has run. So
+                    # over-generate by at most a factor |groups| rather than
+                    # under-generate and pay for refills; `decay_event_mult`
+                    # scales it down for anyone who minds.
+                    gen_jobs[pdg] = {'kind': 'grouped', 'totwidth': totwidth,
+                        'nb_mult': nb_needed // nb_event, 'cumul': False,
+                        'nb_gen': (int(efficiency*nb_event) + nevents_for_max)
+                                  * self.options['decay_event_mult']}
+                elif nb_needed == nb_event:
                     gen_jobs[pdg] = {'kind': 'simple', 'totwidth': totwidth,
                         'cumul': True,
                         'nb_gen': (int(efficiency*nb_needed) + nevents_for_max)
@@ -2109,22 +2308,43 @@ class MadSpinInterface(extended_cmd.Cmd):
             gen_results = self._generate_decays(gen_jobs, mg5)
 
             # 3) Fold the measured partial widths into the branching ratio.
+            channel_widths = {}
             for pdg, job in gen_jobs.items():
-                evt_decayfile[pdg], pwidth = gen_results[pdg]
+                evt_decayfile[pdg], pwidth, channel_widths[pdg] = gen_results[pdg]
                 totwidth = job['totwidth']
-                if pwidth > 1.01*totwidth:
-                    logger.warning('partial width (%s) larger than total width (%s) --from param_card--', pwidth, totwidth)
-                elif pwidth > totwidth:
-                    pwidth = totwidth
+                if job['kind'] == 'grouped':
+                    continue        # done together, below: a group's rate is a
+                                    # product over several particles at once
+                if job['kind'] == 'mult_split':
+                    # ``pwidth`` is the *product* of the channels' widths here,
+                    # so measuring it against a single total width is a category
+                    # error -- it fires as soon as totwidth > 1 GeV (two decay
+                    # lines for a top) and the clamp below would then quietly
+                    # wreck the branching ratio. Check each channel instead.
+                    product = 1.0
+                    for i in sorted(channel_widths[pdg]):
+                        product *= self._clamped_partial_width(
+                            channel_widths[pdg][i], totwidth, pdg)
+                    br *= (product / totwidth**job['nb_mult']
+                           * self._assignment_multiplicity(
+                               self.list_branches[self.model.get_particle(pdg)
+                                                  .get_name()]))
+                    continue
+                pwidth = self._clamped_partial_width(pwidth, totwidth, pdg)
                 if job['kind'] == 'simple':
                     br *= pwidth / totwidth
-                elif job['kind'] == 'mult_split':
-                    br *= pwidth / totwidth**job['nb_mult']
-                    br *= math.factorial(job['nb_mult'])
                 elif job['kind'] == 'mult_cumul':
                     br *= (pwidth / totwidth)**job['nb_mult']
                 else:
                     mixed_pdgs_br[pdg] = pwidth / totwidth
+
+            # 3b) The grouped particles' branching ratio, and with it the
+            #     probability of each group. A group is one complete assignment
+            #     of channels to particles, so its rate is the product of its
+            #     own partial widths over every grouped particle -- and the
+            #     groups are alternatives, so they add.
+            if getattr(self, '_decay_groups', None):
+                br *= self._resolve_group_rates(gen_jobs, channel_widths)
 
         # Equalize branching ratios across mixed productions (legacy
         # add_loose_decay mechanism): pick max_br as the global BR factor and
@@ -2449,6 +2669,25 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "MadSpin: fixed_order is on, keeping the joint "
                            "accept/reject (unweighting ignored)")
             return self._announce_mode('joint', asked)
+        if getattr(self, '_decay_groups', None):
+            # The per-particle test redraws one slot until it is accepted, which
+            # divides E[w_k | group] out of the chain -- and that expectation
+            # differs between groups, so the accepted group fractions would come
+            # out distorted by its reciprocal. The joint test redraws the whole
+            # set, group included, so the group stays part of what is being
+            # unweighted. Lifting this needs a bound and a rate factor per
+            # group; see doc/madspin_decay_groups.md.
+            #
+            # two_stage self-normalises the same way (it redraws the angle set
+            # to acceptance), so it falls back too. Whether
+            # sequential_global_retry could be exempted -- a rejection there
+            # throws the whole chain away rather than renormalising -- depends
+            # on whether the group is redrawn with it, and has not been checked.
+            self._log_once('decay_groups',
+                           "MadSpin: the decay lines are grouped ('@' tags), "
+                           "keeping the joint accept/reject "
+                           "(unweighting ignored)")
+            return self._announce_mode('joint', asked)
         if self.options['spinmode'] not in ['PA', 'onshell', 'madspin', 'full']:
             self._log_once('spinmode',
                            "MadSpin: spinmode=%s keeps the joint accept/reject "
@@ -2601,15 +2840,19 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.seed = (int(self.seed) + 1000003 * seed_offset) % (30081 * 30081)
             self.options['seed'] = self.seed
             self.me_int = {}
-            out, width = self.generate_events(pdg, job['nb_gen'], self.mg5cmd,
-                                              cumul=job['cumul'], output_width=True)
+            out, width, channel_widths = self.generate_events(
+                pdg, job['nb_gen'], self.mg5cmd,
+                cumul=job['cumul'], output_width=True)
             with open(res_path, 'w') as fp:
                 # send back every file of each channel: when the pool is split
                 # per worker (nb_unweight_output) reporting only the first one
                 # would silently shrink the pool to a single slice.
                 json.dump({'files': dict((str(k), self._reader_paths(v))
                                          for k, v in out.items()),
-                           'width': width}, fp)
+                           'width': width,
+                           'channel_widths': dict((str(k), v) for k, v
+                                                  in channel_widths.items())},
+                          fp)
         except Exception as exc:
             import traceback
             try:
@@ -2620,7 +2863,7 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     def _generate_decays(self, gen_jobs, mg5):
         """Generate the decay events for every decaying particle; returns
-        ``{pdg: ({file_nb: EventFile}, partial_width)}``.
+        ``{pdg: ({file_nb: EventFile}, partial_width, {file_nb: width})}``.
 
         The generations are independent (each particle has its own
         ``decay_<pdg>_<i>`` directory) and a single MadEvent generation only
@@ -2670,7 +2913,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 % (pdg, data.get('tb', data['error'])))
             out[pdg] = (dict((int(k), self._reader_from_paths(v))
                              for k, v in data['files'].items()),
-                        data['width'])
+                        data['width'],
+                        dict((int(k), v) for k, v
+                             in data.get('channel_widths', {}).items()))
         return out
 
     def _refill_pool_path(self, decay_dir, gen):
@@ -3630,18 +3875,26 @@ class MadSpinInterface(extended_cmd.Cmd):
             out[particle.pdg].append(decay)
         return out
 
-    def _draw_all_decays(self, production, evt_decayfile, nb_remain):
+    def _draw_all_decays(self, production, evt_decayfile, nb_remain, group=None):
         """Yield (slot_index, particle, decay) for every decaying particle of the
         production event, in production order -- which is the order the density
-        matrix slots are built in."""
+        matrix slots are built in.
+
+        ``group``: the '@' decay group this draw belongs to. Drawn here when the
+        caller does not impose one, so that it is redrawn on every trial of the
+        joint accept/reject along with the decays it selects."""
         particles = [p for p in production if int(p.status) == 1.0]
         ids = [particle.pid for particle in particles]
+        if group is None:
+            group = self._draw_decay_group()
         for i, particle in enumerate(particles):
-            decay = self._draw_one_decay(particle, i, ids, evt_decayfile, nb_remain)
+            decay = self._draw_one_decay(particle, i, ids, evt_decayfile,
+                                         nb_remain, group)
             if decay is not None:
                 yield i, particle, decay
 
-    def _draw_one_decay(self, particle, i, ids, evt_decayfile, nb_remain):
+    def _draw_one_decay(self, particle, i, ids, evt_decayfile, nb_remain,
+                        group=None):
         """Draw one decay event for ``particle`` -- the i-th final-state particle
         of the production event, ``ids`` being the pdgs of all of them -- and
         refill its pool if it runs out. Returns None when that particle does not
@@ -3649,29 +3902,42 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         Factored out of get_decay_from_file so that the sequential accept/reject
         can redraw a single particle without touching the ones already accepted.
+
+        ``group`` restricts the choice to the channels that group gives this
+        particle; the rules below then apply to those, unchanged. That is the
+        whole of the grouping at run time -- a group supplies exactly one channel
+        per particle (or one per identical parent, which the positional rule then
+        deals out), so restricting the candidates is all it takes.
         """
         # check if we need to decay the particle
         if particle.pdg not in evt_decayfile:
             return None # nothing to do for this particle
+        channels = evt_decayfile[particle.pdg]
+        if group is not None:
+            keys = [k for k in self._decay_groups['lines']
+                                    .get(particle.pdg, {}).get(group, ())
+                    if k in channels]
+        else:
+            keys = sorted(channels)
         # check how the decay need to be done
-        nb_decay = len(evt_decayfile[particle.pdg])
+        nb_decay = len(keys)
         if nb_decay == 0:
             return None #nothing to do for this particle
         # Determine the file to read in order to get the decay [decay_file]
         if nb_decay == 1:
-            decay_file = evt_decayfile[particle.pdg][0]
-            decay_file_nb = 0
+            decay_file_nb = keys[0]
+            decay_file = channels[decay_file_nb]
         elif ids.count(particle.pdg) == nb_decay:
-            decay_file = evt_decayfile[particle.pdg][ids[:i].count(particle.pdg)]
-            decay_file_nb = ids[:i].count(particle.pdg)
+            decay_file_nb = keys[ids[:i].count(particle.pdg)]
+            decay_file = channels[decay_file_nb]
         else:
             #need to select the file according to the associate cross-section
             r = random.random()
-            tot = sum(evt_decayfile[particle.pdg][key].cross for key in evt_decayfile[particle.pdg])
+            tot = sum(channels[key].cross for key in keys)
             r = r * tot
             cumul = 0
-            for j,events in evt_decayfile[particle.pdg].items():
-                    
+            for j in keys:
+                events = channels[j]
                 cumul += events.cross
                 if r < cumul:
                     decay_file = events
@@ -4800,6 +5066,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         exist yet); ``probe_extra`` carries the virtualities and the rate-factor
         samples the scan needs to build it.
         """
+        if getattr(self, '_decay_groups', None):
+            # Loud on purpose: this loop redraws one slot until it is accepted,
+            # which would divide E[w_k | group] out of the chain and distort the
+            # group fractions. _sequential_active refuses the whole scheme when
+            # the decays are grouped; if that guard is ever lifted it must come
+            # with a bound and a rate factor per group, not with this loop as it
+            # stands. See doc/madspin_decay_groups.md section 4.4.
+            raise Exception("MadSpin: the per-particle accept/reject cannot "
+                            "honour '@' decay groups; this should have fallen "
+                            "back to the joint one.")
         decays_key = self._decaying_pdgs(production, evt_decayfile)
         if not decays_key:
             return None

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -431,6 +431,65 @@ measurable. Writing the same group as a standalone card two ways:
 The old plain `n!` would have put that ratio at 2. Two code paths, one of which
 has no assignment factor in it, agreeing to 9e-4.
 
+### 7.3 PA, and `sequential_decay`
+
+Grouping forces the joint accept/reject (section 4.1), so both need checking:
+that the fallback happens, and that it costs nothing but efficiency.
+
+**The fallback fires and is a no-op.** `PA` (whose `sequential_decay` auto
+default is on) and `madspin` with `sequential_decay True` both log
+
+```
+MadSpin: the decay lines are grouped ('@' tags), keeping the joint
+accept/reject (sequential_decay ignored)
+```
+
+and `set sequential_decay True` on a grouped card produces event records
+*byte-identical* to the same card run at the default -- the option is read,
+overridden, and changes nothing.
+
+**PA reproduces the dedicated runs.** Same 20000 `p p > t t~` events, `PA`
+throughout, with the dedicated runs put on the joint test too so both sides use
+the same accept/reject:
+
+| | sigma (pb) |
+|---|---|
+| dedicated 1 + dedicated 2 | 71.26739 + 71.24537 = 142.51276 |
+| grouped, one run | 142.54946 &nbsp;&nbsp; ratio 1.000258 |
+
+Sharper than the merged comparison, and free of its binomial noise: split the
+grouped sample by which group each event came from and compare each half with
+*its* dedicated run. Over 3 MadSpin seeds x 2 groups x 5 observables
+(`pT(lepton)`, `m(top)`, both spin analysers and their product) — 30
+comparisons — three land at 2.0-2.7 sigma and none of them reproduces at another
+seed, which is what statistics looks like and not what a bias looks like. Every
+KS is above 0.01.
+
+**A pre-existing bias in `sequential_decay`, found on the way.** The first
+PA/sequential comparison put `m(top)` at 7.8 sigma, and it is not the grouping.
+Taking one *ungrouped* card, the same production events, and changing nothing
+but the accept/reject:
+
+| `decay t > w+ b, w+ > l+ vl` + `decay t~ > w- b~, w- > j j` | mean `m(top_lep)` |
+|---|---|
+| `sequential_decay False` (joint) | 173.16870 |
+| `sequential_decay True` | 172.94647 |
+| | **7.0 sigma**, KS `p = 0.0000` |
+
+Every angular observable agrees between the two (all within 1.0 sigma); only the
+virtuality moves, and it moves *down*. That is the signature the offshell rate
+factor `Z_k` exists to remove: the per-slot stage redraws each decay to
+acceptance, which divides `E[w_k | m] = Z_k(m)` out of the accepted mass sets, so
+the lineshape relaxes towards the Breit-Wigner instead of the offshell one --
+and since the running width grows with `m`, dropping `Z_k` pulls the mean low.
+`PA` shows the same effect at 2.1 sigma, where there is no `Z_k` to lose but the
+per-slot mass redraw normalises itself the same way.
+
+So on this branch `sequential_decay True` under `madspin` is biased in the top
+lineshape, independent of the grouping, and PR #334's `Z_k` tables are what fix
+it. It is also an argument that forcing joint for grouped cards costs nothing
+here: the joint path is the unbiased one.
+
 ## 8. And the honest comparison, still
 
 Section 4.4 remains open, and with it the argument above: two runs plus

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -4,6 +4,14 @@ Design note. Written against `madspin_density` (275462e52) with an eye on the
 sequential/two-stage unweighting schemes of PR #334
 (`claude/madspin-sequential-offshell-rate-factor`, 6c051b6d4).
 
+> **Status.** Sections 3 and 4.1-4.3 are implemented: the density modes
+> (`PA`, `onshell`, `madspin`/`full`) honour the tags for the rectangular card
+> shape described in section 4.6, and the joint accept/reject is forced while
+> they do. Section 4.4 (per-group bounds and `Z_k` tables, so the sequential and
+> two-stage schemes keep working) is **not** implemented and is what section 5
+> calls structural. Everything outside that shape still warns and falls back to
+> the ungrouped behaviour.
+
 ## 1. What the tags mean and where they work
 
 The semi-leptonic *tt* idiom is
@@ -121,18 +129,26 @@ Two consequences worth stating up front:
 
 ### 4.1 Threading the group (contained)
 
-`_draw_all_decays` gains a per-event group index and passes it to
-`_draw_one_decay`, which uses it instead of the positional/random logic when
-groups are declared. The important consumer is
-`sequential_accept_reject`
-([interface_madspin.py:4603 on PR #334](../MadSpin/interface_madspin.py)), which
-calls `_draw_one_decay` per slot and **redraws single slots** on a rejection:
-those redraws must stay inside the group already chosen for the chain. That is a
-parameter, not a restructuring.
+*Implemented.* `_draw_all_decays` draws the group (`_draw_decay_group`) and
+passes it to `_draw_one_decay`, which restricts the candidate channels to the
+ones that group gives the particle and then applies the existing rules to those,
+unchanged. A group supplies exactly one channel per particle -- or one per
+identical parent, which the positional rule then deals out -- so restricting the
+candidates is the whole of the grouping at run time.
 
-The group must be redrawn at the same point the chain restarts (the
-`while True:` mass-set restart), otherwise a group whose feasibility is
-production-dependent would be over-represented.
+The draw sits at the *top* of `_draw_all_decays` rather than anywhere higher, so
+the group is redrawn on every trial of the joint accept/reject along with the
+decays it selects. That is what keeps the group part of what is being unweighted:
+it is proposed and tested together with the angles, and no stage can normalise it
+away. The joint max-weight scan goes through the same entry point, so the bound
+is measured over the group mixture too.
+
+`sequential_accept_reject` is the one caller that cannot take a group: it redraws
+single slots until they are accepted, which divides `E[w_k | group]` out of the
+chain, and that expectation differs between groups. `_sequential_active` refuses
+the scheme outright when the decays are grouped (logged, like the `fixed_order`
+fallback), and `sequential_accept_reject` raises if it is ever reached anyway.
+Lifting that needs section 4.4.
 
 ### 4.2 Pool sizing (contained, but the refill needs care)
 
@@ -151,10 +167,15 @@ With groups, slot `k` of pdg `p` consumes channel `c(g,p)` only on the fraction
 
     sum over {g : c(g,p) = c}  p_g  x  nb_event x multiplicity / eff_k
 
-with `eff_k` the ladder efficiency from `_sequential_pool_ladder`
-([interface_madspin.py:2189 on PR #334](../MadSpin/interface_madspin.py)). This
-is a per-channel weight in `gen_jobs`, which the ladder does not currently carry
-(it is per pdg). Contained.
+with `eff_k` the ladder efficiency from `_sequential_pool_ladder`.
+
+*Implemented, deliberately cruder.* `p_g` is only known once the partial widths
+have been measured, i.e. once the generation this sizing controls has already
+run. Rather than add a width pre-pass, the new `grouped` job kind sizes every
+channel as if its group were drawn on every event. That over-generates by at most
+a factor `|groups|` -- never under-generates, so no refill is forced -- and
+`decay_event_mult` scales it down for anyone who minds. A cheap analytic width
+estimate would recover the factor later.
 
 The refill machinery is the part that needs attention rather than arithmetic.
 `_channel_owner` deals channels out to workers round-robin and
@@ -242,6 +263,39 @@ This is where the cost is.
   already covers every group; the only cost is acceptance, since the bound is
   set by the loudest group.
 
+### 4.6 The shape that is accepted (implemented)
+
+Rectangular: **every group gives exactly `n_part` decay lines for every decaying
+particle**, `n_part` being how many of that particle each production event
+carries. An untagged line belongs to every group, as in `madspin_v1`.
+
+```
+decay t  > w+ b,  w+ > l+ vl   @1        n_part = 1: the semi-leptonic ttbar idiom
+decay t~ > w- b~, w- > j j     @1
+decay t  > w+ b,  w+ > j j     @2
+decay t~ > w- b~, w- > l- vl~  @2
+
+decay t > ... @1 ; decay t > ... @1      n_part = 2: p p > t t t~ t~, the group's
+decay t > ... @2 ; decay t > ... @2      two lines dealt to the two tops by the
+                                         existing positional rule
+```
+
+That single rule subsumes every refusal without a special case of its own: a
+group missing a particle, a line count that does not match the multiplicity, and
+a particle with both a tagged and an untagged line (the untagged one joins every
+group, so that group ends up with one line too many) are all count mismatches.
+Refused separately: a multiparticle parent (one name would own several pools),
+production events that do not all carry the same particles (`drop_prob_per_pdg`
+is per pdg -- section 4.3), `fixed_order`, and `spinmode` `none` / `onshell_v1`.
+
+A refusal warns with its reason and falls back to the ungrouped behaviour rather
+than raising: a card that merely over-specifies (a tagged line for a species that
+never appears in the events, which MadSpin drops anyway) should not stop a run.
+
+Implemented in `_decay_group_layout` (card only), `_validate_decay_groups`
+(against the production events) and `_resolve_decay_groups` (mode, `fixed_order`,
+and the conversion to pdg keys).
+
 ### 4.5 `fixed_order`
 
 `fixed_order` forces the joint accept/reject and processes event *groups*
@@ -255,13 +309,13 @@ worth an explicit test.
 
 | piece | verdict |
 |---|---|
-| group draw + threading through `_draw_*` and the sequential retry | contained |
-| pool sizing weights | contained; refill margins want re-tuning |
-| BR for the plain (one parent per pdg) case | contained |
-| groups x positional rule for identical parents | needs a syntax decision first |
-| BR equalisation across mixed final states (`drop_prob_per_pdg`) | not contained — different data structure |
-| per-group bounds and `Z_k` tables in sequential/two-stage | **structural** — the tabulated per-slot state multiplies by `\|groups\|` and the probe budget has to be split |
-| `fixed_order` event groups | contained, easy to get wrong |
+| group draw + threading through `_draw_*` | contained — **done** |
+| pool sizing | contained — **done**, at the cost noted in 4.2 |
+| BR for the plain (one parent per pdg) case | contained — **done** |
+| groups x positional rule for identical parents | **done**: inside a group the positional rule applies unchanged, so `p p > t t t~ t~` works |
+| BR equalisation across mixed final states (`drop_prob_per_pdg`) | not contained — **refused**, with a reason |
+| per-group bounds and `Z_k` tables in sequential/two-stage | **structural — not done.** The joint accept/reject is forced instead, and `sequential_accept_reject` raises if it is ever reached with groups |
+| `fixed_order` event groups | contained, easy to get wrong — **refused** for now |
 
 Rough effort: a joint-only implementation (density modes, `unweighting = joint`,
 refusing groups with mixed final states and with several identical parents) is a
@@ -297,6 +351,28 @@ normalisation step is exactly the sort of thing users get wrong silently. The
 strongest argument against is that the same week spent on the sequential
 schemes' per-slot bounds buys more.
 
-Recommendation: ship the warning (done on this branch), document the two-run
-recipe (already in `doc/madspin_options.tex`), and treat full support as
-optional — and if it is taken up, do section 6 first.
+Recommendation as first written: ship the warning, document the two-run recipe,
+and treat full support as optional — and if it is taken up, do section 6 first.
+
+That is what happened. Section 6 is what landed: the density modes honour the
+tags for the rectangular shape of section 4.6 and force the joint accept/reject
+while they do. Measured on `p p > t t~`, 2000 events, the card of section 1:
+
+| mode | BR | (W,W) categories |
+|---|---|---|
+| `madspin` (density), before | 0.7529 | 760 semi-lep, 1116 fully hadronic, 124 fully leptonic |
+| `madspin` (density), after | 0.28283 | **2000 semi-lep**, 1015 / 985 by charge |
+| `PA` (density), after | 0.28283 | **2000 semi-lep**, 1037 / 963 by charge |
+| `madspin_v1` | 0.29635 | 2000 semi-lep, 1001 / 999 by charge |
+
+with the same BR serial (`nb_core 1`) and parallel. It is exactly
+`sum_g prod_k Gamma_k / Gamma_tot^2` on this run's own measured widths
+(`Gamma_lep = 0.32407`, `Gamma_had = 0.97099`, `Gamma_t = 1.4915` → `0.28281`).
+The residual gap to `madspin_v1`'s 0.29635 is not from the grouping: it is the
+pre-existing difference between how the two paths measure the partial widths,
+and it shows in the ungrouped runs too (`0.7529 = (BR_l + BR_h)^2` with the same
+widths).
+
+Section 4.4 remains open, and with it the argument above: two runs plus
+`set cross_section` still produce the same sample, so what this bought is
+ergonomics, not reach.

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -1,0 +1,302 @@
+# Supporting the `@` grouping tags in the density spin modes
+
+Design note. Written against `madspin_density` (275462e52) with an eye on the
+sequential/two-stage unweighting schemes of PR #334
+(`claude/madspin-sequential-offshell-rate-factor`, 6c051b6d4).
+
+## 1. What the tags mean and where they work
+
+The semi-leptonic *tt* idiom is
+
+```
+decay t  > w+ b,  w+ > l+ vl   @1
+decay t~ > w- b~, w- > j j     @1
+decay t  > w+ b,  w+ > j j     @2
+decay t~ > w- b~, w- > l- vl~  @2
+```
+
+Lines sharing a tag are used *together*, so only the two charge assignments
+exist and no fully leptonic or fully hadronic event is produced. A line without
+a tag is common to every group.
+
+The grouping lives in `decay_all_events.get_all_ME`
+([MadSpin/decay.py:2869](../MadSpin/decay.py#L2869)): it sorts the branches into
+`decay_text_correlated[tag]` and emits one `generate`/`add process` per group, so
+the correlation is expressed inside the decayed matrix element. Only
+`madspin_v1` instantiates that class ([interface_madspin.py:998](../MadSpin/interface_madspin.py#L998));
+`onshell_v1`, `PA`, `onshell`, `madspin`/`full` and `none` all use
+`decay_all_events_onshell` / `decay_all_events_density`, whose
+`get_decay_command` ([decay.py:4470](../MadSpin/decay.py#L4470)) has no notion of
+groups.
+
+### 1.1 It fails silently — measured
+
+`get_decay_command` appends an `@` process number of its own to every branch:
+
+```python
+newproc = "add process %s @%i --no_warning=duplicate --standalone;" % (proc, i)
+```
+
+so MG5 receives two of them. Its `proc_number_pattern` (`^(.+)@\s*(\d+)\s*(.*)$`,
+greedy) binds the *last*, i.e. MadSpin's, at the top level, and the user's is
+absorbed as the process number of the sub-decay. Checked directly:
+
+```
+IN : generate t* > w+ b, w+ > l+ vl @1 @0 --no_warning=duplicate --standalone
+OUT: Process: t*> w+ b
+       Decay: w+ > e+/mu+ ve/vm WEIGHTED=2 @1      <- id 1 on the SUB-decay
+     top-level id = 0
+```
+
+The amplitude is the correct ungrouped one; nothing errors and (before this
+branch) nothing warned. The legacy path strips the tag explicitly for the same
+generation step ([decay.py:2957](../MadSpin/decay.py#L2957)); the density path
+does not.
+
+End-to-end on `p p > t t~`, 2000 events, the card above:
+
+| mode | BR written to the banner | (W,W) categories |
+|---|---|---|
+| `madspin` (density) | 0.7529 = (BR_l + BR_h)^2 | 760 semi-lep, **1116 fully hadronic, 124 fully leptonic** |
+| `madspin_v1` | 0.2963 = 2 BR_l BR_h | 2000 semi-lep, nothing else |
+
+The density cross section is 2.54x the intended one and three quarters of the
+sample is the wrong final state.
+
+The warning added on this branch
+(`MadSpinInterface._warn_ignored_decay_groups`, called from `do_launch`) closes
+the silent part. The rest of this note is about the full feature.
+
+## 2. The structural obstacle
+
+The density modes never build a decayed matrix element. They fill one decay pool
+per (particle, channel) and draw each particle's channel independently at run
+time in `_draw_one_decay`
+([interface_madspin.py:3328](../MadSpin/interface_madspin.py#L3328)):
+
+* one decay line for the pdg -> that line;
+* `ids.count(pdg) == nb_decay` -> **positional**, the i-th particle takes the
+  i-th line;
+* otherwise -> drawn at random, proportional to the channels' cross sections.
+
+There is no object on which a cross-particle correlation can be imposed. The
+obvious shape of a fix is therefore to move the channel choice from *per
+particle* to *per event*: draw the group once, then let each particle take that
+group's line for its pdg.
+
+## 3. Is a per-event group draw correct?
+
+Yes, and for the same reason the current per-particle draw is.
+
+Write `R_g(prod)` for the physical rate of group `g` at a fixed production
+event,
+
+    R_g(prod) = Integral dOmega_1..dOmega_n  rho_prod . (x)_k D_k^(g) ,
+
+and `Gamma_{k,g}` for the partial width of the channel group `g` gives to slot
+`k`. The unpolarised factorisation of `R_g` is exactly `prod_k Gamma_{k,g}`,
+which is a constant of the run, readable off the pools' cross sections. So:
+
+* draw `g` with probability `p_g = prod_k Gamma_{k,g} / sum_h prod_k Gamma_{k,h}`;
+* draw each slot from its group-`g` channel pool (already unweighted within the
+  channel);
+* keep the accept/reject weight **unchanged**.
+
+The proposal density is then the unpolarised decay density over the union of the
+groups, and the existing spin-correlation weight supplies the polarisation
+dependence — precisely the role the per-channel `cross`-weighted draw plays
+today. The group's polarisation enhancement is carried by the accept/reject, not
+by `p_g`.
+
+Two consequences worth stating up front:
+
+* the branching ratio becomes `sum_g prod_k Gamma_{k,g} / Gamma_tot^n`, with **no
+  factorial**: each group is an explicit assignment, so there is nothing to
+  enumerate;
+* groups with distinct final states do not interfere, so the incoherent sum over
+  groups is exact. `madspin_v1` also treats them incoherently (`add process`).
+  This matters for section 7.
+
+## 4. What has to change
+
+### 4.1 Threading the group (contained)
+
+`_draw_all_decays` gains a per-event group index and passes it to
+`_draw_one_decay`, which uses it instead of the positional/random logic when
+groups are declared. The important consumer is
+`sequential_accept_reject`
+([interface_madspin.py:4603 on PR #334](../MadSpin/interface_madspin.py)), which
+calls `_draw_one_decay` per slot and **redraws single slots** on a rejection:
+those redraws must stay inside the group already chosen for the chain. That is a
+parameter, not a restructuring.
+
+The group must be redrawn at the same point the chain restarts (the
+`while True:` mass-set restart), otherwise a group whose feasibility is
+production-dependent would be over-represented.
+
+### 4.2 Pool sizing (contained, but the refill needs care)
+
+Today `run_onshell` decides per pdg
+([interface_madspin.py:1875-1921](../MadSpin/interface_madspin.py#L1875))
+between three shapes:
+
+| `gen_jobs[pdg]['kind']` | when | pool layout |
+|---|---|---|
+| `simple` | `nb_needed == nb_event` | one merged pool (`cumul=True`), channels mixed by cross section |
+| `mult_split` | `nb_needed == nb_mult*nb_event` and `len(list_branches[name]) == nb_mult` | one pool per channel, positional |
+| `mult_cumul` | same but a different line count | one merged pool, drawn independently `nb_mult` times |
+
+With groups, slot `k` of pdg `p` consumes channel `c(g,p)` only on the fraction
+`p_g` of events, so the pool for `(p,c)` must be sized as
+
+    sum over {g : c(g,p) = c}  p_g  x  nb_event x multiplicity / eff_k
+
+with `eff_k` the ladder efficiency from `_sequential_pool_ladder`
+([interface_madspin.py:2189 on PR #334](../MadSpin/interface_madspin.py)). This
+is a per-channel weight in `gen_jobs`, which the ladder does not currently carry
+(it is per pdg). Contained.
+
+The refill machinery is the part that needs attention rather than arithmetic.
+`_channel_owner` deals channels out to workers round-robin and
+`_open_refill_slice` undersizes the owner's slice by 10% so it runs dry first;
+both assume every channel is consumed at a comparable rate. Under groups a rare
+group's channel drains slowly and a common one fast, so the "owner runs out
+first" heuristic degrades and refills fire unevenly. Nothing breaks — the
+deadlock fail-safe and the published-generation protocol are rate-agnostic — but
+the sizing margins would want re-tuning.
+
+### 4.3 Branching-ratio bookkeeping (contained for the plain cases, not for BR
+equalisation)
+
+The three formulas at
+[interface_madspin.py:1934-1942](../MadSpin/interface_madspin.py#L1934) are keyed
+on line counts, which under groups no longer mean "channels available to a
+slot":
+
+* `mult_split`'s `pwidth / totwidth**nb_mult * factorial(nb_mult)` is the
+  *positional* formula. The factorial compensates for generating only one of the
+  `n!` assignments of `n` distinct channels to `n` identical parents; under
+  groups the assignments are listed explicitly, so it must not be applied.
+  (Verified separately that the factorial is right as it stands for the
+  positional case: `p p > z z` with `decay z > e+ e-` + `decay z > u u~` gives
+  BR = Gamma_ee.Gamma_uu/Gamma_Z^2 x 2 = 0.0081747, matching
+  2 x BR_ee x BR_uu, and every event carries exactly one of each pair.)
+* `mult_cumul`'s `(sum_c Gamma_c / Gamma_tot)**nb_mult` *is* the
+  "each particle independently" formula groups exist to replace; it becomes
+  `sum_g prod_k Gamma_{k,g} / Gamma_tot^n`.
+* what a group means when a pdg has several *identical* parents is not defined
+  by the card syntax at all. `decay z > e+ e- @1` twice? The positional rule and
+  the group rule are two different mechanisms competing for the same slot, and
+  the design has to pick one — the least surprising choice is that within a
+  group the positional rule still applies to identical parents, i.e. a group
+  supplies `n` lines per pdg with `n` parents.
+
+`drop_prob_per_pdg`
+([interface_madspin.py:1950-1965](../MadSpin/interface_madspin.py#L1950)) is the
+uncontained one. It equalises branching ratios across production events that do
+not all contain the same decaying species, by dropping events *per pdg* with
+probability `1 - BR_pdg / BR_max`. Under groups the branching ratio is a property
+of the **group**, not of a pdg: two groups differing in one line have different
+total BR, and the drop probability would have to become per (final-state class,
+group). That is a different data structure and a different correctness argument,
+and it is the piece I would carve out of a first implementation (refuse groups
+together with mixed final states, and say so).
+
+### 4.4 The sequential / two-stage unweighting (structural)
+
+This is where the cost is.
+
+* **Per-slot bounds.** `get_sequential_maxwgt`
+  ([interface_madspin.py:3878 on PR #334](../MadSpin/interface_madspin.py))
+  returns a flat `maxwgts` list indexed by position in the decay ordering, built
+  from one probe vector per production event. Under groups each slot's weight
+  distribution depends on the group, so the bound vector becomes one per group:
+  `|slots| x |groups|` numbers, and `_combine_maxwgt` needs `|groups|` separate
+  populations. The probe budget (`Nevents_for_max_weight x
+  max_weight_ps_point`) then has to be split across groups; a rare group gets
+  few samples, its bound is badly measured, and the sample is biased in exactly
+  the way the overflow counter reports but nobody reads. Sizing the probe per
+  group (rather than per event) is a change to the scan loop, not a parameter.
+
+* **`Z_k(m)` tables.** `_z_slot_keys`
+  ([interface_madspin.py:4400 on PR #334](../MadSpin/interface_madspin.py))
+  keys the offshell rate factor by `<pdg>_<occurrence>`, with the docstring's
+  justification that "slots of one pdg are consecutive and in production order,
+  which is also how `_draw_one_decay` picks a decay file". That justification is
+  exactly what groups break: the slot no longer determines the channel, the
+  (slot, group) pair does. `Z_k` is the running partial width of the channel
+  drawn, so the key must become `<pdg>_<occurrence>_<group>` and the table count
+  multiplies by `|groups|` — with the same probe-splitting problem, and each fit
+  needs enough samples for its quadratic in `ln(m/pole)` to be determined.
+
+* **Cache format.** `_OFFSHELL_CACHE_FORMAT` must be bumped: the bound vector and
+  the table keys both change meaning, and an `ms_dir` written by today's code
+  must not be read back.
+
+* **What does *not* change:** `_decaying_pdgs`, `_density_basis`,
+  `_sequential_slots` and the slot-to-particle map are all group-independent —
+  the group changes which decay is drawn into a slot, never the layout of the
+  density matrix. That is a real simplification and worth stating.
+
+* **The joint scheme needs none of this.** A single bound over the whole chain
+  already covers every group; the only cost is acceptance, since the bound is
+  set by the loudest group.
+
+### 4.5 `fixed_order`
+
+`fixed_order` forces the joint accept/reject and processes event *groups*
+(counter-events) that must all decay consistently. A per-event group draw must be
+made once per event group, not once per event. Small, but easy to get wrong and
+worth an explicit test.
+
+## 5. Contained or structural?
+
+**Structural**, with a contained subset.
+
+| piece | verdict |
+|---|---|
+| group draw + threading through `_draw_*` and the sequential retry | contained |
+| pool sizing weights | contained; refill margins want re-tuning |
+| BR for the plain (one parent per pdg) case | contained |
+| groups x positional rule for identical parents | needs a syntax decision first |
+| BR equalisation across mixed final states (`drop_prob_per_pdg`) | not contained — different data structure |
+| per-group bounds and `Z_k` tables in sequential/two-stage | **structural** — the tabulated per-slot state multiplies by `\|groups\|` and the probe budget has to be split |
+| `fixed_order` event groups | contained, easy to get wrong |
+
+Rough effort: a joint-only implementation (density modes, `unweighting = joint`,
+refusing groups with mixed final states and with several identical parents) is a
+few hundred lines plus tests — call it a few days. Extending it to the
+sequential and two-stage schemes roughly doubles that and adds a validation
+campaign, because the bias it can introduce is a badly measured bound for a rare
+group, which is invisible in a cross-section comparison and only shows up in a
+lineshape or in the overflow counter. A week to two, end to end.
+
+## 6. A cheaper middle option
+
+Implement groups for the joint scheme only, and have `_unweighting_mode` fall
+back to `joint` when groups are declared — the same way it already falls back
+for `fixed_order` and for non-density spin modes, and with the same one-line
+announcement. That gets the feature, keeps the tabulated machinery untouched,
+and costs the user only acceptance. It also means the per-group bound question
+can be answered later, with a working feature to measure against.
+
+## 7. And the honest comparison
+
+Groups with distinct final states do not interfere, and `madspin_v1` itself adds
+them incoherently. So **two MadSpin runs plus a merge is not an approximation of
+this feature — it is the same sample**, up to:
+
+1. the relative normalisation of the groups, which `set cross_section` fixes (or
+   which the user can compute: the groups' rates are in the ratio
+   `prod_k Gamma_{k,g}`), and
+2. having to concatenate two LHE files.
+
+That is worth weighing before spending the week. The strongest argument *for*
+doing the work is not physics reach but ergonomics and error-proneness: the
+normalisation step is exactly the sort of thing users get wrong silently. The
+strongest argument against is that the same week spent on the sequential
+schemes' per-slot bounds buys more.
+
+Recommendation: ship the warning (done on this branch), document the two-run
+recipe (already in `doc/madspin_options.tex`), and treat full support as
+optional — and if it is taken up, do section 6 first.

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -373,6 +373,66 @@ pre-existing difference between how the two paths measure the partial widths,
 and it shows in the ungrouped runs too (`0.7529 = (BR_l + BR_h)^2` with the same
 widths).
 
+### 7.2 The same again with two parents per pdg — `p p > t t~ t t~`
+
+`n_part = 2`, so each group supplies *two* lines for each pdg and the positional
+rule deals them out inside the group:
+
+```
+decay t  > w+ b, w+ > l+ vl  @1        decay t  > w+ b, w+ > j j     @2
+decay t  > w+ b, w+ > j j    @1        decay t  > w+ b, w+ > j j     @2
+decay t~ > w- b~, w- > j j   @1        decay t~ > w- b~, w- > l- vl~ @2
+decay t~ > w- b~, w- > j j   @1        decay t~ > w- b~, w- > j j    @2
+```
+
+Exactly one lepton, from a top in group 1 and from an antitop in group 2. Eight
+pools, four per pdg. Group @1's two `t~` lines are *identical*, which makes this
+card a test of the assignment factor as well.
+
+20000 production events, an independent production seed from section 7.1:
+
+| | sigma (pb) |
+|---|---|
+| dedicated 1 (lepton from a top) | 0.0010721 |
+| dedicated 2 (lepton from an antitop) | 0.0010722 |
+| **sum** | **0.0021442** |
+| grouped, one run | 0.0021416 &nbsp;&nbsp; ratio **0.998801** |
+
+Group shares reported `@1 = 0.5001, @2 = 0.4999` against the 0.49998 the
+dedicated cross sections imply. Every pull against the merged reference is
+within 1.0 sigma -- `cos*_lep` -0.2, `cos*_had` -0.5, `pT(lepton)` -0.9,
+`pT(leptonic top)` -1.0, `m(leptonic top)` +0.3, `HT(4 tops)` 0.0, charge split
+-0.1 -- and two-sample KS over the six distributions gives `p` from 0.20 to 1.00.
+(A first pass at 5000 events had `cos*_lep` at 2.3 sigma, `p = 0.03`; it is
+0.751 here, so that was the fluctuation it looked like.)
+
+Structure, 20000/20000 events in all three samples: exactly one charged lepton;
+the lepton comes from a top 0.4996 of the time in the grouped sample against
+1.0000 and 0.0000 in the two dedicated ones; and **the leptonic parent is always
+the first of its pdg**, which is the positional rule operating inside the group.
+
+The 1.2e-3 on the cross section is again the independent width measurements --
+four factors per group here instead of two, and each MadEvent estimate is good
+to about 0.1%.
+
+#### The assignment factor, against a path that has none
+
+`n!` counts the ways `n` *distinct* channels go to `n` identical parents; with a
+repeated line it counts the same final state twice, so the factor is
+`n!/prod_c m_c!`. Group @1 above repeats its `t~` line, which makes that
+measurable. Writing the same group as a standalone card two ways:
+
+| | sigma (pb) |
+|---|---|
+| `t~` line written **twice** -> `mult_split`, factor `2!/2! = 1` | 0.0010777 |
+| `t~` line written **once** -> `mult_cumul`, which applies no factor at all | 0.0010767 |
+| ratio | **1.000886** |
+
+The old plain `n!` would have put that ratio at 2. Two code paths, one of which
+has no assignment factor in it, agreeing to 9e-4.
+
+## 8. And the honest comparison, still
+
 Section 4.4 remains open, and with it the argument above: two runs plus
 `set cross_section` still produce the same sample, so what this bought is
 ergonomics, not reach.

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -376,3 +376,50 @@ widths).
 Section 4.4 remains open, and with it the argument above: two runs plus
 `set cross_section` still produce the same sample, so what this bought is
 ergonomics, not reach.
+
+### 7.1 The same sample — measured
+
+`p p > t t~`, 20000 production events, decayed four times off the *same*
+production file: the grouped card in one run, each group alone in a dedicated
+run, and the grouped card under `madspin_v1`. The two dedicated runs decayed the
+same events, so the reference is built pairwise — for production event *i*, take
+`dedic1[i]` with probability `p_1 = sigma_1/(sigma_1+sigma_2)` and `dedic2[i]`
+otherwise. That is by construction the mixture the grouped run draws, on
+identical production kinematics, so anything left over is the grouping itself.
+
+| | sigma (pb) |
+|---|---|
+| dedicated 1 (`t > l+ nu`, `t~ > j j`) | 71.26739 |
+| dedicated 2 (`t > j j`, `t~ > l- nu`) | 71.24537 |
+| **sum** | **142.51276** |
+| grouped, one run | 142.54946 &nbsp;&nbsp; ratio **1.000258** |
+| `madspin_v1` | 149.48100 &nbsp;&nbsp; ratio 1.048896 |
+
+The grouped run also reports the group shares as `@1 = 0.4999, @2 = 0.5001`
+against the `0.50008` the two dedicated cross sections imply.
+
+Means, grouped against the merged reference (`cos*` is the child's angle in its
+W rest frame against the W direction in its top's rest frame — the spin
+analyser; `prod` is the ttbar spin-correlation handle):
+
+| | grouped | merged | pull |
+|---|---|---|---|
+| `cos*_lep` | -0.14628 | -0.14162 | -0.9 |
+| `cos*_down` | -0.13923 | -0.14408 | +1.0 |
+| `cos*_lep · cos*_down` | 0.01894 | 0.01972 | -0.3 |
+| `dphi(l, d)` | 1.74943 | 1.75194 | -0.3 |
+| `pT(lepton)` | 51.458 | 51.525 | -0.2 |
+| `pT(leptonic top)` | 120.235 | 120.254 | -0.0 |
+| `m(leptonic top)` | 173.192 | 173.184 | +0.3 |
+| lepton-from-top fraction | 0.4996 | 0.5001 | -0.1 |
+
+Two-sample Kolmogorov-Smirnov on the same seven distributions: `D` between
+0.0027 and 0.0081, `p` between 0.53 and 1.00. Nothing distinguishes them.
+
+The 2.6e-4 on the cross section is the two sides measuring the same partial
+widths in independent MG5 integrations, not a bias. The 4.9% against
+`madspin_v1` is the pre-existing difference already noted above: the density
+path integrates the 3-body `t > b f f'` and gets `Gamma_lep/Gamma_t = 0.21705`
+where the naive `Gamma_t x BR(W)` would give 2/9 = 0.22222, the Breit-Wigner
+being truncated by `bwcutoff` and suppressed below threshold. It is 2.3% per
+leg, hence 4.7% on the product, and it is there in the ungrouped runs too.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1341,6 +1341,24 @@ class TestSequentialPoolLadder(unittest.TestCase):
         stub._nb_decaying = 1
         self.assertEqual(stub._unweighting_mode(True), 'sequential')
 
+    def test_grouped_decays_force_the_joint_test(self):
+        """'@' grouping forces the joint accept/reject, whatever unweighting
+        asks for. The per-particle and two_stage schemes redraw to acceptance,
+        which divides E[w | group] out of the chain -- and that expectation
+        differs between groups, so the accepted group fractions would come out
+        distorted by its reciprocal. Pinned here because the gate was ported by
+        hand onto the unweighting API it now lives in.
+        """
+        for mode in ('auto', 'sequential', 'two_stage',
+                     'sequential_global_retry'):
+            stub = self._stub({6: 2}, unweighting=mode, spinmode='madspin')
+            stub._nb_decaying = 2
+            stub._decay_groups = None
+            self.assertNotEqual(stub._unweighting_mode(True), 'joint', mode)
+            stub._decay_groups = {'1': {}, '2': {}}
+            self.assertEqual(stub._unweighting_mode(True), 'joint',
+                             '%s with grouped decays' % mode)
+
     def test_offshell_only_modes_fall_back_under_pa(self):
         """Asked for explicitly under PA/onshell, the two modes that need the
         up-front mass draw say so and use sequential."""

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -659,6 +659,7 @@ class TestDrawOneDecay(unittest.TestCase):
         get_decay_from_file = interface_madspin.MadSpinInterface.get_decay_from_file
         _draw_all_decays = interface_madspin.MadSpinInterface._draw_all_decays
         _draw_one_decay = interface_madspin.MadSpinInterface._draw_one_decay
+        _draw_decay_group = interface_madspin.MadSpinInterface._draw_decay_group
         efficiency = 0.5
 
     def _setup(self):
@@ -2016,3 +2017,152 @@ class TestDecayGroupLayout(unittest.TestCase):
         branches = self.TTBAR + [('z', ['z > e+ e- @1', 'z > u u~ @2'])]
         ok, reason = self._validate(branches, {6: 100, -6: 100})
         self.assertTrue(ok, reason)
+
+
+class TestDecayGroupDraw(unittest.TestCase):
+    """The run-time half of the grouping: a group is drawn once per event, with
+    the probability of its rate, and every particle then takes that group's
+    channel."""
+
+    class _Pool(object):
+        def __init__(self, tag, n=200, cross=1.0):
+            self.tag = tag
+            self._it = iter(range(n))
+            self.cross = cross
+        def __next__(self):
+            return '%s:%s' % (self.tag, next(self._it))
+
+    class _Part(object):
+        def __init__(self, pid):
+            self.pid = pid
+            self.pdg = pid
+            self.status = 1
+
+    class _Model(object):
+        NAMES = {6: 't', -6: 't~'}
+        def get_particle(self, pdg):
+            name = self.NAMES[pdg]
+            return type('P', (), {'get_name': staticmethod(lambda n=name: n)})()
+
+    class _Stub(object):
+        _DECAY_GROUP_TAG = interface_madspin.MadSpinInterface._DECAY_GROUP_TAG
+        _split_group_tag = interface_madspin.MadSpinInterface._split_group_tag
+        _assignment_multiplicity = \
+            interface_madspin.MadSpinInterface._assignment_multiplicity
+        _clamped_partial_width = staticmethod(
+            interface_madspin.MadSpinInterface._clamped_partial_width)
+        _resolve_group_rates = \
+            interface_madspin.MadSpinInterface._resolve_group_rates
+        _draw_decay_group = interface_madspin.MadSpinInterface._draw_decay_group
+        _draw_one_decay = interface_madspin.MadSpinInterface._draw_one_decay
+        _draw_all_decays = interface_madspin.MadSpinInterface._draw_all_decays
+        get_decay_from_file = \
+            interface_madspin.MadSpinInterface.get_decay_from_file
+        efficiency = 0.5
+
+    # ------------------------------------------------- assignment multiplicity
+    def test_multiplicity_counts_distinct_assignments(self):
+        mult = interface_madspin.MadSpinInterface._assignment_multiplicity
+        self.assertEqual(mult(['t > w+ b, w+ > l+ vl']), 1)
+        self.assertEqual(mult(['a > b c', 'a > d e']), 2)
+        self.assertEqual(mult(['a > b c', 'a > b c']), 1)   # NOT 2
+        self.assertEqual(mult(['a > b c', 'a > d e', 'a > f g']), 6)
+        self.assertEqual(mult(['a > b c', 'a > b c', 'a > d e']), 3)
+
+    def test_multiplicity_ignores_the_tag(self):
+        mult = interface_madspin.MadSpinInterface._assignment_multiplicity
+        self.assertEqual(mult(['a > b c @1', 'a > b c @2']), 1)
+
+    # ------------------------------------------------------------- group rates
+    def _ttbar_stub(self, g_lep=2.0, g_had=6.0, totwidth=9.0):
+        stub = self._Stub()
+        stub.model = self._Model()
+        stub.list_branches = {
+            't':  ['t > w+ b, w+ > l+ vl @1', 't > w+ b, w+ > j j @2'],
+            't~': ['t~ > w- b~, w- > j j @1', 't~ > w- b~, w- > l- vl~ @2']}
+        stub._decay_groups = {'tags': ['1', '2'],
+                              'lines': {6:  {'1': [0], '2': [1]},
+                                        -6: {'1': [0], '2': [1]}},
+                              'prob': None}
+        gen_jobs = {6: {'totwidth': totwidth}, -6: {'totwidth': totwidth}}
+        channel_widths = {6:  {0: g_lep, 1: g_had},
+                          -6: {0: g_had, 1: g_lep}}
+        return stub, gen_jobs, channel_widths
+
+    def test_semileptonic_branching_ratio(self):
+        """the tt~ idiom: BR = 2 x BR_lep x BR_had, which is what madspin_v1
+        writes for the same card."""
+        stub, gen_jobs, widths = self._ttbar_stub()
+        br = stub._resolve_group_rates(gen_jobs, widths)
+        self.assertAlmostEqual(br, 2 * (2. / 9.) * (6. / 9.), places=12)
+        self.assertEqual(stub._decay_groups['prob'], [0.5, 0.5])
+
+    def test_group_probability_follows_the_rate(self):
+        """an asymmetric card: group 1 is lep+had, group 2 had+had, so group 2
+        is the more likely of the two in the ratio of their widths."""
+        stub, gen_jobs, widths = self._ttbar_stub()
+        widths[-6] = {0: 6.0, 1: 6.0}          # t~ hadronic in both groups
+        br = stub._resolve_group_rates(gen_jobs, widths)
+        # br_1 = (2/9)(6/9), br_2 = (6/9)(6/9)
+        self.assertAlmostEqual(br, (2 * 6 + 6 * 6) / 81., places=12)
+        self.assertAlmostEqual(stub._decay_groups['prob'][0], 12. / 48.)
+        self.assertAlmostEqual(stub._decay_groups['prob'][1], 36. / 48.)
+
+    def test_zero_rate_everywhere_is_an_error_not_a_silent_zero(self):
+        stub, gen_jobs, widths = self._ttbar_stub()
+        widths[6] = {0: 0.0, 1: 0.0}
+        self.assertRaises(Exception, stub._resolve_group_rates,
+                          gen_jobs, widths)
+
+    # -------------------------------------------------------------- group draw
+    def test_group_is_drawn_with_its_probability(self):
+        import random
+        stub, gen_jobs, widths = self._ttbar_stub()
+        stub._decay_groups['prob'] = [0.25, 0.75]
+        random.seed(7)
+        drawn = collections.Counter(stub._draw_decay_group()
+                                    for _ in range(20000))
+        self.assertAlmostEqual(drawn['1'] / 20000., 0.25, places=2)
+        self.assertAlmostEqual(drawn['2'] / 20000., 0.75, places=2)
+
+    def test_no_group_declared_draws_none(self):
+        stub = self._Stub()
+        stub._decay_groups = None
+        self.assertIsNone(stub._draw_decay_group())
+
+    # ------------------------------------------------- the draw inside a group
+    def test_every_particle_takes_the_drawn_group_channel(self):
+        import random
+        stub, gen_jobs, widths = self._ttbar_stub()
+        stub._resolve_group_rates(gen_jobs, widths)
+        production = [self._Part(6), self._Part(-6)]
+        random.seed(3)
+        seen = collections.Counter()
+        for _ in range(400):
+            evt_decayfile = {6:  {0: self._Pool('t_lep'), 1: self._Pool('t_had')},
+                             -6: {0: self._Pool('tx_had'), 1: self._Pool('tx_lep')}}
+            out = stub.get_decay_from_file(production, evt_decayfile, 10)
+            seen[(out[6][0].split(':')[0], out[-6][0].split(':')[0])] += 1
+        # only the two tagged assignments, never lep+lep or had+had
+        self.assertEqual(set(seen), {('t_lep', 'tx_had'), ('t_had', 'tx_lep')})
+        for count in seen.values():
+            self.assertGreater(count, 150)      # both groups are used
+
+    def test_identical_parents_inside_a_group_are_positional(self):
+        """p p > t t t~ t~: the group's two lines for a pdg go to its two
+        particles in order."""
+        stub = self._Stub()
+        stub.model = self._Model()
+        stub.list_branches = {'t': ['a @1', 'b @1', 'c @2', 'd @2']}
+        stub._decay_groups = {'tags': ['1', '2'],
+                              'lines': {6: {'1': [0, 1], '2': [2, 3]}},
+                              'prob': [1.0, 0.0]}
+        production = [self._Part(6), self._Part(6)]
+        evt_decayfile = {6: dict((i, self._Pool('c%d' % i)) for i in range(4))}
+        out = stub.get_decay_from_file(production, evt_decayfile, 10)
+        self.assertEqual([d.split(':')[0] for d in out[6]], ['c0', 'c1'])
+
+        stub._decay_groups['prob'] = [0.0, 1.0]
+        evt_decayfile = {6: dict((i, self._Pool('c%d' % i)) for i in range(4))}
+        out = stub.get_decay_from_file(production, evt_decayfile, 10)
+        self.assertEqual([d.split(':')[0] for d in out[6]], ['c2', 'c3'])

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1820,3 +1820,50 @@ class TestPolyfitConditioning(unittest.TestCase):
 
     def test_two_distinct_points_cannot_fix_a_quadratic(self):
         self.assertIsNone(self._fit([0.0, 0.0, 0.1, 0.1], [1.0, 1.0, 2.0, 2.0]))
+
+
+class TestDecayGroupTagWarning(unittest.TestCase):
+    """The `@` grouping tags of the semi-leptonic ttbar idiom are implemented
+    only in madspin_v1. Everywhere else MG5 reads them as an ordinary process
+    number and they change nothing, so MadSpin must say so rather than let the
+    card mean something it does not."""
+
+    class _Stub(object):
+        _DECAY_GROUP_TAG = interface_madspin.MadSpinInterface._DECAY_GROUP_TAG
+        _warn_ignored_decay_groups = \
+            interface_madspin.MadSpinInterface._warn_ignored_decay_groups
+
+        def __init__(self, list_branches):
+            self.list_branches = list_branches
+
+    TAGGED = {'t': ['t > w+ b, w+ > l+ vl @1', 't > w+ b, w+ > j j @2'],
+              't~': ['t~ > w- b~, w- > j j @1', 't~ > w- b~, w- > l- vl~ @2']}
+    UNTAGGED = {'z': ['z > e+ e-', 'z > u u~']}
+
+    def test_tags_are_reported_in_every_density_mode(self):
+        for spinmode in ('madspin', 'full', 'PA', 'onshell', 'onshell_v1',
+                         'none'):
+            stub = self._Stub(self.TAGGED)
+            found = stub._warn_ignored_decay_groups(spinmode)
+            self.assertEqual(len(found), 4, spinmode)
+            self.assertEqual(sorted(set(t[2] for t in found)), ['@1', '@2'])
+
+    def test_madspin_v1_is_silent(self):
+        """v1 implements the grouping, so there is nothing to warn about."""
+        stub = self._Stub(self.TAGGED)
+        self.assertEqual(stub._warn_ignored_decay_groups('madspin_v1'), [])
+
+    def test_untagged_card_is_silent(self):
+        stub = self._Stub(self.UNTAGGED)
+        self.assertEqual(stub._warn_ignored_decay_groups('madspin'), [])
+
+    def test_whitespace_between_at_and_number(self):
+        stub = self._Stub({'t': ['t > w+ b, w+ > l+ vl @ 12']})
+        self.assertEqual([t[2] for t in
+                          stub._warn_ignored_decay_groups('madspin')], ['@12'])
+
+    def test_a_coupling_restriction_is_not_a_group_tag(self):
+        """`@` only tags a group when a number follows it; QED=1 and the like
+        must not trigger the warning."""
+        stub = self._Stub({'t': ['t > w+ b QED=1, w+ > l+ vl']})
+        self.assertEqual(stub._warn_ignored_decay_groups('madspin'), [])

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1830,6 +1830,7 @@ class TestDecayGroupTagWarning(unittest.TestCase):
 
     class _Stub(object):
         _DECAY_GROUP_TAG = interface_madspin.MadSpinInterface._DECAY_GROUP_TAG
+        _split_group_tag = interface_madspin.MadSpinInterface._split_group_tag
         _warn_ignored_decay_groups = \
             interface_madspin.MadSpinInterface._warn_ignored_decay_groups
 
@@ -1867,3 +1868,151 @@ class TestDecayGroupTagWarning(unittest.TestCase):
         must not trigger the warning."""
         stub = self._Stub({'t': ['t > w+ b QED=1, w+ > l+ vl']})
         self.assertEqual(stub._warn_ignored_decay_groups('madspin'), [])
+
+
+class TestDecayGroupLayout(unittest.TestCase):
+    """`@` grouping tags: sorting the decay lines into groups, and deciding
+    whether the grouping can be honoured for a given set of production events.
+
+    Supported shape is rectangular -- every group decays every particle exactly
+    once (or n times for n identical parents). Anything else is refused rather
+    than approximated, because the group is then not a complete assignment and
+    neither its rate nor its branching ratio is defined.
+    """
+
+    class _Stub(object):
+        _DECAY_GROUP_TAG = interface_madspin.MadSpinInterface._DECAY_GROUP_TAG
+        _split_group_tag = interface_madspin.MadSpinInterface._split_group_tag
+        _decay_group_layout = \
+            interface_madspin.MadSpinInterface._decay_group_layout
+        _validate_decay_groups = \
+            interface_madspin.MadSpinInterface._validate_decay_groups
+
+        def __init__(self, list_branches):
+            self.list_branches = collections.OrderedDict(list_branches)
+
+    # the semi-leptonic ttbar idiom: one t and one t~ per event, two groups
+    TTBAR = [('t',  ['t > w+ b, w+ > l+ vl @1', 't > w+ b, w+ > j j @2']),
+             ('t~', ['t~ > w- b~, w- > j j @1', 't~ > w- b~, w- > l- vl~ @2'])]
+    NAME2PDG = staticmethod(lambda name: {'t': 6, 't~': -6, 'z': 23,
+                                          'w+': 24}.get(name))
+
+    # ------------------------------------------------------------------ split
+    def test_split_tag(self):
+        self.assertEqual(
+            interface_madspin.MadSpinInterface._split_group_tag(
+                't > w+ b, w+ > l+ vl @1'),
+            ('t > w+ b, w+ > l+ vl', '1'))
+
+    def test_split_tag_tolerates_spacing(self):
+        self.assertEqual(
+            interface_madspin.MadSpinInterface._split_group_tag(
+                't > w+ b @ 12  '),
+            ('t > w+ b', '12'))
+
+    def test_untagged_line_is_left_alone(self):
+        for branch in ('z > e+ e-', 't > w+ b QED=1', 'z > mu+ mu- {T}'):
+            self.assertEqual(
+                interface_madspin.MadSpinInterface._split_group_tag(branch),
+                (branch, None))
+
+    # ----------------------------------------------------------------- layout
+    def test_no_tag_is_not_a_grouping(self):
+        layout, reason = self._Stub([('z', ['z > e+ e-', 'z > u u~'])]) \
+                             ._decay_group_layout()
+        self.assertIsNone(layout)
+        self.assertIsNone(reason)
+
+    def test_layout_of_the_ttbar_idiom(self):
+        layout, reason = self._Stub(self.TTBAR)._decay_group_layout()
+        self.assertIsNone(reason)
+        self.assertEqual(layout['tags'], ['1', '2'])
+        # index i is also the number of the decay_<pdg>_<i> pool
+        self.assertEqual(layout['lines']['t'],  {'1': [0], '2': [1]})
+        self.assertEqual(layout['lines']['t~'], {'1': [0], '2': [1]})
+
+    def test_untagged_line_belongs_to_every_group(self):
+        layout, reason = self._Stub(
+            self.TTBAR + [('z', ['z > e+ e-'])])._decay_group_layout()
+        self.assertIsNone(reason)
+        self.assertEqual(layout['lines']['z'], {'1': [0], '2': [0]})
+
+    def test_stray_at_is_refused_not_half_read(self):
+        layout, reason = self._Stub(
+            [('t', ['t > w+ b @1 QED=1'])])._decay_group_layout()
+        self.assertIsNone(layout)
+        self.assertIn("not a group tag", reason)
+
+    # --------------------------------------------------------------- validate
+    def _validate(self, branches, to_decay, nb_event=100):
+        stub = self._Stub(branches)
+        layout, reason = stub._decay_group_layout()
+        self.assertIsNone(reason)
+        self.assertIsNotNone(layout)
+        return stub._validate_decay_groups(layout, to_decay, nb_event,
+                                           self.NAME2PDG)
+
+    def test_ttbar_is_supported(self):
+        ok, reason = self._validate(self.TTBAR, {6: 100, -6: 100})
+        self.assertTrue(ok, reason)
+
+    def test_four_tops_two_lines_per_group_is_supported(self):
+        """p p > t t t~ t~: a group hands its two lines for a pdg to the two
+        particles of that pdg, by the positional rule."""
+        branches = [
+            ('t',  ['t > w+ b, w+ > l+ vl @1', 't > w+ b, w+ > j j @1',
+                    't > w+ b, w+ > j j @2',   't > w+ b, w+ > j j @2']),
+            ('t~', ['t~ > w- b~, w- > j j @1', 't~ > w- b~, w- > j j @1',
+                    't~ > w- b~, w- > l- vl~ @2', 't~ > w- b~, w- > j j @2']),
+        ]
+        ok, reason = self._validate(branches, {6: 200, -6: 200})
+        self.assertTrue(ok, reason)
+
+    def test_group_missing_a_particle_is_refused(self):
+        branches = [('t',  ['t > w+ b, w+ > l+ vl @1',
+                            't > w+ b, w+ > j j @2']),
+                    ('t~', ['t~ > w- b~, w- > j j @1'])]      # no @2 for t~
+        ok, reason = self._validate(branches, {6: 100, -6: 100})
+        self.assertFalse(ok)
+        self.assertIn('@2', reason)
+        self.assertIn('t~', reason)
+
+    def test_wrong_line_count_for_the_multiplicity_is_refused(self):
+        """two tops per event but only one line per group."""
+        ok, reason = self._validate(self.TTBAR, {6: 200, -6: 200})
+        self.assertFalse(ok)
+        self.assertIn('1 decay line(s)', reason)
+
+    def test_tagged_and_untagged_for_the_same_particle_is_refused(self):
+        """the untagged line joins every group, so that group has two lines for
+        a particle the event carries once."""
+        branches = [('t',  ['t > w+ b, w+ > l+ vl @1',
+                            't > w+ b, w+ > j j @2',
+                            't > w+ b, w+ > ta+ vt']),
+                    ('t~', ['t~ > w- b~, w- > j j @1',
+                            't~ > w- b~, w- > l- vl~ @2'])]
+        ok, reason = self._validate(branches, {6: 100, -6: 100})
+        self.assertFalse(ok)
+        self.assertIn('2 decay line(s)', reason)
+
+    def test_mixed_final_states_are_refused(self):
+        """not every event carries a t, so there is no branching ratio per
+        group to normalise with."""
+        ok, reason = self._validate(self.TTBAR, {6: 150, -6: 150})
+        self.assertFalse(ok)
+        self.assertIn('same number', reason)
+
+    def test_multiparticle_parent_is_refused(self):
+        branches = [('t',  ['t > w+ b, w+ > l+ vl @1',
+                            't > w+ b, w+ > j j @2']),
+                    ('vv', ['vv > e+ e- @1', 'vv > u u~ @2'])]
+        ok, reason = self._validate(branches, {6: 100})   # 'vv' -> None
+        self.assertFalse(ok)
+        self.assertIn('multiparticle', reason)
+
+    def test_a_particle_absent_from_the_events_is_ignored(self):
+        """a decay line for a species that never appears is ignored anyway, so
+        it must not make the grouping unusable."""
+        branches = self.TTBAR + [('z', ['z > e+ e- @1', 'z > u u~ @2'])]
+        ok, reason = self._validate(branches, {6: 100, -6: 100})
+        self.assertTrue(ok, reason)

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1823,6 +1823,33 @@ class TestPolyfitConditioning(unittest.TestCase):
         self.assertIsNone(self._fit([0.0, 0.0, 0.1, 0.1], [1.0, 1.0, 2.0, 2.0]))
 
 
+class TestClampedPartialWidth(unittest.TestCase):
+    """_clamped_partial_width reconciles a *measured* partial width with the
+    param_card total. The two regimes are deliberate and long-standing, so they
+    are pinned here: a review read the helper as under-clamping, when in fact
+    capping the large-disagreement case is what would be wrong.
+    """
+
+    fct = staticmethod(
+        interface_madspin.MadSpinInterface._clamped_partial_width)
+
+    def test_below_the_total_is_untouched(self):
+        self.assertEqual(self.fct(0.4, 1.0), 0.4)
+        self.assertEqual(self.fct(1.0, 1.0), 1.0)
+
+    def test_a_per_cent_over_is_monte_carlo_noise_and_is_capped(self):
+        """Within 1% the excess is noise in the width measurement; capping keeps
+        the branching ratio at most 1 and costs nothing."""
+        self.assertEqual(self.fct(1.005, 1.0), 1.0)
+        self.assertEqual(self.fct(1.01, 1.0), 1.0)
+
+    def test_a_real_disagreement_is_reported_not_hidden(self):
+        """Past 1% the param_card total genuinely disagrees with what was
+        generated. The measured value is kept: capping would quietly reshape the
+        normalisation to match a card that is wrong, and swallow the evidence.
+        """
+        self.assertEqual(self.fct(1.5, 1.0), 1.5)
+        self.assertEqual(self.fct(20.0, 1.0), 20.0)
 class TestDecayGroupTagWarning(unittest.TestCase):
     """The `@` grouping tags of the semi-leptonic ttbar idiom are implemented
     only in madspin_v1. Everywhere else MG5 reads them as an ordinary process


### PR DESCRIPTION
Work of the "Verify positional decay assignment, scope @-tag support" session. I am opening the PR because the branch was finished but never pushed; **I have not reviewed or re-run it**, and the description below is taken from its own commit messages.

## What it does

The `@` suffix sorts decay lines into groups meant to be used together — the semi-leptonic ttbar idiom, where only the two charge assignments exist and no fully leptonic or fully hadronic event is produced. Only `madspin_v1` implemented it, by generating one decayed matrix element per group. The density modes fill one decay pool per particle and per channel and drew each channel independently, so the tag had nowhere to attach — and it was swallowed **silently**, because the decay-ME generation appends an `@` process number of its own and MG5 absorbs the user's as the sub-decay's. The card did not mean what it looked like it meant, with no warning.

The branch fixes that in three steps: warn that the tags are ignored, then parse and validate them into a layout the rest of the code can act on, then honour them in PA, onshell and madspin/full.

## Validation it reports

- a grouped run against the merge of one run per group, 20000 production events decayed off the same production file, reference built pairwise so the production kinematics are identical on both sides;
- the `n_part = 2` case (`p p > t t~ t t~`), where a group supplies two lines per pdg and the positional rule deals them out inside the group;
- PA: 142.54946 pb grouped against 71.26739 + 71.24537 = 142.51276 dedicated, ratio 1.000258; splitting the grouped sample by group and comparing each half with its own dedicated run, three of thirty comparisons land at 2.0–2.7 sigma and none reproduces at another seed;
- grouping forces the joint accept/reject, and that fallback is a no-op: a grouped card at the sequential default produces event records byte-identical to the same card with the joint test.

It also carries `doc/madspin_decay_groups.md` (544 lines) and 346 lines of unit tests.

## Needs work before merging

**The branch is based on 275462e52, i.e. madspin_density before #334 landed**, and conflicts in all three shared files (`MadSpin/decay.py`, `MadSpin/interface_madspin.py`, `tests/unit_tests/madspin/test_madspin.py`). #334 rewrote large parts of `interface_madspin.py` — 954 insertions in that file alone — so this needs a real merge, not a fast-forward.

One concrete consequence: this branch talks to the **old option API**. #334 replaced `sequential_decay` / `sequential_exact` / `sequential_joint_angles` with a single `unweighting = auto | joint | two_stage | sequential | sequential_global_retry`, so the "grouping forces the joint accept/reject" logic and its tests need re-expressing against `unweighting`.

## An independent confirmation of #334, worth recording

While validating the grouping, this session found — and its final commit documents — that `sequential_decay True` biased the top lineshape under madspin: one ungrouped card, the same production events, only the accept/reject changed, giving mean `m(top)` 173.16870 joint against 172.94647 sequential, 7.0 sigma with KS p = 0.0000, while every angular observable stayed within 1.0 sigma. PA showed the same at 2.1 sigma.

That is the same `Z_k` bias #334 was opened to fix, found independently and by a different route (a grouping study rather than a lineshape A/B). #334 is merged, so this branch will inherit the fix through the merge above.

## Summary by Sourcery

Support and validate MadSpin `@` decay grouping tags in density spin modes, ensuring grouped decays are correctly applied, reported, and fall back safely when unsupported.

New Features:
- Enable per-event decay grouping based on `@` tags in density-based spin modes (PA, onshell, madspin/full), drawing one group per event and assigning its channels to all relevant particles.
- Introduce support for grouped decays with multiple identical parents, using positional assignment within each group while keeping branching ratios consistent.

Bug Fixes:
- Prevent user `@` grouping tags from being silently misinterpreted as MG5 process numbers by stripping them before matrix-element and decay-command generation.
- Warn when `@` decay grouping tags are present but cannot be honoured in the current spin mode or configuration, avoiding misleading cards and unintended ungrouped behaviour.
- Clamp partial widths that exceed the total width to protect branching-ratio calculations and avoid hidden distortions, including for multi-channel positional cases.

Enhancements:
- Add infrastructure to parse, validate, and resolve decay-group layouts from MadSpin cards, including rectangular-shape checks against production events and multiparticle safeguards.
- Extend branching-ratio computation to handle grouped decays via per-group rate factors and probabilities, integrating group rates into the global BR factor.
- Force joint accept/reject when decay groups are present to preserve correct group fractions, and guard sequential accept/reject from being used with grouped decays.
- Refine decay-pool generation to track per-channel widths and support group-aware pool sizing and assignment multiplicity for identical channels.
- Update decay drawing logic to support group-aware channel selection while preserving existing positional and cross-section-weighted rules for ungrouped decays.

Documentation:
- Add `doc/madspin_decay_groups.md` describing the semantics of `@` decay grouping tags, supported card shapes, algorithmic design, limitations with sequential/two-stage unweighting, and validation results.

Tests:
- Add unit tests covering `@` tag parsing and warning behaviour across spin modes, decay-group layout and validation against production multiplicities, group drawing and per-particle channel selection, assignment multiplicity factors, and grouped branching-ratio and probability computations.
- Extend existing MadSpin tests with stubs and helpers for group drawing and decay selection to validate grouped behaviour with single and multiple identical parents.