### PR TITLE
MadSpin plan: record the PA up-front-mass-draw follow-up

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -1092,3 +1092,87 @@ tolerance), automatic for the restart schemes. So variant B's -0.034 GeV is not
 a broken weight. With the weights verified and the error models in the state
 described above, the honest summary is: weights correct, deviation unexplained,
 dropped because it is slower than variant A anyway.
+
+---
+
+## 11. Next: give PA the up-front mass draw
+
+Chipped out as its own task. Recorded here because it closes the asymmetry the
+option table currently has, and because it is the fix for the one measurement in
+section 10 that came out the wrong way round.
+
+### The asymmetry
+
+`two_stage` and `sequential_global_retry` need a mass set to unweight before the
+angles. Only the offshell spinmodes have one, in `_offshell_production`. Under
+PA each slot draws its own virtuality *inside* its own accept/reject
+(`_draw_offshell_mass` in the slot loop, guarded by `draw_mass`), so both modes
+are refused for PA and fall back to `sequential`. Half the option table is
+therefore unavailable in the mode that is the pole approximation's home.
+
+### Rename first: `sequential_with_mass`
+
+What PA does today deserves a name of its own rather than being "sequential,
+except different": the mass is drawn *and redrawn together with* that slot's
+angles. Nothing is frozen at any point, which is exactly why it needs no
+tabulated factor -- there is no conditional normalisation for a redraw-to-accept
+stage to divide out. It becomes a fifth value of `unweighting`, stays available
+for PA, and stays what `auto` picks there until measurement says otherwise.
+
+### What PA gains, and it is not what madspin gains
+
+Offshell, the up-front mass set buys a **fixed `rho_off`**, reused across angle
+retries; that reuse is what makes `two_stage` faster than the joint test. In PA
+rho is evaluated at *on-shell* momenta, is already fixed per production event and
+is already cached on it (`production._ms_density_prod`). There is nothing to
+gain there.
+
+What PA gains is the **production reshuffling jacobian**. With
+`density_keep_jacobian` on, `_production_jacobian_for` runs on every slot trial
+-- an `Event(str(production))` copy plus a reshuffle -- and a mass-set stage
+moves it to once per mass set, with the `J_k/J_{k-1}` telescoping disappearing
+entirely. That is the fix for the measurement in section 10 that came out
+backwards: **PA sequential is 22% slower than PA joint** (11.19 s against 9.17 s
+in one campaign), doing 5.01 production reshufflings per event against joint's
+3.14, despite drawing *fewer* decay events (5.01 against 6.28). The per-particle
+decomposition is supposed to beat the joint test and at n = 2 it does not.
+
+### PA needs its own tabulated factor, with a different integrand
+
+This is the part to get right, because it is the same trap as section 10's. PA
+needs no factor today only because nothing is frozen. Freeze the masses up front
+and the angle stage starts dividing out its own conditional normalisation:
+
+    Z_k^PA(m) = E_pool[ jac_dec(m, Omega) ]
+
+the decay-reshuffling jacobian averaged over the pool at that virtuality. It is
+**not** the offshell integrand: PA evaluates its matrix elements on shell, so
+there is no `Tr(D^off)/|M|^2_on` factor, only the phase-space jacobian. The
+machinery is the same -- bin in m, average, fit, multiply into the mass-set
+weight -- and `_build_z_tables` / `_zhat` / `_z_slot_keys` should be extended
+rather than duplicated, the probe already collecting the samples for free.
+
+Omit it and PA reproduces the bug of section 10 exactly: the accepted
+virtualities come out Breit-Wigner shaped instead of PA shaped.
+
+### What has to be shown
+
+- **the rename is inert**: `sequential_with_mass` must produce event records
+  bit-for-bit identical to PA today, same seed and same production events. If
+  not, the rename changed behaviour;
+- **the weight identity, per chain** (`sequential_debug`) on every new PA mode.
+  Deterministic, no error model to argue about, and it is the check that would
+  have caught the original bias at once;
+- **the lineshape** against PA joint, with replicas. `m(l+ vl)` and
+  `dphi(l+,l-)` are blind to this class of bug -- they were blind to the
+  original one -- and the cross section is blind by construction;
+- **speed**, quoted only within a single campaign with joint as an anchor.
+
+### And a matching question for madspin
+
+Whether `sequential_with_mass` should also exist for the offshell modes, purely
+so that PA and madspin offer the same set of options, is a separate question
+with a real obstacle: offshell, `rho_off` depends on the whole mass set jointly,
+so redrawing one slot's mass invalidates it and every slot already accepted
+against it. That is why `_offshell_production` exists at all. It is chipped out
+separately, with the answer "no, and here is the cost" explicitly allowed.


### PR DESCRIPTION
Documentation only — one new section in `MADSPIN_SEQUENTIAL_PLAN.md`, no code.

Records the follow-up that is now chipped out as its own task, so the reasoning does not live only in a task prompt.

**The asymmetry.** `two_stage` and `sequential_global_retry` need a mass set to unweight before the angles, and only the offshell spinmodes have one. Under PA each slot draws its own virtuality inside its own accept/reject, so both modes are refused there and fall back to `sequential` — half the option table is unavailable in the mode that *is* the pole approximation.

**Three things the section pins down**, because each is easy to get wrong:

- what PA does today earns its own name, `sequential_with_mass`: the mass is drawn *and redrawn together with* that slot's angles, which is precisely why it needs no tabulated factor — nothing is frozen, so no stage has a conditional normalisation to divide out;
- PA gains something *different* from madspin by hoisting the draw. Offshell, the mass set buys a fixed `rho_off` to reuse across angle retries. In PA rho is on-shell, already fixed per event and already cached, so there is nothing to reuse; what PA gains is the production reshuffling jacobian, moving `_production_jacobian_for` from once per slot trial to once per mass set. That is the fix for the section 10 measurement that came out backwards — PA sequential is 22% *slower* than PA joint (11.19 s vs 9.17 s, 5.01 production reshufflings per event against 3.14) despite drawing fewer decays;
- freezing the masses makes PA need its own tabulated normalisation, `Z_k^PA(m) = E_pool[jac_dec(m, Ω)]`. Same machinery as section 10, **different integrand** — PA's matrix elements are on shell, so there is no `Tr(D^off)/|M|²_on` factor, only the phase-space jacobian. Omitting it reproduces the section 10 bug exactly.

It also states what has to be shown before any of it lands: the rename must be bit-for-bit inert, the per-chain weight identity must hold on every new mode, and the lineshape is the observable to compare — `m(l+ vl)`, `dphi` and the cross section are all blind to this class of bug, as they were to the original one.

## Summary by Sourcery

Document the planned change to give PA an up-front mass draw in the madspin sequential plan, clarifying the current asymmetry, the intended `sequential_with_mass` mode, and the validation requirements before implementation.

Documentation:
- Add a new section describing the planned PA up-front mass-draw scheme, its impact on option availability, performance, and required tabulated normalization.
- Record the conditions and checks (bit-for-bit invariance, per-chain weight identity, lineshape comparison, and speed measurement) that must hold before the PA changes are adopted.
- Capture the open design question about offering `sequential_with_mass` for offshell modes and its trade-offs in terms of `rho_off` consistency.