### PR TITLE
Convert self.options['auto_update'] to float before assigning to update_delay

### DIFF
--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -7195,13 +7195,13 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
         if mode == 'mg5_start':
             timeout = 2
             default = 'n'
-            update_delay = self.options['auto_update'] * 24 * 3600
+            update_delay = float(self.options['auto_update']) * 24 * 3600
             if update_delay == 0:
                 return
         elif mode == 'mg5_end':
             timeout = 5
             default = 'n'
-            update_delay = self.options['auto_update'] * 24 * 3600
+            update_delay = float(self.options['auto_update']) * 24 * 3600
             if update_delay == 0:
                 return
             options.remove('on_exit')


### PR DESCRIPTION
Hi, this is a possible (ugly) fix for a minor issue. I am doing dome Madgraph work in LHCb, mainly from cvmfs that is read only. With read/write installations however, I got the auto_update triggered even if auto_update is set to 0. I traced it down to the fact that, under some circumstances (not completely clear when), the auto_update option is a string not an int/float. So for instance multiplying it by 24*3600 when it is '0' gives 24*3600 character zeros, and the '== 0' check fails. I understand that normally there is a `self.options[key] = int(self.options[key])` that should kick in for option auto_update, but in some cases this is not executed. My specific example is when I create a gridpack. Adding some debug printouts gets me
```
INFO: Creating gridpack 
P1_qq_wpwm_wp_lvl_wm_lvl
Cleaning  SubProcesses. 
INFO: gridpack created 
quit
INFO:  
more information in /home/avalassi/Powheg2026/stack11MR/work/41922004_6500_6500/index.html
quit
DEBUG: install_update( args=['update', '--mode=mg5_end'] )
DEBUG: self.options={... 'auto_update': '0', ...}
DEBUG: mode=mg5_end type(self.options[auto_update])=<class 'str'>
```

I think that the real fix would be to understand why the conversion is not executed in this case. As a workaround, I made a simple patch that converts it just before the comparison '==0' so that auto update is skipped in that case.

Please feel free to ignore this and develop a better patch...

Thanks
Andrea

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect nonzero auto-update delays when the auto_update option is stored as a string instead of a numeric value.