### PR TITLE
MadSpin: count the decaying particles per event, not from the per-pdg tally

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -2203,28 +2203,43 @@ class MadSpinInterface(extended_cmd.Cmd):
         # - count the number of particles to be decayed.
         to_decay = collections.defaultdict(int)	
         nb_event = 0
+        nb_decaying = 0
         for event in orig_lhe:
             if self.options['fixed_order']:
                 event = event[0]
             nb_event +=1
+            nb_this_event = 0
             for particle in event:
                 if particle.status == 1 and particle.pdg in asked_to_decay:
                     # final state and tag as to decay
                     to_decay[particle.pdg] += 1
+                    nb_this_event += 1
                     # Properties of decaying particle
                     width = self.banner.get('param_card', 'decay', abs(particle.pdg)).value
                     mass = self.banner.get('param_card', 'mass', abs(particle.pdg)).value
                     color = self.model.get_particle(particle.pdg).get('color')
                     spin = self.model.get_particle(particle.pdg).get('spin')
                     decay_dict[particle.pdg] = [width, mass, color, spin]
+            if nb_this_event > nb_decaying:
+                nb_decaying = nb_this_event
         #print(f"to_decay = {to_decay}")
         # How many particles decay in one event -- the same multiplicity the
         # pool ladder counts. It decides which unweighting scheme 'auto' picks,
         # so it is resolved once here rather than per event: the modes have
         # different bounds, and a mode that changed event to event would be
         # testing against somebody else's.
-        self._nb_decaying = sum(max(1, int(nb) // int(nb_event))
-                                for nb in to_decay.values()) if nb_event else 0
+        #
+        # Counted *per event* and maximised, not rebuilt from the per-pdg
+        # tally: a sample that mixes subprocesses carrying different decaying
+        # pdgs -- `p p > w+ j` together with `p p > w- j` -- decays exactly one
+        # particle per event, but lists two pdgs, and floor-averaging each of
+        # them to at least one reported two decaying particles. That over-count
+        # is what pushed `p p > w+/- j` onto a staged offshell scheme, which is
+        # precisely the case whose mass-set weight carries
+        # Tr(rho_off)/|M_prod|^2_on over orders of magnitude and that no bound
+        # covers (see _unweighting_mode): the acceptance test measured 1.8e4
+        # for the mass bound and 18e6 mass sets for 1000 events.
+        self._nb_decaying = nb_decaying
                 	
         with misc.MuteLogger(["madgraph", "madevent", "ALOHA", "cmdprint"], [50,50,50,50]):
             mg5 = self.mg5cmd


### PR DESCRIPTION
Investigation of the `acceptancetest_wj_ms_decay` CI job (`.github/workflows/acceptancetest.yml:2218` -> `test_wj_production_with_ms_decay`, `tests/acceptance_tests/test_cmd_madevent.py:1300`), and a fix for the miscount that put it on a pathological path.

### Job history

Added 2026-07-25. Full history:

| run | date | result | duration |
|---|---|---|---|
| 30175184450 | Jul 25 | success | 3m31s |
| 30260644362 | Jul 27 | success | 3m16s |
| 30287712257 | Jul 27 | success | 3m20s |
| 30642059276 | Jul 31 | **failure** | – |
| 31666827429 | Aug 13 | **failure** | – |
| 31906511976 | Aug 15 | success | **35m12s** |
| 32116592519 | Aug 18 | success | **38m18s** |

Two separate problems, only one of which is this job's fault.

### The two hard failures are repo-wide infra, not this test

Both are the same shared-cache miss:

```
Cache not found for input keys: heptools-ubuntu22
Cache not found for input keys: lhapdf-ubuntu22
...
Exception: lhapdf executable (/home/runner/.cache/HEPtools/bin/lhapdf-config) is not found on your system.
```

`.github/actions/restore_heptools*` only *restore*; on a total miss they still append the now-bogus `lhapdf = .../HEPtools/bin/lhapdf-config` line to `input/mg5_configuration.txt`, so the job dies ~20 minutes later inside `configure_directory`. **21 jobs failed together** in that run (contur, emela, madspin_LI, PA_decay, wj_ms_decay, acceptancetest_37/70/77, ...). The test genuinely needs lhapdf (`set lhaid 10042`, `set pdlabel lhapdf`) and pythia8, so the dependency cannot be dropped. Not touched here: it is a repo-wide infra issue affecting ~50 jobs and orthogonal to this one.

### The 3m -> 38m regression: `auto` picked the one scheme it must not

From the passing Aug 18 run:

```
INFO: MadSpin: unweighting = two_stage (auto, 2 decaying particle(s))
INFO: Sequential maximum weights: 1.78e+04 4.707
INFO: MadSpin sequential mass stage: 18265.64 mass sets per accepted event (18265643 drawn, 18264643 rejected)
CRITICAL: MadSpin sequential: 2 weights exceeded their per-particle maximum. That bound is
          under-estimated and the sample is biased
```

18.3 million mass sets for 1000 events, and a **biased** sample. `_unweighting_mode`'s own docstring names this exact case: offshell at n=1, the mass-set weight carries `Tr(rho_off)/|M_prod|^2_on`, and when the single decaying particle carries most of the production matrix element's virtuality dependence (`p p > w+ j`) that ratio spans orders of magnitude and no bound covers it.

### Root cause

`p p > w+ j` + `p p > w- j` decays **exactly one** particle per event. But `_nb_decaying` was rebuilt from the per-pdg tally:

```python
self._nb_decaying = sum(max(1, int(nb) // int(nb_event))
                        for nb in to_decay.values()) if nb_event else 0
```

With `to_decay = {24: N/2, -24: N/2}` and `nb_event = N`, each pdg floors to 0, `max(1, 0)` lifts it to 1, and the sum reports **2** — walking straight past the `n <= 1 -> joint` guard that was in force.

### The fix

Count the decaying particles **per event and take the maximum**, instead of summing per-pdg floor-averages. Homogeneous processes — the ones the `auto` timings were measured on — are unchanged (`t t~` -> 2, `t t~ z` -> 3, `t t~ t t~` -> 4, `t`-only -> 1); only mixed-pdg samples move.

### Scope, stated honestly

**The 38-minute regression is already fixed on the tip of `madspin_density`** by `2ce853acc` ("switch the auto unweighting to the two-branch rule"), which routes offshell n<=2 to `joint`. That commit is not in the Aug 18 run, which is why it was still 38 min. So this PR does **not** by itself change this job's behaviour today. What it does is repair the miscount that put the job on the pathological path in the first place, restore the honest diagnostic, and stop a mixed-pdg sample being pushed a multiplicity step up (a `t t~` + `w+ j` mix reported 3 -> `sequential`; it now reports 2 -> `joint`).

### Verification

Local A/B on `p p > w+ j; add process p p > w- j`, spinmode madspin, same code path, identical events:

```
before (madspin_density unmodified):
INFO: MadSpin: unweighting = joint (auto, 2 decaying particle(s))

after (this commit):
INFO: MadSpin: unweighting = joint (auto, 1 decaying particle(s))
```

`./tests/test_manager.py test_madspin -p U -t0` -> `Ran 131 tests ... OK`.

**Not verified:** the full acceptance test could not be run locally (the local lhapdf python module is broken for this interpreter, and MadSpin's f2py build fails on this machine). There is also no CI confirmation yet that the job is back to ~3 min post-`2ce853acc` — the run that would have shown it was cancelled and its successor is still queued.

### Out of scope, flagged separately

`tests/parallel_tests/test_madspin_factory.py:565` (`test_short_madspin_unweighting_resolution`, run by the `madspin_factory` job) still asserts `auto` + offshell + 2 decaying -> `two_stage`, which `2ce853acc` changed to `joint`. The unit tests were updated, that one was not. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Count MadSpin decaying particles per event to select the appropriate automatic unweighting scheme for mixed-PDG samples.

Bug Fixes:
- Correct the MadSpin decaying-particle count for mixed-PDG samples by determining the maximum number of decaying particles in any event.

Enhancements:
- Ensure automatic unweighting scheme selection uses the actual per-event decay multiplicity and avoids overestimating mixed-subprocess samples.