### PR TITLE
MadSpin: CI coverage for the unweighting schemes and their consistency

### DIFF
--- a/.github/workflows/madspin_parallel.yml
+++ b/.github/workflows/madspin_parallel.yml
@@ -27,11 +27,16 @@ on:
         description: 'Cores for test_short_madspin_multicore (parallel unweighting)'
         required: false
         default: '8'
+      identity_nevents:
+        description: 'Events for the unweighting identity / mode-resolution tests'
+        required: false
+        default: '800'
 
 env:
   MADSPIN_TEST_NEVENTS: ${{ github.event.inputs.nevents || '10000' }}
   MADSPIN_TEST_EFF_TOL: ${{ github.event.inputs.eff_tol || '0.15' }}
   MADSPIN_TEST_NB_CORE: ${{ github.event.inputs.nb_core || '8' }}
+  MADSPIN_IDENTITY_NEVENTS: ${{ github.event.inputs.identity_nevents || '800' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,6 +53,13 @@ jobs:
           - test_short_madspin_singletop
           - test_short_madspin_zz
           - test_short_madspin_multicore
+          # `set unweighting`: the four accept/reject schemes. The first two are
+          # deterministic (a per-chain weight identity, and the mode each run
+          # resolved to) and run on a few hundred events; the third is the
+          # statistical lineshape comparison and carries the real event count.
+          - test_short_madspin_unweighting_identity
+          - test_short_madspin_unweighting_resolution
+          - test_long_madspin_unweighting_consistency
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/checkout_mg5

--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -22,6 +22,12 @@ ratio, unweighting efficiency, log path, and decayed-LHE path.
 
 The factory is meant to be reused from a ``unittest.TestCase`` so that the
 heavy production step is shared across configurations within one test.
+
+The same machinery drives the ``unweighting`` comparisons: ``run_mode`` takes a
+per-run ``seed`` (for same-scheme replicas off one production sample) and
+``decays`` override, and the assertions at the bottom of this module cover the
+resolved scheme, the ``sequential_debug`` weight identity, and observable-level
+agreement between schemes.
 """
 
 from __future__ import absolute_import
@@ -101,12 +107,36 @@ DEFAULT_FAMILIES = {
 }
 
 
+# The four accept/reject schemes ``set unweighting`` selects, plus ``auto``.
+# They differ only in how the test is split and in what a rejection redraws --
+# every one of them is supposed to sample the same distribution.
+UNWEIGHTING_MODES = ('joint', 'two_stage', 'sequential',
+                     'sequential_global_retry')
+
+# ``sequential_debug`` compares two evaluations of the same weight that run
+# through different code, and the density matrices are complex64, so the ratio
+# can only be constant to single-precision epsilon. This is the floor of the
+# arithmetic, not of the physics: nothing may be asserted below it.
+FLOAT32_EPS = 1.1920929e-7
+# What the test actually requires. Measured spreads sit at 1.5-1.7e-7 -- just
+# above the float32 floor, as the arithmetic demands -- so a few times that
+# leaves room for the last bits to land differently on another platform while
+# staying 100x tighter than MadSpin's own CRITICAL (which fires at
+# ``density_tolerance`` = 1e-4). The margin costs nothing in sensitivity: a
+# decomposition missing a factor spreads by percent, not by 1e-6. Measured on
+# the mass-set weight before its jacobian was added, the spread was 1.4e-2 --
+# four orders of magnitude above this bound.
+IDENTITY_SPREAD_TOL = 1e-6
+
+
 class MadSpinResult(object):
     """Container for a single MadSpin run's outputs."""
 
     def __init__(self, config, lhe_path, log_path, wall_seconds,
                  BR, BR_err, efficiency, nevents_in,
-                 cross_out=None, cross_in=None):
+                 cross_out=None, cross_in=None,
+                 unweighting_mode=None, unweighting_why=None,
+                 identity=None, overflows=0, seed=None):
         self.config = config
         self.lhe_path = lhe_path
         self.log_path = log_path
@@ -115,6 +145,20 @@ class MadSpinResult(object):
         self.BR_err = BR_err
         self.efficiency = efficiency
         self.nevents_in = nevents_in
+        # Which accept/reject scheme the run actually used, as the run itself
+        # reported it ("MadSpin: unweighting = <mode> (<why>)"), plus the
+        # parenthesised reason. ``auto`` resolves on the process, so the card
+        # value alone does not answer this.
+        self.unweighting_mode = unweighting_mode
+        self.unweighting_why = unweighting_why
+        # ``sequential_debug`` report: an :class:`IdentityReport` or ``None``
+        # when the run did not do the check.
+        self.identity = identity
+        # Weights that exceeded their per-particle bound. Non-zero means that
+        # bound is under-estimated and the sample is (slightly) biased; kept
+        # for diagnostics rather than asserted on.
+        self.overflows = overflows
+        self.seed = seed
         # Final cross-section from the decayed LHE banner (pb). This is the
         # physics-observable that must match across modes: it is the product
         # production-cross-section x branching-ratio integrated over the
@@ -170,6 +214,75 @@ _RE_AVG_TRIAL = re.compile(
 _RE_WRITTEN = re.compile(
     r'Total number of events written:\s*(\d+)\s*/\s*(\d+)'
 )
+# Every density-mode run says once which accept/reject scheme it resolved to.
+# Matched per line rather than against the flattened text: the reason itself
+# ends in "particle(s)", so the closing parenthesis has to be the last one on
+# the line and not the first one the pattern reaches.
+_RE_UNWEIGHTING = re.compile(
+    r'MadSpin: unweighting = (\w+) \((.*)\)\s*$'
+)
+# ``sequential_debug``: the deterministic per-chain check that the product of
+# the stage weights is proportional to the joint weight recomputed by the joint
+# code for the same production event, virtualities and decays.
+_RE_IDENTITY_OK = re.compile(
+    r'MadSpin sequential: weight identity verified on (\d+) accepted chains'
+    r' -- chain weight / joint weight constant to ([0-9eE.+\-]+)'
+    r' \(ratio ([0-9eE.+\-]+)\)'
+)
+_RE_IDENTITY_FAIL = re.compile(
+    r'MadSpin sequential: the weight identity FAILED on (\d+) accepted chains'
+    r'.*?relative spread of the ratio ([0-9eE.+\-]+), mean ([0-9eE.+\-]+)'
+)
+_RE_OVERFLOW = re.compile(
+    r'MadSpin sequential: (\d+) weights exceeded their per-particle maximum'
+)
+
+
+IdentityReport = collections.namedtuple(
+    'IdentityReport', ['checks', 'spread', 'ratio', 'ok']
+)
+
+
+def _flatten(text):
+    """Collapse every run of whitespace to one space.
+
+    The log lines above are long enough that a handler (or a terminal capture)
+    may fold them; matching against the flattened text makes the regexes
+    insensitive to where the fold lands."""
+    return re.sub(r'\s+', ' ', text)
+
+
+def _parse_unweighting(text):
+    """``(mode, why)`` from the run's own announcement, or ``(None, None)``."""
+    match = None
+    for line in text.splitlines():
+        found = _RE_UNWEIGHTING.search(line)
+        if found:
+            match = found  # logged once, but take the last just in case
+    if match is None:
+        return None, None
+    return match.group(1), match.group(2)
+
+
+def _parse_identity(text):
+    """The ``sequential_debug`` report as an :class:`IdentityReport`.
+
+    Returns ``None`` when the run did not run the check at all (the option is
+    off, or the mode/spinmode combination does not support it) -- which is a
+    different thing from the check running and failing, and callers must not
+    confuse the two."""
+    flat = _flatten(text)
+    match = _RE_IDENTITY_FAIL.search(flat)
+    if match:
+        return IdentityReport(checks=int(match.group(1)),
+                              spread=float(match.group(2)),
+                              ratio=float(match.group(3)), ok=False)
+    match = _RE_IDENTITY_OK.search(flat)
+    if match:
+        return IdentityReport(checks=int(match.group(1)),
+                              spread=float(match.group(2)),
+                              ratio=float(match.group(3)), ok=True)
+    return None
 
 
 def _parse_log(text):
@@ -349,21 +462,27 @@ class MadSpinFactory(object):
     # ------------------------------------------------------------------
     # Per-mode MadSpin execution.
     # ------------------------------------------------------------------
-    def _write_madspin_card(self, card_path, evt_path, config, extra_settings=None):
-        lines = [
-            'set spinmode %s' % config.spinmode,
-            'set seed %d' % self.seed,
-            'set max_running_process 4',
-        ]
+    def _write_madspin_card(self, card_path, evt_path, config,
+                            extra_settings=None, seed=None, decays=None):
         merged = dict(self.extra_madspin_settings)
         if extra_settings:
             merged.update(extra_settings)
+        # MadSpin seeds its RNG on the *first* ``set seed`` of the card and
+        # ignores every later one, so a seed override has to replace that line
+        # rather than be appended: an appended one silently reproduces the same
+        # run. Pull it out of the merged settings for the same reason.
+        seed = merged.pop('seed', seed)
+        lines = [
+            'set spinmode %s' % config.spinmode,
+            'set seed %d' % (self.seed if seed is None else int(seed)),
+            'set max_running_process 4',
+        ]
         for key, val in merged.items():
             lines.append('set %s %s' % (key, val))
         for mp_name, mp_def in self.multiparticles.items():
             lines.append('define %s = %s' % (mp_name, mp_def))
         lines.append('import %s' % evt_path)
-        for decay in self.decays:
+        for decay in (self.decays if decays is None else decays):
             stripped = decay.strip()
             if not stripped.startswith('decay '):
                 stripped = 'decay ' + stripped
@@ -372,7 +491,8 @@ class MadSpinFactory(object):
         with open(card_path, 'w') as fp:
             fp.write('\n'.join(lines) + '\n')
 
-    def run_mode(self, config, extra_settings=None, run_tag=None):
+    def run_mode(self, config, extra_settings=None, run_tag=None, seed=None,
+                 decays=None):
         """Run MadSpin once for the given :class:`SpinModeConfig`.
 
         ``extra_settings`` -- optional ``{key: val}`` merged over the factory's
@@ -380,6 +500,13 @@ class MadSpinFactory(object):
         exercise the process-parallel unweighting path).
         ``run_tag`` -- optional suffix so the *same* config can be run more than
         once into distinct run dirs / result keys (defaults to ``config.label``).
+        ``seed`` -- optional MadSpin seed for this run only, replacing the
+        factory's. Use it to run the same configuration twice off the *same*
+        production events, which is the replica needed to calibrate how far
+        apart two runs of one scheme land.
+        ``decays`` -- optional decay lines replacing the factory's for this run
+        only. Mainly so a run can decay *fewer* particles off the same
+        production sample, which is what ``auto`` keys its choice of scheme on.
         """
         key = config.label if not run_tag else '%s_%s' % (config.label, run_tag)
         if key in self._results:
@@ -397,7 +524,8 @@ class MadSpinFactory(object):
         files.cp(self.events_file, evt_path)
 
         card_path = pjoin(run_dir, 'madspin_card.dat')
-        self._write_madspin_card(card_path, evt_path, config, extra_settings)
+        self._write_madspin_card(card_path, evt_path, config, extra_settings,
+                                 seed=seed, decays=decays)
 
         log_path = pjoin(run_dir, 'madspin.log')
         _logger.info('%s[%s]: running MadSpin (log: %s)',
@@ -431,6 +559,10 @@ class MadSpinFactory(object):
         BR, accepted, trials, efficiency = _parse_log(log_text)
         if efficiency is None and accepted is not None and trials:
             efficiency = float(accepted) / float(trials)
+        unweighting_mode, unweighting_why = _parse_unweighting(log_text)
+        identity = _parse_identity(log_text)
+        overflow_match = _RE_OVERFLOW.search(_flatten(log_text))
+        overflows = int(overflow_match.group(1)) if overflow_match else 0
 
         # Always read the decayed banner's cross-section -- this is the
         # physics-observable we want to compare across modes.
@@ -458,6 +590,11 @@ class MadSpinFactory(object):
             nevents_in=self.nevents,
             cross_out=cross_out,
             cross_in=getattr(self, 'cross_in', None),
+            unweighting_mode=unweighting_mode,
+            unweighting_why=unweighting_why,
+            identity=identity,
+            overflows=overflows,
+            seed=self.seed if seed is None else int(seed),
         )
         self._results[key] = result
         return result
@@ -719,28 +856,39 @@ def assert_efficiency_ordering(test, results,
                eff['PA_density'], madspin_density_slack, eff))
 
 
-def _resonance_masses(result, parent_pdg, child_pdgs=None):
+def resonance_masses(result, parent_pdg, child_pdgs=None):
     """Return the list of invariant masses of the parent resonance.
 
     The mass is reconstructed from the sum of its decay products' 4-momenta.
     If ``child_pdgs`` is provided, only resonances whose children match the
-    given (sorted) PDG tuple are included; otherwise any decay is kept."""
+    given (sorted) PDG tuple are included; otherwise any decay is kept.
+
+    ``Event.parse`` rewrites each particle's ``mother1`` from the 1-indexed LHE
+    field into a reference to the mother :class:`Particle` itself (whose
+    ``event_id`` is its 0-based position), so the mother has to be resolved
+    through the object and not by casting the field to an int. Both forms are
+    handled here: an unparsed event still carries the numeric field."""
     target_children = tuple(sorted(child_pdgs)) if child_pdgs else None
     masses = []
     for event in result.open_lhe():
-        # Group particles by mother index (LHE mother fields are 1-indexed).
+        # Group particles by their mother's 0-based index in the event.
         by_mother = collections.defaultdict(list)
         for idx, p in enumerate(event):
-            try:
-                m1 = int(p.mother1)
-            except (TypeError, ValueError):
-                m1 = 0
-            if m1 > 0:
-                by_mother[m1].append(idx)
+            mother = p.mother1
+            if not mother:
+                continue
+            event_id = getattr(mother, 'event_id', None)
+            if event_id is None:
+                try:
+                    event_id = int(mother) - 1  # LHE field is 1-indexed
+                except (TypeError, ValueError):
+                    continue
+            if event_id >= 0:
+                by_mother[event_id].append(idx)
         for idx, p in enumerate(event):
             if p.pdg != parent_pdg:
                 continue
-            kids = by_mother.get(idx + 1, [])
+            kids = by_mother.get(idx, [])
             if not kids:
                 continue
             if target_children is not None:
@@ -755,6 +903,10 @@ def _resonance_masses(result, parent_pdg, child_pdgs=None):
             if m2 > 0:
                 masses.append(math.sqrt(m2))
     return masses
+
+
+# Back-compat alias: the name was private when only this module used it.
+_resonance_masses = resonance_masses
 
 
 def assert_offshell_mass_distribution(test, results, parent_pdg,
@@ -849,3 +1001,223 @@ def assert_offshell_mass_distribution(test, results, parent_pdg,
             5 * width / pole_mass + 0.02,
             'mode %s median mass %.3f far from pole %.3f (Gamma=%.3f)'
             % (label, median, pole_mass, width))
+
+
+# ---------------------------------------------------------------------------
+# Unweighting-scheme comparisons.
+#
+# ``set unweighting`` picks how the accept/reject is organised; all four
+# schemes are supposed to sample the *same* distribution, differing only in how
+# the test is split and in what a rejection redraws. The helpers below are what
+# a test needs to hold them to that.
+# ---------------------------------------------------------------------------
+
+def final_state_dphi(result, pdgs_a, pdgs_b):
+    """``|delta phi|`` in ``[0, pi]``, one entry per event, between the first
+    final-state particle whose PDG is in ``pdgs_a`` and the first in
+    ``pdgs_b``. Events not containing both are skipped."""
+    set_a = set(pdgs_a)
+    set_b = set(pdgs_b)
+    out = []
+    for event in result.open_lhe():
+        pa = pb = None
+        for particle in event:
+            if particle.status != 1:
+                continue
+            # independent tests, not elif: the two PDG sets are disjoint in
+            # every current caller, but an overlapping one must not have its
+            # first match consumed by whichever branch was tried first
+            if pa is None and particle.pdg in set_a:
+                pa = particle
+                continue
+            if pb is None and particle.pdg in set_b:
+                pb = particle
+            if pa is not None and pb is not None:
+                break
+        if pa is None or pb is None:
+            continue
+        dphi = math.atan2(pa.py, pa.px) - math.atan2(pb.py, pb.px)
+        while dphi > math.pi:
+            dphi -= 2 * math.pi
+        while dphi < -math.pi:
+            dphi += 2 * math.pi
+        out.append(abs(dphi))
+    return out
+
+
+def mean_and_error(values, window=None):
+    """``(mean, standard error, n)`` over ``values``, optionally truncated to
+    ``window=(lo, hi)``.
+
+    A window cuts the Breit-Wigner tails out of the mean and so reduces its
+    run-to-run scatter -- but for comparing *lineshapes* that is a bad trade,
+    and measurably so: on the reconstructed top mass a +-10 GeV window cuts the
+    replica scatter by 1.7x and the offshell-vs-pole-approximation difference by
+    2.2x, i.e. it costs more signal than noise. Those tails carry a
+    disproportionate share of what distinguishes the two shapes. Leave ``window``
+    unset unless something has been measured that says otherwise.
+
+    Note the returned error is the *naive* per-run one; see
+    :func:`assert_observable_consistent` for why it is not the right yardstick
+    for comparing two MadSpin runs off one production sample."""
+    if window is not None:
+        lo, hi = window
+        values = [v for v in values if lo <= v <= hi]
+    n = len(values)
+    if n < 2:
+        return (values[0] if n else float('nan')), float('inf'), n
+    mean = sum(values) / n
+    variance = sum((v - mean) ** 2 for v in values) / (n - 1)
+    return mean, math.sqrt(variance / n), n
+
+
+def assert_unweighting_mode(test, result, expected, expected_why=None):
+    """The scheme the run *actually used*, as the run itself announced it.
+
+    Non-statistical and instant, and it is the guard on the resolution logic:
+    ``auto`` resolves on the process, and several combinations override what
+    the card asked for (``fixed_order`` and unsupported spinmodes force
+    ``joint``; ``two_stage`` and ``sequential_global_retry`` need an offshell
+    spinmode and fall back to ``sequential`` under PA/onshell). Without this a
+    consistency matrix could compare four runs of the same scheme and pass."""
+    test.assertIsNotNone(
+        result.unweighting_mode,
+        "no 'MadSpin: unweighting = ...' line in %s -- the run never announced "
+        "which accept/reject scheme it used" % result.log_path)
+    test.assertEqual(
+        result.unweighting_mode, expected,
+        'run %s resolved unweighting = %s (%s), expected %s (log: %s)'
+        % (result.label, result.unweighting_mode, result.unweighting_why,
+           expected, result.log_path))
+    if expected_why is not None:
+        test.assertIn(
+            expected_why, result.unweighting_why or '',
+            'run %s resolved to %s but for the wrong reason: %r does not '
+            'mention %r (log: %s)'
+            % (result.label, expected, result.unweighting_why, expected_why,
+               result.log_path))
+
+
+def assert_weight_identity(test, result, min_checks=100,
+                           max_spread=IDENTITY_SPREAD_TOL):
+    """``sequential_debug``: the per-chain check that the product of the stage
+    weights is proportional to the joint weight, recomputed by the joint code
+    for the same production event, the same virtualities and the same decays.
+
+    This is the assertion to lead with. It settles the weight algebra with *no
+    statistics at all*: a scheme whose decomposition is broken has a ratio that
+    varies chain to chain, and that shows up on the first few hundred chains
+    whatever the sample size. It cannot flake, and it catches exactly the class
+    of bug -- a missing mass-dependent normalisation -- that left every angular
+    observable and the cross section clean while moving the reconstructed
+    lineshape by 0.25 GeV.
+
+    ``max_spread`` defaults to :data:`IDENTITY_SPREAD_TOL`, a few times float32
+    epsilon: the density matrices are ``complex64``, so the two evaluation
+    routes cannot agree better than that however correct the algebra is. Never
+    assert below :data:`FLOAT32_EPS`."""
+    test.assertIsNotNone(
+        result.identity,
+        'run %s produced no weight-identity report: sequential_debug was off, '
+        'or the mode/spinmode combination skipped the check. This test is '
+        'meaningless without it (log: %s)' % (result.label, result.log_path))
+    report = result.identity
+    test.assertTrue(
+        report.ok,
+        'weight identity FAILED for %s on %d chains: the chain weight is not '
+        'proportional to the joint weight (relative spread %.3g, mean %.10g). '
+        'This scheme is not sampling the joint distribution (log: %s)'
+        % (result.label, report.checks, report.spread, report.ratio,
+           result.log_path))
+    test.assertGreaterEqual(
+        report.checks, min_checks,
+        'weight identity for %s was only exercised on %d chains (< %d): too '
+        'few for the check to mean anything (log: %s)'
+        % (result.label, report.checks, min_checks, result.log_path))
+    test.assertLess(
+        report.spread, max_spread,
+        'weight identity for %s holds only to %.3g over %d chains, above the '
+        'bound %.3g (float32 floor %.3g). MadSpin did not flag it itself -- its '
+        'CRITICAL fires at density_tolerance, which is far looser than this '
+        'test (log: %s)'
+        % (result.label, report.spread, report.checks, max_spread,
+           FLOAT32_EPS, result.log_path))
+
+
+def assert_identity_ratios_agree(test, results, rel_tol=1e-6):
+    """Every scheme must reach the *same* proportionality constant.
+
+    The constant is the number of helicity states times the normalisation the
+    density path applies to the decay matrix elements -- it depends on the
+    process, not on how the accept/reject was split -- so two schemes reporting
+    different constants means one of them folds an extra factor into its chain
+    weight even though each is internally self-consistent."""
+    ratios = {label: r.identity.ratio for label, r in results.items()
+              if r.identity is not None}
+    if len(ratios) < 2:
+        return
+    items = sorted(ratios.items())
+    ref_label, ref = items[0]
+    for label, ratio in items[1:]:
+        rel = abs(ratio - ref) / max(abs(ref), 1e-30)
+        test.assertLess(
+            rel, rel_tol,
+            'weight-identity constant differs between schemes: %s=%.10g vs '
+            '%s=%.10g (rel=%.3g > %g). Each is self-consistent, so one of them '
+            'carries a factor the other does not.'
+            % (ref_label, ref, label, ratio, rel, rel_tol))
+
+
+def assert_observable_consistent(test, samples, tolerance, name,
+                                 reference=None, window=None):
+    """Every scheme's mean of ``name`` must sit within ``tolerance`` (absolute,
+    in the observable's own units) of the reference scheme's.
+
+    ``samples`` is ``{label: [values]}``; ``reference`` names the scheme to
+    compare against and defaults to the first key.
+
+    **On the tolerance.** Do not derive it from the naive per-run Monte Carlo
+    error. Runs of the same scheme with different MadSpin seeds share the
+    production events, so they are strongly correlated and land much closer
+    together than that error suggests -- measured on 10000-event ttbar, joint
+    replicas scatter by 0.005 GeV on the mean reconstructed top mass against a
+    naive per-run error of 0.023. Using the naive error would have let the
+    original 0.25 GeV bias through at small statistics. The tolerance passed
+    here must instead be calibrated by running the *same* scheme twice at the
+    event count the test actually uses; the caller is expected to say in a
+    comment what it measured."""
+    stats = collections.OrderedDict()
+    for label, values in samples.items():
+        stats[label] = mean_and_error(values, window=window)
+    labels = list(stats.keys())
+    test.assertTrue(labels, 'no samples given for %s' % name)
+    ref_label = reference if reference is not None else labels[0]
+    test.assertIn(ref_label, stats,
+                  'reference scheme %s absent from the %s comparison'
+                  % (ref_label, name))
+    ref_mean, ref_err, ref_n = stats[ref_label]
+
+    dump = ', '.join('%s=%.4f+-%.4f (n=%d)' % (lab, m, e, n)
+                     for lab, (m, e, n) in stats.items())
+    test.assertGreater(
+        ref_n, 100,
+        'reference scheme %s has only %d entries of %s -- too few to compare '
+        'against (dump: %s)' % (ref_label, ref_n, name, dump))
+
+    for label in labels:
+        if label == ref_label:
+            continue
+        mean, err, n = stats[label]
+        test.assertGreater(
+            n, 100,
+            'scheme %s has only %d entries of %s (dump: %s)'
+            % (label, n, name, dump))
+        delta = mean - ref_mean
+        test.assertLess(
+            abs(delta), tolerance,
+            '%s: %s mean %.4f differs from %s %.4f by %+.4f, above the '
+            'calibrated tolerance %.4f. All four unweighting schemes must '
+            'sample the same distribution, so this is a real difference in '
+            'what the scheme samples, not a tuning knob. (dump: %s)'
+            % (name, label, mean, ref_label, ref_mean, delta, tolerance, dump))
+    return stats

--- a/tests/parallel_tests/test_madspin_factory.py
+++ b/tests/parallel_tests/test_madspin_factory.py
@@ -32,27 +32,48 @@ MadSpin density-mode table, and then asserts:
 CI runtime is dominated by the production step plus five MadSpin runs. With
 ``NEVENTS=10000`` and four-core MadSpin this is roughly 5-8 minutes per test
 on a GitHub Linux runner.
+
+:class:`MadSpinUnweightingTest` covers a different axis: ``set unweighting``,
+which chooses how the accept/reject is split, at a fixed spinmode. Its three
+tests are ordered by how much they assume --
+
+    * ``test_short_madspin_unweighting_identity``: per-chain, deterministic,
+      no statistics at all. This is the one to read first when something breaks;
+    * ``test_short_madspin_unweighting_resolution``: which scheme each run
+      actually resolved to, parsed from the run's own announcement;
+    * ``test_long_madspin_unweighting_consistency``: the statistical comparison
+      of the reconstructed resonance lineshape across schemes, with tolerances
+      calibrated from measured replicas (see the calibration note in the file).
 """
 
 from __future__ import absolute_import
 from __future__ import division
 
+import collections
 import logging
+import math
 import os
 import unittest
 
 from tests.parallel_tests.madspin_comparator import (
     DEFAULT_FAMILIES,
     DEFAULT_MODES,
+    UNWEIGHTING_MODES,
     MadSpinFactory,
     SpinModeConfig,
     assert_branching_ratios_consistent,
     assert_cross_sections_consistent,
     assert_efficiency_close,
     assert_efficiency_ordering,
+    assert_identity_ratios_agree,
     assert_lhe_well_formed,
     assert_multiplicities_consistent,
+    assert_observable_consistent,
     assert_offshell_mass_distribution,
+    assert_unweighting_mode,
+    assert_weight_identity,
+    final_state_dphi,
+    resonance_masses,
 )
 
 
@@ -77,9 +98,26 @@ EXTRA_MADSPIN_SETTINGS = {'sequential_decay': False}
 if _MAX_WEIGHT_PS_POINT:
     EXTRA_MADSPIN_SETTINGS['max_weight_ps_point'] = _MAX_WEIGHT_PS_POINT
 
+# The unweighting tests below drive ``unweighting`` directly, so they must not
+# inherit the deprecated ``sequential_decay`` alias above -- it resolves to a
+# mode of its own and would fight the per-run setting.
+UNWEIGHTING_BASE_SETTINGS = {'nb_core': 1}
+if _MAX_WEIGHT_PS_POINT:
+    UNWEIGHTING_BASE_SETTINGS['max_weight_ps_point'] = _MAX_WEIGHT_PS_POINT
 
-class MadSpinFactoryTest(unittest.TestCase):
-    """Base class that owns the factory lifetime."""
+# Event count for the weight-identity / mode-resolution test. Both checks are
+# deterministic -- the identity is verified chain by chain and the resolved mode
+# is announced during setup -- so this only has to be large enough to accumulate
+# a few hundred accepted chains.
+IDENTITY_NEVENTS = int(os.environ.get('MADSPIN_IDENTITY_NEVENTS', '800'))
+
+
+class _MadSpinFactoryBase(unittest.TestCase):
+    """Factory lifetime, shared by the test classes below.
+
+    Deliberately holds no ``test_*`` method of its own: unittest collects every
+    TestCase subclass, so a concrete test living here would be re-run once per
+    subclass."""
 
     maxDiff = None
 
@@ -112,6 +150,11 @@ class MadSpinFactoryTest(unittest.TestCase):
         factory = MadSpinFactory(**kw)
         self._factories.append(factory)
         return factory
+
+
+class MadSpinFactoryTest(_MadSpinFactoryBase):
+    """The five (spinmode, ME_mode) configurations of the MadSpin density-mode
+    table, compared against each other on one production sample."""
 
     def _run_all_modes(self, factory, modes=DEFAULT_MODES, skip_modes=()):
         """Run every config in ``modes`` whose label isn't in ``skip_modes``.
@@ -316,3 +359,320 @@ class MadSpinFactoryTest(unittest.TestCase):
         # 3. Unweighting efficiency should be statistically consistent (the two
         #    runs use independent RNG streams).
         assert_efficiency_close(self, serial, parallel, rel_tol=EFF_TOL)
+
+
+# ---------------------------------------------------------------------------
+# ``set unweighting``: the four accept/reject schemes.
+# ---------------------------------------------------------------------------
+
+# Fully leptonic ttbar. Two decaying particles at the top level (t and t~), so
+# ``auto`` lands on ``two_stage`` under an offshell spinmode -- and both tops
+# give a reconstructable lineshape while the two leptons give the angular
+# no-regression observable.
+TTBAR_LEPTONIC = dict(
+    production_process='p p > t t~',
+    decays=['t > b w+, w+ > l+ vl',
+            't~ > b~ w-, w- > l- vl~'],
+    multiparticles={'p': 'g u d s c u~ d~ s~ c~',
+                    'l+': 'e+ mu+', 'vl': 've vm',
+                    'l-': 'e- mu-', 'vl~': 've~ vm~'},
+    extra_run_card={'ebeam1': 6500, 'ebeam2': 6500},
+)
+
+L_PLUS = (-11, -13)
+L_MINUS = (11, 13)
+
+# ``joint`` first: it is the historical scheme and the reference every other one
+# is compared against. The rest need an offshell spinmode to keep the name they
+# were asked for, which is why the identity test runs them under ``madspin``.
+NON_JOINT_MODES = tuple(m for m in UNWEIGHTING_MODES if m != 'joint')
+
+# ---------------------------------------------------------------------------
+# Calibration of the consistency tolerances.  Re-derive it, do not guess at it.
+#
+# Campaign: `p p > t t~`, `t > b w+, w+ > l+ vl` and charge conjugate, spinmode
+# madspin, 5000 production events, nine MadSpin runs off that ONE sample -- the
+# four schemes with two seeds each (three for joint). All nine are replicas of
+# the same quantity if the schemes agree, so they estimate the run-to-run
+# scatter with 8 degrees of freedom rather than the 1 a single pair gives.
+# Both tops are pooled (same lineshape; pooling halves the error on it).
+#
+#                       m(l+ vl b)   m(l+ vl)   dphi(l+,l-)
+#   replica sd            0.0261      0.0275      0.0146
+#   naive per-run error   0.0316      0.0426      0.0128
+#   signal (see below)    0.2126      0.0334      0.0014
+#   signal / replica sd      8.2         1.2         0.1
+#
+# The *signal* is the bias this test exists to catch. The PR #334 bug made the
+# offshell scheme sample the PA/Breit-Wigner lineshape instead of the offshell
+# one, so a PA run off the same production sample reproduces it: the row above
+# is offshell-minus-PA, measured, and it lands on the -0.248 GeV that bug was
+# originally reported at.
+#
+# Three things fall out, and they are the whole design of the test:
+#
+# 1. **Only the lineshape can see it.** m(l+ vl) and dphi(l+,l-) have a
+#    signal-to-noise of 1.2 and 0.1 -- they would not have moved measurably had
+#    the bug still been there. They are asserted below as no-regression checks
+#    and must not be read as standing in for the lineshape.
+#
+# 2. **Do not window the lineshape.** The obvious refinement -- restrict the
+#    mean to the peak, where a mis-normalised virtuality weight bites -- was
+#    measured and is a net loss: a +-10 GeV window cuts the replica sd from
+#    0.0261 to 0.0155 but the signal from 0.2126 to 0.0949, so S/N falls from
+#    8.2 to 6.1. The Breit-Wigner tails carry a disproportionate share of the
+#    difference between the two lineshapes. The untruncated mean it is.
+#
+# 3. **Neither published error model is right, and the replicas settle it.**
+#    The plan document's two-replica estimate had joint scattering by 0.005
+#    against a naive error of 0.023, suggesting the runs were strongly
+#    correlated through the shared production events and the naive error was 4x
+#    too loose. Over nine replicas the ratio of replica sd to naive error is
+#    0.82 (lineshape), 0.65 (W mass) and 1.14 (dphi): mildly correlated at
+#    most. The 0.005 was a small-sample fluctuation. The tolerances below are
+#    therefore built on the measured replica sd, which is the thing the test
+#    actually has to survive.
+LINESHAPE_CALIB_NEVENTS = 5000
+# Replica sd (GeV, GeV, rad) at LINESHAPE_CALIB_NEVENTS, from the table above.
+CALIB_SD = {'lineshape': 0.0261, 'w_mass': 0.0275, 'dphi': 0.0146}
+# Two runs differ by sqrt(2) times a single run's scatter, and 4 sigma of that
+# leaves a per-comparison false-positive rate around 6e-5 -- with four
+# comparisons per test, a flake roughly once in four thousand runs. Even if the
+# sd above is underestimated by the ~25% its 8 degrees of freedom allow, that
+# only relaxes to 3.2 sigma.
+CALIB_NSIGMA = 4.0
+# Measured offshell-minus-PA on the lineshape: the size of the bias to catch.
+LINESHAPE_SIGNAL = 0.213
+
+
+def _consistency_tolerance(key, nevents):
+    """Tolerance for ``key`` at ``nevents``, scaled off the calibration.
+
+    The replica scatter is 0.65-1.14 of the naive Monte Carlo error, i.e.
+    dominated by it, so it scales as 1/sqrt(N) to the accuracy this needs."""
+    scale = math.sqrt(LINESHAPE_CALIB_NEVENTS / float(nevents))
+    return CALIB_NSIGMA * math.sqrt(2) * CALIB_SD[key] * scale
+
+
+class MadSpinUnweightingTest(_MadSpinFactoryBase):
+    """``set unweighting`` selects how the accept/reject is organised:
+
+        joint                    one test over the virtualities and every decay
+        two_stage                virtualities first, then all angles, one bound
+        sequential               virtualities first, then one test per particle
+        sequential_global_retry  as sequential, but a rejected decay redraws the
+                                 virtualities too
+
+    All four are supposed to sample the *same* distribution -- they differ only
+    in how the test is split and in what a rejection redraws. The tests here
+    hold them to that, and they are deliberately ordered weakest-assumption
+    first: the weight identity settles the algebra with no statistics at all,
+    the mode assertions are non-statistical guards on the resolution logic, and
+    only the lineshape comparison needs an error model.
+    """
+
+    def _unweighting_factory(self, name, nevents):
+        return self._make_factory(
+            name=name, nevents=nevents,
+            extra_madspin_settings=dict(UNWEIGHTING_BASE_SETTINGS),
+            **TTBAR_LEPTONIC)
+
+    # ------------------------------------------------------------------
+    def test_short_madspin_unweighting_identity(self):
+        """The deterministic check, plus the resolved-mode guards.
+
+        ``set sequential_debug True`` makes MadSpin recompute, on every accepted
+        chain, the joint weight for the *same* production event, the same
+        virtualities and the same decays, and verify that the product of the
+        stage weights is proportional to it. A scheme whose decomposition is
+        broken has a ratio that varies chain to chain, so this fails on the
+        first few hundred chains whatever the sample size -- no statistics, no
+        error model, nothing to flake.
+
+        That matters because the bug this whole area exists for (PR #334) was a
+        scheme sampling a subtly different distribution: the reconstructed top
+        lineshape came out Breit-Wigner shaped and 7.8 sigma off while every
+        angular observable and the cross section stayed clean. A statistical A/B
+        can only bound such a bias at the level its Monte Carlo error allows;
+        this settles the weight algebra outright.
+        """
+        factory = self._unweighting_factory('unweighting_identity',
+                                            IDENTITY_NEVENTS)
+        cfg = SpinModeConfig('madspin_density', 'madspin')
+
+        results = collections.OrderedDict()
+        for mode in NON_JOINT_MODES:
+            results[mode] = factory.run_mode(
+                cfg, run_tag=mode,
+                extra_settings={'unweighting': mode,
+                                'sequential_debug': 'True'})
+
+        for mode, result in results.items():
+            assert_lhe_well_formed(self, result)
+            _logger.info('[unweighting/%s] resolved=%s identity=%s eff=%s '
+                         'overflows=%d wall=%.1fs',
+                         mode, result.unweighting_mode, result.identity,
+                         result.efficiency, result.overflows,
+                         result.wall_seconds)
+            # An explicit setting is always honoured; if it were not, the
+            # identity below would be checking whatever scheme actually ran.
+            assert_unweighting_mode(self, result, mode, 'set explicitly')
+            # The lead assertion.
+            assert_weight_identity(
+                self, result, min_checks=max(100, IDENTITY_NEVENTS // 4))
+
+        # The proportionality constant is a property of the process (helicity
+        # states x the density path's decay-ME normalisation), not of how the
+        # accept/reject was split, so all three schemes must report the same
+        # one. Each could be internally self-consistent and still disagree here.
+        assert_identity_ratios_agree(self, results)
+
+    # ------------------------------------------------------------------
+    def test_short_madspin_unweighting_resolution(self):
+        """Which scheme a run actually uses, end to end.
+
+        ``auto`` resolves on the process, and several combinations override what
+        the card asked for, so the card value does not answer this -- but every
+        run announces the answer ("MadSpin: unweighting = <mode> (<why>)"). The
+        checks are instant and non-statistical, and without them a consistency
+        matrix could silently compare four runs of the same scheme and pass.
+
+        Covered here, all off one production sample:
+
+          * ``auto`` + offshell, two decaying particles -> ``two_stage``;
+          * ``auto`` + offshell, *one* decaying particle -> ``joint`` (every
+            split degenerates there). This is the one case that exercises the
+            real ``_nb_decaying`` count against real events;
+          * ``auto`` + PA -> ``sequential`` (PA has no up-front mass draw);
+          * ``two_stage`` / ``sequential_global_retry`` asked for explicitly
+            under PA/onshell -> ``sequential``, the documented fallback;
+          * ``joint`` asked for explicitly -> ``joint``.
+
+        Not covered: ``fixed_order`` forcing joint, which needs a fixed-order
+        sample this factory does not produce, and the unsupported-spinmode
+        fallback, which is unreachable from a real run (only PA/onshell/madspin
+        reach the resolution at all). Both are unit-tested against a stub.
+        """
+        factory = self._unweighting_factory('unweighting_resolution',
+                                            IDENTITY_NEVENTS)
+        offshell = SpinModeConfig('madspin_density', 'madspin')
+        pa = SpinModeConfig('PA_density', 'PA')
+        onshell = SpinModeConfig('onshell_density', 'onshell')
+
+        # (tag, config, asked, decays, expected mode, expected reason)
+        cases = [
+            ('auto_offshell', offshell, 'auto', None,
+             'two_stage', 'auto, 2 decaying particle(s)'),
+            ('auto_offshell_single', offshell, 'auto',
+             ['t > b w+, w+ > l+ vl'],
+             'joint', 'auto, 1 decaying particle(s)'),
+            ('auto_pa', pa, 'auto', None,
+             'sequential', 'auto, 2 decaying particle(s)'),
+            ('two_stage_pa', pa, 'two_stage', None,
+             'sequential', 'set explicitly'),
+            ('global_retry_onshell', onshell, 'sequential_global_retry', None,
+             'sequential', 'set explicitly'),
+            ('joint_offshell', offshell, 'joint', None,
+             'joint', 'set explicitly'),
+        ]
+        for tag, cfg, asked, decays, expected, why in cases:
+            result = factory.run_mode(cfg, run_tag=tag, decays=decays,
+                                      extra_settings={'unweighting': asked})
+            _logger.info('[resolution/%s] asked=%s spinmode=%s -> %s (%s)',
+                         tag, asked, cfg.spinmode, result.unweighting_mode,
+                         result.unweighting_why)
+            assert_unweighting_mode(self, result, expected, why)
+
+    # ------------------------------------------------------------------
+    def test_long_madspin_unweighting_consistency(self):
+        """One production sample, the four schemes run off it, compared on the
+        observable that the class of bug they can carry actually moves.
+
+        **The reconstructed resonance lineshape is that observable.** ``m(l+ vl
+        b)`` -- the top reconstructed from its decay products -- is what the
+        original bug shifted by 0.25 GeV, and the calibration above measures its
+        signal-to-noise at 8.2 against 1.2 for ``m(l+ vl)`` and 0.1 for
+        ``dphi(l+, l-)``. The other two are asserted as no-regression checks and
+        nothing more: at those ratios they would not have moved measurably even
+        with the bug still in place, so they must never be read as standing in
+        for the lineshape.
+
+        **The cross section is deliberately not compared.** MadSpin writes
+        sigma_in x BR into the decayed banner, which does not depend on the
+        unweighting weight at all -- it would agree to machine precision between
+        a correct scheme and a broken one.
+
+        A ``joint`` replica (same scheme, same production events, different
+        MadSpin seed) is run as a control. It is held to the same tolerance as
+        the other schemes, so a failure says which of the two things went wrong:
+        if the control fails too, the tolerance is too tight for this event
+        count; if only a scheme fails, that scheme samples something else.
+        """
+        lineshape_tol = _consistency_tolerance('lineshape', NEVENTS)
+        # State the test's own power rather than letting it quietly evaporate
+        # if someone turns MADSPIN_TEST_NEVENTS down.
+        self.assertLess(
+            lineshape_tol, LINESHAPE_SIGNAL,
+            'at %d events the calibrated lineshape tolerance is %.3f GeV, at or '
+            'above the %.3f GeV bias this test exists to catch -- it would pass '
+            'the PR #334 bug. Raise MADSPIN_TEST_NEVENTS to at least %d.'
+            % (NEVENTS, lineshape_tol, LINESHAPE_SIGNAL,
+               int(math.ceil(LINESHAPE_CALIB_NEVENTS
+                             * (CALIB_NSIGMA * math.sqrt(2)
+                                * CALIB_SD['lineshape'] / LINESHAPE_SIGNAL) ** 2))))
+        if lineshape_tol > 0.5 * LINESHAPE_SIGNAL:
+            _logger.warning(
+                'lineshape tolerance %.3f GeV is over half the %.3f GeV bias '
+                'being guarded against: %d events leaves little margin',
+                lineshape_tol, LINESHAPE_SIGNAL, NEVENTS)
+        factory = self._unweighting_factory('unweighting_consistency', NEVENTS)
+        cfg = SpinModeConfig('madspin_density', 'madspin')
+
+        runs = collections.OrderedDict()
+        for mode in UNWEIGHTING_MODES:
+            runs[mode] = factory.run_mode(
+                cfg, run_tag=mode, extra_settings={'unweighting': mode})
+        # The control: joint again, off the same production events, with a
+        # different MadSpin seed. MadSpin seeds its RNG on the first `set seed`
+        # of the card and ignores every later one, so this has to replace that
+        # line -- which is what the factory's `seed` argument does.
+        runs['joint_replica'] = factory.run_mode(
+            cfg, run_tag='joint_replica', seed=factory.seed + 1,
+            extra_settings={'unweighting': 'joint'})
+
+        for label, result in runs.items():
+            assert_lhe_well_formed(self, result)
+            _logger.info('[consistency/%s] resolved=%s seed=%s eff=%s '
+                         'cross_out=%s overflows=%d wall=%.1fs',
+                         label, result.unweighting_mode, result.seed,
+                         result.efficiency, result.cross_out, result.overflows,
+                         result.wall_seconds)
+            expected = 'joint' if label.startswith('joint') else label
+            assert_unweighting_mode(self, result, expected, 'set explicitly')
+
+        # Pool both tops: they are the same lineshape, and pooling halves the
+        # statistical error on it.
+        lineshape = collections.OrderedDict(
+            (label, resonance_masses(r, 6) + resonance_masses(r, -6))
+            for label, r in runs.items())
+        w_mass = collections.OrderedDict(
+            (label, resonance_masses(r, 24) + resonance_masses(r, -24))
+            for label, r in runs.items())
+        dphi = collections.OrderedDict(
+            (label, final_state_dphi(r, L_PLUS, L_MINUS))
+            for label, r in runs.items())
+
+        # The observable that matters. Untruncated on purpose -- see the
+        # calibration note: a peak window cuts the signal harder than the noise.
+        assert_observable_consistent(
+            self, lineshape, lineshape_tol, 'm(l+ vl b) [GeV]',
+            reference='joint')
+        # No-regression only (S/N 1.2 and 0.1 against this class of bug).
+        assert_observable_consistent(
+            self, w_mass, _consistency_tolerance('w_mass', NEVENTS),
+            'm(l+ vl) [GeV] (no-regression only, blind to the lineshape bias)',
+            reference='joint')
+        assert_observable_consistent(
+            self, dphi, _consistency_tolerance('dphi', NEVENTS),
+            'dphi(l+,l-) [rad] (no-regression only, blind to the lineshape '
+            'bias)', reference='joint')


### PR DESCRIPTION
`set unweighting` picks how the accept/reject is split — `joint`, `two_stage`, `sequential`, `sequential_global_retry` — and all four are supposed to sample the same distribution. Nothing in CI checked that.

The bug that motivated the option (#334) was exactly a scheme sampling a subtly different distribution: the reconstructed top lineshape came out Breit-Wigner shaped, 7.8σ off, while every angular observable and the cross section stayed clean.

## Three tests, ordered by how much they assume

| test | events | wall |
|---|---|---|
| `test_short_madspin_unweighting_identity` | 800 | 173 s |
| `test_short_madspin_unweighting_resolution` | 800 | 305 s |
| `test_long_madspin_unweighting_consistency` | 10000 | 383 s |

All three are added to the `madspin_parallel.yml` matrix (now 7 jobs), each on its own runner, invoked with `-t0` — `test_manager` otherwise applies a 400 s cap to `tests/parallel_tests` and would silently skip the long one.

**`..._identity` leads.** `set sequential_debug True` makes MadSpin recompute the joint weight on every accepted chain — same production event, same virtualities, same decays — and check the product of the stage weights is proportional to it. No statistics at all, so it cannot flake and it fails the moment a decomposition breaks. Asserted at `1e-6`: a few times the float32 floor the `complex64` density matrices impose (measured spreads 1.33–1.71e-7), and 100× tighter than MadSpin's own CRITICAL at `density_tolerance = 1e-4`. All three schemes must also agree on the proportionality constant, which depends on the process and not on how the test was split.

**`..._resolution`** asserts the mode each run actually resolved to, parsed from the run's own announcement: `auto` → `two_stage` on two decaying particles, `joint` on one, `sequential` under PA, and the offshell-only fallback of `two_stage` / `sequential_global_retry` to `sequential`. Instant and non-statistical; without it the matrix below could compare four runs of the same scheme and pass. `fixed_order` and the unsupported-spinmode fallback are not reachable from a real run here and stay unit-tested against a stub.

**`..._consistency`** runs the four schemes plus a `joint` replica off one production sample and compares the reconstructed resonance lineshape.

## The tolerance is calibrated, not picked

Nine MadSpin runs off one 5000-event ttbar sample (four schemes × two seeds, three for `joint`) give the run-to-run scatter with 8 dof. A PA run off the same sample reproduces what the buggy scheme sampled, and gives the signal:

```
                      m(l+ vl b)   m(l+ vl)   dphi(l+,l-)
  replica sd            0.0261      0.0275      0.0146
  naive per-run error   0.0316      0.0426      0.0128
  signal (offshell-PA)  0.2126      0.0334      0.0014
  signal / replica sd      8.2         1.2         0.1
```

So only the lineshape can see this class of bug. `m(l+ vl)` and `dphi(l+,l-)` are asserted as no-regression checks and labelled as blind. Substituting the PA sample in as `sequential` was verified to **fail the lineshape assertion while leaving both others passing** — the blindness is demonstrated, not assumed.

The cross section is deliberately not compared: MadSpin writes `sigma_in × BR`, which is independent of the unweighting weight entirely.

Two measurement notes worth keeping:

- **Windowing the lineshape is a net loss.** A ±10 GeV window cuts the noise 1.7× but the signal 2.2×, so the mean is untruncated.
- **The plan document's error model was a small-sample artefact.** Its two-replica estimate had `joint` scattering 0.005 against a naive error of 0.023, suggesting the runs were strongly correlated through the shared production events. Over nine replicas the ratio of replica sd to naive error is 0.65–1.14 — mildly correlated at most.

Tolerance is 4σ of the difference, scaled `1/sqrt(N)`. The test asserts its own power rather than letting it evaporate if `MADSPIN_TEST_NEVENTS` is turned down: below ~2400 events it refuses to run instead of passing vacuously.

## Drive-by fix: `resonance_masses` reconstructed nothing

`Event.parse` rewrites `mother1` into a reference to the mother `Particle`, so `int(p.mother1)` raised and every mass was silently dropped. **`assert_offshell_mass_distribution` has therefore been a no-op in `test_short_madspin_ttbar` and `test_short_madspin_zz`.** It is live now and both still pass — but it has never actually constrained anything before, so treat its tolerances as unvalidated rather than proven.

## Scope

`tests/parallel_tests/` only, plus `.github/workflows/madspin_parallel.yml` (the tests need matrix entries there or they never run). Nothing touched in `MadSpin/`, `madgraph/` or `tests/unit_tests/`, so no overlap with the parallel PA-unweighting work.

`MadSpinFactory` gains per-run `seed` (replacing the card's first `set seed`, the only one MadSpin honours — an appended one silently reproduces the same run) and `decays` overrides. The shared factory lifetime moves to `_MadSpinFactoryBase` so the new class does not re-run the existing tests.

## Note on CI gating

The workflow trigger is unchanged: `push` only on the literal `3.x`, plus `pull_request` and `workflow_dispatch`. These jobs therefore will **not** fire on `madspin_density` pushes — only on a PR like this one, or a manual run. Left alone on purpose rather than widening the trigger as a side effect; change the `branches:` list if you want them on every `madspin_density` push.

Timings above are on an Apple-silicon machine that generated 5000 ttbar events in 19 s; a GitHub `ubuntu-22.04` runner is considerably slower. The long test is 5 offshell `madspin` runs and the only one scaling with `MADSPIN_TEST_NEVENTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate that MadSpin's unweighting schemes resolve as intended and sample consistent physics distributions in CI.

New Features:
- Add CI tests covering unweighting-scheme resolution, deterministic weight identities, and observable consistency across all MadSpin schemes.

Bug Fixes:
- Fix resonance-mass reconstruction so off-shell mass distribution assertions process parsed LHE event ancestry correctly.

Enhancements:
- Extend MadSpin test utilities to support per-run seeds, decay overrides, log diagnostics, and cross-scheme observable comparisons.
- Refactor shared MadSpin factory lifecycle for reuse across the existing and new test classes.

CI:
- Add three unweighting test jobs and configurable identity-test event counts to the MadSpin parallel CI workflow.

Tests:
- Add deterministic identity and resolution coverage plus statistical resonance-lineshape and no-regression observable checks for MadSpin unweighting schemes.