### PR TITLE
MadSpin: pair decay branches to identical-PID mothers in order

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -1050,7 +1050,15 @@ class AllMatrixElement(dict):
             pid =  leg.get('id')
             nb = leg.get('number')
             if pid in to_decay and leg.get('state'):
-                i, proc = to_decay[pid].pop()
+                # FIFO: pair the n-th leg of a given pid with the n-th decay
+                # branch written for that pid. pop() (LIFO) reverses that
+                # pairing whenever two or more final-state particles share a
+                # pid and carry *different* branches (p p > z z with
+                # 'decay z > e+ e-' / 'decay z > u u~'), so the branch used to
+                # build the spin-correlated weight is not the one whose decay
+                # products get attached to that leg. Single-branch pids (t/t~,
+                # w+/w-) are unaffected: the list holds one entry either way.
+                i, proc = to_decay[pid].pop(0)
                 decay_struct[nb] = dc_branch_from_me(proc)
                 identical = [me.get('decay_chains')[i] for me in me_list[1:]]
                 decay_struct[nb].add_decay_ids(identical)

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -5,6 +5,16 @@ ANNOUNCEMENT:
    A new LTS (based on the current 3.5.X) is starting now and will act as the stable release for the coming years.
 
 3.7.3 (XX/XX/XX):
+    OM: BUG FIX (MadSpin): when two or more final-state particles with the same PDG code were decayed
+        via *different* decay lines -- e.g. "p p > z z" with "decay z > e+ e-" and "decay z > u u~" --
+        the two decay branches were paired with the two mothers in reverse order. The spin-correlated
+        weight of a given mother was therefore evaluated with one decay branch while the decay products
+        of the other branch were attached to it. Decay angular distributions were consequently wrong
+        (in p p > z z the lepton/quark helicity angle is off by ~45 sigma on a 200k event sample), while
+        the cross-section, the branching ratios, the decay-plane angle and the spin-correlation
+        observable <cos(theta_1) cos(theta_2)> were left exactly invariant -- which is why this stayed
+        unnoticed. Processes where each decayed particle carries a distinct PDG code (t t~, w+ w-, ...)
+        were never affected.
     OM: BUG FIX (polarisation): LO cross-sections computed with a run_card "me_frame" that selects a
         single particle -- e.g. "me_frame = 3" to work in the Z rest frame, which is the standard way
         to ask for the polarisation of that Z -- were wrong for a fraction of the events.


### PR DESCRIPTION
## The bug

`get_full_process_structure` (`MadSpin/decay.py`) builds the map *production leg → decay branch*. It collected the branches per PDG into a list and handed them out with `to_decay[pid].pop()` — LIFO. With legs `[z, z]` and card lines `[ee, uu]`, the **first** Z was paired with the **last** branch.

The spin-correlated weight for a given mother was therefore evaluated with one decay branch, while the decay products of the *other* branch were attached to that mother.

## When it fires

Only when two or more final-state particles share a PDG code **and** carry different decay branches:

```
generate p p > z z
decay z > e+ e-
decay z > u u~
```

`t t~` and `w+ w-` have distinct PDG codes, so their per-PDG list holds a single entry and `pop()` / `pop(0)` agree — `p p > t t~` output is byte-identical across this change.

On this branch `spinmode` is `['full','madspin','none','onshell']`; anything outside `none`/`onshell`/`bridge` falls through to this legacy path, so **the default `spinmode=madspin` was affected**.

## Why it went unnoticed

The swap leaves the cross-section, the branching ratios, the decay-plane angle and the spin-correlation observable `<cos(theta_1) cos(theta_2)>` **exactly** invariant. Only the single-particle decay-angle asymmetries move, and only strongly in the lab helicity frame.

## Validation

Against a MadGraph spin-correlated decay chain — `generate p p > z z, (z > e+ e-), (z > u u~)` — which uses no MadSpin at all. 200k events:

| pulls vs decay chain | cos_e | cos_u | cosL_e | cosL_u |
|---|---|---|---|---|
| before | 7.3 | 8.4 | −45.2 | −43.4 |
| after | −1.4 | −0.4 | −1.5 | 0.2 |

`cosL` is the helicity angle w.r.t. the Z direction in the lab; `cos` uses the Z direction in the ZZ rest frame, which partially cancels the effect.

Reproduced on two independent production samples. Cross-checked with a `d d~` second channel (A_d = 0.94 vs A_e = 0.15, so the two channels differ by 4x): the branch-swap hypothesis fits at 1.3 sigma, while a plain sign flip is excluded at 35 sigma.

The independent density-matrix implementation on `madspin_density` already pairs the n-th particle of a PDG with the n-th decay line (`interface_madspin.py`, `evt_decayfile[pdg][ids[:i].count(pdg)]`) and agrees with the decay chain. This change aligns the legacy path with that convention. The same one-line fix is already merged into `madspin_density` via #334.

## Tests

- madspin unit tests 5/5 pass
- madspin acceptance tests 3/3 pass
- full unit suite: identical 3 pre-existing errors (`test_write_model`, `test_wj_loonly_gen`, `test_fks_ppzz_in_RS`) with and without the change

## Note for the reviewer

The same LIFO pattern appears twice more in `decay.py` (lines ~459 and ~645, in `add_decay`), pairing daughters *within* one branch's tree. The trigger would be something like `decay h > z z, z > e+ e-, z > mu+ mu-`. **I have not tested those** — they build the topology tree rather than the particle-identity map, so they may well be harmless. Left untouched here to keep this a two-file fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Preserve the written ordering of decay branches when assigning branches to identical-PDG mother particles, correcting spin-correlated decay-angle assignments in the legacy MadSpin path.