### PR TITLE
MadSpin: correct the stale unweighting expectations in the factory tests

### DIFF
--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -1075,11 +1075,14 @@ def assert_unweighting_mode(test, result, expected, expected_why=None):
     """The scheme the run *actually used*, as the run itself announced it.
 
     Non-statistical and instant, and it is the guard on the resolution logic:
-    ``auto`` resolves on the process, and several combinations override what
-    the card asked for (``fixed_order`` and unsupported spinmodes force
-    ``joint``; ``two_stage`` and ``sequential_global_retry`` need an offshell
-    spinmode and fall back to ``sequential`` under PA/onshell). Without this a
-    consistency matrix could compare four runs of the same scheme and pass."""
+    ``auto`` resolves on the process (offshell it takes ``joint`` up to two
+    decaying particles and ``sequential`` from three; under PA/onshell it is
+    always ``sequential``), and several combinations override what the card
+    asked for (``fixed_order``, grouped '@' decays and unsupported spinmodes
+    force ``joint``; ``sequential_with_mass`` needs a per-particle mass draw
+    and falls back to ``sequential`` under the offshell spinmodes). Without
+    this a consistency matrix could compare four runs of the same scheme and
+    pass."""
     test.assertIsNotNone(
         result.unweighting_mode,
         "no 'MadSpin: unweighting = ...' line in %s -- the run never announced "

--- a/tests/parallel_tests/test_madspin_factory.py
+++ b/tests/parallel_tests/test_madspin_factory.py
@@ -366,9 +366,10 @@ class MadSpinFactoryTest(_MadSpinFactoryBase):
 # ---------------------------------------------------------------------------
 
 # Fully leptonic ttbar. Two decaying particles at the top level (t and t~), so
-# ``auto`` lands on ``two_stage`` under an offshell spinmode -- and both tops
-# give a reconstructable lineshape while the two leptons give the angular
-# no-regression observable.
+# ``auto`` lands on ``joint`` under an offshell spinmode (offshell it only
+# leaves joint from three decaying particles up) and on ``sequential`` under
+# PA/onshell -- and both tops give a reconstructable lineshape while the two
+# leptons give the angular no-regression observable.
 TTBAR_LEPTONIC = dict(
     production_process='p p > t t~',
     decays=['t > b w+, w+ > l+ vl',
@@ -539,19 +540,38 @@ class MadSpinUnweightingTest(_MadSpinFactoryBase):
 
         Covered here, all off one production sample:
 
-          * ``auto`` + offshell, two decaying particles -> ``two_stage``;
-          * ``auto`` + offshell, *one* decaying particle -> ``joint`` (every
-            split degenerates there). This is the one case that exercises the
-            real ``_nb_decaying`` count against real events;
-          * ``auto`` + PA -> ``sequential`` (PA has no up-front mass draw);
-          * ``two_stage`` / ``sequential_global_retry`` asked for explicitly
-            under PA/onshell -> ``sequential``, the documented fallback;
+          * ``auto`` + offshell, two decaying particles -> ``joint``. Offshell,
+            a mass set costs a production reshuffle *and* a production density,
+            so ``auto`` only leaves joint from three decaying particles up;
+          * ``auto`` + offshell, *one* decaying particle -> ``joint`` as well,
+            by the same branch. Both auto/offshell cases land on the same
+            scheme, so what separates them is the announced count -- and this
+            is the one case that exercises the real ``_nb_decaying`` against
+            real events, since it needs the decay lines to be counted rather
+            than the default assumed;
+          * ``auto`` + PA -> ``sequential``: PA keeps rho fixed on shell, so
+            its mass stage costs a reshuffling jacobian and nothing else, and
+            sequential was the fastest at every multiplicity measured;
+          * ``two_stage`` under PA and ``sequential_global_retry`` under
+            onshell -> themselves. PA has an up-front mass draw of its own, so
+            the up-front-mass schemes are honoured there rather than downgraded
+            -- this is the end-to-end guard on that (``two_stage`` in
+            particular is no longer offered in the card but must still run when
+            asked for by name);
+          * ``sequential_with_mass`` + offshell -> ``sequential``: the one
+            fallback left in the resolution. It draws each slot's virtuality
+            inside that slot's accept/reject, which the offshell spinmodes
+            cannot do -- they reshuffle the whole production onto the mass set
+            at once;
           * ``joint`` asked for explicitly -> ``joint``.
 
-        Not covered: ``fixed_order`` forcing joint, which needs a fixed-order
-        sample this factory does not produce, and the unsupported-spinmode
-        fallback, which is unreachable from a real run (only PA/onshell/madspin
-        reach the resolution at all). Both are unit-tested against a stub.
+        Not covered here: the offshell ``auto`` boundary itself (three decaying
+        particles -> ``sequential``), which would need a third production
+        sample this factory does not build; ``fixed_order`` forcing joint,
+        which needs a fixed-order sample; the decay-group override; and the
+        unsupported-spinmode fallback, which is unreachable from a real run
+        (only PA/onshell/madspin/full reach the resolution at all). All of
+        those are unit-tested against a stub.
         """
         factory = self._unweighting_factory('unweighting_resolution',
                                             IDENTITY_NEVENTS)
@@ -562,15 +582,17 @@ class MadSpinUnweightingTest(_MadSpinFactoryBase):
         # (tag, config, asked, decays, expected mode, expected reason)
         cases = [
             ('auto_offshell', offshell, 'auto', None,
-             'two_stage', 'auto, 2 decaying particle(s)'),
+             'joint', 'auto, 2 decaying particle(s)'),
             ('auto_offshell_single', offshell, 'auto',
              ['t > b w+, w+ > l+ vl'],
              'joint', 'auto, 1 decaying particle(s)'),
             ('auto_pa', pa, 'auto', None,
              'sequential', 'auto, 2 decaying particle(s)'),
             ('two_stage_pa', pa, 'two_stage', None,
-             'sequential', 'set explicitly'),
+             'two_stage', 'set explicitly'),
             ('global_retry_onshell', onshell, 'sequential_global_retry', None,
+             'sequential_global_retry', 'set explicitly'),
+            ('with_mass_offshell', offshell, 'sequential_with_mass', None,
              'sequential', 'set explicitly'),
             ('joint_offshell', offshell, 'joint', None,
              'joint', 'set explicitly'),


### PR DESCRIPTION
`madspin_factory (test_short_madspin_unweighting_resolution)` is **currently red on `madspin_density` itself** — run 32121452880 (2026-08-18 09:24), one red job out of seven:

```
AssertionError: 'joint' != 'two_stage'
 : run madspin_density resolved unweighting = joint (auto, 2 decaying particle(s)),
   expected two_stage
```

`unweighting_identity` and `unweighting_consistency` were green in the same run, so this is purely stale expectations in the test, not a production-code problem.

### It was three stale rows, not one

CI only ever showed the first failure because the loop asserts inside the iteration and aborts. Driving `_unweighting_mode` directly for every asserted case:

| case | asked | spinmode | n | code returns | file said |
|---|---|---|---|---|---|
| `auto_offshell` | auto | madspin | 2 | `joint` | `two_stage` ❌ |
| `auto_offshell_single` | auto | madspin | 1 | `joint` | `joint` ✓ |
| `auto_pa` | auto | PA | 2 | `sequential` | `sequential` ✓ |
| `two_stage_pa` | two_stage | PA | 2 | `two_stage` | `sequential` ❌ |
| `global_retry_onshell` | seq_global_retry | onshell | 2 | `sequential_global_retry` | `sequential` ❌ |
| `joint_offshell` | joint | madspin | 2 | `joint` | `joint` ✓ |

Rows 4 and 5 were asserting a PA/onshell downgrade of the up-front-mass schemes that **no longer exists**. The only fallback left in the resolution is `sequential_with_mass` -> `sequential` under offshell.

### Why the new values are right, not merely green

Both corrections are pinned independently by unit tests in `tests/unit_tests/madspin/test_madspin.py` that the parallel tests had drifted away from:

- `test_auto_picks_the_scheme_by_the_number_of_decays` pins offshell `auto`: `joint` at n=1,2 and `sequential` from n=3. Combined with the fact that the `mode == 'auto'` block only ever yields `sequential` or `joint`, `auto` -> `two_stage` is unreachable.
- `test_up_front_mass_modes_are_available_under_pa` pins `two_stage` / `sequential` / `sequential_global_retry` resolving **to themselves** under PA, onshell and madspin — "PA has an up-front mass draw of its own now, so the three schemes are honoured rather than downgraded".

### Changes

1. Three expected values corrected (`joint`, `two_stage`, `sequential_global_retry`).
2. **Added** a `with_mass_offshell` row (`sequential_with_mass` + madspin -> `sequential`). The docstring claimed to cover "the documented fallback"; after the corrections it covered no fallback at all. This is the one that survives, and it was untested end-to-end. Costs one extra 800-event MadSpin run off the already-built production sample.
3. Prose at the `TTBAR_LEPTONIC` header and the test docstring rewritten with the real reason per case, plus an honest "not covered here" noting that the n>=3 side of the offshell `auto` boundary is unit-tested only — the factory builds no three-decay production sample.
4. Same wrong claim fixed in `assert_unweighting_mode`'s docstring in `madspin_comparator.py` ("`two_stage` and `sequential_global_retry` ... fall back to `sequential` under PA/onshell").

### Verification

- `python3 tests/test_manager.py -p tests/unit_tests/madspin` -> `Ran 131 tests in 10.364s / OK`.
- The parallel tests need real MG5 process generation and **were not run here**. Instead the `cases` list was parsed straight out of the edited file with `ast` and the real `_unweighting_mode` driven for each row's `(spinmode, asked, nb_decaying)`: **7 rows checked, 0 mismatches**, announced reason string included. That reproduces what `assert_unweighting_mode` compares, minus the log round-trip.

**Not verified:** that `sequential_with_mass` survives the card round-trip in a live run. It is in `allowed` and is not among the hidden schemes, so it should — but only real CI will confirm that, as it will rows 4 and 5, which the aborted CI run never reached.

### Relation to the other open PRs

Consistent with both by inspection: #344 drops `two_stage` from `allowed` but re-admits it in `__setitem__`, so the `two_stage_pa` row still holds; #346 does not change any return value. Neither touches these two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align MadSpin factory tests with the current unweighting resolution rules and cover the remaining documented fallback.

Bug Fixes:
- Correct stale MadSpin factory expectations for automatic and explicitly requested unweighting modes.
- Add end-to-end coverage for the remaining offshell fallback from sequential_with_mass to sequential.

Enhancements:
- Update MadSpin test documentation and comparator guidance to reflect current unweighting resolution behavior and uncovered cases.

Tests:
- Expand the factory unweighting-resolution matrix to validate corrected mode selections across offshell, PA, and onshell configurations.