### PR TITLE
MadSpin: hide the two_stage unweighting scheme from the user interface

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -52,7 +52,17 @@ logger_stderr = logging.getLogger('decay.stderr') # ->stderr
 cmd_logger = logging.getLogger('cmdprint2') # -> print
 
 class MadSpinOptions(banner.ConfigFile):
-    
+
+    # Unweighting schemes that still work but are no longer offered to the
+    # user: they are kept out of the 'allowed' list above so that they show up
+    # neither in the completion nor in the "allowed values are ..." message,
+    # and are re-admitted one call at a time by __setitem__ below. 'two_stage'
+    # is here because it is not the fastest scheme at any multiplicity measured
+    # (see _unweighting_mode) -- it survives as an internal cross-check, the
+    # one staged scheme whose angle stage is a single joint test, and as such
+    # is still exercised by the parallel tests and the benchmarks.
+    hidden_unweighting_modes = ('two_stage',)
+
     def default_setup(self):
 
         self.add_param("max_weight", -1)
@@ -82,25 +92,53 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('nb_core', 0, comment='Number of cores for the MadSpin parallel unweighting (0 = use the global MG5 nb_core). nb_core>1 enables the process-parallel unweighting path.')
         self.add_param('density_keep_jacobian', True, comment='PA spinmode only: fold the offshell-reshuffling phase-space jacobian into the accept/reject weight (default) instead of applying the reshuffle as a post-acceptance kinematic dressing (False). Ignored by the madspin/full spinmodes, which always include that jacobian.')
         self.add_param('unweighting', 'auto',
-                       allowed=['auto', 'joint', 'two_stage', 'sequential',
+                       allowed=['auto', 'joint', 'sequential',
                                 'sequential_global_retry',
                                 'sequential_with_mass'],
                        comment="how the accept/reject is organised (density modes). "
                        "joint: one test over the virtualities and every decay at once, the historical scheme. "
-                       "two_stage: unweight the set of virtualities first, then every decay against a single bound, redrawing only the decays on a rejection -- the production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial. "
-                       "sequential: as two_stage but one test per decaying particle, redrawing only the particle that was rejected. "
+                       "sequential: unweight the set of virtualities first, then one test per decaying particle, redrawing only the particle that was rejected -- the production reshuffling and its density matrix are then evaluated once per accepted mass set instead of once per trial. "
                        "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
                        "sequential_with_mass: one test per decaying particle with that particle's virtuality drawn *inside* its own accept/reject, so nothing is ever frozen and no stage has a conditional normalisation to divide out. Needs a per-particle mass draw, i.e. the PA spinmode; elsewhere it falls back to sequential. "
-                       "two_stage, sequential and sequential_global_retry unweight the set of virtualities first; the first two then need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
+                       "sequential and sequential_global_retry unweight the set of virtualities first; the former then needs a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
                        "auto: sequential under PA/onshell, where it was the fastest scheme at every decay multiplicity measured; offshell joint up to two decaying particles and sequential from three, since offshell every mass set costs a production reshuffle and a production density and below three decays there are not enough of them to save to pay for it.")
         self.add_param('sequential_decay', 'auto',
                        comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
         self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in the sequential unweighting modes: default fermions, then vectors, then scalars (which can never be rejected).')
-        self.add_param('sequential_debug', False, comment='the up-front-mass unweighting schemes (two_stage, sequential, sequential_global_retry): on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
+        self.add_param('sequential_debug', False, comment='the up-front-mass unweighting schemes (sequential, sequential_global_retry): on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
+
+    def __setitem__(self, name, value, change_userdefine=False, raiseerror=False):
+        """Let an old card keep an unweighting scheme we no longer advertise.
+
+        Hiding a scheme means dropping it from 'allowed', and ConfigFile then
+        refuses it outright -- which would turn a card written before the
+        scheme was retired into a warning plus a silent switch back to 'auto'.
+        The code path is untouched, so accept the value instead: widen the
+        allowed list for the duration of this one assignment and note it at
+        debug level, quietly enough not to re-advertise it.
+        """
+        if isinstance(name, str) and isinstance(value, str) and \
+                name.strip().lower() == 'unweighting' and \
+                value.strip().lower() in self.hidden_unweighting_modes:
+            value = value.strip().lower()
+            allowed = getattr(self, 'allowed_value', {}).get('unweighting')
+            if allowed is not None and value not in allowed:
+                logger.debug("MadSpin: unweighting = %s is an internal "
+                             "cross-check scheme, no longer offered in the "
+                             "card; honouring it since it was asked for "
+                             "explicitly.", value)
+                self.allowed_value['unweighting'] = list(allowed) + [value]
+                try:
+                    return super(MadSpinOptions, self).__setitem__(
+                        name, value, change_userdefine, raiseerror)
+                finally:
+                    self.allowed_value['unweighting'] = allowed
+        return super(MadSpinOptions, self).__setitem__(
+            name, value, change_userdefine, raiseerror)
 
     ############################################################################
-    ##  Special post-processing of the options                                ## 
+    ##  Special post-processing of the options                                ##
     ############################################################################
     def post_set_ms_dir(self, value, change_userdefine, raiseerror, *opts):
         """ special handling for set ms_dir """
@@ -850,7 +888,13 @@ class MadSpinInterface(extended_cmd.Cmd):
             return self.path_completion(text, curr_path, only_dirs = True)
         elif args[1] == "spinmode":
             return self.list_completion(text, ["full", "madspin", "none", "onshell", "PA", "madspin_v1", "onshell_v1"], line)
-         
+        elif args[1] == "unweighting":
+            # the advertised schemes only: the hidden ones stay settable but
+            # are not proposed (see MadSpinOptions.hidden_unweighting_modes)
+            return self.list_completion(text,
+                       list(self.options.allowed_value['unweighting']), line)
+
+
     def help_set(self):
         """help the set command"""
         
@@ -2719,9 +2763,13 @@ class MadSpinInterface(extended_cmd.Cmd):
         accepted event. From n=3 the per-particle test wins by 2.2x and 4.3x.
 
         ``two_stage`` is not the fastest scheme at any measured point -- joint
-        beats it at n<=2 and ``sequential`` at n>=3 -- so it is reachable but
-        never chosen here. It stays useful as a cross-check, being the one
-        staged scheme whose angle stage is a single joint test.
+        beats it at n<=2 and ``sequential`` at n>=3 -- so ``auto`` never
+        returns it, and it is no longer offered in the card either (it is not
+        in the advertised ``allowed`` list; see
+        ``MadSpinOptions.hidden_unweighting_modes``, which still honours an
+        explicit request for it). It stays useful as a cross-check, being the
+        one staged scheme whose angle stage is a single joint test, and the
+        code path below is unchanged.
 
         ``fixed_order`` forces joint: its counter-events ride along with the
         decays and have not been thought through here.


### PR DESCRIPTION
`two_stage` is not the fastest unweighting scheme at any decay multiplicity measured — `joint` beats it at n<=2 and `sequential` at n>=3 — so there is no reason to keep offering it in the MadSpin card. This hides it from the user interface while leaving the code path completely untouched: it stays available as an internal cross-check (the one staged scheme whose angle stage is a single joint test) and is still exercised by the unit tests, the parallel tests and the benchmarks.

### What changed (UI/doc only, `MadSpin/interface_madspin.py`)

- New `MadSpinOptions.hidden_unweighting_modes = ('two_stage',)`, documenting why the scheme is hidden and why the code path stays.
- `two_stage` removed from the `allowed=[...]` list of the `unweighting` option, so it appears neither in the completion nor in the "allowed values are ..." rejection message.
- The `comment=` text of `unweighting` and of `sequential_debug` no longer describes or mentions it. The `sequential:` sentence used to be phrased as "as two_stage but ..." and is rewritten to stand alone.
- New `complete_set` branch for `unweighting`, completing from the advertised list. (There was no completion branch for this option at all before, so this is a new guarantee rather than a removal.)
- `_unweighting_mode` docstring now records that `auto` never returns `two_stage` and points at `hidden_unweighting_modes`.

### Old cards keep working

Dropping a value from `allowed` makes `ConfigFile.__setitem__` reject it outright — a warning plus a silent revert to `auto` — which would break cards written before the scheme was retired. So `MadSpinOptions.__setitem__` intercepts *only* `unweighting` set to a hidden value, widens the allowed list for the duration of that single assignment (restored in a `finally`) and logs at DEBUG.

Verified live:

```
allowed:              ['auto', 'joint', 'sequential', 'sequential_global_retry', 'sequential_with_mass']
'two_stage'   -> two_stage   (DEBUG note only)
'TWO_STAGE'   -> two_stage   (case/whitespace insensitive, as before)
'sequential'  -> sequential
'not_a_mode'  -> rejected: "allowed values are auto, joint, sequential, sequential_global_retry, sequential_with_mass"
```

Genuine typos are still caught — no `'*'` escape hatch — and the rejection message no longer names `two_stage`.

### `auto` can never select it

Confirmed by reading the code, not just the docstring: the `mode == 'auto'` block in `_unweighting_mode` assigns only `sequential` (PA/onshell, and offshell with `nb_decaying >= 3`) or `joint` (offshell, `nb_decaying <= 2`), and every later branch can only downgrade to `joint` or `sequential`. This was already true before this change.

### Verification

`python3 -m unittest discover -s tests/unit_tests/madspin -t .` — 131 tests, OK. That includes the existing test which sets `unweighting` to each of `joint, two_stage, sequential, sequential_global_retry, sequential_with_mass` and asserts the value sticks, so the hidden-value path is covered.

Not run: `tests/parallel_tests/` (needs generated processes and long runs). An end-to-end MadSpin run with `set unweighting two_stage` was not exercised; only the option layer was, and the scheme's code path is byte-for-byte unchanged.

### Pre-existing issue noticed in passing

`tests/parallel_tests/test_madspin_factory.py:565` expects `auto` + offshell + 2 decaying particles to give `two_stage`, but `_unweighting_mode` on `madspin_density` already returns `joint` there. That expectation is stale on the base branch independently of this PR (as is the surrounding prose at lines 369 and 542); it is left alone here and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Hide the slower `two_stage` unweighting scheme from MadSpin’s advertised options while preserving explicit use by existing cards and internal validation.