### PR TITLE
MadSpin: factor the spinmode branching out of the unweighting decisions

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -2430,13 +2430,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.error *= self.branching_ratio
         
 
-        density_pole_approximation = self.options['spinmode'] in ['PA', 'onshell']
-        density_do_reshuffle = self.options['spinmode'] == 'PA'
-        density_needs_reshuffle = (
-            density_method
-            and (not density_pole_approximation
-                 or density_do_reshuffle)
-        )
+        density_pole_approximation = self._density_pole_approximation()
+        density_needs_reshuffle = self._density_needs_reshuffle(density_method)
 
         # 3. generate the various matrix-elements
         time_me_generation = time.time()
@@ -2647,6 +2642,57 @@ class MadSpinInterface(extended_cmd.Cmd):
             position += multiplicity
         return ladder
 
+    # ------------------------------------------------------------------
+    # The two questions the unweighting branches keep asking
+    # ------------------------------------------------------------------
+    # (a) which *spinmode family* is this -- is the density matrix evaluated at
+    #     onshell momenta (pole approximation) or at the reshuffled ones? -- and
+    # (b) which *accept/reject scheme* is this -- is there a mass-set stage in
+    #     front of the angle stage?
+    # Both are asked from several places, so they get names rather than being
+    # spelled out as spinmode/mode string comparisons at each site.
+
+    def _density_pole_approximation(self):
+        """Whether the density matrix is taken in the pole approximation, i.e.
+        evaluated at onshell momenta (``PA``/``onshell``) rather than at the
+        reshuffled offshell ones (``madspin``/``full``)."""
+        return self.options['spinmode'] in ['PA', 'onshell']
+
+    def _density_do_reshuffle(self):
+        """Whether a pole-approximation run nevertheless reshuffles the
+        production onto the sampled virtualities. Only ``PA`` does: it samples a
+        virtuality per resonance, while ``onshell`` keeps the production
+        kinematics as they are."""
+        return self.options['spinmode'] == 'PA'
+
+    def _density_needs_reshuffle(self, in_density_mode):
+        """Whether the chain reshuffles the production event at all. Offshell it
+        always does -- that is where its density matrix is evaluated -- ``PA``
+        does because it samples virtualities, ``onshell`` never does, and
+        nothing does outside density mode.
+
+        ``in_density_mode`` is the caller's own way of knowing it is in density
+        mode (the ``density_method`` flag before the generation exists, and
+        ``self.generate_all.mode == 'density'`` afterwards)."""
+        return in_density_mode and (not self._density_pole_approximation()
+                                    or self._density_do_reshuffle())
+
+    def _spinmode_has_density(self):
+        """Whether the spinmode carries the density-matrix machinery the staged
+        accept/reject schemes are built on. The v1 spinmodes, ``none`` and
+        ``bridge`` do not, and keep the historical joint test."""
+        return (self._density_pole_approximation()
+                or self.options['spinmode'] in ['madspin', 'full'])
+
+    @staticmethod
+    def _is_upfront_scheme(mode):
+        """Whether ``mode`` draws every virtuality *before* the angles, i.e.
+        whether it has a mass-set accept/reject in front of its angle stage.
+        True for every scheme but ``joint`` -- which tests the virtualities and
+        the angles together -- and ``sequential_with_mass``, which draws each
+        slot's mass inside that slot's own accept/reject."""
+        return mode not in ('joint', 'sequential_with_mass')
+
     def _log_once(self, key, message, *args):
         """Log a resolution message the first time only: these are decided per
         production event but say something about the run."""
@@ -2656,6 +2702,53 @@ class MadSpinInterface(extended_cmd.Cmd):
         if key not in seen:
             seen.add(key)
             logger.info(message, *args)
+
+    def _auto_unweighting_mode(self):
+        """What ``unweighting = auto`` resolves to, before any of the
+        fallbacks: one branch per spinmode family, keyed on the number of
+        decaying particles.
+
+        The two branches were measured over the number of decaying particles n
+        on `p p > w+ j` (n=1), `p p > t t~` (2), `p p > t t~ z` (3) and
+        `p p > t t~ t t~` (4), 50000 events each -- see
+        MADSPIN_SEQUENTIAL_PLAN.md section 12.
+
+        **PA/onshell -> ``sequential``, at every n.** It was the fastest of the
+        three at all four multiplicities, by 1.2x at n=1 rising to 3.8x at n=4.
+        The joint test's cost grows as n x (trials per event), since one
+        rejection throws every decay away, while the per-particle one's grows
+        far more slowly; and the up-front mass draw evaluates the production
+        reshuffling jacobian once per mass set instead of once per slot trial.
+        Even at n=1, where the angle stage degenerates to the joint test, the
+        mass stage still pays for itself: a mass set can be rejected before any
+        decay is drawn.
+
+        **madspin/full -> ``joint`` up to two decaying particles, then
+        ``sequential``.** Offshell, each mass set costs a production reshuffle
+        *and* an offshell production density, which the joint test pays per
+        trial but which a staged scheme pays per mass set -- and below n=3 there
+        are not enough decays to save to cover it. At n=1 it is worse than that:
+        the mass-set weight carries ``Tr(rho_off)/|M_prod|^2_on``, and when the
+        single decaying particle carries most of the production matrix
+        element's virtuality dependence (`p p > w+ j`) that ratio spans orders
+        of magnitude, no bound covers it, and the mass stage needs ~790 sets per
+        accepted event. From n=3 the per-particle test wins by 2.2x and 4.3x.
+
+        ``two_stage`` is not the fastest scheme at any measured point -- joint
+        beats it at n<=2 and ``sequential`` at n>=3 -- so it is reachable but
+        never chosen here. It stays useful as a cross-check, being the one
+        staged scheme whose angle stage is a single joint test.
+        """
+        if self._density_pole_approximation():
+            # fastest at every multiplicity measured; rho is fixed on shell
+            # so the mass stage costs a reshuffling jacobian and nothing else
+            return 'sequential'
+        if getattr(self, '_nb_decaying', 2) <= 2:
+            # offshell a mass set costs a production reshuffle and a
+            # production density, and there are not yet enough decays to
+            # save to pay for it
+            return 'joint'
+        return 'sequential'
 
     def _unweighting_mode(self, density_method=True):
         """Which accept/reject scheme this run uses: one of 'joint',
@@ -2692,36 +2785,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         spinmodes reshuffle the whole production onto the mass set at once, so
         there they fall back to ``sequential``.
 
-        ``auto`` has two branches, one per spinmode family. They were measured
-        over the number of decaying particles n on `p p > w+ j` (n=1),
-        `p p > t t~` (2), `p p > t t~ z` (3) and `p p > t t~ t t~` (4), 50000
-        events each -- see MADSPIN_SEQUENTIAL_PLAN.md section 12.
-
-        **PA/onshell -> ``sequential``, at every n.** It was the fastest of the
-        three at all four multiplicities, by 1.2x at n=1 rising to 3.8x at n=4.
-        The joint test's cost grows as n x (trials per event), since one
-        rejection throws every decay away, while the per-particle one's grows
-        far more slowly; and the up-front mass draw evaluates the production
-        reshuffling jacobian once per mass set instead of once per slot trial.
-        Even at n=1, where the angle stage degenerates to the joint test, the
-        mass stage still pays for itself: a mass set can be rejected before any
-        decay is drawn.
-
-        **madspin/full -> ``joint`` up to two decaying particles, then
-        ``sequential``.** Offshell, each mass set costs a production reshuffle
-        *and* an offshell production density, which the joint test pays per
-        trial but which a staged scheme pays per mass set -- and below n=3 there
-        are not enough decays to save to cover it. At n=1 it is worse than that:
-        the mass-set weight carries ``Tr(rho_off)/|M_prod|^2_on``, and when the
-        single decaying particle carries most of the production matrix
-        element's virtuality dependence (`p p > w+ j`) that ratio spans orders
-        of magnitude, no bound covers it, and the mass stage needs ~790 sets per
-        accepted event. From n=3 the per-particle test wins by 2.2x and 4.3x.
-
-        ``two_stage`` is not the fastest scheme at any measured point -- joint
-        beats it at n<=2 and ``sequential`` at n>=3 -- so it is reachable but
-        never chosen here. It stays useful as a cross-check, being the one
-        staged scheme whose angle stage is a single joint test.
+        What ``auto`` resolves to, and why, is in ``_auto_unweighting_mode``.
+        Whatever is asked for or resolved to, the fallbacks below can still send
+        the run back to ``joint``.
 
         ``fixed_order`` forces joint: its counter-events ride along with the
         decays and have not been thought through here.
@@ -2730,18 +2796,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             return 'joint'
         asked = mode = self.options['unweighting']
         if mode == 'auto':
-            nb_decaying = getattr(self, '_nb_decaying', 2)
-            if self.options['spinmode'] in ['PA', 'onshell']:
-                # fastest at every multiplicity measured; rho is fixed on shell
-                # so the mass stage costs a reshuffling jacobian and nothing else
-                mode = 'sequential'
-            elif nb_decaying <= 2:
-                # offshell a mass set costs a production reshuffle and a
-                # production density, and there are not yet enough decays to
-                # save to pay for it
-                mode = 'joint'
-            else:
-                mode = 'sequential'
+            mode = self._auto_unweighting_mode()
         if mode == 'joint':
             return self._announce_mode('joint', asked)
         if self.options['fixed_order']:
@@ -2768,13 +2823,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "keeping the joint accept/reject "
                            "(unweighting ignored)")
             return self._announce_mode('joint', asked)
-        if self.options['spinmode'] not in ['PA', 'onshell', 'madspin', 'full']:
+        if not self._spinmode_has_density():
             self._log_once('spinmode',
                            "MadSpin: spinmode=%s keeps the joint accept/reject "
                            "(unweighting ignored)", self.options['spinmode'])
             return self._announce_mode('joint', asked)
         if (mode == 'sequential_with_mass'
-                and self.options['spinmode'] not in ['PA', 'onshell']):
+                and not self._density_pole_approximation()):
             self._log_once('with_mass_pa_only',
                            "MadSpin: unweighting=sequential_with_mass needs a "
                            "per-particle mass draw, which the offshell "
@@ -4235,11 +4290,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         worker."""
         self.efficiency = 1. / nb_ps_point
         t0 = time.time()
-        density_pole_approximation = self.options['spinmode'] in ['PA', 'onshell']
-        density_do_reshuffle = self.options['spinmode'] == 'PA'
-        density_needs_reshuffle = (
-            self.generate_all.mode == 'density'
-            and (not density_pole_approximation or density_do_reshuffle))
+        density_pole_approximation = self._density_pole_approximation()
+        density_needs_reshuffle = self._density_needs_reshuffle(
+            self.generate_all.mode == 'density')
         per_event = []
         for i in range(start, stop):
             if (i - start) % 5 == 1 and getattr(self, '_shard_tag', None) in (None, 0):
@@ -4929,24 +4982,21 @@ class MadSpinInterface(extended_cmd.Cmd):
         """Whether the sequential accept/reject runs its offshell (madspin/full)
         branch: the production density is evaluated at reshuffled momenta, so the
         virtualities are drawn up front and rho is fixed per chain."""
-        return self.options['spinmode'] not in ['PA', 'onshell']
+        return not self._density_pole_approximation()
 
     def _sequential_upfront(self, density_method=True):
-        """Whether the chain draws every virtuality *before* the angles, i.e.
-        whether there is a mass-set accept/reject in front of the angle stage.
+        """Whether *this run* draws every virtuality before the angles, i.e.
+        ``_is_upfront_scheme`` of the scheme it resolved to.
 
-        True for every scheme but ``sequential_with_mass``, which draws each
-        slot's mass inside that slot's own accept/reject. What the up-front draw
-        buys differs by spinmode: offshell it fixes rho for the chain (which is
-        what makes the per-particle decomposition possible at all), while under
-        PA rho is already fixed at the onshell momenta and what is frozen
-        instead is the *production reshuffling jacobian* -- one reshuffle per
-        mass set rather than one per slot trial. Either way the angle stage then
-        redraws to acceptance and divides out its own normalisation, which is
-        what the tabulated ``_zhat`` puts back.
+        What the up-front draw buys differs by spinmode: offshell it fixes rho
+        for the chain (which is what makes the per-particle decomposition
+        possible at all), while under PA rho is already fixed at the onshell
+        momenta and what is frozen instead is the *production reshuffling
+        jacobian* -- one reshuffle per mass set rather than one per slot trial.
+        Either way the angle stage then redraws to acceptance and divides out
+        its own normalisation, which is what the tabulated ``_zhat`` puts back.
         """
-        return self._unweighting_mode(density_method) not in \
-                    ('joint', 'sequential_with_mass')
+        return self._is_upfront_scheme(self._unweighting_mode(density_method))
 
     # ------------------------------------------------------------------
     # Z_k(m): the rate factor of one slot, in the up-front-mass schemes
@@ -5344,7 +5394,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         # stage normalises itself) and it keeps Z_hat only as a preconditioner,
         # since it cancels between the two stages.
         mode = self._unweighting_mode()
-        upfront = mode not in ('joint', 'sequential_with_mass')
+        upfront = self._is_upfront_scheme(mode)
         joint_angles = upfront and mode == 'two_stage'
         exact = upfront and mode == 'sequential_global_retry'
         zkeys = self._z_slot_keys(particles, slot_to_index) if upfront else None
@@ -5834,8 +5884,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             Carefull this modifies production event (pass to the full one)
             build_event: if False (density mode) compute weight without building event"""
         #print("\n\n\n\n\n======== debug get_onshell_evt_and_wgt =========")
-        density_pole_approximation = self.options['spinmode'] in ['PA', 'onshell']
-        density_do_reshuffle = self.options['spinmode'] == 'PA'
+        density_pole_approximation = self._density_pole_approximation()
+        density_do_reshuffle = self._density_do_reshuffle()
         decay_me = 1.0
         decay_me_debug = 1.0
         jac = 1.0
@@ -6089,8 +6139,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         # acceptance) and for 2 -> 1 production (no phase space to redistribute).
         jac_reshuffle = 1.0
         prod_static = getattr(production, '_ms_density_static', None)
-        density_pole_approximation = self.options['spinmode'] in ['PA', 'onshell']
-        density_do_reshuffle = self.options['spinmode'] == 'PA'
+        density_pole_approximation = self._density_pole_approximation()
+        density_do_reshuffle = self._density_do_reshuffle()
         if not density_pole_approximation or \
             (not prod_static or prod_static.get('decays_key') != decays_key):
             prod_static = self._density_basis(production, decays_key)

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -35,6 +35,7 @@ import madgraph.various.banner as banner
 import copy
 import array
 import collections
+import inspect
 import math
 
 import madgraph.core.base_objects as MG
@@ -46,6 +47,22 @@ import models.import_ufo as import_ufo
 
 
 from madgraph import MG5DIR
+
+
+def _borrow_decision_helpers(namespace):
+    """Add the small spinmode/scheme predicates that `_unweighting_mode` and
+    `_sequential_upfront`/`_sequential_offshell` are built on to a stub class
+    namespace. Call as ``_borrow_decision_helpers(locals())`` from the class
+    body of any stub that borrows one of those.
+
+    getattr_static keeps the staticmethod wrappers intact.
+    """
+    for name in ('_auto_unweighting_mode', '_density_pole_approximation',
+                 '_density_do_reshuffle', '_density_needs_reshuffle',
+                 '_spinmode_has_density', '_is_upfront_scheme'):
+        namespace[name] = inspect.getattr_static(
+            interface_madspin.MadSpinInterface, name)
+    return namespace
 #
 class TestBanner(unittest.TestCase):
     """Test class for the reading of the banner"""
@@ -1322,6 +1339,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _unweighting_mode = interface._unweighting_mode
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
+            _borrow_decision_helpers(locals())
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
             def __init__(self):
@@ -1520,6 +1538,7 @@ class TestPAUpFrontMass(unittest.TestCase):
             _unweighting_mode = interface._unweighting_mode
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
+            _borrow_decision_helpers(locals())
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
 
@@ -1787,6 +1806,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
             _log_once = interface._log_once
             _sequential_spin_order = interface._sequential_spin_order
             _decay_pool_ladder = staticmethod(interface._decay_pool_ladder)
+            _borrow_decision_helpers(locals())
         stub = Stub()
         stub.model = self._Model(spins)
         stub.options = {'unweighting': 'sequential', 'fixed_order': False,
@@ -2066,6 +2086,7 @@ class TestOffshellRateFactor(unittest.TestCase):
         _unweighting_mode = interface_madspin.MadSpinInterface._unweighting_mode
         _announce_mode = interface_madspin.MadSpinInterface._announce_mode
         _log_once = interface_madspin.MadSpinInterface._log_once
+        _borrow_decision_helpers(locals())
         _build_z_tables = interface_madspin.MadSpinInterface._build_z_tables
         _weighted_polyfit2 = staticmethod(
                         interface_madspin.MadSpinInterface._weighted_polyfit2)
@@ -2813,3 +2834,213 @@ class TestDecayGroupDraw(unittest.TestCase):
         evt_decayfile = {6: dict((i, self._Pool('c%d' % i)) for i in range(4))}
         out = stub.get_decay_from_file(production, evt_decayfile, 10)
         self.assertEqual([d.split(':')[0] for d in out[6]], ['c2', 'c3'])
+
+
+class TestUnweightingDecisionTable(unittest.TestCase):
+    """The upfront / unweighting decision logic, exhaustively.
+
+    `_unweighting_mode` and the predicates built on it (`_sequential_active`,
+    `_sequential_upfront`, `_sequential_offshell`, `_sequential_pool_ladder`)
+    decide, per run, how the accept/reject is organised. The branching is
+    spinmode-specific and layered -- `auto` resolves on the spinmode family and
+    the decay multiplicity, then several fallbacks can still send the run back
+    to the joint test -- so it is pinned here over *every* reachable
+    combination, against the rules restated independently of the implementation
+    (`_reference_mode` below, written from the `unweighting` option comment).
+    """
+
+    # every declared spinmode, plus 'bridge' and a name no branch knows about
+    SPINMODES = ('full', 'madspin', 'none', 'onshell', 'PA', 'madspin_v1',
+                 'onshell_v1', 'bridge', 'not_a_spinmode')
+    UNWEIGHTING = ('auto', 'joint', 'two_stage', 'sequential',
+                   'sequential_global_retry', 'sequential_with_mass')
+    NB_DECAYING = (0, 1, 2, 3, 4, 7)
+    POLE_APPROXIMATION = ('PA', 'onshell')
+
+    class _Part(object):
+        def __init__(self, spin):
+            self.spin = spin
+
+        def get(self, key):
+            assert key == 'spin'
+            return self.spin
+
+    class _Model(object):
+        SPINS = {6: 2, -6: 2, 24: 3, 23: 3, 25: 1}
+
+        def get_particle(self, pdg):
+            if pdg not in self.SPINS:
+                raise Exception('unknown particle')
+            return TestUnweightingDecisionTable._Part(self.SPINS[pdg])
+
+    class _Stub(object):
+        """The real methods, on the smallest object that can carry them."""
+        for _name in ('_unweighting_mode', '_auto_unweighting_mode',
+                      '_announce_mode', '_log_once', '_sequential_active',
+                      '_sequential_upfront', '_sequential_offshell',
+                      '_sequential_pool_ladder', '_sequential_spin_order',
+                      '_decay_pool_ladder', '_density_pole_approximation',
+                      '_density_do_reshuffle', '_density_needs_reshuffle',
+                      '_spinmode_has_density', '_is_upfront_scheme'):
+            # getattr_static keeps the staticmethod wrappers intact
+            locals()[_name] = inspect.getattr_static(
+                interface_madspin.MadSpinInterface, _name)
+        del _name
+
+        def __init__(self, spinmode='madspin', unweighting='auto',
+                     nb_decaying=2, fixed_order=False, decay_groups=None):
+            self.options = {'spinmode': spinmode, 'unweighting': unweighting,
+                            'fixed_order': fixed_order,
+                            'sequential_spin_order': '2 3 1'}
+            self._nb_decaying = nb_decaying
+            self._decay_groups = decay_groups
+            self.model = TestUnweightingDecisionTable._Model()
+            self._logged_once = set()
+
+    @classmethod
+    def _reference_mode(cls, spinmode, unweighting, nb_decaying, fixed_order,
+                        decay_groups, density_method):
+        """The rules as documented on the `unweighting` option, restated here
+        rather than read off the implementation, so this is a check and not a
+        tautology."""
+        if not density_method:
+            return 'joint'                       # only scheme outside density
+        mode = unweighting
+        if mode == 'auto':
+            if spinmode in cls.POLE_APPROXIMATION:
+                mode = 'sequential'              # fastest at every measured n
+            elif nb_decaying <= 2:
+                mode = 'joint'                   # offshell, too few decays
+            else:
+                mode = 'sequential'
+        if mode == 'joint':
+            return 'joint'
+        if fixed_order:
+            return 'joint'                       # counter-events ride along
+        if decay_groups:
+            return 'joint'                       # '@' groups self-normalise
+        if spinmode not in ('PA', 'onshell', 'madspin', 'full'):
+            return 'joint'                       # no density matrix to stage
+        if (mode == 'sequential_with_mass'
+                and spinmode not in cls.POLE_APPROXIMATION):
+            return 'sequential'                  # needs a per-particle mass
+        return mode
+
+    def _cases(self):
+        for spinmode in self.SPINMODES:
+            for unweighting in self.UNWEIGHTING:
+                for nb_decaying in self.NB_DECAYING:
+                    for fixed_order in (False, True):
+                        for groups in (None, {'tags': ['1', '2']}):
+                            for density_method in (True, False):
+                                yield (spinmode, unweighting, nb_decaying,
+                                       fixed_order, groups, density_method)
+
+    def test_every_combination_matches_the_documented_rules(self):
+        seen = set()
+        for case in self._cases():
+            stub = self._Stub(*case[:5])
+            got = stub._unweighting_mode(case[5])
+            seen.add(got)
+            self.assertEqual(got, self._reference_mode(*case), msg=str(case))
+        # the table is not degenerate: every scheme is reachable through it
+        self.assertEqual(seen, {'joint', 'two_stage', 'sequential',
+                                'sequential_global_retry',
+                                'sequential_with_mass'})
+
+    def test_auto_resolves_on_the_family_then_the_multiplicity(self):
+        """Spelled out, since it is the branch a user never sets by hand:
+        sequential everywhere under PA/onshell, joint offshell up to two
+        decaying particles and sequential from three."""
+        for spinmode in ('PA', 'onshell'):
+            for nb in self.NB_DECAYING:
+                self.assertEqual(
+                    self._Stub(spinmode, 'auto', nb)._auto_unweighting_mode(),
+                    'sequential', (spinmode, nb))
+        for spinmode in ('madspin', 'full'):
+            for nb, expected in ((0, 'joint'), (1, 'joint'), (2, 'joint'),
+                                 (3, 'sequential'), (4, 'sequential'),
+                                 (7, 'sequential')):
+                self.assertEqual(
+                    self._Stub(spinmode, 'auto', nb)._auto_unweighting_mode(),
+                    expected, (spinmode, nb))
+
+    def test_auto_without_a_measured_multiplicity_assumes_two(self):
+        """`_nb_decaying` is set while the decays are prepared; anything asking
+        before that must not crash."""
+        stub = self._Stub('madspin', 'auto')
+        del stub._nb_decaying
+        self.assertEqual(stub._unweighting_mode(), 'joint')
+
+    def test_sequential_active_is_exactly_not_joint(self):
+        for case in self._cases():
+            stub = self._Stub(*case[:5])
+            self.assertEqual(stub._sequential_active(case[5]),
+                             stub._unweighting_mode(case[5]) != 'joint',
+                             msg=str(case))
+
+    def test_upfront_is_every_scheme_but_joint_and_with_mass(self):
+        for mode, expected in (('joint', False), ('two_stage', True),
+                               ('sequential', True),
+                               ('sequential_global_retry', True),
+                               ('sequential_with_mass', False)):
+            self.assertEqual(self._Stub()._is_upfront_scheme(mode), expected,
+                             mode)
+        for case in self._cases():
+            stub = self._Stub(*case[:5])
+            self.assertEqual(
+                stub._sequential_upfront(case[5]),
+                stub._unweighting_mode(case[5]) not in
+                    ('joint', 'sequential_with_mass'),
+                msg=str(case))
+
+    def test_with_mass_falls_back_to_sequential_offshell_only(self):
+        """It needs a per-particle mass draw; the offshell spinmodes reshuffle
+        the whole production onto the mass set at once."""
+        for spinmode in ('PA', 'onshell'):
+            stub = self._Stub(spinmode, 'sequential_with_mass', 2)
+            self.assertEqual(stub._unweighting_mode(), 'sequential_with_mass')
+            self.assertFalse(stub._sequential_upfront())
+        for spinmode in ('madspin', 'full'):
+            stub = self._Stub(spinmode, 'sequential_with_mass', 2)
+            self.assertEqual(stub._unweighting_mode(), 'sequential')
+            self.assertTrue(stub._sequential_upfront())
+
+    def test_the_spinmode_family_predicates(self):
+        for spinmode in self.SPINMODES:
+            stub = self._Stub(spinmode)
+            self.assertEqual(stub._density_pole_approximation(),
+                             spinmode in ('PA', 'onshell'), spinmode)
+            self.assertEqual(stub._density_do_reshuffle(), spinmode == 'PA',
+                             spinmode)
+            self.assertEqual(stub._spinmode_has_density(),
+                             spinmode in ('PA', 'onshell', 'madspin', 'full'),
+                             spinmode)
+            # offshell is exactly the complement of the pole approximation
+            self.assertEqual(stub._sequential_offshell(),
+                             not stub._density_pole_approximation(), spinmode)
+
+    def test_needs_reshuffle_is_offshell_or_pa_inside_density_mode(self):
+        for spinmode in self.SPINMODES:
+            stub = self._Stub(spinmode)
+            self.assertFalse(stub._density_needs_reshuffle(False), spinmode)
+            self.assertEqual(bool(stub._density_needs_reshuffle(True)),
+                             spinmode != 'onshell', spinmode)
+
+    def test_pool_ladder_is_empty_unless_a_staged_scheme_is_in_use(self):
+        to_decay, nb_event = {6: 100, -6: 100}, 100
+        for case in self._cases():
+            stub = self._Stub(*case[:5])
+            ladder = stub._sequential_pool_ladder(dict(to_decay), nb_event,
+                                                  case[5])
+            if stub._unweighting_mode(case[5]) == 'joint':
+                self.assertEqual(ladder, {}, msg=str(case))
+            else:
+                self.assertEqual(sorted(ladder), [-6, 6], msg=str(case))
+                self.assertEqual(sorted(ladder.values()), [1.5, 2.0],
+                                 msg=str(case))
+
+    def test_pool_ladder_gives_up_on_a_particle_the_model_does_not_know(self):
+        stub = self._Stub('PA', 'sequential', 2)
+        self.assertEqual(stub._sequential_pool_ladder({6: 100, 999: 100}, 100,
+                                                      True), {})


### PR DESCRIPTION
Follow-up to the review remark that the `_sequential_upfront` / `_unweighting_mode` interaction had become hard to follow. Strictly behaviour-preserving: the spinmode-specific branching is pulled out into named predicates so the up-front/offshell decisions can be read rather than re-derived.

### New helpers

All private on `MadSpinInterface`; no public or option-facing name changed, no log message changed.

| helper | contract |
|---|---|
| `_density_pole_approximation()` | `spinmode in ['PA','onshell']` — density matrix at onshell momenta |
| `_density_do_reshuffle()` | `spinmode == 'PA'` — a PA run that still reshuffles onto sampled virtualities |
| `_density_needs_reshuffle(in_density_mode)` | `in_density_mode and (not PA or do_reshuffle)`; the argument is the caller's own "am I in density mode" (`density_method` before generation, `self.generate_all.mode == 'density'` after) |
| `_spinmode_has_density()` | `spinmode in ['PA','onshell','madspin','full']`, expressed as PA-family union offshell-family |
| `_is_upfront_scheme(mode)` | static; `mode not in ('joint','sequential_with_mass')` — does the scheme have a mass-set stage |
| `_auto_unweighting_mode()` | what `unweighting='auto'` resolves to before the fallbacks: `sequential` under PA/onshell; offshell `joint` at <=2 decaying particles, `sequential` from 3 |

The `auto` benchmark docstring (the `p p > w+ j` / `t t~` / `t t~ z` / `t t~ t t~` numbers, the `Tr(rho_off)/|M_prod|^2` argument, the `two_stage` note) was moved **verbatim** onto `_auto_unweighting_mode`, with a pointer left behind. `_sequential_upfront` keeps its spinmode paragraph; only the "which schemes" sentence moved to `_is_upfront_scheme`.

Also: `density_do_reshuffle` in `decay_events` was computed and never used — it only ever fed `density_needs_reshuffle`, which now derives it internally — so it is gone.

### Evidence that behaviour is unchanged

**Exhaustive before/after snapshot.** A throwaway script borrows the real unbound methods onto a stub (via `inspect.getattr_static`, so staticmethods stay static) and enumerates 9 spinmodes (all 7 declared + `bridge` + an unknown name) x 6 `unweighting` values x 6 decay multiplicities (0,1,2,3,4,7) x `fixed_order` x decay-groups-present x `density_method` = **2610 rows**. Each row records `_unweighting_mode`, `_sequential_active`, `_sequential_upfront`, `_sequential_offshell`, the default-argument variants, and `_sequential_pool_ladder` over 7 `to_decay`/`nb_event` shapes; plus the `density_*` triple per spinmode x `density_method`.

```
$ diff before.json after.json && echo "SNAPSHOT IDENTICAL (2610/2610)"
SNAPSHOT IDENTICAL (2610/2610)
```

Not vacuous: 0 error rows, 114 non-empty ladders, all five schemes reachable.

**Parametrized unit test.** `TestUnweightingDecisionTable` (10 tests) checks `_unweighting_mode` over the full 1296-case product against a `_reference_mode` written from the `unweighting` option comment rather than read off the implementation, plus the `auto` table, the with-mass fallback, the family predicates and the pool ladder.

**Runs.** No pytest in this environment; the repo convention is `tests/test_manager.py`.

```
$ python3 tests/test_manager.py -p tests/unit_tests/madspin
Ran 141 tests in 10.316s
OK
```

(131 before this change, so the 10 new tests are additive and nothing regressed.)

Full unit suite: `Ran 918 tests ... FAILED (errors=1)` — `test_DensityMatrixObservables22`, `ModuleNotFoundError: No module named 'scipy'` in `madgraph/various/Density_functions.py:1035`. Pre-existing environment gap, untouched by this diff.

### Notes for review

- **Four existing test stubs had to be touched.** They borrow a hand-listed set of unbound methods, so the new helper calls inside `_unweighting_mode` broke 26 tests with `AttributeError`. Rather than repeat six lines per stub there is now a module-level `_borrow_decision_helpers(locals())` (`test_madspin.py:52`) called from each. Any new stub that borrows `_unweighting_mode` needs that call too.
- **Not verified by execution:** `tests/parallel_tests/test_madspin_factory.py` asserts the resolved scheme by parsing the `MadSpin: unweighting = ...` log line, and needs real MG5 runs. `_announce_mode`, `_log_once` and every message string are byte-identical so the announced line cannot have moved — but that is reasoning, not a run.
- `draw_mass = (spinmode == 'PA' and nb_prod_final > 1)` was deliberately left alone: same predicate, but it reads as "does this mode draw a mass" rather than "does it reshuffle", and folding it in would have obscured rather than clarified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify MadSpin’s spinmode-dependent unweighting decisions by factoring them into reusable predicates while preserving existing behavior.

Enhancements:
- Extract spinmode, density, automatic unweighting, and upfront-scheme decisions into named MadSpin predicates without changing behavior or user-facing messages.

Tests:
- Add exhaustive parametrized coverage for unweighting decisions, spinmode predicates, fallbacks, and sequential pool ladders across supported combinations.