### PR TITLE
MadSpin: give the PA spinmode the up-front mass draw

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -1312,13 +1312,48 @@ The remaining overflow counts are 11 (`sequential_with_mass`, unchanged), 6
 events -- the "PA sequential logged 11 weight overflows" observation of section
 10 is improved but not removed, and remains worth a look on its own.
 
-**`auto` still takes `sequential_with_mass` under PA.** The counters say the
-up-front `sequential` is the better scheme, and the decay phase agrees, but the
-decay phase is ~12% of the run here (the max-weight probe and the fixed
-per-event cost dominate, as section 10 warns), so the gain on the wall clock is
-inside the noise. Against that, `sequential_with_mass` is exact by construction
-while `sequential` carries a tabulated factor -- an ~0.2% one on a factor that
-is worth 0.04 GeV, so ~0.0001 GeV of residual, but a dependence nonetheless.
-Flipping the default is a judgement call for whoever owns the branch; the
-measurement above is what it should be made on, and the one-line change is in
-`_unweighting_mode`.
+**At 250000 events the ordering changes, and the gap widens.** The run above
+is dominated by costs the scheme does not touch, so it was repeated on a single
+250000-event sample where the decay phase is 51-66% of the wall clock:
+
+    scheme                  decay phase  total wall  decay MEs/ev  prod reshuffles  mass sets  over bound
+    sequential                226.0 s      446.5 s       4.56           2.83          2.83         40
+    two_stage                 285.2 s      507.3 s       6.57           2.83          2.83         42
+    joint                     324.3 s      544.6 s       9.06           4.53           --           0
+    sequential_with_mass      403.7 s      629.8 s       8.07           8.07           --          37
+    sequential_global_retry   436.6 s      660.2 s       7.22          11.15         11.15        180
+
+Against joint: `sequential` is 30% faster in the decay phase and 18% on the
+whole run; against `sequential_with_mass`, which is what `auto` picks, it is
+**44% and 29%**. All five agree on the cross section to 0.003% (23.75487 joint,
+23.755604 for the other four).
+
+Two things move between the two sample sizes, and both favour the up-front
+split as N grows.
+
+- The fixed costs stop hiding it. At 10000 events the decay-pool generation
+  (~35 s) and the probe dwarf a 2 s difference; at 250000 the pool costs ~165 s
+  against a 226-436 s decay phase.
+- `nb_sigma` is `max(4.5, log_7.7 N)`, so it goes from 4.51 to 6.09 and every
+  bound widens. That costs the schemes unequally: `sequential_with_mass`'s
+  per-slot weights carry the Breit-Wigner jacobian and `J_k/J_{k-1}`, so they
+  are the broadest and lose the most (slot 1's bound 5.201, acceptance 1/5.31,
+  against the up-front `sequential`'s 3.287 and 1/3.29). Moving those factors
+  into a mass stage that is bounded once is worth more the wider the margin
+  gets. `two_stage` overtakes `sequential_with_mass` for the same reason.
+
+So the 10000-event ordering (sequential < joint < with_mass < two_stage <
+global_retry) is not the asymptotic one; at 250000 it is sequential < two_stage
+< joint < with_mass < global_retry, and the advantage of the up-front draw over
+the scheme PA shipped with is a factor 1.8 on the accept/reject.
+
+**`auto` still takes `sequential_with_mass` under PA.** That is now a
+conservative default rather than the fast one: at 10000 events the gain was
+inside the noise, but at 250000 the up-front `sequential` takes 29% off the
+whole run and the margin grows with N. What it buys against that is exactness
+by construction -- `sequential_with_mass` freezes nothing and needs no table,
+where `sequential` carries a tabulated factor accurate to ~0.2% on something
+worth 0.04 GeV, i.e. ~0.0001 GeV of residual. That is three orders of magnitude
+inside the pole approximation's own error, so the case for flipping is strong;
+it is left as a judgement call for whoever owns the branch, and the one-line
+change is in `_unweighting_mode`.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -1221,17 +1221,26 @@ at the accepted mass distribution. Four replicas of each scheme over the same
 10000 production events with independent MadSpin seeds (42-45), against a
 four-replica joint reference:
 
-    scheme                <m(top)>, both resonances    vs joint
-    joint                 172.9469 +- 0.0135            --
-    sequential_with_mass  172.9480 +- 0.0104           +0.0011  (+0.06 sigma)
-    sequential            172.9558 +- 0.0068           +0.0089  (+0.59 sigma)
-    Z_hat forced to 1     172.9083 +- 0.0087           -0.0386  (-2.40 sigma)
+    scheme                   <m(top)>, both resonances   vs joint        chi2/ndf
+    joint                    172.9469 +- 0.0135           --              --
+    sequential_with_mass     172.9480 +- 0.0104          +0.0011 (+0.06)  12.6/24
+    sequential               172.9558 +- 0.0068          +0.0089 (+0.59)   9.4/24
+    two_stage                172.9589 +- 0.0067          +0.0119 (+0.79)  11.3/24
+    sequential_global_retry  172.9632 +- 0.0057          +0.0162 (+1.11)  20.3/24
+    sequential, Z_hat = 1    172.9083 +- 0.0087          -0.0386 (-2.40)  12.3/24
 
 (errors are the replica scatter; the naive per-run MC error on the pooled sample
-is 0.0111 and gives the same significances to within 0.05 sigma. Lineshape
-chi2/ndf against joint: 12.6/24, 9.4/24 and 12.3/24.)
+is 0.0111 and gives the same significances to within 0.08 sigma.)
 
-The third row is the point. PA's `Z_k` spans a factor 1.16 where the offshell
+The three up-front schemes sit 0.6 to 1.1 sigma above joint, all on the same
+side. That is not the table: `sequential_global_retry` needs no table at all --
+`Z_hat` cancels identically there -- and it is the *highest* of the three. What
+it is is the joint reference, whose own replica scatter (0.0135) is the largest
+of the six and whose seed-42 replica (172.9161) is a visible low outlier. As in
+section 10, the scatter between two runs of the same scheme is as large as
+anything the scheme-to-scheme differences show.
+
+The last row is the point. PA's `Z_k` spans a factor 1.16 where the offshell
 one spans 3.2, so the bias it protects against is ~0.04 GeV rather than the
 0.25 GeV of section 10 -- at the edge of what a 10000-event A/B can see, which
 would have made a plain "sequential agrees with joint" statement

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -1092,3 +1092,224 @@ tolerance), automatic for the restart schemes. So variant B's -0.034 GeV is not
 a broken weight. With the weights verified and the error models in the state
 described above, the honest summary is: weights correct, deviation unexplained,
 dropped because it is slower than variant A anyway.
+
+## 11. PA: the up-front mass draw, and `sequential_with_mass`
+
+Section 10 built the up-front mass draw for the offshell spinmodes, where it is
+a *necessity*: rho depends on the whole mass set, so it has to be fixed before
+the per-particle loop or the decomposition does not apply. Under PA the same
+split is optional -- rho is evaluated at the onshell momenta and is already
+fixed per production event -- and this section is about doing it anyway,
+because of what else the mass set freezes.
+
+### The scheme PA had is a fifth scheme, not a variant
+
+What PA did before this section is now called **`sequential_with_mass`**: one
+test per decaying particle, with that particle's virtuality drawn *inside* its
+own accept/reject (`_draw_offshell_mass` in the slot loop) and redrawn together
+with its angles. That is a genuinely different scheme, not a flavour of
+`sequential`. Nothing is ever frozen, so no stage redraws-to-acceptance under a
+condition it then divides out, so there is no `Z_k` to tabulate and no
+`Z_hat/Z` residual to argue about. It is also the reason `two_stage` and
+`sequential_global_retry` used to be refused under PA: they split the
+accept/reject at a mass draw that did not exist there.
+
+It stays the `auto` choice for PA and onshell. The bit-for-bit check below is
+what makes the rename safe.
+
+### What PA gains by freezing the masses
+
+Not `rho`, which is cached per production event either way
+(`production._ms_density_prod`). What it gains is the **production reshuffling
+jacobian**. With `density_keep_jacobian` on -- the default -- the per-slot
+scheme needs `J_k`, the jacobian with the slots drawn so far offshell, at
+*every slot trial*: an `Event(str(production))` copy and a `reshuffle_production`
+each time, with the ratios `J_k/J_{k-1}` telescoping over the chain. Freeze the
+mass set and there is one `J` for the whole set, evaluated once, with no
+telescoping at all.
+
+The weight splits the way it does offshell, minus the pieces PA does not have:
+
+    stage 1   w_mass  = J(m_1..m_n) * prod_k jac_bw_k * prod_k Z_hat_k(m_k)
+    stage 2   w_k     = (N_k/N_{k-1}) * jac_dec_k
+
+`Tr(rho)` is absent because it cancels between `N_n` and `N_0`, which is also
+why PA needs no `|M_prod|^2_on` normalisation of the mass weight (section 10)
+-- there is no production matrix element in `w_mass` to normalise. The product
+over the chain is `J * prod jac_bw * prod jac_dec * N_n/N_0`, which is the joint
+PA weight: `reshuffle_production` on the *complete* event returns exactly
+`J_RAMBO * prod_k jac_dec_k`, the two pieces the chain computes separately
+through `_production_jacobian_for` and `_decay_reshuffle_jacobian`.
+
+### Z_k under PA is *not* the running width
+
+Freezing the masses immediately buys the problem section 10 spent itself on: the
+angle stage redraws until it accepts, so it divides out
+
+    Z_k^PA(m) = E_pool[ w_k ] = E_pool[ jac_dec(m, Omega) ]
+
+-- the density ratio `N_k/N_{k-1}` averages to one at fixed m, so what is left
+is the decay reshuffling jacobian alone. This is **not** the offshell
+integrand. Offshell, `w_k` also carries `Tr(D^off)/|M_dec|^2_on` and `Z_k`
+comes out as the running partial width `(m/M) Gamma(m)/Gamma(M)`; PA evaluates
+every matrix element on shell, so there is no offshell reweighting to
+normalise and only the phase-space cost of mapping a pool decay onto the
+sampled virtuality survives.
+
+That makes it a much gentler function, and the measured table says so. On
+`p p > t t~`, `t > w+ b, w+ > l+ vl`, from the 37500 probe samples per slot the
+scan collects for free:
+
+    slot    Z(150.7)   Z(173)   Z(195.3)   bin/fit deviation
+    6_0       0.913      1        1.059         0.2%
+    -6_0      0.912      1        1.059         0.1%
+
+against the offshell table's 0.53 / 1 / 1.71 over the same window. A factor 1.16
+across the Breit-Wigner window where offshell has a factor 3.2. The machinery is
+the same -- `_z_slot_keys`, `_build_z_tables`, `_zhat`, samples recorded by
+`sequential_accept_reject` in probe mode -- only the quantity averaged differs
+(`rate = jac_dec` instead of `jac_dec * Tr(D^off)/|M_dec|^2_on`).
+
+**It is still needed.** The argument of section 10 does not care how big the
+factor is: the angle stage divides out the *true* `Z_k` whatever weight it is
+given, so omitting the compensation leaves the accepted virtualities
+Breit-Wigner distributed rather than physically distributed, and the residual
+is exactly `Z_hat/Z`. What the small factor does change is the *sensitivity of
+the lineshape test*: see below.
+
+`density_keep_jacobian = False` is the degenerate case. There the reshuffle is a
+post-acceptance dressing and `jac_dec` is in no weight, so `w_k` is the density
+ratio alone and `Z_k(m)` collapses to the fraction of the pool that can reach
+`m` -- still a function of the virtuality, still tabulated by the same code
+(a decay that cannot be reshuffled onto `m` records a zero, exactly as
+offshell), and identically one wherever the whole pool is reachable.
+
+### Validation
+
+**Bit-for-bit, first.** `sequential_with_mass` on 10000 `p p > t t~` events is
+byte-identical to what the branch produced before this section: same seed, same
+production sample, every event record in the decayed LHE the same, and the same
+counters (5.01 decay events per accepted event, 1.88 + 3.13 per slot, 11
+weights above their bound, 17 chains restarted). The only difference anywhere in
+the file is the path of the input LHE echoed in the banner, which is the test
+harness giving each mode its own directory.
+
+**The weight identity, per chain.** `sequential_debug` now covers the PA
+up-front schemes: it rebuilds the joint PA weight for the same production event,
+the same virtualities and the same decays -- `calculate_matrix_element_from_density`
+for the density part (PA leaves the momenta onshell there, so it returns
+`jac_reshuffle = 1`), the Breit-Wigner jacobians recomputed from the sampling
+window, and the reshuffling jacobian from a `reshuffle_production` of the
+*complete* rebuilt event, which is the route the joint path takes and is
+therefore an independent check of the chain's two separate pieces. Over 10000
+accepted chains each:
+
+    sequential                spread 7.91e-08   ratio 1108198227
+    two_stage                 spread 1.23e-07   ratio 1108198225
+    sequential_global_retry   spread 8.54e-08   ratio 1108198230
+
+Float32 epsilon is 1.19e-7 and the density matrices are `complex64`, so that is
+the floor of the arithmetic. Worth noting that the constant is the *same* one
+the offshell schemes report (1108198255-261, section 10) to nine significant
+figures, from a different spinmode and a different set of factors -- the
+number is the helicity/normalisation constant of the density path, as claimed.
+
+**The lineshape, and how to make the test sensitive.** `m(l+ vl b)` is the
+observable the missing factor distorts, and under PA it *is* the sampled
+virtuality (the accepted decay is reshuffled onto it), so this is a direct look
+at the accepted mass distribution. Four replicas of each scheme over the same
+10000 production events with independent MadSpin seeds (42-45), against a
+four-replica joint reference:
+
+    scheme                <m(top)>, both resonances    vs joint
+    joint                 172.9469 +- 0.0135            --
+    sequential_with_mass  172.9480 +- 0.0104           +0.0011  (+0.06 sigma)
+    sequential            172.9558 +- 0.0068           +0.0089  (+0.59 sigma)
+    Z_hat forced to 1     172.9083 +- 0.0087           -0.0386  (-2.40 sigma)
+
+(errors are the replica scatter; the naive per-run MC error on the pooled sample
+is 0.0111 and gives the same significances to within 0.05 sigma. Lineshape
+chi2/ndf against joint: 12.6/24, 9.4/24 and 12.3/24.)
+
+The third row is the point. PA's `Z_k` spans a factor 1.16 where the offshell
+one spans 3.2, so the bias it protects against is ~0.04 GeV rather than the
+0.25 GeV of section 10 -- at the edge of what a 10000-event A/B can see, which
+would have made a plain "sequential agrees with joint" statement
+uninformative. Measuring it directly instead, with a scratch build whose
+`_zhat` returns 1, puts the factor at **-0.039 +- 0.016 GeV** (-0.047 +- 0.011
+against `sequential` itself, -4.3 sigma) and in the direction section 10
+predicts: down, towards the Breit-Wigner prior. Restoring it recovers joint to
++0.009 +- 0.015.
+
+The two no-regression observables behave as section 10 says they do -- blind to
+this class of bug. Even with `Z_hat` forced to 1, `m(l+ vl)` moves by -0.17
+sigma and `dphi(l+,l-)` by -0.21 sigma, while the resonance mass is off by 2.4.
+Anyone checking a new unweighting scheme on those two alone would have passed
+this build.
+
+**What the up-front branch must not have disturbed.** The offshell path now
+shares `_upfront_production` and the merged slot body with PA, so it was
+re-run against the base commit: `spinmode = madspin` on the same 10000 events
+gives identical event records, the same Z table to every digit
+(0.527 / 1 / 1.705 and 0.529 / 1 / 1.710), the same bounds (3.09, 2.881) and the
+same 57448 trials. `spinmode = onshell` with an explicit `sequential` -- no
+virtuality anywhere, so the mass stage is the degenerate one -- runs and gives
+3.98 decay events per accepted event with no overflow. `nb_core = 4` reproduces
+the cross section and the counters up to the workers' own RNG streams (2.09
+mass sets per event against 1.95 serial), i.e. the tables survive the fork.
+
+(The offshell re-run earned its place: the first version of this branch passed
+PA's `draw_mass` flag straight into `_upfront_production`, which under an
+offshell spinmode is False, and skipped the mass draw entirely. Offshell always
+samples -- its rho is only defined at the reshuffled momenta -- and the PA flag
+only ever described the PA draw.)
+
+### Speed
+
+Decay phase and counters for the same 10000 production events,
+`p p > t t~`, `t > w+ b, w+ > l+ vl`, `nb_core 1`, two campaigns with joint as
+the anchor in each. The counters are byte-identical between the two (same
+seed), so the pair of clocks is a read on the machine, not on the schemes:
+
+    scheme                  decay phase   decay MEs/event   mass sets   prod reshuffles
+    joint                   7.6 / 7.6 s   6.28 (3.14 x 2)      --           3.14
+    sequential              7.4 / 7.3 s   4.06 (1.21 + 2.85)  1.95          1.95
+    sequential_with_mass    9.4 / 9.3 s   5.01 (1.88 + 3.13)   --           5.01
+    two_stage              10.4 / 8.9 s   5.73 (2.87 + 2.87)  1.93          1.93
+    sequential_global_retry 12.2 / 12.1 s 6.22 (3.38 + 2.84)  6.61          6.61
+
+(`two_stage`'s 10.4 s is the one entry the second campaign does not reproduce;
+that run also took 38% longer to generate its matrix elements, so it was load.
+Section 10's warning about cross-campaign clocks applies inside a campaign too
+when the difference being read is 10%.)
+
+The observation section 10 closed on -- "PA sequential is 22% slower than PA
+joint on this process ... 5.01 production reshufflings per event against joint's
+3.14" -- is what the up-front draw was built for, and it is fixed: **1.95
+reshufflings per event**, a factor 2.6, and the decay phase goes from 22% above
+joint to level with it. The decay-ME count drops too (4.06 against 5.01),
+because the per-slot bounds no longer have to cover the production jacobian's
+spread: slot 0's bound falls from 1.836 to 1.21 and its acceptance rises from
+1/1.88 to 1/1.21.
+
+`two_stage` loses here, unlike offshell. Its single angle bound (2.865) is
+barely tighter than the product of the per-slot ones (1.21 x 2.863 = 3.46),
+because under PA slot 0's weight is nearly flat, so it pays the lost early exit
+for almost nothing. `sequential_global_retry` costs 3.4x the mass sets, as it
+does offshell, and is a cross-check rather than a candidate.
+
+The remaining overflow counts are 11 (`sequential_with_mass`, unchanged), 6
+(`sequential`), 9 (`two_stage`) and 11 (`sequential_global_retry`) out of 10000
+events -- the "PA sequential logged 11 weight overflows" observation of section
+10 is improved but not removed, and remains worth a look on its own.
+
+**`auto` still takes `sequential_with_mass` under PA.** The counters say the
+up-front `sequential` is the better scheme, and the decay phase agrees, but the
+decay phase is ~12% of the run here (the max-weight probe and the fixed
+per-event cost dominate, as section 10 warns), so the gain on the wall clock is
+inside the noise. Against that, `sequential_with_mass` is exact by construction
+while `sequential` carries a tabulated factor -- an ~0.2% one on a factor that
+is worth 0.04 GeV, so ~0.0001 GeV of residual, but a dependence nonetheless.
+Flipping the default is a judgement call for whoever owns the branch; the
+measurement above is what it should be made on, and the one-line change is in
+`_unweighting_mode`.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -1357,3 +1357,122 @@ worth 0.04 GeV, i.e. ~0.0001 GeV of residual. That is three orders of magnitude
 inside the pole approximation's own error, so the case for flipping is strong;
 it is left as a judgement call for whoever owns the branch, and the one-line
 change is in `_unweighting_mode`.
+
+## 12. Which scheme should be the default: a multiplicity scan
+
+Sections 10 and 11 each measured one process with two decaying particles, which
+is exactly the multiplicity at which the schemes are closest. This scans the
+number of decaying particles instead, 50000 events per point, `nb_core 1`, seed
+42, one campaign per process (so the clocks are comparable within a block, not
+across blocks):
+
+    n=1   p p > w+ j        w+ > l+ vl
+    n=2   p p > t t~        t > w+ b, w+ > l+ vl                (both tops)
+    n=3   p p > t t~ z      as above, plus z > l+ l-
+    n=4   p p > t t~ t t~   as above, all four tops
+
+All 24 runs agree on the cross section: identical within a process except for
+the 5e-5 relative offset between the joint runs and the rest, which is the
+Breit-Wigner sampling and not the scheme.
+
+### PA
+
+    n  scheme                decay phase   total wall   decay MEs/ev   mass sets/ev
+    1  joint                    50.3 s       92.9 s         6.12            --
+    1  sequential_with_mass     58.7 s       99.5 s         6.39            --
+    1  sequential               40.4 s       81.8 s         5.09           2.42
+    2  joint                    83.4 s      178.2 s        10.96            --
+    2  sequential_with_mass    127.0 s      231.6 s        12.27            --
+    2  sequential               39.8 s      139.0 s         4.39           3.23
+    3  joint                   186.6 s      292.4 s        24.30            --
+    3  sequential_with_mass     88.7 s      205.4 s         9.78            --
+    3  sequential               66.0 s      177.0 s         7.73           4.48
+    4  joint                   324.3 s      472.4 s        42.56            --
+    4  sequential_with_mass    110.5 s      298.2 s         9.47            --
+    4  sequential               85.5 s      263.9 s         8.79           2.42
+
+**`sequential` wins at every multiplicity**, by 20% at n=1 and by a factor 3.8
+at n=4, and it is never worse than the other two on any counter. The joint
+test's cost grows as n x (trials per event) because a single rejection throws
+away every decay; the per-particle test's grows far more slowly.
+
+`sequential_with_mass` -- today's PA default -- is the *worst* of the three at
+n=1 and n=2 on this campaign, and slower than `sequential` everywhere. Note how
+much worse it looks at 50000 events than at the 10000 of section 11 (n=2: 12.27
+decay MEs per event against 5.01): `nb_sigma` is `max(4.5, log_7.7 N)`, and its
+per-slot weights carry the Breit-Wigner jacobian and the `J_k/J_{k-1}` ratios,
+so they are the broadest and lose the most as the safety margin widens. That is
+the same effect section 11 saw between 10000 and 250000, and it says the
+measured gap is a lower bound on what a production-sized run would see.
+
+### madspin (full offshell)
+
+    n  scheme          decay phase   total wall   decay MEs/ev   mass sets/ev
+    1  joint              65.5 s      112.5 s         6.57            --
+    1  sequential       2534.6 s     2576.7 s         8.11         786.61
+    1  two_stage        2495.1 s     2539.8 s         4.96         787.32
+    2  joint              54.3 s      151.1 s         8.08            --
+    2  sequential         70.1 s      169.6 s         6.73           3.51
+    2  two_stage          59.5 s      162.7 s         6.24           3.50
+    3  joint             231.4 s      338.5 s        25.32            --
+    3  sequential        107.0 s      223.0 s        11.79           3.59
+    3  two_stage         244.7 s      359.4 s        24.94           3.59
+    4  joint             722.4 s      882.7 s        50.60            --
+    4  sequential        167.3 s      365.7 s        13.21           3.23
+    4  two_stage         315.8 s      514.3 s        28.70           3.22
+
+Three separate findings.
+
+**n=1 offshell is a disaster, and it is the mass stage.** 787 mass sets per
+accepted event, `C_mass` = 781.6, a decay phase 38x the joint one. `two_stage`
+gives the same 787, which localises it precisely: not the angle granularity,
+not `Z_k` (the table is clean, bin/fit deviation 0.0%), but the mass-set weight
+`Tr(rho_off)/|M_prod|^2_on`. On `p p > w+ j` the decaying particle carries
+essentially all of the production matrix element's virtuality dependence, so
+that ratio spans orders of magnitude over the 15-width window and no single
+bound can cover it. The PA run of the same process has `C_mass` = 2.37, which
+confirms the diagnosis -- PA evaluates rho on shell, so its mass weight has no
+production matrix element in it at all. `auto` already routes n=1 to joint, so
+nothing is broken; this is why that rule has to stay.
+
+**n=2 offshell still belongs to joint.** 54.3 s against 59.5 (`two_stage`) and
+70.1 (`sequential`), even though both draw *fewer* decay matrix elements (6.24
+and 6.73 against 8.08): each mass set costs a production reshuffle and an
+offshell production density, and at 3.5 mass sets per event that outweighs the
+decays saved. Section 10 measured the opposite at 10000 events (`two_stage`
+13.55 s against joint's 14.61 s); the difference is again `nb_sigma`, 4.51 there
+against 5.60 here, which widens `C_mass` and costs the staged schemes.
+
+**From n=3 `sequential` wins outright**, 2.2x at n=3 and 4.3x at n=4 on the
+decay phase, and `two_stage` is not competitive there: its single bound over the
+product forces every slot to be redrawn together, 8.31 angle sets per event at
+n=3 and 7.17 at n=4, so it draws as many decay matrix elements as the joint test
+while also paying the mass stage.
+
+### What this says about `auto`
+
+The current rule is: 1 -> joint; PA/onshell -> `sequential_with_mass`; 2 ->
+`two_stage`; 3+ -> `sequential`. The scan says two of those four branches are
+wrong and one is unnecessary:
+
+    spinmode         n      current               measured best
+    PA / onshell     any    sequential_with_mass  sequential  (1.2x - 3.8x)
+    madspin / full   1      joint                 joint       (correct)
+    madspin / full   2      two_stage             joint       (1.1x)
+    madspin / full   3+     sequential            sequential  (correct)
+
+`two_stage` is not the fastest scheme at any point measured here, in either
+spinmode: joint beats it at n<=2 and `sequential` beats it at n>=3. It remains
+worth keeping as an option -- it is the one staged scheme whose angle stage is a
+single joint test, which makes it the natural cross-check against joint -- but
+it does not earn a branch in `auto`.
+
+So the recommended rule is two lines instead of four:
+
+    PA / onshell     ->  sequential
+    madspin / full   ->  joint for n <= 2, sequential from n = 3
+
+with the caveat that every number above is one process per multiplicity on one
+machine, and that the n=2 offshell call is a 10% difference that went the other
+way at a smaller sample size. The n=1 offshell and the n>=3 conclusions are not
+close and are safe.

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -925,7 +925,9 @@ difference nobody can measure. `sequential_global_retry` says what the mode does
 and leaves the accuracy statement to the documentation, where it can carry the
 numbers.
 
-**`auto`** resolves once per run, from the number of decaying particles counted
+**`auto`** (as of this section; **superseded by section 12**, which measured
+the schemes over the decay multiplicity and replaced the four branches below
+with two) resolves once per run, from the number of decaying particles counted
 where `to_decay` is built -- not per event, since the modes carry different
 bounds and one that changed event to event would be testing against the wrong
 ones:
@@ -1347,16 +1349,16 @@ global_retry) is not the asymptotic one; at 250000 it is sequential < two_stage
 < joint < with_mass < global_retry, and the advantage of the up-front draw over
 the scheme PA shipped with is a factor 1.8 on the accept/reject.
 
-**`auto` still takes `sequential_with_mass` under PA.** That is now a
-conservative default rather than the fast one: at 10000 events the gain was
-inside the noise, but at 250000 the up-front `sequential` takes 29% off the
-whole run and the margin grows with N. What it buys against that is exactness
-by construction -- `sequential_with_mass` freezes nothing and needs no table,
-where `sequential` carries a tabulated factor accurate to ~0.2% on something
-worth 0.04 GeV, i.e. ~0.0001 GeV of residual. That is three orders of magnitude
-inside the pole approximation's own error, so the case for flipping is strong;
-it is left as a judgement call for whoever owns the branch, and the one-line
-change is in `_unweighting_mode`.
+**`auto` took `sequential_with_mass` under PA when this section was written,
+and no longer does** -- section 12 scanned the decay multiplicity and switched
+it to `sequential`. At 10000 events the gain was inside the noise; at 250000 the
+up-front draw takes 29% off the whole run, and the margin grows with N. What it
+costs is exactness by construction: `sequential_with_mass` freezes nothing and
+needs no table, where `sequential` carries a tabulated factor accurate to ~0.2%
+on something worth 0.04 GeV, i.e. ~0.0001 GeV of residual -- three orders of
+magnitude inside the pole approximation's own error. `sequential_with_mass`
+remains available, and is the scheme to reach for if that residual ever needs
+to be excluded rather than bounded.
 
 ## 12. Which scheme should be the default: a multiplicity scan
 
@@ -1467,12 +1469,20 @@ worth keeping as an option -- it is the one staged scheme whose angle stage is a
 single joint test, which makes it the natural cross-check against joint -- but
 it does not earn a branch in `auto`.
 
-So the recommended rule is two lines instead of four:
+**`auto` now implements the two-line rule** (`_unweighting_mode`):
 
     PA / onshell     ->  sequential
     madspin / full   ->  joint for n <= 2, sequential from n = 3
 
 with the caveat that every number above is one process per multiplicity on one
 machine, and that the n=2 offshell call is a 10% difference that went the other
-way at a smaller sample size. The n=1 offshell and the n>=3 conclusions are not
-close and are safe.
+way at a smaller sample size -- so that boundary is the one to revisit if a
+process is found where a staged scheme pays off at two decays. The n=1 offshell
+and the n>=3 conclusions are not close and are safe.
+
+What changes for a user who never set `unweighting`: PA and onshell runs move
+from `sequential_with_mass` to `sequential` (faster everywhere measured, at the
+price of the tabulated factor -- section 11 bounds its effect on the top
+lineshape at ~0.0001 GeV); offshell runs with two decaying particles move from
+`two_stage` to `joint`, i.e. back to the historical scheme. Nothing changes for
+offshell runs with one or with three or more decaying particles.

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -92,7 +92,7 @@ class MadSpinOptions(banner.ConfigFile):
                        "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
                        "sequential_with_mass: one test per decaying particle with that particle's virtuality drawn *inside* its own accept/reject, so nothing is ever frozen and no stage has a conditional normalisation to divide out. Needs a per-particle mass draw, i.e. the PA spinmode; elsewhere it falls back to sequential. "
                        "two_stage, sequential and sequential_global_retry unweight the set of virtualities first; the first two then need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
-                       "auto: joint when a single particle decays (every split degenerates there), sequential_with_mass under PA/onshell, and offshell two_stage for two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are).")
+                       "auto: sequential under PA/onshell, where it was the fastest scheme at every decay multiplicity measured; offshell joint up to two decaying particles and sequential from three, since offshell every mass set costs a production reshuffle and a production density and below three decays there are not enough of them to save to pay for it.")
         self.add_param('sequential_decay', 'auto',
                        comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
         self.auto_set.add('sequential_decay')
@@ -2266,19 +2266,36 @@ class MadSpinInterface(extended_cmd.Cmd):
         spinmodes reshuffle the whole production onto the mass set at once, so
         there they fall back to ``sequential``.
 
-        ``auto`` picks by the number of decaying particles. With one, it takes
-        ``joint``: every split degenerates there -- the per-particle test is the
-        joint test, and the mass/angle one only moves the same factors between
-        two stages -- so there is nothing to win and the identity machinery is
-        pure cost. Beyond one it takes ``sequential_with_mass`` under
-        PA/onshell, which is what those modes have always done and what the
-        measurements still favour there. Offshell the two splits trade off
-        against each other: one bound over all the angles is tighter than the
-        product of per-particle bounds, while testing each particle as it is
-        drawn lets a rejection skip the decays not yet drawn. The first wins
-        while there is little to skip and the second as the chain gets longer,
-        so auto takes ``two_stage`` up to two decaying particles and
-        ``sequential`` from three.
+        ``auto`` has two branches, one per spinmode family. They were measured
+        over the number of decaying particles n on `p p > w+ j` (n=1),
+        `p p > t t~` (2), `p p > t t~ z` (3) and `p p > t t~ t t~` (4), 50000
+        events each -- see MADSPIN_SEQUENTIAL_PLAN.md section 12.
+
+        **PA/onshell -> ``sequential``, at every n.** It was the fastest of the
+        three at all four multiplicities, by 1.2x at n=1 rising to 3.8x at n=4.
+        The joint test's cost grows as n x (trials per event), since one
+        rejection throws every decay away, while the per-particle one's grows
+        far more slowly; and the up-front mass draw evaluates the production
+        reshuffling jacobian once per mass set instead of once per slot trial.
+        Even at n=1, where the angle stage degenerates to the joint test, the
+        mass stage still pays for itself: a mass set can be rejected before any
+        decay is drawn.
+
+        **madspin/full -> ``joint`` up to two decaying particles, then
+        ``sequential``.** Offshell, each mass set costs a production reshuffle
+        *and* an offshell production density, which the joint test pays per
+        trial but which a staged scheme pays per mass set -- and below n=3 there
+        are not enough decays to save to cover it. At n=1 it is worse than that:
+        the mass-set weight carries ``Tr(rho_off)/|M_prod|^2_on``, and when the
+        single decaying particle carries most of the production matrix
+        element's virtuality dependence (`p p > w+ j`) that ratio spans orders
+        of magnitude, no bound covers it, and the mass stage needs ~790 sets per
+        accepted event. From n=3 the per-particle test wins by 2.2x and 4.3x.
+
+        ``two_stage`` is not the fastest scheme at any measured point -- joint
+        beats it at n<=2 and ``sequential`` at n>=3 -- so it is reachable but
+        never chosen here. It stays useful as a cross-check, being the one
+        staged scheme whose angle stage is a single joint test.
 
         ``fixed_order`` forces joint: its counter-events ride along with the
         decays and have not been thought through here.
@@ -2288,19 +2305,15 @@ class MadSpinInterface(extended_cmd.Cmd):
         asked = mode = self.options['unweighting']
         if mode == 'auto':
             nb_decaying = getattr(self, '_nb_decaying', 2)
-            if nb_decaying <= 1:
-                # with a single decaying particle every split degenerates: the
-                # per-particle test *is* the joint test, and the mass/angle one
-                # only moves the same factors between two stages. Nothing to
-                # win, so do not pay for the identity machinery.
-                mode = 'joint'
-            elif self.options['spinmode'] in ['PA', 'onshell']:
-                # what PA has always done, and still the fastest of the five
-                # there; the up-front schemes are reachable but are not the
-                # default until a measurement says otherwise
-                mode = 'sequential_with_mass'
+            if self.options['spinmode'] in ['PA', 'onshell']:
+                # fastest at every multiplicity measured; rho is fixed on shell
+                # so the mass stage costs a reshuffling jacobian and nothing else
+                mode = 'sequential'
             elif nb_decaying <= 2:
-                mode = 'two_stage'
+                # offshell a mass set costs a production reshuffle and a
+                # production density, and there are not yet enough decays to
+                # save to pay for it
+                mode = 'joint'
             else:
                 mode = 'sequential'
         if mode == 'joint':

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -83,20 +83,21 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('density_keep_jacobian', True, comment='PA spinmode only: fold the offshell-reshuffling phase-space jacobian into the accept/reject weight (default) instead of applying the reshuffle as a post-acceptance kinematic dressing (False). Ignored by the madspin/full spinmodes, which always include that jacobian.')
         self.add_param('unweighting', 'auto',
                        allowed=['auto', 'joint', 'two_stage', 'sequential',
-                                'sequential_global_retry'],
+                                'sequential_global_retry',
+                                'sequential_with_mass'],
                        comment="how the accept/reject is organised (density modes). "
                        "joint: one test over the virtualities and every decay at once, the historical scheme. "
                        "two_stage: unweight the set of virtualities first, then every decay against a single bound, redrawing only the decays on a rejection -- the production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial. "
                        "sequential: as two_stage but one test per decaying particle, redrawing only the particle that was rejected. "
                        "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
-                       "two_stage and sequential need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
-                       "auto: joint when a single particle decays (every split degenerates there), two_stage for two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are), or sequential under PA/onshell. "
-                       "two_stage and sequential_global_retry need an offshell spinmode and fall back to sequential elsewhere.")
+                       "sequential_with_mass: one test per decaying particle with that particle's virtuality drawn *inside* its own accept/reject, so nothing is ever frozen and no stage has a conditional normalisation to divide out. Needs a per-particle mass draw, i.e. the PA spinmode; elsewhere it falls back to sequential. "
+                       "two_stage, sequential and sequential_global_retry unweight the set of virtualities first; the first two then need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
+                       "auto: joint when a single particle decays (every split degenerates there), sequential_with_mass under PA/onshell, and offshell two_stage for two decaying particles and sequential from three (one bound over all the angles is tighter, testing each particle as it is drawn skips the decays not yet drawn, and which wins depends on how many there are).")
         self.add_param('sequential_decay', 'auto',
                        comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
         self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in the sequential unweighting modes: default fermions, then vectors, then scalars (which can never be rejected).')
-        self.add_param('sequential_debug', False, comment='offshell spinmodes with a non-joint unweighting: on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
+        self.add_param('sequential_debug', False, comment='the up-front-mass unweighting schemes (two_stage, sequential, sequential_global_retry): on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
 
     ############################################################################
     ##  Special post-processing of the options                                ## 
@@ -2232,7 +2233,8 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     def _unweighting_mode(self, density_method=True):
         """Which accept/reject scheme this run uses: one of 'joint',
-        'two_stage', 'sequential', 'sequential_global_retry'.
+        'two_stage', 'sequential', 'sequential_global_retry',
+        'sequential_with_mass'.
 
         All of them sample the same distribution; they differ in how the test is
         split and in what a rejection redraws.
@@ -2250,25 +2252,36 @@ class MadSpinInterface(extended_cmd.Cmd):
                                    was rejected.
           sequential_global_retry  as sequential, but a rejected decay redraws
                                    the virtualities as well.
+          sequential_with_mass     one test per decaying particle, with that
+                                   particle's virtuality drawn *inside* its own
+                                   accept/reject rather than up front.
+
+        The first four share an up-front mass draw and so a mass-set stage;
+        ``sequential_with_mass`` is the odd one out and not a variant of
+        ``sequential``: the mass is drawn and redrawn together with that slot's
+        angles, so nothing is ever frozen, no stage has a conditional
+        normalisation to divide out, and the tabulated running-width factor the
+        two-stage schemes need does not arise. It is the historical PA scheme.
+        It needs a per-particle mass draw, i.e. the PA spinmode; the offshell
+        spinmodes reshuffle the whole production onto the mass set at once, so
+        there they fall back to ``sequential``.
 
         ``auto`` picks by the number of decaying particles. With one, it takes
         ``joint``: every split degenerates there -- the per-particle test is the
         joint test, and the mass/angle one only moves the same factors between
         two stages -- so there is nothing to win and the identity machinery is
-        pure cost. Beyond one, the two splits trade off against each other: one bound over all the angles is
-        tighter than the product of per-particle bounds, while testing each
-        particle as it is drawn lets a rejection skip the decays not yet drawn.
-        The first wins while there is little to skip and the second as the
-        chain gets longer, so auto takes ``two_stage`` up to two decaying
-        particles and ``sequential`` from three. Under PA/onshell it is always
-        ``sequential``, the other two needing an offshell spinmode.
+        pure cost. Beyond one it takes ``sequential_with_mass`` under
+        PA/onshell, which is what those modes have always done and what the
+        measurements still favour there. Offshell the two splits trade off
+        against each other: one bound over all the angles is tighter than the
+        product of per-particle bounds, while testing each particle as it is
+        drawn lets a rejection skip the decays not yet drawn. The first wins
+        while there is little to skip and the second as the chain gets longer,
+        so auto takes ``two_stage`` up to two decaying particles and
+        ``sequential`` from three.
 
         ``fixed_order`` forces joint: its counter-events ride along with the
-        decays and have not been thought through here. ``two_stage`` and
-        ``sequential_global_retry`` need the offshell (madspin/full) spinmodes,
-        where the virtualities are drawn up front; under PA/onshell each slot
-        draws its own mass, there is no mass-set stage to hang them on, and they
-        fall back to ``sequential``.
+        decays and have not been thought through here.
         """
         if not density_method:
             return 'joint'
@@ -2282,9 +2295,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                 # win, so do not pay for the identity machinery.
                 mode = 'joint'
             elif self.options['spinmode'] in ['PA', 'onshell']:
-                # two_stage and sequential_global_retry need the up-front mass
-                # draw, which these modes do not have
-                mode = 'sequential'
+                # what PA has always done, and still the fastest of the five
+                # there; the up-front schemes are reachable but are not the
+                # default until a measurement says otherwise
+                mode = 'sequential_with_mass'
             elif nb_decaying <= 2:
                 mode = 'two_stage'
             else:
@@ -2301,13 +2315,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "MadSpin: spinmode=%s keeps the joint accept/reject "
                            "(unweighting ignored)", self.options['spinmode'])
             return self._announce_mode('joint', asked)
-        if (mode in ('two_stage', 'sequential_global_retry')
-                and self.options['spinmode'] in ['PA', 'onshell']):
-            self._log_once('offshell_only',
-                           "MadSpin: unweighting=%s needs an offshell spinmode "
-                           "(it splits the accept/reject at the up-front mass "
-                           "draw, which PA/onshell do not have); using "
-                           "sequential instead", mode)
+        if (mode == 'sequential_with_mass'
+                and self.options['spinmode'] not in ['PA', 'onshell']):
+            self._log_once('with_mass_pa_only',
+                           "MadSpin: unweighting=sequential_with_mass needs a "
+                           "per-particle mass draw, which the offshell "
+                           "spinmodes do not have (they reshuffle the whole "
+                           "production onto the mass set at once); using "
+                           "sequential instead")
             return self._announce_mode('sequential', asked)
         return self._announce_mode(mode, asked)
 
@@ -3639,21 +3654,22 @@ class MadSpinInterface(extended_cmd.Cmd):
     def _scan_maxwgt_range(self, events, start, stop, evt_decayfile,
                            nevents, nb_ps_point):
         """Per-event probe data for ``events[start:stop]``, and the samples of
-        the offshell rate factor collected along the way.
+        the rate factor collected along the way.
 
         Returns ``(per_event, z_samples)``, or ``(None, {})`` as soon as a
         production event turns out to have nothing to decay (the caller then
         falls back to the joint bound).
 
-        For PA/onshell ``per_event`` is one max-weight vector per event, holding
-        for each ordering position the largest w_k over ``nb_ps_point`` chains --
-        all the bound needs. The offshell branch keeps every chain instead: its
-        mass-set weight is only complete once Z_k is known, and Z_k is fitted
-        from ``z_samples``, which this same probe produces. Taking the maximum
-        there is deferred to the caller, over the completed weights.
+        Under ``sequential_with_mass`` ``per_event`` is one max-weight vector
+        per event, holding for each ordering position the largest w_k over
+        ``nb_ps_point`` chains -- all the bound needs. The up-front-mass schemes
+        keep every chain instead: their mass-set weight is only complete once
+        Z_k is known, and Z_k is fitted from ``z_samples``, which this same
+        probe produces. Taking the maximum there is deferred to the caller, over
+        the completed weights.
         """
         self.efficiency = 1. / nb_ps_point
-        offshell = self._sequential_offshell()
+        upfront = self._sequential_upfront()
         t0 = time.time()
         per_event = []
         z_samples = collections.defaultdict(list)
@@ -3678,7 +3694,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                                     probe_extra=extra)
                 if out is None:
                     return None, {}
-                if offshell:
+                if upfront:
                     chains.append([list(probe), list(extra['mass'])])
                     for key, mass, value in extra.pop('z', ()):
                         z_samples[key].append((mass, value))
@@ -3686,7 +3702,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     best = list(probe)
                 else:
                     best = [max(old, new) for old, new in zip(best, probe)]
-            if offshell:
+            if upfront:
                 if chains:
                     per_event.append({'keys': extra['keys'],
                                       'order': extra['order'],
@@ -3891,17 +3907,21 @@ class MadSpinInterface(extended_cmd.Cmd):
         kept and the accept/reject counts its overflows.
         """
         offshell = self._sequential_offshell()
+        upfront = self._sequential_upfront()
         cache = None
         if self.options['ms_dir']:
             # a distinct name: the joint bound is a single float, this is a list.
-            # The offshell bounds come with the Z_k tables and depend on
-            # the unweighting mode, so they get a name (and a format) of their own --
-            # a cache written for one cannot be read back for the other.
-            if offshell:
+            # The up-front-mass bounds come with the Z_k tables and depend on the
+            # unweighting mode *and* on the spinmode family (the mass-set weight
+            # is a different quantity offshell and under PA), so they get a name
+            # (and a format) of their own -- a cache written for one cannot be
+            # read back for the other.
+            if upfront:
                 mode = self._unweighting_mode()
                 variant = '' if mode == 'sequential' else '_%s' % mode
                 cache = pjoin(self.options['ms_dir'],
-                              'max_wgt_sequential_offshell%s' % variant)
+                              'max_wgt_sequential_%s%s'
+                              % ('offshell' if offshell else 'pa', variant))
                 cached = self._read_offshell_cache(cache)
                 if cached is not None:
                     self._z_tables = cached['z_tables']
@@ -3963,16 +3983,16 @@ class MadSpinInterface(extended_cmd.Cmd):
             # _combine_maxwgt needs a spread to work with
             return []
 
-        if offshell:
+        if upfront:
             self._z_tables = self._build_z_tables(z_samples)
-            per_event = [self._complete_offshell_probe(event)
+            per_event = [self._complete_upfront_probe(event)
                          for event in per_event]
 
         maxwgts = [self._combine_maxwgt([event[slot] for event in per_event])
                    for slot in range(len(per_event[0]))]
         logger.info("Sequential maximum weights: %s",
                     ' '.join('%.4g' % w for w in maxwgts))
-        if cache and offshell:
+        if cache and upfront:
             import json
             with open(cache, 'w') as f:
                 json.dump({'format': self._OFFSHELL_CACHE_FORMAT,
@@ -3981,11 +4001,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             open(cache, 'w').write(' '.join(repr(w) for w in maxwgts))
         return maxwgts
 
-    # Bumped whenever the offshell cache's *meaning* changes: another entry in
-    # the bound vector, a different fit variable or degree, another key in a
-    # table. The file name already separates the unweighting modes,
-    # and PA/onshell from both; this separates one version of this code from the
-    # next, which a name cannot.
+    # Bumped whenever the cache's *meaning* changes: another entry in the bound
+    # vector, a different fit variable or degree, another key in a table. The
+    # file name already separates the unweighting modes, and the offshell
+    # spinmodes from PA/onshell; this separates one version of this code from
+    # the next, which a name cannot.
     # 2: the mass-set weight is normalised by |M_prod|^2 on shell, so every
     #    bound in the vector changed scale.
     _OFFSHELL_CACHE_FORMAT = 2
@@ -4031,9 +4051,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             return None
         return {'maxwgts': maxwgts, 'z_tables': tables}
 
-    def _complete_offshell_probe(self, event):
-        """The per-event maximum-weight vector of the offshell probe, over the
-        chains it recorded and with the Z_k factors the loop could not apply
+    def _complete_upfront_probe(self, event):
+        """The per-event maximum-weight vector of an up-front-mass probe, over
+        the chains it recorded and with the Z_k factors the loop could not apply
         while they were still being measured: Z_k(m_k) into the mass-set weight,
         and -- under sequential_global_retry, where the mass stage pays it and the
         per-angle stage takes it back -- 1/Z_k into that slot's own weight.
@@ -4321,31 +4341,67 @@ class MadSpinInterface(extended_cmd.Cmd):
         dec[0].reshuffle_info = info
         return budget - mass, jac
 
-    def _offshell_production(self, production, order, particles, slot_to_index,
-                             prod_static):
-        """Set up the offshell (madspin/full) production for one chain attempt.
+    def _upfront_production(self, production, order, particles, slot_to_index,
+                            prod_static, offshell, draw_mass=True,
+                            density_prod=None):
+        """Set up the production for one chain attempt of an up-front-mass
+        scheme: draw a virtuality for every decaying particle *before* the
+        per-particle loop, and settle everything that depends on the mass set
+        but not on the decay angles.
 
-        Draws a virtuality for every decaying particle up front, reshuffles a
-        *copy* of the production to that mass set (leaving the shared event
-        untouched), and evaluates the production density there. Because every
-        mass is fixed before the per-particle loop, that density (rho) is fixed
-        for the whole chain -- which is what the per-particle decomposition needs
-        and what madspin does not give for free (see MADSPIN_SEQUENTIAL_PLAN.md
-        section 10).
+        Returns ``(rho, jac_prod, slot_mass, parents)`` or None if the mass set
+        is one the production cannot be reshuffled onto (the caller redraws the
+        whole set):
+        - ``slot_mass[slot]`` = (mass, reshuffle_info, jac_bw), empty when
+          ``draw_mass`` is False (onshell, and 2 -> 1 production under PA, have
+          no virtuality to sample). ``draw_mass`` describes the *PA* draw only:
+          offshell always samples, since its rho is defined at the reshuffled
+          momenta and there is nothing to evaluate without a mass set;
+        - ``jac_prod``        = the production reshuffling jacobian of that mass
+          set;
+        - ``parents[slot]``   = the production particle to boost that slot's
+          decay to.
 
-        Returns ``(rho_off, jac_reshuffle, slot_mass, parents)`` or None if the
-        mass set cannot be reshuffled (the caller redraws the whole set):
-        - ``slot_mass[slot]`` = (mass, reshuffle_info, jac_bw);
-        - ``parents[slot]``   = the reshuffled (offshell) production particle to
-          boost that slot's decay to.
+        The two spinmode families differ in what the up-front draw is *for*.
+
+        Offshell (madspin/full): rho depends on the whole mass set, so a *copy*
+        of the production is reshuffled here (leaving the shared event
+        untouched) and the density is evaluated at those momenta. Fixing rho
+        before the loop is what makes the per-particle decomposition possible at
+        all -- see MADSPIN_SEQUENTIAL_PLAN.md section 10.
+
+        PA: rho is evaluated at the *onshell* momenta and is already fixed per
+        production event (cached on it), so there is nothing to gain there. What
+        the up-front draw buys instead is ``jac_prod``: with
+        ``density_keep_jacobian`` on, the per-slot scheme calls
+        ``_production_jacobian_for`` -- an event copy and a reshuffle -- on every
+        slot trial and telescopes the results, whereas here it is one call per
+        mass set and the J_k/J_{k-1} ratios disappear. The production event
+        itself is never reshuffled here: under PA that is a post-acceptance
+        dressing (or the final ``reshuffle_production``), and the decays are
+        boosted to the onshell parents.
         """
         budget = production.sqrts
         slot_mass = {}
-        for slot in order:
-            pdg = particles[slot_to_index[slot]].pid
-            mass, info, jac_bw = self._draw_mass_value(pdg, budget)
-            slot_mass[slot] = (mass, info, jac_bw)
-            budget -= mass
+        if offshell or draw_mass:
+            for slot in order:
+                pdg = particles[slot_to_index[slot]].pid
+                mass, info, jac_bw = self._draw_mass_value(pdg, budget)
+                slot_mass[slot] = (mass, info, jac_bw)
+                budget -= mass
+
+        if not offshell:
+            # PA/onshell: onshell rho, onshell parents. Only the feasibility of
+            # the mass set and its reshuffling jacobian are settled here.
+            jac_prod = 1.0
+            if slot_mass:
+                jac_prod = self._production_jacobian_for(
+                    production, slot_to_index,
+                    {slot: (mass, info)
+                     for slot, (mass, info, _) in slot_mass.items()})
+                if jac_prod in (0, -1):
+                    return None
+            return density_prod, jac_prod, slot_mass, prod_static['init_part']
 
         prod_off = lhe_parser.Event(str(production))
         finals = [p for p in prod_off if int(p.status) == 1]
@@ -4371,24 +4427,60 @@ class MadSpinInterface(extended_cmd.Cmd):
         virtualities are drawn up front and rho is fixed per chain."""
         return self.options['spinmode'] not in ['PA', 'onshell']
 
+    def _sequential_upfront(self, density_method=True):
+        """Whether the chain draws every virtuality *before* the angles, i.e.
+        whether there is a mass-set accept/reject in front of the angle stage.
+
+        True for every scheme but ``sequential_with_mass``, which draws each
+        slot's mass inside that slot's own accept/reject. What the up-front draw
+        buys differs by spinmode: offshell it fixes rho for the chain (which is
+        what makes the per-particle decomposition possible at all), while under
+        PA rho is already fixed at the onshell momenta and what is frozen
+        instead is the *production reshuffling jacobian* -- one reshuffle per
+        mass set rather than one per slot trial. Either way the angle stage then
+        redraws to acceptance and divides out its own normalisation, which is
+        what the tabulated ``_zhat`` puts back.
+        """
+        return self._unweighting_mode(density_method) not in \
+                    ('joint', 'sequential_with_mass')
+
     # ------------------------------------------------------------------
-    # Z_k(m): the offshell rate factor of one slot (madspin/full only)
+    # Z_k(m): the rate factor of one slot, in the up-front-mass schemes
     # ------------------------------------------------------------------
-    # The offshell chain is unweighted in two stages -- the mass set first, then
-    # each slot's decay angles -- and the per-angle stage redraws until it
-    # accepts. That divides its own normalisation
+    # Those chains are unweighted in two stages -- the mass set first, then each
+    # slot's decay angles -- and the per-angle stage redraws until it accepts.
+    # That divides its own normalisation
     #
     #     Z_k(m) = Integral p_pool(Omega) w_k(Omega, m) dOmega
-    #            = Integral dPhi_off(m) |M_dec|^2 / Integral dPhi_on |M_dec|^2
     #
     # out of the accepted sample, so without a compensating factor in the
     # mass-set weight the accepted virtualities follow the Breit-Wigner instead
-    # of the offshell one -- the resonance lineshape comes out PA-shaped. Z_k is
-    # the running partial width (times m/M, there being no 1/2m flux factor
-    # here), a smooth function of that slot's virtuality *alone*: the production
-    # event, the other slots' masses and the angles already accepted all cancel
-    # out of it, which is what makes it tabulable. See MADSPIN_SEQUENTIAL_PLAN.md
-    # section 10.
+    # of the physical one. Either way Z_k is a smooth function of that slot's
+    # virtuality *alone*: the production event, the other slots' masses and the
+    # angles already accepted all cancel out of it, which is what makes it
+    # tabulable. See MADSPIN_SEQUENTIAL_PLAN.md sections 10 and 11.
+    #
+    # What sits inside the average is the spinmode's own per-angle weight:
+    #
+    #   offshell   Z_k(m) = Integral dPhi_off(m) |M_dec|^2
+    #                       / Integral dPhi_on |M_dec|^2
+    #                     = (m/M) Gamma_k(m) / Gamma_k(M)
+    #              -- the decay reshuffling jacobian *and* the offshell/onshell
+    #              rate ratio Tr(D^off)/|M_dec|^2_on, the running width;
+    #
+    #   PA         Z_k(m) = E_pool[ jac_dec(m, Omega) ]
+    #              -- the decay reshuffling jacobian alone. PA evaluates its
+    #              matrix elements on shell, so there is no offshell integrand
+    #              to reweight; what the angle stage normalises away is purely
+    #              the phase-space cost of mapping a pool decay onto the sampled
+    #              virtuality. (With density_keep_jacobian off that jacobian is
+    #              not in the weight at all, and Z_k degenerates to the fraction
+    #              of the pool that can reach m.)
+    #
+    # Same machinery for both: bin in m, average, fit, multiply into the
+    # mass-set weight. Note that ``sequential_with_mass`` needs none of this --
+    # it redraws the mass with the angles, so no stage freezes a virtuality and
+    # none of them has a conditional normalisation to divide out.
     #
     # A *wrong* Z_hat does not cancel: the per-angle stage divides out the true
     # Z_k whatever weight it is given (rescaling w_k by anything that does not
@@ -4486,8 +4578,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         for key, samples in sorted(z_samples.items()):
             if len(samples) < 4 * min_per_bin:
                 logger.warning("MadSpin sequential: only %d probe samples for "
-                               "slot %s, not tabulating its offshell rate "
-                               "factor", len(samples), key)
+                               "slot %s, not tabulating its rate factor",
+                               len(samples), key)
                 continue
             pole = self.banner.get('param', 'mass',
                                    abs(int(key.split('_')[0]))).value
@@ -4520,7 +4612,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                             [p[1] for p in points],
                                             [float(p[2]) for p in points])
             if coeff is None:
-                logger.warning("MadSpin sequential: could not fit the offshell "
+                logger.warning("MadSpin sequential: could not fit the "
                                "rate factor of slot %s (%d usable bins)",
                                key, len(points))
                 continue
@@ -4533,7 +4625,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             tables[key] = {'pole': pole, 'coeff': coeff,
                            'zero_below': zero_below,
                            'range': (max(lo, zero_below), hi)}
-            logger.info("MadSpin sequential: slot %s offshell rate factor "
+            logger.info("MadSpin sequential: slot %s rate factor "
                         "Z(%.5g)=%.3f  Z(%.5g)=1  Z(%.5g)=%.3f "
                         "(%d samples, %d bins, bin/fit deviation up to %.1f%%)",
                         key, lo, fit(math.log(max(lo, zero_below) / pole)),
@@ -4542,7 +4634,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         return tables
 
     def _check_weight_identity(self, production, decays, decay_dict, w_seq,
-                               helicities, stats):
+                               helicities, stats, offshell=True, keep_jac=True,
+                               parents=None):
         """sequential_debug: the identity the whole decomposition rests on,
         checked on the accepted chain instead of inferred from a distribution.
 
@@ -4563,18 +4656,34 @@ class MadSpinInterface(extended_cmd.Cmd):
         prod_copy = lhe_parser.Event(str(production))
         decays_copy = collections.defaultdict(list)
         jac_bw = 1.0
+        index = 0
         for pdg, decay_list in decays.items():
             for decay in decay_list:
                 copy = lhe_parser.Event(str(decay))
-                copy[0].new_mass = decay[0].new_mass
-                copy[0].reshuffle_info = decay[0].reshuffle_info
+                if not offshell and parents is not None:
+                    # PA hands back its accepted decays already boosted to the
+                    # lab frame -- _slot_density boosts them in place, and that
+                    # is the frame add_decays wants -- while
+                    # calculate_matrix_element_from_density does that boost
+                    # itself. Undo it so the joint route starts where it
+                    # expects to. (Offshell takes its density on a copy, so
+                    # there the drawn decay is still in its rest frame.)
+                    copy.boost(lhe_parser.FourMomentum(parents[index]))
+                mass = getattr(decay[0], 'new_mass', None)
+                if mass is not None:
+                    copy[0].new_mass = mass
+                    copy[0].reshuffle_info = decay[0].reshuffle_info
                 decays_copy[pdg].append(copy)
+                index += 1
         # the Breit-Wigner sampling jacobians: the joint path folds them in
         # itself when it draws the masses, and here the masses are given, so
         # they are recomputed from the same (pole, width, window) the draw used
         for pdg, decay_list in decays.items():
             for decay in decay_list:
-                pole, width, min_mass, max_mass = decay[0].reshuffle_info
+                info = getattr(decay[0], 'reshuffle_info', None)
+                if info is None:
+                    continue        # no virtuality was sampled for this slot
+                pole, width, min_mass, max_mass = info
                 gap = math.atan((pole ** 2 - min_mass ** 2) / pole / width)
                 gap += math.atan((max_mass ** 2 - pole ** 2) / pole / width)
                 jac_bw *= gap / math.pi
@@ -4582,6 +4691,31 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.calculate_matrix_element_from_density(prod_copy, decays_copy,
                                                        decay_dict)
         w_joint = full_me / (prod_diag * dec_diag) * jac_reshuffle * jac_bw
+        if not offshell and keep_jac:
+            # PA's reshuffling jacobian is not inside
+            # calculate_matrix_element_from_density: the pole approximation
+            # leaves the momenta onshell there (it returns jac_reshuffle = 1)
+            # and the joint path takes the jacobian from a reshuffle of the
+            # *complete* event, done outside. Recomputing it that way is what
+            # makes this an independent check of the two pieces the chain used
+            # instead -- the mass stage's _production_jacobian_for and the
+            # per-slot _decay_reshuffle_jacobian -- whose product it must equal.
+            rebuilt = collections.defaultdict(list)
+            for pdg, decay_list in decays.items():
+                for decay in decay_list:
+                    copy = lhe_parser.Event(str(decay))
+                    copy[0].new_mass = decay[0].new_mass
+                    copy[0].reshuffle_info = decay[0].reshuffle_info
+                    rebuilt[pdg].append(copy)
+            full_evt = lhe_parser.Event(str(production)).add_decays(rebuilt)
+            jac_full = full_evt.reshuffle_production(_allow_retry=False)
+            if jac_full in (0, -1):
+                # the chain kept this mass set, so this should not happen; skip
+                # the chain rather than compare against a meaningless number
+                logger.debug('sequential_debug: the accepted mass set does not '
+                             'reshuffle through the joint route, chain skipped')
+                return
+            w_joint *= jac_full
         nb_hel = 1
         for hel in helicities:
             nb_hel *= len(hel)
@@ -4622,19 +4756,25 @@ class MadSpinInterface(extended_cmd.Cmd):
         is redrawn; the slots already accepted are kept. See
         MADSPIN_SEQUENTIAL_PLAN.md.
 
-        Failure handling follows the scope of the failure. In PA, where slot k
-        draws its own mass, a mass its decay products cannot accommodate is
-        redrawn on the spot; a mass *set* the production cannot reshuffle is only
-        knowable once every slot has a mass, so it trashes the whole set and
-        restarts the chain. Offshell the mass set is fixed before the loop, so
-        the same decay-side failure is a rejection of that decay instead.
+        Failure handling follows the scope of the failure. Under
+        ``sequential_with_mass``, where slot k draws its own mass, a mass its
+        decay products cannot accommodate is redrawn on the spot; a mass *set*
+        the production cannot reshuffle is only knowable once every slot has a
+        mass, so it trashes the whole set and restarts the chain. In the
+        up-front schemes the mass set is fixed before the loop, so the same
+        decay-side failure is a rejection of that decay instead.
 
-        The offshell (madspin/full) branch splits this in two: a mass-set
-        accept/reject first, then the per-angle loop above. The per-angle loop
-        redraws until it accepts and so divides out its own normalisation
-        Z_k(m), which is a function of the sampled virtuality -- hence the
-        tabulated ``_zhat`` factor in the mass-set weight, without which the
-        accepted resonance lineshape is the Breit-Wigner one. Under
+        Every scheme but ``sequential_with_mass`` splits this in two: a mass-set
+        accept/reject first, then the per-angle loop above. The mass stage
+        carries everything that depends on the virtualities but not on the
+        angles -- the Breit-Wigner sampling jacobians, the production
+        reshuffling jacobian, and offshell also the offshell production trace --
+        so those are evaluated once per mass set instead of once per slot trial,
+        which is the whole point of drawing the masses first. The per-angle loop
+        then redraws until it accepts and so divides out its own normalisation
+        Z_k(m), a function of the sampled virtuality -- hence the tabulated
+        ``_zhat`` factor in the mass-set weight, without which the accepted
+        resonance lineshape is the Breit-Wigner one. Under
         ``sequential_global_retry`` a rejected decay trashes the mass set, the
         per-angle stage stops normalising, and Z_hat cancels from the chain
         (leaving it a pure efficiency preconditioner).
@@ -4677,19 +4817,23 @@ class MadSpinInterface(extended_cmd.Cmd):
         # the up-front reshuffle) rather than once at onshell. PA/onshell keep a
         # fixed onshell rho, cached on the production event.
         offshell = self._sequential_offshell()
-        # Offshell only: reject the mass set on a rejected decay instead of
-        # redrawing that decay, so the per-angle stage never normalises. See the
-        # Z_k discussion above _z_slot_keys.
-        # One bound over all the angles instead of one per particle, the mass
-        # set paying for a rejection either way: the joint accept/reject with a
-        # mass-set stage in front of it. Exact for the same reason
-        # sequential_global_retry is -- nothing is redrawn in place, so no stage
-        # normalises itself -- and it keeps Z_hat only as a preconditioner,
+        # Whether the virtualities are drawn before the angle loop. True for
+        # every scheme but sequential_with_mass, which draws each slot's mass
+        # inside that slot's own accept/reject.
+        # sequential_global_retry: reject the mass set on a rejected decay
+        # instead of redrawing that decay, so the per-angle stage never
+        # normalises. See the Z_k discussion above _z_slot_keys.
+        # two_stage: one bound over all the angles instead of one per particle,
+        # the mass set paying for a rejection either way -- the joint
+        # accept/reject with a mass-set stage in front of it. Exact for the same
+        # reason sequential_global_retry is (nothing is redrawn in place, so no
+        # stage normalises itself) and it keeps Z_hat only as a preconditioner,
         # since it cancels between the two stages.
         mode = self._unweighting_mode()
-        joint_angles = offshell and mode == 'two_stage'
-        exact = offshell and mode == 'sequential_global_retry'
-        zkeys = self._z_slot_keys(particles, slot_to_index) if offshell else None
+        upfront = mode not in ('joint', 'sequential_with_mass')
+        joint_angles = upfront and mode == 'two_stage'
+        exact = upfront and mode == 'sequential_global_retry'
+        zkeys = self._z_slot_keys(particles, slot_to_index) if upfront else None
         # |M_prod|^2 on shell: the denominator the joint offshell weight divides
         # by (calculate_matrix_element_from_density evaluates it *before*
         # reshuffle_production and returns it as prod_diag). It depends on the
@@ -4740,30 +4884,47 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         while True:     # restart point: an impossible/rejected production mass set
             parents = init_part
-            jac_reshuffle = 1.0
+            jac_prod = 1.0
             slot_mass = {}
-            if offshell:
-                # draw every virtuality, reshuffle the production once, fix rho
-                setup = self._offshell_production(production, order, particles,
-                                                  slot_to_index, prod_static)
+            if upfront:
+                # draw every virtuality, then settle whatever depends on the
+                # mass set alone: offshell that is the production reshuffle and
+                # rho, under PA the production reshuffling jacobian
+                setup = self._upfront_production(production, order, particles,
+                                                 slot_to_index, prod_static,
+                                                 offshell, draw_mass=draw_mass,
+                                                 density_prod=density_prod)
                 if setup is None:
                     stats['nb_production_restart'] += 1
                     continue
-                density_prod, jac_reshuffle, slot_mass, parents = setup
+                density_prod, jac_prod, slot_mass, parents = setup
 
                 # Mass-set accept/reject, before the per-angle loop. All the
                 # factors that depend on the mass set but not the decay angles --
                 # the production reshuffling jacobian, the Breit-Wigner sampling
-                # jacobians, and the offshell production trace -- go here, so the
+                # jacobians, and offshell the production trace -- go here, so the
                 # per-angle loop no longer carries them (that bundling made slot
-                # 0's acceptance ~1/300). See MADSPIN_SEQUENTIAL_PLAN.md sec 10.
-                # Tr(rho_off)/|M_prod|^2_on -- the offshell production matrix
-                # element over the onshell one, which is what the joint weight
-                # carries. Applied in probe mode too, unlike Z_hat: it is known
-                # before the scan, so the bound is measured on the same quantity
-                # the accept/reject will test.
-                w_mass = density_prod.trace().real / me_prod_on * jac_reshuffle
-                for s in order:
+                # 0's acceptance ~1/300 offshell, and cost PA one production
+                # reshuffling per slot trial). See MADSPIN_SEQUENTIAL_PLAN.md
+                # sections 10 and 11.
+                if offshell:
+                    # Tr(rho_off)/|M_prod|^2_on -- the offshell production matrix
+                    # element over the onshell one, which is what the joint weight
+                    # carries. Applied in probe mode too, unlike Z_hat: it is known
+                    # before the scan, so the bound is measured on the same quantity
+                    # the accept/reject will test. jac_prod is the jacobian of the
+                    # reshuffle that produced rho_off.
+                    w_mass = density_prod.trace().real / me_prod_on * jac_prod
+                else:
+                    # PA/onshell: rho is the onshell one and cancels between N_n
+                    # and N_0, so nothing of the production matrix element rides
+                    # here. jac_prod is the reshuffling jacobian of the whole
+                    # mass set -- the factor the per-slot scheme re-evaluates on
+                    # every trial and telescopes. Under density_keep_jacobian =
+                    # False the reshuffle is a post-acceptance dressing and is
+                    # not in the weight at all; only its feasibility was checked.
+                    w_mass = jac_prod if keep_jac else 1.0
+                for s in slot_mass:
                     w_mass *= slot_mass[s][2]
                 # before Z_hat, which cancels between the two stages:
                 # this is what the weight-identity check compares
@@ -4773,7 +4934,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                     probe.append(float(w_mass))
                     probe_extra['keys'] = zkeys
                     probe_extra['order'] = list(order)
-                    probe_extra['mass'] = [slot_mass[s][0]
+                    probe_extra['mass'] = [slot_mass[s][0] if s in slot_mass
+                                           else 0.0
                                            for s in range(len(order))]
                     # not reset with the rest: a chain that ends up restarting
                     # still drew valid (virtuality, rate factor) pairs, and Z_k
@@ -4784,22 +4946,25 @@ class MadSpinInterface(extended_cmd.Cmd):
                 else:
                     # Z_k(m_k): what the per-angle stage will divide out again.
                     # Without it the accepted virtualities are Breit-Wigner
-                    # distributed instead of offshell distributed.
-                    for s in order:
+                    # distributed instead of physically distributed.
+                    for s in slot_mass:
                         w_mass *= self._zhat(zkeys[s], slot_mass[s][0])
-                if probe is None and maxwgts:
+                if probe is None and maxwgts and slot_mass:
+                    # no virtuality to unweight means w_mass is the constant 1
+                    # (onshell, and 2 -> 1 production under PA): testing it
+                    # against its bound would only throw chains away
                     if w_mass > maxwgts[0]:
                         stats['nb_overflow_mass'] += 1
                     if random.random() * maxwgts[0] >= w_mass:
                         stats['nb_mass_reject'] += 1
                         continue            # redraw the whole mass set
 
-            # Angle stage. The mass set, the offshell production density and
-            # the reshuffled parents are all fixed above and are *reused* by
+            # Angle stage. The mass set, the production density and its
+            # reshuffling jacobian are all fixed above and are *reused* by
             # every pass of this loop -- which is the whole point of drawing the
             # virtualities first: the joint accept/reject pays a production
-            # reshuffling and a production density matrix on every trial,
-            # because a rejection there redraws the masses too.
+            # reshuffling (and, offshell, a production density matrix) on every
+            # trial, because a rejection there redraws the masses too.
             #   two_stage: a rejected angle set is redrawn
             #     against the same mass set, so this loop is where the reuse
             #     happens -- and, redrawing to acceptance, it normalises itself,
@@ -4822,9 +4987,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                 for position, slot in enumerate(order):
                     index = slot_to_index[slot]
                     particle = particles[index]
-                    # offshell reserves maxwgts[0] for the mass set, so the per-slot
-                    # bounds start at index 1
-                    wpos = position + 1 if offshell else position
+                    # the up-front schemes reserve maxwgts[0] for the mass set,
+                    # so their per-slot bounds start at index 1
+                    wpos = position + 1 if upfront else position
                     if joint_angles:
                         # every slot contributes to the single angle weight, tested
                         # once the last one has been drawn
@@ -4840,28 +5005,44 @@ class MadSpinInterface(extended_cmd.Cmd):
                         decay = self._draw_one_decay(particle, index, ids,
                                                      evt_decayfile, nb_remain)
 
-                        if offshell:
-                            # madspin/full: offshell numerator over onshell
-                            # denominator. The mass was drawn up front, so the
-                            # decay is reshuffled to it.
-                            me_on = self.calculate_matrix_element(decay)   # |M_dec|^2_on
-                            decay[0].new_mass, decay[0].reshuffle_info = \
-                                slot_mass[slot][0], slot_mass[slot][1]
-                            # The offshell density is taken on a copy: the drawn
-                            # decay must stay in its onshell rest frame (only tagged
-                            # with new_mass) so the final add_decays + a single
-                            # reshuffle_production rebuild consistent kinematics.
-                            # Reshuffling/boosting it in place leaves it on the
-                            # offshell parent and add_decays then rejects it.
-                            dcopy = lhe_parser.Event(str(decay))
-                            dcopy[0].new_mass = slot_mass[slot][0]
-                            dcopy[0].reshuffle_info = slot_mass[slot][1]
-                            # jac_dec_k: the decay reshuffling jacobian. Joint
-                            # madspin has it (calculate_matrix_element_from_density,
-                            # 'jac *= dec.reshuffle_decayevt()'), so it belongs in
-                            # the per-slot weight here -- it depends on this slot's
-                            # decay only, hence no telescoping ratio.
-                            jac_dec = dcopy.reshuffle_decayevt()
+                        if upfront:
+                            mass = slot_mass.get(slot)
+                            me_on = 1.0
+                            dcopy = None
+                            jac_dec = 1.0
+                            if offshell:
+                                # madspin/full: offshell numerator over onshell
+                                # denominator. The mass was drawn up front, so the
+                                # decay is reshuffled to it.
+                                me_on = self.calculate_matrix_element(decay)   # |M_dec|^2_on
+                                decay[0].new_mass, decay[0].reshuffle_info = \
+                                    mass[0], mass[1]
+                                # The offshell density is taken on a copy: the drawn
+                                # decay must stay in its onshell rest frame (only tagged
+                                # with new_mass) so the final add_decays + a single
+                                # reshuffle_production rebuild consistent kinematics.
+                                # Reshuffling/boosting it in place leaves it on the
+                                # offshell parent and add_decays then rejects it.
+                                dcopy = lhe_parser.Event(str(decay))
+                                dcopy[0].new_mass = mass[0]
+                                dcopy[0].reshuffle_info = mass[1]
+                                # jac_dec_k: the decay reshuffling jacobian. Joint
+                                # madspin has it (calculate_matrix_element_from_density,
+                                # 'jac *= dec.reshuffle_decayevt()'), so it belongs in
+                                # the per-slot weight here -- it depends on this slot's
+                                # decay only, hence no telescoping ratio.
+                                jac_dec = dcopy.reshuffle_decayevt()
+                            elif mass is not None:
+                                # PA: the decay stays onshell, only *tagged* with
+                                # the virtuality that add_decays and the final
+                                # reshuffle_production will consume, exactly as
+                                # the per-slot mass draw leaves it. Its
+                                # reshuffling jacobian is probed on a copy, and
+                                # it is the same factor the joint PA weight picks
+                                # up inside its full-event reshuffle_production.
+                                decay[0].new_mass, decay[0].reshuffle_info = \
+                                    mass[0], mass[1]
+                                jac_dec = self._decay_reshuffle_jacobian(decay)
                             if jac_dec in (0, -1):
                                 # This decay cannot be mapped onto the sampled
                                 # virtuality (its products do not fit). That is a
@@ -4877,7 +5058,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 stats['nb_infeasible_%d' % position] += 1
                                 if probe is not None:
                                     probe_extra['z'].append(
-                                        (zkeys[slot], slot_mass[slot][0], 0.0))
+                                        (zkeys[slot], mass[0], 0.0))
                                 elif joint_angles:
                                     # A zero anywhere makes the whole angle set
                                     # weight zero, so the set is rejected: stop
@@ -4909,31 +5090,50 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 stats['nb_production_restart'] += 1
                                 restart = True
                                 break
-                            density = self._slot_density(dcopy, parents[slot],
-                                                         helicities[slot])
+                            if offshell:
+                                # per-angle factor only: (N_k/N_{k-1}) * jac_dec_k
+                                # * Tr(D_off)/|M_dec|^2_on. jac_bw and the
+                                # *production* reshuffling jacobian are in w_mass.
+                                density = self._slot_density(dcopy, parents[slot],
+                                                             helicities[slot])
+                                rate = jac_dec * (density.trace().real / me_on)
+                            else:
+                                # PA/onshell: the matrix elements are on shell, so
+                                # there is no offshell/onshell rate ratio -- the
+                                # only angle-dependent factor left over the density
+                                # ratio is the decay reshuffling jacobian. With
+                                # density_keep_jacobian off, joint PA does not put
+                                # it in its weight either (the reshuffle runs after
+                                # acceptance), so neither does this; a decay that
+                                # cannot reach the virtuality is still a zero, and
+                                # Z_k then measures the feasible fraction.
+                                density = self._slot_density(decay, parents[slot],
+                                                             helicities[slot])
+                                rate = jac_dec if keep_jac else 1.0
                             slot_densities[slot] = density
                             n_k = self._partial_density_contraction(
                                             density_prod, helicities, slot_densities)
-                            # per-angle factor only: (N_k/N_{k-1}) * jac_dec_k *
-                            # Tr(D_off)/|M_dec|^2_on. jac_bw and the *production*
-                            # reshuffling jacobian are in w_mass.
-                            rate = jac_dec * (density.trace().real / me_on)
                             wgt = (n_k / n_prev).real * rate
                             wgt_raw = wgt        # before any Z_hat division
                             j_k, new_budget = j_prev, budget
+                            # Z_hat_k(m_k), or 1 where there is no virtuality to
+                            # condition on (onshell, 2 -> 1 production under PA)
+                            zhat = self._zhat(zkeys[slot], mass[0]) \
+                                   if mass is not None else 1.0
                             if probe is not None:
                                 probe.append(float(wgt))
-                                # E[rate | m] = E[w_k | m] = Z_k(m) -- the same
-                                # expectation, without the polarisation modulation
-                                # of the density ratio, so it is the tighter
-                                # estimator of the two.
-                                probe_extra['z'].append(
-                                    (zkeys[slot], slot_mass[slot][0], float(rate)))
+                                # E[rate | m] = E[w_k | m] = Z_k(m) -- the pool
+                                # average of the density ratio is one at fixed m,
+                                # so the two have the same expectation and rate
+                                # carries no polarisation modulation, which makes
+                                # it the tighter estimator of the two.
+                                if mass is not None:
+                                    probe_extra['z'].append(
+                                        (zkeys[slot], mass[0], float(rate)))
                                 accept = True
                             elif joint_angles:
                                 # no test here: every slot feeds the single angle
                                 # weight, tested once the last decay is drawn
-                                zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
                                 w_angles *= wgt / zhat if zhat > 0 else 0.0
                                 accept = True
                             elif maxwgt is None:
@@ -4944,7 +5144,6 @@ class MadSpinInterface(extended_cmd.Cmd):
                                     # bound this is tested against is the one of
                                     # w_k/Z_hat_k -- flat in the virtuality, and the
                                     # two factors cancel over the chain
-                                    zhat = self._zhat(zkeys[slot], slot_mass[slot][0])
                                     wgt = wgt / zhat if zhat > 0 else 0.0
                                 if wgt > maxwgt:
                                     stats['nb_overflow_%d' % position] += 1
@@ -5062,9 +5261,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                         # drawn again. That reuse is the point of this scheme.
                         continue
                 break
-            if not restart and draw_mass and not keep_jac and probe is None:
-                # feasibility of the complete mass set: one reshuffle for the
-                # whole chain instead of one per trial
+            if (not restart and not upfront and draw_mass and not keep_jac
+                    and probe is None):
+                # sequential_with_mass, jacobian off: the masses are only all
+                # known once the chain is complete, so the feasibility of the
+                # set is checked here -- one reshuffle for the whole chain
+                # instead of one per trial. The up-front schemes settled it
+                # before the angle loop.
                 if self._production_jacobian_for(production, slot_to_index,
                                                  slot_masses) in (0, -1):
                     stats['nb_production_restart'] += 1
@@ -5080,10 +5283,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         decays = collections.defaultdict(list)
         for slot in range(len(order)):
             decays[particles[slot_to_index[slot]].pid].append(slot_decays[slot])
-        if (offshell and probe is None and decay_dict
+        if (upfront and probe is None and decay_dict
                 and self.options['sequential_debug']):
             self._check_weight_identity(production, decays, decay_dict,
-                                        w_mass_raw * w_slots, helicities, stats)
+                                        w_mass_raw * w_slots, helicities, stats,
+                                        offshell, keep_jac, parents)
         return decays
 
     def get_onshell_evt_and_wgt(self, production, decays, decay_dict, prod_density_cached=None, build_event=True):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1128,7 +1128,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             allowed.extend(combo)
         return madspin.DensityMatrix(arr, 2, allowed, dim)
 
-    def _stub(self, rho, pools):
+    def _stub(self, rho, pools, unweighting='sequential_with_mass'):
         interface = interface_madspin.MadSpinInterface
         hels = self.HELS
         pool = self.POOL
@@ -1143,13 +1143,19 @@ class TestSequentialAcceptReject(unittest.TestCase):
             sequential_accept_reject = interface.sequential_accept_reject
             _scan_maxwgt_range = interface._scan_maxwgt_range
             _sequential_offshell = interface._sequential_offshell
+            _sequential_upfront = interface._sequential_upfront
+            _upfront_production = interface._upfront_production
+            _z_slot_keys = staticmethod(interface._z_slot_keys)
+            _zhat = interface._zhat
+            _complete_upfront_probe = interface._complete_upfront_probe
             _unweighting_mode = interface._unweighting_mode
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
             def __init__(self):
                 self.options = {'spinmode': 'onshell',
                                 'sequential_spin_order': '2 3 1',
-                                'unweighting': 'sequential',
+                                'unweighting': unweighting,
+                                'sequential_debug': False,
                                 'fixed_order': False}
             def _density_basis(self, production, decays_key):
                 particles, slots = interface._sequential_slots(production, decays_key)
@@ -1178,26 +1184,33 @@ class TestSequentialAcceptReject(unittest.TestCase):
                           for d in pool) / self.POOL
             self.assertTrue(np.allclose(average, np.eye(2) / 2))
 
+    def _target(self, stub, rho, pools):
+        """p(decays) proportional to N_n, normalised -- what every scheme has to
+        sample."""
+        exact = {(a, b): stub._partial_density_contraction(
+                            rho, self.HELS, {0: pools[0][a], 1: pools[1][b]}).real
+                 for a in range(self.POOL) for b in range(self.POOL)}
+        total = sum(exact.values())
+        return {k: v / total for k, v in exact.items()}
+
+    def _fixture(self, unweighting='sequential_with_mass'):
+        rho = self._production_density()
+        pools = {0: self._pool(100), 1: self._pool(200)}
+        stub = self._stub(rho, pools, unweighting=unweighting)
+        production = self._Prod([self._Part(2, -1), self._Part(-2, -1),
+                                 self._Part(6), self._Part(-6)])
+        _, slots = interface_madspin.MadSpinInterface._sequential_slots(
+                                                    production, (6, -6))
+        stub._slot_of = {index: slot for slot, index in enumerate(slots)}
+        return stub, rho, pools, production, {6: {0: 'f'}, -6: {0: 'f'}}
+
     def test_reproduces_the_joint_distribution(self):
         """The whole claim: p(decays) proportional to N_n, i.e. the same target
         the joint accept/reject samples -- while only ever redrawing one
         particle at a time."""
         import random
-        rho = self._production_density()
-        pools = {0: self._pool(100), 1: self._pool(200)}
-        stub = self._stub(rho, pools)
-        production = self._Prod([self._Part(2, -1), self._Part(-2, -1),
-                                 self._Part(6), self._Part(-6)])
-        evt_decayfile = {6: {0: 'f'}, -6: {0: 'f'}}
-        particles, slots = interface_madspin.MadSpinInterface._sequential_slots(
-                                                    production, (6, -6))
-        stub._slot_of = {index: slot for slot, index in enumerate(slots)}
-
-        exact = {(a, b): stub._partial_density_contraction(
-                            rho, self.HELS, {0: pools[0][a], 1: pools[1][b]}).real
-                 for a in range(self.POOL) for b in range(self.POOL)}
-        total = sum(exact.values())
-        exact = {k: v / total for k, v in exact.items()}
+        stub, rho, pools, production, evt_decayfile = self._fixture()
+        exact = self._target(stub, rho, pools)
         self.assertTrue(all(v > 0 for v in exact.values()))
 
         random.seed(0)
@@ -1212,6 +1225,355 @@ class TestSequentialAcceptReject(unittest.TestCase):
             got = counts[combo] / float(nb_run)
             self.assertLess(abs(got / want - 1), 0.15,
                             'combo %s: got %.4f, expected %.4f' % (combo, got, want))
+
+    def test_every_scheme_samples_the_same_target(self):
+        """The up-front-mass schemes must land on that same distribution. There
+        is no virtuality here (onshell), so their mass stage is the degenerate
+        one -- what is exercised is the plumbing the PA up-front draw shares
+        with them: the shifted bound vector, the Z_hat divisions cancelling
+        against a table that does not exist, and the three rejection policies.
+        """
+        import random
+        for mode in ('sequential', 'two_stage', 'sequential_global_retry'):
+            stub, rho, pools, production, evt_decayfile = self._fixture(mode)
+            self.assertTrue(stub._sequential_upfront(True), mode)
+            exact = self._target(stub, rho, pools)
+            # maxwgts[0] bounds the (constant) mass weight; then either one
+            # bound per slot -- C_k over w_k = N_k/N_{k-1} -- or, for two_stage,
+            # a single one over their product N_n/N_0
+            contract = stub._partial_density_contraction
+            n_0 = contract(rho, self.HELS, {}).real
+            n_1 = [contract(rho, self.HELS, {0: pools[0][a]}).real
+                   for a in range(self.POOL)]
+            n_2 = [[contract(rho, self.HELS,
+                             {0: pools[0][a], 1: pools[1][b]}).real
+                    for b in range(self.POOL)] for a in range(self.POOL)]
+            c_0 = 1.01 * max(n_1[a] / n_0 for a in range(self.POOL))
+            c_1 = 1.01 * max(n_2[a][b] / n_1[a]
+                             for a in range(self.POOL)
+                             for b in range(self.POOL))
+            if mode == 'two_stage':
+                maxwgts = [1.1, 1.01 * max(n_2[a][b] / n_0
+                                           for a in range(self.POOL)
+                                           for b in range(self.POOL))]
+            else:
+                maxwgts = [1.1, c_0, c_1]
+
+            random.seed(0)
+            counts = collections.Counter()
+            nb_run = 20000
+            for _ in range(nb_run):
+                decays = stub.sequential_accept_reject(production, evt_decayfile,
+                                                       maxwgts, 10)
+                counts[(decays[6][0][2], decays[-6][0][2])] += 1
+            for combo, want in exact.items():
+                got = counts[combo] / float(nb_run)
+                self.assertLess(abs(got / want - 1), 0.15,
+                                '%s combo %s: got %.4f, expected %.4f'
+                                % (mode, combo, got, want))
+
+
+class TestPAUpFrontMass(unittest.TestCase):
+    """The PA up-front mass draw and the rate factor it makes necessary.
+
+    Freezing the virtualities before the angles buys the production reshuffling
+    jacobian -- one evaluation per mass set instead of one per slot trial -- but
+    it also makes the angle stage self-normalising: redrawing a slot until it
+    accepts divides out
+
+        Z_k(m) = E_pool[ w_k ] = E_pool[ jac_dec(m, Omega) ]
+
+    (the density ratio N_k/N_{k-1} averages to one at fixed m, so only the decay
+    reshuffling jacobian is left). Unless the mass stage pays that factor back,
+    the accepted virtualities come out distributed as the Breit-Wigner prior
+    rather than as the physical lineshape -- exactly the bias the offshell path
+    was fixed for.
+
+    Driven synthetically: a fake ``jac_dec(m, decay) = f(m) g(decay)`` with
+    ``E_pool[g] = 1``, so ``Z_k(m) = f(m)`` exactly and the accepted mass
+    distribution has a closed form to compare against. ``g`` is constant over
+    each antipodal pair of the pool, which is what keeps ``E[g D] = E[g] E[D]``
+    exact and hence the factorisation above.
+    """
+
+    POOL = 4
+    HELS = TestSequentialAcceptReject.HELS
+    MASSES = (160.0, 173.0, 190.0)
+    POLE = 173.0
+    ALPHA = 3.0                     # f(m) = (m/pole)**ALPHA
+
+    def _f(self, mass):
+        return (mass / self.POLE) ** self.ALPHA
+
+    def _g(self, index):
+        # constant over each antipodal pair, mean one over the pool
+        return 0.5 if index < 2 else 1.5
+
+    class _Decay(object):
+        """The minimum a decay event needs to be here: a slot/pool identity and
+        a first particle that can carry new_mass."""
+        class _Head(object):
+            pass
+        def __init__(self, slot, index):
+            self.slot = slot
+            self.index = index
+            self.head = self._Head()
+        def __getitem__(self, position):
+            assert position == 0
+            return self.head
+
+    def _stub(self, rho, pools, z_table=True, keep_jac=True,
+              unweighting='sequential'):
+        interface = interface_madspin.MadSpinInterface
+        outer = self
+        hels = self.HELS
+
+        class Stub(object):
+            _decaying_pdgs = staticmethod(interface._decaying_pdgs)
+            _sequential_slots = staticmethod(interface._sequential_slots)
+            _slot_identity = interface._slot_identity
+            _partial_density_contraction = interface._partial_density_contraction
+            _sequential_spin_order = interface._sequential_spin_order
+            _decay_slot_order = interface._decay_slot_order
+            sequential_accept_reject = interface.sequential_accept_reject
+            _upfront_production = interface._upfront_production
+            _sequential_offshell = interface._sequential_offshell
+            _sequential_upfront = interface._sequential_upfront
+            _z_slot_keys = staticmethod(interface._z_slot_keys)
+            _zhat = interface._zhat
+            _draw_offshell_mass = interface._draw_offshell_mass
+            _unweighting_mode = interface._unweighting_mode
+            _announce_mode = interface._announce_mode
+            _log_once = interface._log_once
+
+            def __init__(self):
+                self.options = {'spinmode': 'PA',
+                                'sequential_spin_order': '2 3 1',
+                                'unweighting': unweighting,
+                                'density_keep_jacobian': keep_jac,
+                                'sequential_debug': False,
+                                'fixed_order': False}
+                # Z_k(m) = f(m) = exp(ALPHA * ln(m/pole)) is exactly the
+                # log-quadratic the tabulation fits, so the "perfect table"
+                # can be written down instead of measured
+                self._z_tables = {}
+                if z_table:
+                    for key in ('6_0', '-6_0'):
+                        self._z_tables[key] = {
+                            'pole': outer.POLE,
+                            'coeff': [0.0, outer.ALPHA, 0.0],
+                            'zero_below': 0.0,
+                            'range': (min(outer.MASSES), max(outer.MASSES))}
+
+            def _density_basis(self, production, decays_key):
+                particles, slots = interface._sequential_slots(production,
+                                                               decays_key)
+                return {'decays_key': decays_key, 'helicities': hels,
+                        'init_part': [particles[i] for i in slots],
+                        'decaying_spins': [2, 2], 'position': [1, 2],
+                        'allowed_hel': [], 'ncomb': 0, 'dimension': 4}
+
+            def create_and_initialise_f2py_modules(self, *args):
+                pass
+
+            def get_density(self, *args, **opts):
+                return rho
+
+            def _draw_mass_value(self, pdg, budget):
+                """Discrete and flat, so the prior is uniform and any structure
+                in the accepted virtualities comes from the weights."""
+                import random
+                mass = random.choice(outer.MASSES)
+                return mass, (outer.POLE, 1.5, min(outer.MASSES),
+                              max(outer.MASSES)), 1.0
+
+            def _production_jacobian_for(self, production, slot_to_index,
+                                         slot_masses):
+                return 1.0
+
+            def _decay_reshuffle_jacobian(self, decay):
+                return outer._f(decay[0].new_mass) * outer._g(decay.index)
+
+            def _draw_one_decay(self, particle, index, ids, evt_decayfile,
+                                nb_remain):
+                import random
+                return TestPAUpFrontMass._Decay(self._slot_of[index],
+                                                random.randrange(outer.POOL))
+
+            def _slot_density(self, decay, parent, hel):
+                return pools[decay.slot][decay.index]
+
+        return Stub()
+
+    def _fixture(self, **opts):
+        base = TestSequentialAcceptReject()
+        rho = base._production_density()
+        pools = {0: base._pool(100), 1: base._pool(200)}
+        stub = self._stub(rho, pools, **opts)
+        production = base._Prod([base._Part(2, -1), base._Part(-2, -1),
+                                 base._Part(6), base._Part(-6)])
+        _, slots = interface_madspin.MadSpinInterface._sequential_slots(
+                                                    production, (6, -6))
+        stub._slot_of = {index: slot for slot, index in enumerate(slots)}
+        return stub, rho, pools, production, {6: {0: 'f'}, -6: {0: 'f'}}
+
+    def _bounds(self, stub, rho, pools):
+        contract = stub._partial_density_contraction
+        n_0 = contract(rho, self.HELS, {}).real
+        n_1 = [contract(rho, self.HELS, {0: pools[0][a]}).real
+               for a in range(self.POOL)]
+        n_2 = [[contract(rho, self.HELS,
+                         {0: pools[0][a], 1: pools[1][b]}).real
+                for b in range(self.POOL)] for a in range(self.POOL)]
+        top_jac = max(self._f(m) for m in self.MASSES) * \
+                  max(self._g(d) for d in range(self.POOL))
+        c_0 = 1.01 * top_jac * max(n_1[a] / n_0 for a in range(self.POOL))
+        c_1 = 1.01 * top_jac * max(n_2[a][b] / n_1[a]
+                                   for a in range(self.POOL)
+                                   for b in range(self.POOL))
+        c_mass = 1.01 * max(self._f(m) for m in self.MASSES) ** 2
+        return [c_mass, c_0, c_1], n_0, n_1, n_2
+
+    def _run(self, stub, production, evt_decayfile, maxwgts, nb_run=30000,
+             seed=0):
+        import random
+        random.seed(seed)
+        masses = collections.Counter()
+        combos = collections.Counter()
+        for _ in range(nb_run):
+            decays = stub.sequential_accept_reject(production, evt_decayfile,
+                                                   maxwgts, 10)
+            masses[decays[6][0][0].new_mass] += 1
+            combos[(decays[6][0].index, decays[-6][0].index)] += 1
+        return masses, combos
+
+    def test_the_rate_factor_is_the_decay_reshuffling_jacobian(self):
+        """What the probe records for Z_k under PA: the jacobian of mapping the
+        drawn decay onto the sampled virtuality, and nothing else. Offshell that
+        slot also carries Tr(D^off)/|M|^2_on -- PA evaluates on shell, so there
+        is no such ratio to carry."""
+        import random
+        stub, _, _, production, evt_decayfile = self._fixture()
+        random.seed(3)
+        probe, extra = [], {}
+        stub.sequential_accept_reject(production, evt_decayfile, None, 10,
+                                      probe=probe, probe_extra=extra)
+        self.assertEqual(extra['keys'], ['6_0', '-6_0'])
+        self.assertEqual(len(extra['z']), 2)
+        for (key, mass, value), slot in zip(extra['z'], (0, 1)):
+            self.assertIn(mass, self.MASSES)
+            # f(m) g(d) for one of the four pool members
+            self.assertTrue(any(abs(value - self._f(mass) * self._g(d)) < 1e-9
+                                for d in range(self.POOL)),
+                            'slot %s recorded %s at m=%s' % (slot, value, mass))
+
+    def test_no_rate_factor_recorded_when_the_jacobian_is_not_in_the_weight(self):
+        """density_keep_jacobian off: joint PA applies the reshuffle after
+        acceptance, so it is in no weight, and the only mass dependence left in
+        w_k is whether the decay can reach the virtuality at all."""
+        import random
+        stub, _, _, production, evt_decayfile = self._fixture(keep_jac=False)
+        random.seed(3)
+        probe, extra = [], {}
+        stub.sequential_accept_reject(production, evt_decayfile, None, 10,
+                                      probe=probe, probe_extra=extra)
+        self.assertEqual([value for _, _, value in extra['z']], [1.0, 1.0])
+
+    def test_the_accepted_virtualities_follow_the_rate_factor(self):
+        """The closure: with Z_k in the mass weight the accepted virtualities
+        are distributed as prior(m) * f(m), which is what the joint PA
+        accept/reject produces."""
+        stub, rho, pools, production, evt_decayfile = self._fixture()
+        maxwgts, _, _, _ = self._bounds(stub, rho, pools)
+        masses, _ = self._run(stub, production, evt_decayfile, maxwgts)
+
+        total = sum(self._f(m) for m in self.MASSES)
+        nb_run = sum(masses.values())
+        for mass in self.MASSES:
+            want = self._f(mass) / total
+            got = masses[mass] / float(nb_run)
+            self.assertLess(abs(got / want - 1), 0.05,
+                            'm=%s: got %.4f, expected %.4f' % (mass, got, want))
+
+    def test_without_the_rate_factor_the_virtualities_are_the_prior(self):
+        """The bug the factor exists for: the angle stage divides Z_k out
+        whatever the mass stage paid, so leaving it out leaves the accepted
+        virtualities distributed as the Breit-Wigner prior -- here flat --
+        instead of as the physical lineshape."""
+        stub, rho, pools, production, evt_decayfile = self._fixture(
+                                                            z_table=False)
+        maxwgts, _, _, _ = self._bounds(stub, rho, pools)
+        masses, _ = self._run(stub, production, evt_decayfile, maxwgts)
+
+        nb_run = sum(masses.values())
+        for mass in self.MASSES:
+            got = masses[mass] / float(nb_run)
+            self.assertLess(abs(got * len(self.MASSES) - 1), 0.05,
+                            'm=%s: got %.4f, expected the flat prior %.4f'
+                            % (mass, got, 1.0 / len(self.MASSES)))
+        # and that is a real distortion, not a wash: the correct answer is far
+        # outside the tolerance just used
+        total = sum(self._f(m) for m in self.MASSES)
+        self.assertGreater(abs(masses[self.MASSES[-1]] / float(nb_run)
+                               / (self._f(self.MASSES[-1]) / total) - 1), 0.15)
+
+    def test_the_decays_are_unaffected_by_the_table(self):
+        """The angle stage normalises itself, so its accepted decays are the
+        same whatever the mass stage pays -- which is exactly why an inaccurate
+        Z_hat shows up in the virtualities and nowhere else. (Their target is
+        N_n weighted by the decay's own share g of the reshuffling jacobian; the
+        virtuality-dependent share f cancels here.)"""
+        for z_table in (True, False):
+            stub, rho, pools, production, evt_decayfile = self._fixture(
+                                                            z_table=z_table)
+            maxwgts, _, _, n_2 = self._bounds(stub, rho, pools)
+            _, combos = self._run(stub, production, evt_decayfile, maxwgts)
+            nb_run = sum(combos.values())
+            weighted = [[n_2[a][b] * self._g(a) * self._g(b)
+                         for b in range(self.POOL)] for a in range(self.POOL)]
+            total = sum(sum(row) for row in weighted)
+            for a in range(self.POOL):
+                for b in range(self.POOL):
+                    want = weighted[a][b] / total
+                    got = combos[(a, b)] / float(nb_run)
+                    self.assertLess(abs(got / want - 1), 0.15,
+                                    'table=%s combo %s: got %.4f, expected %.4f'
+                                    % (z_table, (a, b), got, want))
+
+    def test_the_production_jacobian_is_evaluated_once_per_mass_set(self):
+        """What the up-front draw buys under PA. The per-slot mass draw calls
+        _production_jacobian_for -- an event copy and a reshuffle -- on every
+        slot trial and telescopes the results; here it is one call per mass
+        set."""
+        import random
+        for unweighting, expected in (('sequential', 'per mass set'),
+                                      ('sequential_with_mass', 'per trial')):
+            stub, rho, pools, production, evt_decayfile = self._fixture(
+                                                    unweighting=unweighting)
+            maxwgts, _, _, _ = self._bounds(stub, rho, pools)
+            counts = collections.Counter()
+
+            def _count(name, wrapped):
+                def counted(*args, **opts):
+                    counts[name] += 1
+                    return wrapped(*args, **opts)
+                return counted
+
+            stub._production_jacobian_for = _count(
+                            'jacobian', stub._production_jacobian_for)
+            stub._draw_one_decay = _count('trial', stub._draw_one_decay)
+            random.seed(7)
+            if unweighting == 'sequential_with_mass':
+                maxwgts = maxwgts[1:]
+            for _ in range(200):
+                stub.sequential_accept_reject(production, evt_decayfile,
+                                              maxwgts, 10)
+            if expected == 'per mass set':
+                # one per mass set, and there are fewer mass sets than trials
+                self.assertLess(counts['jacobian'], counts['trial'])
+                self.assertGreaterEqual(counts['jacobian'], 200)
+            else:
+                self.assertEqual(counts['jacobian'], counts['trial'])
 
 
 class TestSequentialPoolLadder(unittest.TestCase):
@@ -1237,6 +1599,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
         class Stub(object):
             _sequential_pool_ladder = interface._sequential_pool_ladder
             _sequential_active = interface._sequential_active
+            _sequential_upfront = interface._sequential_upfront
             _unweighting_mode = interface._unweighting_mode
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
@@ -1311,20 +1674,23 @@ class TestSequentialPoolLadder(unittest.TestCase):
         per-particle bounds, while a per-particle test lets a rejection skip the
         decays not yet drawn. The first wins while there is little to skip, so
         auto takes two_stage up to two decaying particles and sequential from
-        three -- offshell only, since the other modes have no mass-set stage to
-        split at."""
+        three -- offshell only, since PA/onshell keep the scheme they have
+        always used."""
         for nb, expected in [(1, 'joint'), (2, 'two_stage'),
                              (3, 'sequential'), (6, 'sequential')]:
             stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin')
             stub._nb_decaying = nb
             self.assertEqual(stub._unweighting_mode(True), expected,
                              '%d decaying particles' % nb)
-        # PA has no up-front mass draw: per particle whenever there is a
-        # decomposition to make at all
-        for nb in (2, 5):
-            stub = self._stub({6: 2}, unweighting='auto', spinmode='PA')
-            stub._nb_decaying = nb
-            self.assertEqual(stub._unweighting_mode(True), 'sequential')
+        # PA/onshell: the mass drawn with the angles, which is what they have
+        # always done and still the fastest of the five there
+        for spinmode in ('PA', 'onshell'):
+            for nb in (2, 5):
+                stub = self._stub({6: 2}, unweighting='auto', spinmode=spinmode)
+                stub._nb_decaying = nb
+                self.assertEqual(stub._unweighting_mode(True),
+                                 'sequential_with_mass',
+                                 '%s, %d decaying particles' % (spinmode, nb))
 
     def test_auto_is_joint_for_a_single_decaying_particle(self):
         """One decaying particle: the per-particle test is the joint test and
@@ -1340,14 +1706,38 @@ class TestSequentialPoolLadder(unittest.TestCase):
         stub._nb_decaying = 1
         self.assertEqual(stub._unweighting_mode(True), 'sequential')
 
-    def test_offshell_only_modes_fall_back_under_pa(self):
-        """Asked for explicitly under PA/onshell, the two modes that need the
-        up-front mass draw say so and use sequential."""
-        for mode in ('two_stage', 'sequential_global_retry'):
-            stub = self._stub({6: 2}, unweighting=mode, spinmode='PA')
+    def test_up_front_mass_modes_are_available_under_pa(self):
+        """PA has an up-front mass draw of its own now, so the three schemes
+        that split the accept/reject there are honoured rather than downgraded
+        to the per-slot mass draw."""
+        for mode in ('two_stage', 'sequential', 'sequential_global_retry'):
+            for spinmode in ('PA', 'onshell', 'madspin'):
+                stub = self._stub({6: 2}, unweighting=mode, spinmode=spinmode)
+                self.assertEqual(stub._unweighting_mode(True), mode,
+                                 '%s under %s' % (mode, spinmode))
+                self.assertTrue(stub._sequential_upfront(True))
+
+    def test_with_mass_needs_a_per_particle_mass_draw(self):
+        """sequential_with_mass draws each slot's virtuality inside that slot's
+        accept/reject, which the offshell spinmodes cannot do -- they reshuffle
+        the whole production onto the mass set at once."""
+        stub = self._stub({6: 2}, unweighting='sequential_with_mass',
+                          spinmode='PA')
+        self.assertEqual(stub._unweighting_mode(True), 'sequential_with_mass')
+        self.assertFalse(stub._sequential_upfront(True))
+        for spinmode in ('madspin', 'full'):
+            stub = self._stub({6: 2}, unweighting='sequential_with_mass',
+                              spinmode=spinmode)
             self.assertEqual(stub._unweighting_mode(True), 'sequential')
-            stub = self._stub({6: 2}, unweighting=mode, spinmode='madspin')
-            self.assertEqual(stub._unweighting_mode(True), mode)
+            self.assertTrue(stub._sequential_upfront(True))
+
+    def test_joint_is_not_an_up_front_scheme(self):
+        """_sequential_upfront gates the mass stage, so it must be False
+        wherever there is no sequential accept/reject at all."""
+        stub = self._stub({6: 2}, unweighting='joint', spinmode='PA')
+        self.assertFalse(stub._sequential_upfront(True))
+        stub = self._stub({6: 2}, unweighting='sequential', spinmode='PA')
+        self.assertFalse(stub._sequential_upfront(False))   # not density mode
 
     def test_madspin_option_defaults(self):
         """The shipped defaults: spinmode=madspin, jacobian in the weight,
@@ -1357,7 +1747,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
         self.assertEqual(options['density_keep_jacobian'], True)
         self.assertEqual(options['unweighting'], 'auto')
         for value in ('joint', 'two_stage', 'sequential',
-                      'sequential_global_retry'):
+                      'sequential_global_retry', 'sequential_with_mass'):
             options['unweighting'] = value
             self.assertEqual(options['unweighting'], value)
 
@@ -1381,17 +1771,10 @@ class TestScanMaxwgtDecomposition(unittest.TestCase):
     fork, on the synthetic densities of TestSequentialAcceptReject.
     """
 
-    def _fixture(self):
+    def _fixture(self, unweighting='sequential_with_mass'):
         base = TestSequentialAcceptReject()
-        rho = base._production_density()
-        pools = {0: base._pool(100), 1: base._pool(200)}
-        stub = base._stub(rho, pools)
-        production = base._Prod([base._Part(2, -1), base._Part(-2, -1),
-                                 base._Part(6), base._Part(-6)])
-        _, slots = interface_madspin.MadSpinInterface._sequential_slots(
-                                                    production, (6, -6))
-        stub._slot_of = {index: slot for slot, index in enumerate(slots)}
-        return stub, [production] * 6, {6: {0: 'f'}, -6: {0: 'f'}}
+        stub, _, _, production, evt_decayfile = base._fixture(unweighting)
+        return stub, [production] * 6, evt_decayfile
 
     def test_range_split_matches_the_whole(self):
         """scan[0:6] == scan[0:2] + scan[2:6], event for event, at fixed seed."""
@@ -1418,6 +1801,32 @@ class TestScanMaxwgtDecomposition(unittest.TestCase):
         for vec in per_event:
             self.assertEqual(len(vec), 2)          # two decaying particles
             self.assertTrue(all(w >= 0 for w in vec))
+
+    def test_the_up_front_probe_keeps_its_chains(self):
+        """The up-front-mass schemes cannot max online -- their mass-set weight
+        is only complete once Z_k is known, and Z_k is fitted from this same
+        probe -- so the scan hands every chain back and the bound is taken
+        later, over the completed weights. One entry per chain, and one more
+        entry per vector than there are slots (the mass set takes index 0)."""
+        import random
+        stub, events, evt_decayfile = self._fixture('sequential')
+        random.seed(1)
+        per_event, z_samples = stub._scan_maxwgt_range(events, 0, 6,
+                                                       evt_decayfile, 6, 20)
+        self.assertEqual(len(per_event), 6)
+        for event in per_event:
+            self.assertEqual(event['keys'], ['6_0', '-6_0'])
+            self.assertEqual(len(event['chains']), 20)
+            for weights, masses in event['chains']:
+                self.assertEqual(len(weights), 3)   # mass set + two slots
+                self.assertEqual(len(masses), 2)
+        # onshell samples no virtuality, so there is nothing to tabulate and the
+        # completed vector is the raw one
+        self.assertEqual(z_samples, {})
+        best = stub._complete_upfront_probe(per_event[0])
+        self.assertEqual(best, [max(chain[0][slot]
+                                    for chain in per_event[0]['chains'])
+                                for slot in range(3)])
 
 
 class TestOffshellRateFactor(unittest.TestCase):
@@ -1451,8 +1860,8 @@ class TestOffshellRateFactor(unittest.TestCase):
         _z_slot_keys = staticmethod(
                         interface_madspin.MadSpinInterface._z_slot_keys)
         _zhat = interface_madspin.MadSpinInterface._zhat
-        _complete_offshell_probe = \
-                        interface_madspin.MadSpinInterface._complete_offshell_probe
+        _complete_upfront_probe = \
+                        interface_madspin.MadSpinInterface._complete_upfront_probe
         def __init__(self, exact=False, joint_angles=False):
             self.banner = TestOffshellRateFactor._Banner()
             mode = 'sequential'
@@ -1571,7 +1980,7 @@ class TestOffshellRateFactor(unittest.TestCase):
         stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
                                                '-6_0': self._samples(seed=9)})
         z0, z1 = stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)
-        best = stub._complete_offshell_probe(self._probe_event())
+        best = stub._complete_upfront_probe(self._probe_event())
         self.assertAlmostEqual(best[0], max(2.0 * z0 * z1, 1.0), places=10)
         self.assertEqual(best[1], 7.0)      # position 0 = slot 1
         self.assertEqual(best[2], 5.0)
@@ -1584,7 +1993,7 @@ class TestOffshellRateFactor(unittest.TestCase):
         stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
                                                '-6_0': self._samples(seed=9)})
         z_by_slot = [stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)]
-        best = stub._complete_offshell_probe(self._probe_event())
+        best = stub._complete_upfront_probe(self._probe_event())
         # order [1, 0]: probe position 0 is slot 1, position 1 is slot 0
         self.assertAlmostEqual(best[1], max(3.0 / z_by_slot[1], 7.0), places=10)
         self.assertAlmostEqual(best[2], max(5.0 / z_by_slot[0], 4.0), places=10)
@@ -1598,7 +2007,7 @@ class TestOffshellRateFactor(unittest.TestCase):
         stub._z_tables = stub._build_z_tables({'6_0': self._samples(),
                                                '-6_0': self._samples(seed=9)})
         z = [stub._zhat('6_0', 160.0), stub._zhat('-6_0', 180.0)]
-        best = stub._complete_offshell_probe(self._probe_event())
+        best = stub._complete_upfront_probe(self._probe_event())
         self.assertEqual(len(best), 2)
         # chain 1: masses (160, 180), weights w_slot1 = 3.0, w_slot0 = 5.0
         # chain 2: masses (173, 173) where Z = 1, weights 7.0 and 4.0

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1656,47 +1656,57 @@ class TestSequentialPoolLadder(unittest.TestCase):
         self.assertTrue(self._stub({6: 2}, spinmode='onshell')._sequential_active(True))
 
     def test_sequential_active_auto(self):
-        """'auto' resolves per spinmode: a per-particle or two-stage scheme
-        everywhere it is supported, joint outside the density modes."""
+        """'auto' resolves per spinmode: per-particle under PA/onshell, and
+        offshell only once there are enough decays to pay for the mass stage
+        (the default _nb_decaying here is 2, so offshell still takes joint)."""
         for mode, expected in [('PA', True), ('onshell', True),
-                               ('madspin', True), ('full', True),
+                               ('madspin', False), ('full', False),
                                ('none', False)]:
             stub = self._stub({6: 2}, unweighting='auto', spinmode=mode)
             self.assertEqual(stub._sequential_active(True), expected,
                              'auto + spinmode=%s' % mode)
+        for mode in ('madspin', 'full'):
+            stub = self._stub({6: 2}, unweighting='auto', spinmode=mode)
+            stub._nb_decaying = 3
+            self.assertTrue(stub._sequential_active(True), mode)
         # fixed_order still forces the joint test
         stub = self._stub({6: 2}, unweighting='auto', fixed_order=True)
         self.assertFalse(stub._sequential_active(True))
         self.assertEqual(stub._unweighting_mode(True), 'joint')
 
     def test_auto_picks_the_scheme_by_the_number_of_decays(self):
-        """One bound over all the angles is tighter than the product of
-        per-particle bounds, while a per-particle test lets a rejection skip the
-        decays not yet drawn. The first wins while there is little to skip, so
-        auto takes two_stage up to two decaying particles and sequential from
-        three -- offshell only, since PA/onshell keep the scheme they have
-        always used."""
-        for nb, expected in [(1, 'joint'), (2, 'two_stage'),
+        """Offshell, a mass set costs a production reshuffle and a production
+        density, so the staged schemes only pay off once there are enough decays
+        to save: auto takes joint up to two decaying particles and sequential
+        from three. See MADSPIN_SEQUENTIAL_PLAN.md section 12."""
+        for nb, expected in [(1, 'joint'), (2, 'joint'),
                              (3, 'sequential'), (6, 'sequential')]:
-            stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin')
-            stub._nb_decaying = nb
-            self.assertEqual(stub._unweighting_mode(True), expected,
-                             '%d decaying particles' % nb)
-        # PA/onshell: the mass drawn with the angles, which is what they have
-        # always done and still the fastest of the five there
-        for spinmode in ('PA', 'onshell'):
-            for nb in (2, 5):
+            for spinmode in ('madspin', 'full'):
                 stub = self._stub({6: 2}, unweighting='auto', spinmode=spinmode)
                 stub._nb_decaying = nb
-                self.assertEqual(stub._unweighting_mode(True),
-                                 'sequential_with_mass',
+                self.assertEqual(stub._unweighting_mode(True), expected,
                                  '%s, %d decaying particles' % (spinmode, nb))
 
-    def test_auto_is_joint_for_a_single_decaying_particle(self):
-        """One decaying particle: the per-particle test is the joint test and
-        the mass/angle split only moves the same factors between two stages, so
-        auto pays for neither -- in every spinmode."""
-        for spinmode in ('PA', 'onshell', 'madspin', 'full'):
+    def test_auto_is_per_particle_under_pa_at_every_multiplicity(self):
+        """PA/onshell keep rho fixed on shell, so their mass stage costs a
+        reshuffling jacobian and nothing else -- sequential was the fastest of
+        the three at every multiplicity measured, including one decaying
+        particle, where the mass set can still be rejected before any decay is
+        drawn."""
+        for spinmode in ('PA', 'onshell'):
+            for nb in (1, 2, 3, 6):
+                stub = self._stub({6: 2}, unweighting='auto', spinmode=spinmode)
+                stub._nb_decaying = nb
+                self.assertEqual(stub._unweighting_mode(True), 'sequential',
+                                 '%s, %d decaying particles' % (spinmode, nb))
+
+    def test_auto_is_joint_for_a_single_decaying_particle_offshell(self):
+        """One decaying particle offshell is the worst case for a mass stage:
+        the mass-set weight carries Tr(rho_off)/|M_prod|^2_on, and when that one
+        particle carries most of the production matrix element's virtuality
+        dependence the ratio spans orders of magnitude (measured: ~790 mass sets
+        per accepted event on p p > w+ j). auto must not go there."""
+        for spinmode in ('madspin', 'full'):
             stub = self._stub({6: 1}, unweighting='auto', spinmode=spinmode)
             stub._nb_decaying = 1
             self.assertEqual(stub._unweighting_mode(True), 'joint', spinmode)


### PR DESCRIPTION
Implements the follow-up specified in #338: gives the PA spinmode an up-front mass draw, so the schemes that split the accept/reject at that draw work there with the same meaning they have offshell.

## What changes

**`sequential_with_mass` is a fifth value of `unweighting`.** It names the scheme PA already had: each slot's virtuality drawn and redrawn *inside* that slot's own accept/reject. It is not a variant of `sequential` — nothing is ever frozen, so no stage has a conditional normalisation to divide out and the tabulated factor never arises. Offshell it falls back to `sequential` with a log line.

**PA gains the up-front draw.** `_offshell_production` becomes `_upfront_production` and serves both spinmode families. Offshell it reshuffles a copy of the production and fixes `rho`, which is what makes the decomposition possible at all. Under PA `rho` is already fixed on shell and cached, so what the mass set freezes instead is the **production reshuffling jacobian**: `_production_jacobian_for` — an event copy plus a reshuffle — moves from once per slot trial to once per mass set, and the `J_k/J_{k-1}` telescoping disappears.

That was the point. It fixes the measurement section 10 recorded as coming out backwards (PA sequential 22% *slower* than PA joint, 5.01 production reshufflings per event against 3.14): now **1.95 per event**, and the decay phase goes from 22% above joint to level with it.

**PA needs its own tabulated normalisation**, `Z_k^PA(m) = E_pool[jac_dec(m, Ω)]`. Same machinery as section 10 (`_build_z_tables` / `_zhat` / `_z_slot_keys`, samples free from the max-weight probe), **different integrand**: PA evaluates its matrix elements on shell, so there is no `Tr(D^off)/|M|²_on` factor and only the phase-space jacobian survives. Measured it spans a factor 1.16 over the Breit-Wigner window where the offshell one spans 3.2.

**`auto` becomes two branches instead of four**, after a multiplicity scan (section 12):

```
PA / onshell   ->  sequential
madspin / full ->  joint for n <= 2, sequential from n >= 3
```

For a user who never sets `unweighting`: PA/onshell move from `sequential_with_mass` to `sequential`; offshell runs with two decaying particles move from `two_stage` back to `joint`; n=1 and n>=3 offshell are unchanged.

## Validation

- **`sequential_with_mass` is bit-for-bit what PA did before** — every event record in the decayed LHE identical to `madspin_density`'s PA `sequential`, same counters. Re-checked after the merge.
- **The weight identity, per chain** (`sequential_debug`, now covering the PA schemes): over 10000 accepted chains each, `sequential` 7.91e-08, `two_stage` 1.23e-07, `sequential_global_retry` 8.54e-08 — float32 epsilon, the floor of `complex64` arithmetic — and on the *same* constant the offshell schemes report (1108198227/225/230 against 1108198255-261), from a different spinmode and a different set of factors.
- **The lineshape**, four replicas each against a four-replica joint reference: `sequential` +0.009 ± 0.015 GeV (+0.59σ), `two_stage` +0.79σ, `sequential_global_retry` +1.11σ. PA's `Z` is gentle enough that this agreement alone would say little, so the factor was measured directly against a build with `_zhat` forced to 1: **−0.039 ± 0.016 GeV**, in the direction section 10 predicts, while `m(l+ vl)` and `dphi(l+,l-)` stay blind to it at 0.2σ.
- **Speed**, two campaigns at 10k, one at 250k, and a multiplicity scan at 50k over `p p > w+ j`, `t t~`, `t t~ z`, `t t~ t t~` — see section 12. All 24 scan runs agree on the cross section.
- **No regressions**: `spinmode = madspin` reproduces the base commit event for event, `onshell` with an explicit up-front scheme runs clean, and `nb_core = 4` reproduces the counters up to the workers' own RNG streams.
- 131 unit tests pass.

## Merge notes

Reconciled with #336, #337 and #338 in d04b39db6.

- `_upfront_production` returns a 5-tuple from both arms, threading #336's `frame_boost`: offshell derives its own from the reshuffled production, PA hands back the one the cached onshell `rho` was built with. Both arms of the split slot body pass it to `_slot_density`.
- #337's `@` grouping gate survives untouched; its test moves to three decaying particles, since offshell `auto` at two decays is now joint and no longer discriminates.
- #338's planning section is superseded by section 11, which records the work as done. Its one open question — should the offshell modes offer `sequential_with_mass` too — is answered in place: no, because `rho_off` depends on the whole mass set jointly.

**Also fixes a latent bug inherited from #336.** `frame_boost` was computed only on a cache miss of `production._ms_density_prod`, so every chain after the first got `None` while the cached `rho` still carried the boost — 499 of the 500 probe chains per production event contracting lab-frame decay densities against an me_frame production one. Latent on a default card (`_frame_boost` short-circuits for unpolarised beams) and silent when it is not. The boost is now cached alongside the density it belongs to.

`tests/parallel_tests/` is untouched.

## Summary by Sourcery

Extend MadSpin’s sequential unweighting to support PA up-front mass draws, improve default scheme selection, and correct frame-boost caching.

New Features:
- Add the `sequential_with_mass` unweighting mode for preserving PA’s per-slot mass-draw behavior.
- Enable PA and onshell spinmodes to use up-front mass unweighting with production reshuffling reuse and PA-specific normalization tables.

Bug Fixes:
- Fix cached production frame boosts so repeated chains use the same frame as the cached production density.

Enhancements:
- Update automatic scheme selection to choose sequential for PA/onshell and joint through two decays before switching to sequential for offshell modes.
- Share up-front production and normalization handling across PA and offshell spinmode families while preserving their distinct weighting factors.

Documentation:
- Update the MadSpin sequential-unweighting plan with the PA implementation, validation results, performance measurements, and revised automatic-selection rules.

Tests:
- Add coverage for PA up-front mass weighting, normalization factors, scheme equivalence, production-jacobian reuse, fallback behavior, and automatic scheme selection.