### PR TITLE
MadSpin: rename the up-front-mass max-weight cache helpers

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -732,7 +732,7 @@ bounds. The fit is a weighted quadratic in `ln(m/pole)` through the *bin means*
 (Z is an expectation, so the mean estimates it and the mean of the logarithms
 would not), held constant outside the probed range and reported in the log
 against the running width it estimates. `C_mass` is then derived from the
-completed weights `w_mass * prod_k Z_hat_k` (`_complete_offshell_probe`), which
+completed weights `w_mass * prod_k Z_hat_k` (`_complete_upfront_probe`), which
 is why the probe now keeps its chains instead of maxing them online.
 
 Two related points fell out:
@@ -746,9 +746,13 @@ Two related points fell out:
   rejection; counting it as one makes `Z_k`, which includes those zeros, the
   exact correction again. A virtuality no pool decay can reach is killed by the
   table itself (`zero_below`), with a 200-draw fail-safe behind it.
-- The `max_wgt_sequential` cache splits: the offshell bounds travel with their
-  tables (and depend on `sequential_exact`), so they get their own file name and
-  a JSON format.
+- The `max_wgt_sequential` cache splits: the up-front-mass bounds travel with
+  their tables (and depend on `sequential_exact`), so they get their own file
+  name and a JSON format (`_read_upfront_cache` / `_UPFRONT_CACHE_FORMAT`). The
+  file name still carries the spinmode family that wrote it
+  (`max_wgt_sequential_offshell...` / `max_wgt_sequential_pa...`), since the
+  mass-set weight is a different quantity in each and neither cache may be read
+  back for the other.
 
 #### `sequential_exact`: the escape hatch
 

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4400,14 +4400,18 @@ class MadSpinInterface(extended_cmd.Cmd):
             # unweighting mode *and* on the spinmode family (the mass-set weight
             # is a different quantity offshell and under PA), so they get a name
             # (and a format) of their own -- a cache written for one cannot be
-            # read back for the other.
+            # read back for the other. The ``offshell``/``pa`` piece of the file
+            # name names the spinmode family that wrote it, which is still what
+            # it does now that both families take the up-front-mass path; it is
+            # deliberately left alone so that caches already on disk keep being
+            # found.
             if upfront:
                 mode = self._unweighting_mode()
                 variant = '' if mode == 'sequential' else '_%s' % mode
                 cache = pjoin(self.options['ms_dir'],
                               'max_wgt_sequential_%s%s'
                               % ('offshell' if offshell else 'pa', variant))
-                cached = self._read_offshell_cache(cache)
+                cached = self._read_upfront_cache(cache)
                 if cached is not None:
                     self._z_tables = cached['z_tables']
                     return cached['maxwgts']
@@ -4480,7 +4484,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         if cache and upfront:
             import json
             with open(cache, 'w') as f:
-                json.dump({'format': self._OFFSHELL_CACHE_FORMAT,
+                json.dump({'format': self._UPFRONT_CACHE_FORMAT,
                            'maxwgts': maxwgts, 'z_tables': self._z_tables}, f)
         elif cache:
             open(cache, 'w').write(' '.join(repr(w) for w in maxwgts))
@@ -4493,10 +4497,14 @@ class MadSpinInterface(extended_cmd.Cmd):
     # the next, which a name cannot.
     # 2: the mass-set weight is normalised by |M_prod|^2 on shell, so every
     #    bound in the vector changed scale.
-    _OFFSHELL_CACHE_FORMAT = 2
+    # (Renaming this constant from _OFFSHELL_CACHE_FORMAT, when the up-front
+    #  mass draw stopped being offshell-only, is *not* such a change: the
+    #  payload is the same, so the tag stays at 2 and caches already written
+    #  keep being accepted.)
+    _UPFRONT_CACHE_FORMAT = 2
 
-    def _read_offshell_cache(self, path):
-        """The cached offshell bounds and Z_k tables, or None if there is
+    def _read_upfront_cache(self, path):
+        """The cached up-front-mass bounds and Z_k tables, or None if there is
         nothing usable there.
 
         A cache that does not match what this code writes is *ignored*, not
@@ -4513,10 +4521,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         try:
             with open(path) as f:
                 cached = json.load(f)
-            if cached.get('format') != self._OFFSHELL_CACHE_FORMAT:
+            if cached.get('format') != self._UPFRONT_CACHE_FORMAT:
                 raise ValueError('format %s, expected %s'
                                  % (cached.get('format'),
-                                    self._OFFSHELL_CACHE_FORMAT))
+                                    self._UPFRONT_CACHE_FORMAT))
             maxwgts = [float(w) for w in cached['maxwgts']]
             if not maxwgts:
                 raise ValueError('no bounds')

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -250,7 +250,7 @@ This is where the cost is.
   multiplies by `|groups|` — with the same probe-splitting problem, and each fit
   needs enough samples for its quadratic in `ln(m/pole)` to be determined.
 
-* **Cache format.** `_OFFSHELL_CACHE_FORMAT` must be bumped: the bound vector and
+* **Cache format.** `_UPFRONT_CACHE_FORMAT` must be bumped: the bound vector and
   the table keys both change meaning, and an `ms_dir` written by today's code
   must not be read back.
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2329,20 +2329,21 @@ class TestTwoStageMassDistribution(unittest.TestCase):
             self._assert_close(self._run(zhat, exact=True), self._target(), 0.03)
 
 
-class TestOffshellCache(unittest.TestCase):
-    """The offshell sequential bounds travel with the Z_k tables that complete
-    them, so the cache holds two coupled objects and must not be read back under
-    a schema it was not written with.  A mismatch is ignored rather than raised
-    on: the scan is reproducible, so re-measuring is always available, whereas a
-    table dereferenced under the wrong schema would either crash inside the
-    accept/reject or silently weight the virtualities with the wrong fit.
+class TestUpfrontCache(unittest.TestCase):
+    """The up-front-mass sequential bounds travel with the Z_k tables that
+    complete them, so the cache holds two coupled objects and must not be read
+    back under a schema it was not written with.  A mismatch is ignored rather
+    than raised on: the scan is reproducible, so re-measuring is always
+    available, whereas a table dereferenced under the wrong schema would either
+    crash inside the accept/reject or silently weight the virtualities with the
+    wrong fit.
     """
 
     class _Stub(object):
-        _OFFSHELL_CACHE_FORMAT = \
-            interface_madspin.MadSpinInterface._OFFSHELL_CACHE_FORMAT
-        _read_offshell_cache = \
-            interface_madspin.MadSpinInterface._read_offshell_cache
+        _UPFRONT_CACHE_FORMAT = \
+            interface_madspin.MadSpinInterface._UPFRONT_CACHE_FORMAT
+        _read_upfront_cache = \
+            interface_madspin.MadSpinInterface._read_upfront_cache
 
     def _write(self, payload):
         import json, tempfile
@@ -2353,19 +2354,19 @@ class TestOffshellCache(unittest.TestCase):
         return path
 
     def _good(self):
-        return {'format': self._Stub._OFFSHELL_CACHE_FORMAT,
+        return {'format': self._Stub._UPFRONT_CACHE_FORMAT,
                 'maxwgts': [17.0, 2.3, 3.9],
                 'z_tables': {'6_0': {'pole': 173.0, 'coeff': [0.0, 2.0, -1.0],
                                      'zero_below': 0.0, 'range': [150.0, 195.0]}}}
 
     def test_round_trip(self):
-        got = self._Stub()._read_offshell_cache(self._write(self._good()))
+        got = self._Stub()._read_upfront_cache(self._write(self._good()))
         self.assertEqual(got['maxwgts'], [17.0, 2.3, 3.9])
         self.assertEqual(got['z_tables']['6_0']['pole'], 173.0)
 
     def test_missing_file_is_not_an_error(self):
-        self.assertIsNone(self._Stub()._read_offshell_cache('/no/such/file'))
-        self.assertIsNone(self._Stub()._read_offshell_cache(''))
+        self.assertIsNone(self._Stub()._read_upfront_cache('/no/such/file'))
+        self.assertIsNone(self._Stub()._read_upfront_cache(''))
 
     def test_every_malformed_shape_is_ignored(self):
         """Each of these would otherwise surface as a KeyError, an IndexError or
@@ -2388,7 +2389,7 @@ class TestOffshellCache(unittest.TestCase):
         cases['a malformed range'] = window
         for name, payload in cases.items():
             self.assertIsNone(
-                self._Stub()._read_offshell_cache(self._write(payload)), name)
+                self._Stub()._read_upfront_cache(self._write(payload)), name)
 
     def test_garbage_is_ignored(self):
         import tempfile
@@ -2396,7 +2397,7 @@ class TestOffshellCache(unittest.TestCase):
         with os.fdopen(handle, 'w') as f:
             f.write('not json at all')
         self.addCleanup(os.remove, path)
-        self.assertIsNone(self._Stub()._read_offshell_cache(path))
+        self.assertIsNone(self._Stub()._read_upfront_cache(path))
 
 
 class TestPolyfitConditioning(unittest.TestCase):


### PR DESCRIPTION
Follow-up to the review remark on the up-front-mass work: now that `_complete_offshell_probe` has become `_complete_upfront_probe` and serves both the offshell and the PA paths, the `_OFFSHELL_CACHE_FORMAT` naming no longer describes what it guards.

### What changed

Pure renaming of the Python-side symbols, no behaviour change:

| old | new |
|---|---|
| `MadSpinInterface._OFFSHELL_CACHE_FORMAT` | `MadSpinInterface._UPFRONT_CACHE_FORMAT` |
| `MadSpinInterface._read_offshell_cache` | `MadSpinInterface._read_upfront_cache` |
| `TestOffshellCache` | `TestUpfrontCache` |

Plus two stale `_complete_offshell_probe` references in the docs (`MADSPIN_SEQUENTIAL_PLAN.md`, `doc/madspin_decay_groups.md`).

### The on-disk cache is deliberately left alone

- **File names kept** (`max_wgt_sequential_offshell[_<mode>]` / `max_wgt_sequential_pa[_<mode>]`). The `offshell`/`pa` piece names the *spinmode family* that wrote the file, not the code path, and that discriminator is still load-bearing: the mass-set weight is a different quantity offshell and under PA, so the two caches must never be read for each other. A comment at the construction site now says so.
- **Format tag stays at 2.** The JSON payload is unchanged, so renaming the Python constant is not a change in the cache's meaning. Existing user caches keep being found and accepted; nothing is silently invalidated and no re-measurement is forced.

### Verification

`python3 -m unittest discover -s tests/unit_tests/madspin -t .` — 131 tests, OK, including the seven `test_every_malformed_shape_is_ignored` stale-cache-detection cases.

Not covered: no end-to-end MadSpin run against a real `ms_dir`. The unit tests exercise `_read_upfront_cache` directly but not the write path in `get_sequential_maxwgt`, whose change is a one-token constant substitution serialising the same value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename MadSpin’s up-front-mass cache helpers and documentation without changing cache contents, filenames, format compatibility, or runtime behavior.

Enhancements:
- Rename the up-front-mass cache format constant, cache reader, and related tests to reflect their use across offshell and PA spinmode paths while preserving cache compatibility.

Documentation:
- Update MadSpin planning and decay-group documentation to use the up-front cache and probe terminology and clarify the retained spinmode-specific cache filenames.

Tests:
- Rename the cache reader test suite and update its coverage to exercise the new up-front cache symbols.