### PR TITLE
MadSpin: restrict the density convolution to the production polarisation

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -63,19 +63,40 @@ Two things this is NOT:
   they build, so `rho_prod` comes back **fully unpolarised** in those indices
   even for a polarised process -- verified by evaluating `M0_GET_DENSITY`
   directly for `p p > t{L} t~` and for `p p > t t~`: identical entries,
-  including `rho(+1,+1)`. The restriction therefore changes results.
+  including `rho(+1,+1)`. End to end, `p p > t{R} t~` before this change gave
+  event blocks *byte-identical* to `p p > t t~`: the brace was ignored outright.
 - it is not free of a basis reordering. `GET_DENSITY` selects the rows of the
   process' `NHEL` table by matching them against the *first* `ALLOW_HEL`
   combination, and a polarised process has no `NHEL` row outside its
   polarisation. With the default `hel_dict` order (`[1,-1]`, `[-1,0,1]`) a
   `{L}`/`{-}`/`{0}` production matched nothing and handed back an identically
-  zero density matrix. `_apply_production_polarization` therefore puts an
+  zero density matrix -- and a zero `rho_prod` rejects *every* accept/reject
+  trial, so MadSpin did not fail, it **looped forever** regenerating decay-event
+  pools (observed: `p p > t{L} t~` and `p p > w+{0} w-` both spin indefinitely
+  on the pre-change code). `_apply_production_polarization` therefore puts an
   allowed helicity first in that particle's basis; the order is untouched when
   there is no brace.
 
 Polarisation on a **decay** line is rejected outright in the density spin modes
 (`do_decay`): the braces there would restrict the decay matrix element that
 defines the branching ratio, not the density matrix that is contracted.
+
+Validated end to end against the analytic decay distributions (`spinmode` in
+parentheses; theta measured in the parent rest frame against the parent's lab
+direction, which is the axis the helicity is quantised along):
+
+| production | observable | measured | expected |
+|---|---|---|---|
+| `p p > t t~` | `<cos>` of e+ from t | +0.015 +- 0.061 | ~0 (unpolarised) |
+| `p p > t{R} t~` (madspin) | idem | +0.409 +- 0.045 | +1/3 |
+| `p p > t{L} t~` (madspin) | idem | -0.352 +- 0.051 | -1/3 |
+| `p p > w+ w-` (madspin) | `<cos^2>` of e+ from W+ | 0.347 +- 0.007 | SM mixture |
+| `p p > w+{T} w-` (madspin / onshell) | idem | 0.393 / 0.398 +- 0.007 | 2/5 |
+| `p p > w+{0} w-` (madspin / PA) | idem | 0.198 / 0.208 +- 0.005 | 1/5 |
+
+In every polarised run the *un*polarised partner in the same event (the `t~`,
+which carries no brace) stayed compatible with zero, confirming the mask is
+per particle. A no-brace run is byte-identical to the pre-change code.
 
 ### The partial weight
 

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -82,8 +82,9 @@ Polarisation on a **decay** line is rejected outright in the density spin modes
 defines the branching ratio, not the density matrix that is contracted.
 
 Validated end to end against the analytic decay distributions (`spinmode` in
-parentheses; theta measured in the parent rest frame against the parent's lab
-direction, which is the axis the helicity is quantised along):
+parentheses; theta measured in the parent rest frame against the parent's
+direction **in the `me_frame` frame**, which is the axis the helicity is
+quantised along -- see the next section, which is what fixed that axis):
 
 | production | observable | measured | expected |
 |---|---|---|---|
@@ -97,6 +98,112 @@ direction, which is the axis the helicity is quantised along):
 In every polarised run the *un*polarised partner in the same event (the `t~`,
 which carries no brace) stayed compatible with zero, confirming the mask is
 per particle. A no-brace run is byte-identical to the pre-change code.
+
+Those `w+` rows were measured against the parent's **lab** direction, which at
+the time was also the axis MadSpin quantised on -- self-consistent, and the
+wrong axis. See below.
+
+### Which frame the brace is defined in (`me_frame`)
+
+A polarised matrix element is **not Lorentz invariant**, so `w+{0}` is only a
+statement once a frame is named. MG5 names it in the run_card:
+
+    me_frame = 1, 2      # frame_id = sum(2**n) = 6
+
+Measured, on 200 events of `p p > w+{0} w-` (`SMATRIX` from the library MadSpin
+itself builds, evaluated on the LHE momenta and on the same momenta boosted into
+the partonic CM):
+
+    SMATRIX(lab) / SMATRIX(partonic CM)
+      {0}       min 0.512   max 7.251   mean 1.562
+      {T}       min 0.483   max 1.180   mean 0.892
+      {0}+{T}   min 1.000   max 1.000   mean 1.000   (|ratio-1| <= 1.3e-8)
+
+Each polarised piece moves by up to a factor 7 between the two frames; their sum
+-- the unpolarised `|M|^2`, which *is* invariant -- is unchanged to numerical
+precision. That is the cleanest statement of what is at stake: the frame does
+not change any physics, it changes **which helicity `{0}` names**.
+
+**MadEvent means the `me_frame` frame, and the default is the partonic CM.**
+`auto_dsig_v4.inc:134` calls `boost_to_frame(PP, frame_id, P1)` and skips it
+only for `frame_id.eq.6`, because `genps.f` (`x_to_f_arg`, `mom2cx` on
+`p(0,-nbranch) = (sqrt(shat),0,0,0)`) already builds `PP` in the partonic CM;
+`cm_rap` is carried separately for the rapidity cuts, and `unwgt.f`
+(`zboost_with_beta`) boosts to the lab only on the way out to the LHE file. So
+the momenta the polarised matrix element sees are the partonic-CM ones, and the
+lab momenta in the event file are a *later* z boost. MadSpin's own v1 Fortran
+driver agrees: `driver.f:266` calls `boost_to_frame(pfull, frame_id, P2)`
+unconditionally, and its copy of `boost_to_frame` has no `frame_id.eq.6`
+short-circuit, so it really does boost. Note also that no `me_frame` value can
+name the lab frame -- it selects the rest frame of a subset of the external
+momenta, and the lab is not one of those.
+
+**The density spin modes did not.** `_frame_boost` opened with
+
+    if self._beampol() is None:
+        return None
+
+so with unpolarised beams -- the common case, and every `p p >` run -- the
+production and decay density matrices were both built from **lab** momenta. The
+justification given when that guard was written (b231141fe) was explicit and, at
+the time, correct: *"the frame cannot change an observable here at all"*, because
+the contraction `sum_ij rho_prod(i,j) rho_dec(i,j)` is a trace and a boost acts
+on it as a unitary change of basis that cancels between the two factors.
+
+The previous section is exactly what breaks that argument. `set_hel_restriction`
+is a **projection**, not a change of basis, and a projection does not commute
+with one. The guard was safe before the restriction existed and is a live bug
+after it.
+
+Measured end to end, 10000 unweighted events per row, `p p > w+ w-` at 13 TeV,
+`spinmode madspin`, `decay w+ > e+ ve`, one MadEvent sample per polarisation
+reused by both MadSpin variants (`<|y_boost|>` = 1.57 / 1.48, so the lab and the
+partonic CM are far apart):
+
+| production | MadSpin | `<cos^2>` on the lab axis | `<cos^2>` on the me_frame axis |
+|---|---|---|---|
+| `p p > w+{0} w-` | before | **0.1977 +- 0.0021** | 0.2732 +- 0.0027 |
+| `p p > w+{0} w-` | after  | 0.2738 +- 0.0027 | **0.1974 +- 0.0021** |
+| `p p > w+{T} w-` | before | **0.4017 +- 0.0031** | 0.3783 +- 0.0031 |
+| `p p > w+{T} w-` | after  | 0.3646 +- 0.0031 | **0.4019 +- 0.0031** |
+
+(analytic: 1/5 for a pure `{0}`, 2/5 for a pure `{T}`, 1/3 for flat.)
+
+The two rows of each pair simply swap which axis carries the textbook value. The
+old code was self-consistent -- it put a clean `sin^2(theta)` on the lab axis --
+but the events it was decaying had been generated with `{0}` meaning the
+partonic-CM helicity, so it restricted the wrong one. Reading the "before" line
+as a helicity decomposition on the axis MG5 actually meant, `0.4 - 0.2 f_0`
+gives `f_0 = 0.63` for the nominally 100% longitudinal sample and `f_0 = 0.11`
+for the nominally 0% one: roughly a third of the polarisation purity the user
+asked for, thrown away by the frame alone. This is a live bug for ordinary
+`p p >` runs, not a latent trap.
+
+Two changes, both in `_frame_boost`:
+
+- the guard is now `if self._beampol() is None and not
+  self._production_polarization(): return None`. The frame is honoured when it
+  can change an observable -- polarised beams, or a brace on a final-state
+  particle of the production -- and skipped otherwise, so unpolarised density
+  runs keep the bit-for-bit behaviour b231141fe was careful to preserve. The
+  brace does not have to be on a particle MadSpin decays: a restricted helicity
+  sum over any final-state leg is frame dependent and reshapes `rho_prod`.
+- `_, orig_order, _, _ = self.get_pdir(event)` unpacked **four** values from a
+  `get_pdir` that has returned five (`pdir, orig_order, prefix, pos, tag`) since
+  6ba177c56, i.e. since well before b231141fe. `_frame_boost` therefore raised
+  `ValueError: too many values to unpack (expected 4, got 5)` the first time it
+  was ever reached. Nothing reached it, because the guard above turned it off
+  for unpolarised beams -- so **the whole `me_frame` path in the density modes
+  had never executed**, and `polbeam1`/`polbeam2` in a density spinmode crashed.
+  The unit-test stub `_FrameStub.get_pdir` returned a 4-tuple, which is why the
+  tests were green; it now returns the real 5-tuple.
+
+Cross-checks: the integrated weight is untouched (10.60038 pb for `{0}`,
+54.1049 pb for `{T}`, identical before and after and equal to the production
+cross section -- the restriction enters `N_0 = Tr(rho)` too, so the normalisation
+does not move); an unpolarised run is byte-identical to the pre-change code; and
+a brace on a particle MadSpin does *not* decay (`p p > w+{0} w-` with
+`decay w- > e- ve~`) runs through the newly-live frame path without incident.
 
 ### The partial weight
 

--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -31,6 +31,52 @@ The weight actually used in the accept/reject (interface_madspin.py:3033) is
 (the color / symmetry / `prod_denominators` factors cancel between the numerator
 and the two diagonals).
 
+### Production polarisation restricts the double sum
+
+`<rho, ...>` is `sum_i sum_j rho_prod(i,j) rho_dec(i,j)` over the *full*
+helicity basis. When the production process carries a polarisation brace on a
+particle MadSpin decays (`p p > t{L} t~`, `p p > w+{0} w-{T}`), that particle's
+index is restricted:
+
+- a single-state brace (`{0}`, `{+}`/`{R}`, `{-}`/`{L}`) keeps only the diagonal
+  `rho_prod(X,X) rho_dec(X,X)` term;
+- `{T}` (= `[-1,1]`) keeps the double sum but drops the `0` row and column;
+- no brace leaves that index summed in full -- unrestricted runs are bit-for-bit
+  unchanged.
+
+The restriction is per decaying particle and combines multiplicatively over the
+tensor product, so `t{0} t~{T}` masks index 1 to its `0` diagonal entry and
+index 2 to the `-1/+1` block. It is carried by the production `DensityMatrix`
+itself (`set_hel_restriction`, a bool row mask cached per
+`(basis_id, restriction)`), so every `scalar_multiplication` and every `trace()`
+-- including `N_k` in the sequential accept/reject -- applies it without any
+call site passing it along. `Tr(rho)` is restricted with the same mask, which is
+what keeps `N_0 = Tr(rho)/prod_i n_i` and hence the accept/reject normalisation
+untouched, and matches the polarised `|M_prod|^2` the input events were
+generated with. The *decay* diagonals stay unrestricted: the decay events come
+from the full, unpolarised decay matrix element.
+
+Two things this is NOT:
+
+- it is not a speed-only consistency tweak. `GET_DENSITY`/`GET_ALL_INTER`
+  overwrite the decaying particle's helicity from `ALLOW_HEL` for every entry
+  they build, so `rho_prod` comes back **fully unpolarised** in those indices
+  even for a polarised process -- verified by evaluating `M0_GET_DENSITY`
+  directly for `p p > t{L} t~` and for `p p > t t~`: identical entries,
+  including `rho(+1,+1)`. The restriction therefore changes results.
+- it is not free of a basis reordering. `GET_DENSITY` selects the rows of the
+  process' `NHEL` table by matching them against the *first* `ALLOW_HEL`
+  combination, and a polarised process has no `NHEL` row outside its
+  polarisation. With the default `hel_dict` order (`[1,-1]`, `[-1,0,1]`) a
+  `{L}`/`{-}`/`{0}` production matched nothing and handed back an identically
+  zero density matrix. `_apply_production_polarization` therefore puts an
+  allowed helicity first in that particle's basis; the order is untouched when
+  there is no brace.
+
+Polarisation on a **decay** line is rejected outright in the density spin modes
+(`do_decay`): the braces there would restrict the decay matrix element that
+defines the branching ratio, not the density matrix that is contracted.
+
 ### The partial weight
 
 For a decay ordering sigma, define after k particles are fixed:

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -4699,9 +4699,17 @@ class DensityMatrix:
     # Cache tensor-product helicity tables by basis_id
     _tp_hel_cache = {}
 
-    # Cache helicity-restriction row masks.
+    # Cache helicity-restriction row selections.
     # Key: (basis_id, normalised restriction key)
+    # Value: (mask[bool], rows[int64], diag_rows[int64]) -- see _restriction_rows
     _restriction_cache = {}
+
+    # Same, but for the sorted-alignment path: the surviving positions *within*
+    # the cached sort permutation. Filled lazily, since the map-built fast path
+    # never needs a sort order at all.
+    # Key: (basis_id, normalised restriction key)
+    # Value: (keep[int64], sorted_rows[int64])
+    _restriction_sort_cache = {}
 
     def __init__(self, array, nchanging, all_helicity_combinations, dimension):
         """
@@ -4958,14 +4966,24 @@ class DensityMatrix:
         self.hel_restriction = DensityMatrix.normalize_hel_restriction(restriction)
         return self
 
-    def _restriction_row_mask(self, restriction):
-        """Boolean row mask implementing ``restriction`` on this matrix' labels.
+    def _restriction_rows(self, restriction):
+        """(mask, rows, diag_rows) implementing ``restriction`` on this matrix.
 
-        Depends only on the helicity labels, so it is cached per
-        (basis_id, restriction) and never recomputed per event.
+        ``mask`` is the boolean row mask, ``rows`` the indices of the surviving
+        rows and ``diag_rows`` the indices surviving *and* diagonal (what the
+        restricted trace sums). All three depend only on the helicity labels, so
+        they are cached per (basis_id, restriction) and never recomputed per
+        event.
+
+        The contractions use ``rows``/``diag_rows`` rather than ``mask``: a
+        restriction typically keeps a handful of rows out of hundreds, and
+        gathering with a short index array is markedly cheaper than boolean
+        indexing, which has to scan (and count) the full-length array. The rows
+        come out in increasing index order, i.e. exactly the order boolean
+        indexing would have produced, so the sums are bit-for-bit identical.
         """
         if restriction is None:
-            return None
+            return None, None, None
         cache_key = (self._basis_id, restriction)
         cached = DensityMatrix._restriction_cache.get(cache_key)
         if cached is not None:
@@ -4982,8 +5000,34 @@ class DensityMatrix:
             mask &= np.isin(h[:, 2 * k], allowed)
             mask &= np.isin(h[:, 2 * k + 1], allowed)
 
-        DensityMatrix._restriction_cache[cache_key] = mask
-        return mask
+        out = (mask, np.flatnonzero(mask), np.flatnonzero(self._diag_mask & mask))
+        DensityMatrix._restriction_cache[cache_key] = out
+        return out
+
+    def _restriction_row_mask(self, restriction):
+        """Boolean row mask implementing ``restriction`` on this matrix' labels."""
+        return self._restriction_rows(restriction)[0]
+
+    def _restriction_sorted_rows(self, restriction):
+        """(keep, sorted_rows) for the sorted-alignment path.
+
+        ``keep`` are the positions inside the cached sort permutation whose row
+        survives, and ``sorted_rows`` the rows themselves (``sort_order[keep]``).
+        Contracting ``self.values[sorted_rows]`` against
+        ``other.values[other_sort_order[keep]]`` visits exactly the entries, in
+        exactly the order, that masking the two sorted views would have.
+
+        Requires ``_ensure_sorted_view`` to have run.
+        """
+        cache_key = (self._basis_id, restriction)
+        cached = DensityMatrix._restriction_sort_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        order = self._sort_order
+        keep = np.flatnonzero(self._restriction_rows(restriction)[0][order])
+        out = (keep, order[keep])
+        DensityMatrix._restriction_sort_cache[cache_key] = out
+        return out
 
     @staticmethod
     def _combine_restrictions(a, b):
@@ -5055,14 +5099,13 @@ class DensityMatrix:
         if hel_restriction is not None:
             restriction = DensityMatrix._combine_restrictions(
                 restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
-        mask = self._restriction_row_mask(restriction)
-
         # Fastest correct path for map-built matrices
         if (self.map_density_matrix_ind is not None and
                 self.map_density_matrix_ind is other.map_density_matrix_ind):
-            if mask is None:
+            if restriction is None:
                 return np.sum(self.values * other.values)
-            return np.sum(self.values[mask] * other.values[mask])
+            rows = self._restriction_rows(restriction)[1]
+            return np.sum(self.values[rows] * other.values[rows])
 
         # Align by cached ordering for each basis
         self._ensure_sorted_view()
@@ -5070,12 +5113,13 @@ class DensityMatrix:
 
         a = self._sort_order
         b = other._sort_order
-        if mask is None:
+        if restriction is None:
             return np.sum(self.values[a] * other.values[b])
-        # the mask lives on self's rows; permuting it with the same order keeps
-        # it aligned with both sorted views
-        aligned = mask[a]
-        return np.sum(self.values[a][aligned] * other.values[b][aligned])
+        # the restriction lives on self's rows; the surviving positions inside
+        # the sort permutation are the same on both sides, so one cached gather
+        # does the masking and the alignment at once
+        keep, rows = self._restriction_sorted_rows(restriction)
+        return np.sum(self.values[rows] * other.values[b[keep]])
 
     def tensor_product(self, other):
         """
@@ -5191,10 +5235,9 @@ class DensityMatrix:
         if hel_restriction is not None:
             restriction = DensityMatrix._combine_restrictions(
                 restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
-        mask = self._restriction_row_mask(restriction)
-        if mask is None:
+        if restriction is None:
             return np.sum(self.values[self._diag_mask])
-        return np.sum(self.values[self._diag_mask & mask])
+        return np.sum(self.values[self._restriction_rows(restriction)[2]])
 
 
     def print_full_matrix(self, precision=6):

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -4613,7 +4613,11 @@ class decay_all_events_density(decay_all_events_onshell):
             particle, final = final[:end], final[end:]
             new_particle = []
             for p in particle.split():
-                if p in to_decay:
+                # a polarised leg is written "t{L}"; the label MadSpin decays is
+                # the part before the brace, and MG5 parses the off-shell star
+                # after it ("t{L}*"), so strip the brace for the lookup only.
+                name = p.split('{', 1)[0]
+                if name in to_decay:
                     new_particle.append('%s*' % p)
                 else:
                     new_particle.append(p)
@@ -4695,6 +4699,10 @@ class DensityMatrix:
     # Cache tensor-product helicity tables by basis_id
     _tp_hel_cache = {}
 
+    # Cache helicity-restriction row masks.
+    # Key: (basis_id, normalised restriction key)
+    _restriction_cache = {}
+
     def __init__(self, array, nchanging, all_helicity_combinations, dimension):
         """
         Parameters
@@ -4730,6 +4738,9 @@ class DensityMatrix:
         # Basis identifier (stable across events) for caching sort permutations and diag masks.
         # For "map-built" matrices, this is fully determined by (allowed_hel, n_changing).
         self._basis_id = ("map", tuple(all_helicity_combinations), self.nchanging)
+
+        # Per-particle helicity restriction (see set_hel_restriction). None = full sum.
+        self.hel_restriction = None
 
         # Lazy per-instance cache
         self._sort_order = None
@@ -4868,6 +4879,7 @@ class DensityMatrix:
         obj.values = values.astype(np.complex64, copy=False)
 
         obj._basis_id = basis_id
+        obj.hel_restriction = None
         obj._sort_order = None
 
         # Diagonal mask is cached per basis_id
@@ -4893,6 +4905,100 @@ class DensityMatrix:
         mask = np.all(h[:, 0::2] == h[:, 1::2], axis=1)
         DensityMatrix._diag_cache[self._basis_id] = mask
         return mask
+
+    # -------------------------------------------------------------------------
+    # Helicity restriction (production polarisation)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def normalize_hel_restriction(restriction):
+        """Canonical, hashable form of a per-particle helicity restriction.
+
+        ``restriction`` is a sequence with one entry per *changing* helicity
+        (i.e. per decaying particle, in the order the density matrix' helicity
+        columns are laid out). Each entry is either
+
+          - ``None`` (or an empty container): that index is summed over its
+            whole basis -- the historical behaviour, and
+
+          - a container of the helicity values that index is allowed to take.
+
+        Returns ``None`` when nothing is restricted, so that the unrestricted
+        code paths stay bit-for-bit identical.
+        """
+        if restriction is None:
+            return None
+        key = []
+        for allowed in restriction:
+            if allowed is None:
+                key.append(None)
+                continue
+            allowed = tuple(sorted(set(int(h) for h in allowed)))
+            key.append(allowed if allowed else None)
+        if all(a is None for a in key):
+            return None
+        return tuple(key)
+
+    def set_hel_restriction(self, restriction):
+        """Attach a per-particle helicity restriction to this matrix.
+
+        The restriction travels with the matrix rather than with the call, so
+        that ``scalar_multiplication`` / ``trace`` pick it up wherever the
+        production density matrix is contracted -- including the sequential
+        accept/reject, which contracts it against partially filled decay
+        tensors. Returns self so it can be chained onto ``get_density``.
+
+        A restricted index is one whose production process carries a
+        polarisation brace: ``{0}``/``{+}``/``{-}`` select a single helicity X
+        and so keep only the diagonal ``rho_prod(X,X) rho_dec(X,X)`` term,
+        ``{T}`` keeps the whole ``-1/+1`` block and drops the ``0`` row and
+        column. The rule is uniform: a matrix element (i,j) of particle k
+        survives iff *both* i and j are allowed for k.
+        """
+        self.hel_restriction = DensityMatrix.normalize_hel_restriction(restriction)
+        return self
+
+    def _restriction_row_mask(self, restriction):
+        """Boolean row mask implementing ``restriction`` on this matrix' labels.
+
+        Depends only on the helicity labels, so it is cached per
+        (basis_id, restriction) and never recomputed per event.
+        """
+        if restriction is None:
+            return None
+        cache_key = (self._basis_id, restriction)
+        cached = DensityMatrix._restriction_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        h = self.helicities
+        mask = np.ones(h.shape[0], dtype=np.bool_)
+        for k, allowed in enumerate(restriction):
+            if allowed is None:
+                continue
+            allowed = np.asarray(allowed, dtype=np.int32)
+            # column 2k is the row (bra) helicity of particle k, 2k+1 the column
+            # (ket) one -- see get_map_density_matrix
+            mask &= np.isin(h[:, 2 * k], allowed)
+            mask &= np.isin(h[:, 2 * k + 1], allowed)
+
+        DensityMatrix._restriction_cache[cache_key] = mask
+        return mask
+
+    @staticmethod
+    def _combine_restrictions(a, b):
+        """The restriction in force for a contraction between two matrices.
+
+        Only one side ever carries one (the production density matrix knows the
+        polarisation, the decay side does not), so this is really "whichever is
+        set", with a guard against two contradicting ones.
+        """
+        if a is None:
+            return b
+        if b is None or a == b:
+            return a
+        raise ValueError("Contradicting helicity restrictions between the "
+                         "production and decay spin-density matrices")
 
     # -------------------------------------------------------------------------
     # Cached permutation for alignment by helicity labels
@@ -4925,7 +5031,7 @@ class DensityMatrix:
     # Operations
     # -------------------------------------------------------------------------
 
-    def scalar_multiplication(self, other):
+    def scalar_multiplication(self, other, hel_restriction=None):
         """
         Scalar contraction between two density matrices.
 
@@ -4936,14 +5042,27 @@ class DensityMatrix:
         General path:
         - Align by cached helicity-sort permutations (one per basis_id), then
           dot-product on aligned values.
+
+        ``hel_restriction`` (or, when omitted, the one either operand carries --
+        see ``set_hel_restriction``) drops the (i,j) terms the production
+        polarisation forbids before summing.
         """
         if len(self.values) != len(other.values):
             raise TypeError("Non-compatible dimensions of production and decay spin-density matrices")
 
+        restriction = DensityMatrix._combine_restrictions(
+            self.hel_restriction, other.hel_restriction)
+        if hel_restriction is not None:
+            restriction = DensityMatrix._combine_restrictions(
+                restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
+        mask = self._restriction_row_mask(restriction)
+
         # Fastest correct path for map-built matrices
         if (self.map_density_matrix_ind is not None and
                 self.map_density_matrix_ind is other.map_density_matrix_ind):
-            return np.sum(self.values * other.values)
+            if mask is None:
+                return np.sum(self.values * other.values)
+            return np.sum(self.values[mask] * other.values[mask])
 
         # Align by cached ordering for each basis
         self._ensure_sorted_view()
@@ -4951,7 +5070,12 @@ class DensityMatrix:
 
         a = self._sort_order
         b = other._sort_order
-        return np.sum(self.values[a] * other.values[b])
+        if mask is None:
+            return np.sum(self.values[a] * other.values[b])
+        # the mask lives on self's rows; permuting it with the same order keeps
+        # it aligned with both sorted views
+        aligned = mask[a]
+        return np.sum(self.values[a][aligned] * other.values[b][aligned])
 
     def tensor_product(self, other):
         """
@@ -4988,14 +5112,21 @@ class DensityMatrix:
         # Often faster than np.kron
         vals = (v1[:, None] * v2[None, :]).ravel().astype(np.complex64, copy=False)
 
-        return DensityMatrix.from_components(
+        out = DensityMatrix.from_components(
             hel,
             vals,
             self.nchanging + other.nchanging,
-            self.all_helicity_combinations,  
+            self.all_helicity_combinations,
             self.dimension,
             basis_id=basis_id,
         )
+        # a restriction is per-index, so the tensor product simply concatenates
+        # the two (the decay side normally carries none, and this stays None)
+        if self.hel_restriction is not None or other.hel_restriction is not None:
+            left = self.hel_restriction or (None,) * self.nchanging
+            right = other.hel_restriction or (None,) * other.nchanging
+            out.set_hel_restriction(tuple(left) + tuple(right))
+        return out
 
     @classmethod
     def identity(cls, nchanging, all_helicity_combinations, dimension):
@@ -5041,14 +5172,29 @@ class DensityMatrix:
             self.dimension,
             basis_id=self._basis_id,
         )
+        out.hel_restriction = self.hel_restriction
         self._normalized_cache = out
         return out
 
-    def trace(self):
+    def trace(self, hel_restriction=None):
         """
         Order-independent trace.
+
+        With a helicity restriction in force (production polarisation) this is
+        the *restricted* trace, sum_{h in allowed} rho(h,h): that is the
+        normalisation the polarised production cross-section actually uses, and
+        keeping it consistent with ``scalar_multiplication`` is what leaves the
+        accept/reject weight averaging to 1/n exactly as in the unrestricted
+        case.
         """
-        return np.sum(self.values[self._diag_mask])
+        restriction = self.hel_restriction
+        if hel_restriction is not None:
+            restriction = DensityMatrix._combine_restrictions(
+                restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
+        mask = self._restriction_row_mask(restriction)
+        if mask is None:
+            return np.sum(self.values[self._diag_mask])
+        return np.sum(self.values[self._diag_mask & mask])
 
 
     def print_full_matrix(self, precision=6):

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -758,6 +758,23 @@ class MadSpinInterface(extended_cmd.Cmd):
         #if self.model and not self.model['case_sensitive']:
         #    decaybranch = decaybranch.lower()
 
+        if '{' in decaybranch and self._density_spinmode():
+            # The density spin modes contract a production and a decay
+            # spin-density matrix over the decaying particle's helicity. A
+            # polarisation written on the *decay* side would have to project
+            # that decay density matrix, which is not what the {..} braces do
+            # here (they would restrict the decay matrix element that defines
+            # the branching ratio instead), so refuse rather than quietly
+            # produce a wrong answer. The production-side braces ARE supported:
+            # they restrict the convolution (see _production_polarization).
+            raise self.InvalidCmd(
+                "MadSpin: polarization (the {...} braces) is not supported on a "
+                "'decay' line with spinmode=%s. Only the polarization of the "
+                "production process is taken into account by the density spin "
+                "modes (madspin/full/PA/onshell); use spinmode=none or "
+                "spinmode=madspin_v1 for decay-side polarization."
+                % self.options['spinmode'])
+
         if self.options['spinmode'] not in  ['full','madspin', 'madspin_v1'] and '{' in decaybranch:
             if self.options['spinmode'] == 'none':
                 logger.warning("polarization option used with spinmode=none. The polarization definition will be done according to the rest-frame of the decaying particles (which is likely not what you expect).")
@@ -1305,6 +1322,10 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.options['spinmode'] = spinmode
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
+        if self._density_spinmode():
+            # read (and validate) the production polarisation braces now rather
+            # than on the first event, deep inside a worker process
+            self._production_polarization()
         # The density modes decide about the '@' grouping later, in run_onshell,
         # where the production events say how many of each particle an event
         # carries. These two never can, so say it now rather than after the
@@ -4640,6 +4661,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         decaying_spins = [self.model.get_particle(i).get('spin') for i in decaying_pdg]
         helicities = [hel_dict[i] for i in decaying_spins]
 
+        helicities, hel_restriction = self._apply_production_polarization(
+                                                    decaying_pdg, helicities)
+
         allowed_hel_pairs, allowed_hel = self.get_allowed_hel(helicities)
 
         return {
@@ -4652,9 +4676,136 @@ class MadSpinInterface(extended_cmd.Cmd):
             'helicities': helicities,
             'decaying_spins': decaying_spins,
             'allowed_hel': allowed_hel,
+            'hel_restriction': hel_restriction,
             'ncomb': len(allowed_hel_pairs),
             'dimension': math.prod(len(i) for i in helicities),
         }
+
+    # ------------------------------------------------------------------
+    # Production polarisation ({0}/{+}/{-}/{L}/{R}/{T} on the decaying leg)
+    # ------------------------------------------------------------------
+
+    def _density_spinmode(self):
+        """Whether the current spinmode goes through the density-matrix path.
+        'full' is the user-facing alias of 'madspin' and is only rewritten in
+        do_launch, so both spellings have to be accepted here."""
+        return self.options['spinmode'] in ['madspin', 'full', 'PA', 'onshell']
+
+    def _production_polarization(self):
+        """``pdg -> tuple(allowed helicities)`` from the polarisation braces of
+        the *production* process, e.g. ``p p > t{0} t~``.
+
+        MadSpin regenerates the production matrix element from the banner's
+        proc_card, braces included, so the braces are exactly what MG5 saw. They
+        do NOT however restrict the density matrix: ``GET_DENSITY`` overrides
+        the decaying particle's helicity from ``ALLOW_HEL`` for every entry it
+        builds, so rho_prod comes back fully unpolarised in those indices and
+        the restriction has to be applied here.
+
+        Parsing is delegated to MG5's own process parser so that the brace
+        semantics ({L} -> [-1], {R} -> [1], {T} -> [1,-1], {0} -> [0]) cannot
+        drift away from ``madgraph_interface``'s.
+        """
+        cached = getattr(self, '_production_polarization_cache', None)
+        if cached is not None:
+            return cached
+
+        out = {}
+        try:
+            proc_card = list(self.banner.proc_card)
+        except Exception:
+            proc_card = []
+        lines = [line[9:].strip() for line in proc_card
+                 if line.startswith('generate')]
+        lines += [' '.join(line.split()[2:]) for line in proc_card
+                  if re.search(r'^\s*add\s+process', line)]
+
+        if any('{' in line for line in lines):
+            unpolarized = set()
+            for line in lines:
+                try:
+                    procdef = self.mg5cmd.extract_process(line)
+                except Exception as error:
+                    logger.warning('MadSpin could not re-read the polarisation of '
+                                   'the production process "%s" (%s); the density '
+                                   'matrix convolution is left unrestricted.'
+                                   % (line, error))
+                    continue
+                for leg in procdef.get('legs'):
+                    # initial-state polarisation is the beampol machinery, not this
+                    if not leg.get('state'):
+                        continue
+                    pol = leg.get('polarization')
+                    ids = [int(i) for i in leg.get('ids')]
+                    if not pol:
+                        unpolarized.update(ids)
+                        continue
+                    pol = tuple(sorted(set(int(p) for p in pol)))
+                    for pdg in ids:
+                        if out.setdefault(pdg, pol) != pol:
+                            raise self.InvalidCmd(
+                                'MadSpin: particle %s is produced with two different '
+                                'polarisations (%s and %s) in the production process. '
+                                'The density spin modes cannot tell which one a given '
+                                'final-state particle carries.'
+                                % (pdg, out[pdg], pol))
+            clash = unpolarized.intersection(out)
+            if clash:
+                raise self.InvalidCmd(
+                    'MadSpin: particle(s) %s are polarised in one production process '
+                    'and unpolarised in another. Please use a single, consistent '
+                    'polarisation for the particles MadSpin decays.'
+                    % ', '.join(str(p) for p in sorted(clash)))
+
+        self._production_polarization_cache = out
+        return out
+
+    def _apply_production_polarization(self, decaying_pdg, helicities):
+        """Turn the production polarisation into (helicity bases, restriction).
+
+        Returns the per-particle helicity lists to build the density basis with
+        and the per-particle restriction handed to ``DensityMatrix``.
+
+        Two things happen here:
+
+        * the restriction itself -- the (i,j) entries the polarisation forbids
+          are dropped from the production/decay convolution and from the trace
+          that normalises it (see ``DensityMatrix.set_hel_restriction``);
+
+        * a reordering of the helicity basis. ``GET_DENSITY`` picks the rows of
+          the process' NHEL table by matching them against the *first*
+          combination of ``ALLOW_HEL``; a polarised process has no NHEL row
+          outside its polarisation, so leaving the default order ([1,-1] for a
+          fermion, [-1,0,1] for a vector) would match nothing and hand back an
+          identically zero density matrix for ``{L}``/``{-}``/``{0}``. Putting
+          an allowed helicity first is what makes the spectator helicity sum
+          find its rows. The order is untouched without braces, so nothing
+          moves for unpolarised runs.
+        """
+        pol_map = self._production_polarization()
+        if not pol_map:
+            return helicities, None
+
+        helicities = list(helicities)
+        restriction = []
+        for k, pdg in enumerate(decaying_pdg):
+            allowed = pol_map.get(pdg)
+            basis = list(helicities[k])
+            if not allowed:
+                restriction.append(None)
+                continue
+            unknown = [h for h in allowed if h not in basis]
+            if unknown:
+                raise self.InvalidCmd(
+                    'MadSpin: the polarisation %s requested for particle %s is not '
+                    'expressible in the helicity basis %s used by the density spin '
+                    'modes. Only {0}, {+}/{R}, {-}/{L} and {T} are supported.'
+                    % (list(allowed), pdg, basis))
+            kept = [h for h in basis if h in allowed]
+            restriction.append(tuple(kept))
+            helicities[k] = kept + [h for h in basis if h not in allowed]
+
+        return helicities, madspin.DensityMatrix.normalize_hel_restriction(restriction)
 
     @staticmethod
     def _decaying_pdgs(production, evt_decayfile):
@@ -4921,7 +5072,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         rho_off = self.get_density(prod_off, prod_static['position'],
                                    prod_static['allowed_hel'],
                                    prod_static['ncomb'], prod_static['dimension'],
-                                   frame_boost=frame_boost)
+                                   frame_boost=frame_boost,
+                                   hel_restriction=prod_static.get('hel_restriction'))
         parents = {slot: finals[slot_to_index[slot]] for slot in order}
         return rho_off, jac_reshuffle, slot_mass, parents, frame_boost
 
@@ -5390,7 +5542,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                                                 prod_static['allowed_hel'],
                                                 prod_static['ncomb'],
                                                 prod_static['dimension'],
-                                                frame_boost=frame_boost)
+                                                frame_boost=frame_boost,
+                                                hel_restriction=prod_static.get('hel_restriction'))
                 production._ms_density_prod = density_prod
                 production._ms_frame_boost = frame_boost
             else:
@@ -6199,7 +6352,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                                         allowed_hel,
                                         ncomb,
                                         dimension,
-                                        frame_boost=frame_boost) \
+                                        frame_boost=frame_boost,
+                                        hel_restriction=prod_static.get('hel_restriction')) \
             if prod_density_cached is None else prod_density_cached
 
         # ------------------------------------------------------------------
@@ -6445,7 +6599,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         return out
 
     def get_density(self, event, position, allow_hel, ncomb, dimension,
-                    frame_boost=None, frame_rest_leg=-1):
+                    frame_boost=None, frame_rest_leg=-1, hel_restriction=None):
         """``frame_boost`` is the momentum whose rest frame ``frame_id`` picks
         (see ``_frame_boost``); the momenta are boosted there before the matrix
         element sees them, which is what defines the axis the initial-state
@@ -6512,10 +6666,15 @@ class MadSpinInterface(extended_cmd.Cmd):
 
 
         #print(f"density_array = {density_array}") 
-        density_matrix = madspin.DensityMatrix(density_array, 
-                                               n_changing, 
-                                               allow_hel, 
+        density_matrix = madspin.DensityMatrix(density_array,
+                                               n_changing,
+                                               allow_hel,
                                                dimension)
+        # production polarisation braces: the restriction travels with the
+        # matrix, so every later contraction/trace applies it (see
+        # DensityMatrix.set_hel_restriction). None for the decay densities.
+        if hel_restriction is not None:
+            density_matrix.set_hel_restriction(hel_restriction)
         return density_matrix
 
    

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6538,13 +6538,37 @@ class MadSpinInterface(extended_cmd.Cmd):
         ``Event.boost`` / ``_boost_momenta``, which negate the spatial part
         themselves (HELAS ``boostx``, exactly what ``boost_to_frame`` does in
         driver.f).
+
+        Two things switch it on, and both are cases where the frame is
+        *observable*:
+
+        - polarised beams. ``beampol`` reweights the initial-state helicity sum
+          and that sum is quantised along the frame's axis.
+        - a polarisation brace on a final-state particle of the production
+          process (``p p > w+{0} w-``). MG5 defines those braces in the
+          ``me_frame`` frame -- MadEvent evaluates the polarised matrix element
+          there (``auto_dsig_v4.inc``, ``boost_to_frame``; the default
+          ``me_frame=[1,2]`` is skipped only because ``genps.f`` already builds
+          its momenta in the partonic CM and ``unwgt.f`` boosts to the lab on
+          the way out), and MadSpin's own v1 driver does the same
+          (``boost_to_frame`` in driver.f, unconditionally). The density modes
+          apply that brace as a *projection* on rho_prod
+          (``set_hel_restriction``), and a projection does not commute with the
+          change of helicity basis a boost induces, so leaving the momenta in
+          the lab would restrict a different helicity than the one the input
+          events were generated with.
+
+        Everything else stays in the lab, which keeps unpolarised density runs
+        bit-for-bit unchanged: there the full double sum
+        ``sum_ij rho_prod(i,j) rho_dec(i,j)`` is a trace, and a boost acts on it
+        as a unitary change of basis that cancels between the two factors.
         """
-        if self._beampol() is None:
+        if self._beampol() is None and not self._production_polarization():
             return None
         frame_id = int(self.options['frame_id'])
         if frame_id <= 0:
             return None
-        _, orig_order, _, _ = self.get_pdir(event)
+        _, orig_order, _, _, _ = self.get_pdir(event)
         momenta = event.get_momenta(orig_order)
         selected = [n for n in range(1, len(momenta) + 1) if frame_id >> n & 1]
         if not selected:

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -16,6 +16,7 @@
 from __future__ import division
 from __future__ import absolute_import
 import collections
+import itertools
 import logging
 import math
 import os
@@ -125,23 +126,45 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
         self.add_param('beampol', [0., 0.], comment='beam polarisation of each beam in percent, -100 .. 100, exactly as the run_card polbeam1/polbeam2 (0 is unpolarised). Taken from the run_card of the production when it has one.')
-        self.add_param('keep_weight_for_polarization', [], typelist=str,
-                       comment="density spin modes only. List of polarisations "
-                       "(0, +, -, T; L/R accepted as aliases of -/+) for which an "
-                       "EXTRA weight is written in the LHEF v3 <rwgt> block of every "
-                       "event, equal to nominal_weight * (density convolution "
-                       "restricted to that polarisation) / (nominal density "
+        self.add_param('keep_weight_for_polarization_vector', [], typelist=str,
+                       comment="density spin modes only. Polarisations (0, +, -, T; "
+                       "L/R accepted as aliases of -/+) offered to each decaying "
+                       "SPIN-1 particle. Together with "
+                       "keep_weight_for_polarization_fermion it defines a set of "
+                       "polarisation COMBINATIONS -- one per element of the cartesian "
+                       "product over the decaying particles, each particle drawing "
+                       "from the list of its own species -- and every event then "
+                       "carries one EXTRA weight per combination in its LHEF v3 <rwgt> "
+                       "block, equal to nominal_weight * (density convolution "
+                       "restricted to that combination) / (nominal density "
                        "convolution). The nominal weight and the cross-section are "
-                       "untouched, and an empty list (the default) changes nothing. "
-                       "The same entry is applied to EVERY decaying particle at once, "
-                       "and is silently skipped -- i.e. that particle stays summed "
-                       "over its full helicity basis -- for the particles the "
-                       "polarisation is unphysical for, so on 'p p > t t~ z' the entry "
-                       "'0' restricts the Z only. When the production process itself "
-                       "carries a polarisation brace, the restriction is intersected "
-                       "with it and the denominator is the (already restricted) "
-                       "nominal convolution, so the weight stays the fraction of the "
-                       "sample that is written out.")
+                       "untouched, and two empty lists (the default) change nothing at "
+                       "all. Example: on 'p p > t t~ z' with vector=[0, T, +, -] and "
+                       "fermion=[+, -] an event carries 2*2*4 = 16 extra weights, "
+                       "named after the per-particle assignment "
+                       "(ms_pol_6:+_-6:-_23:0 and so on, in density-basis slot order). "
+                       "A particle whose species list is empty -- and a scalar, which "
+                       "has no polarisation -- is left summed over its helicities and "
+                       "does not multiply the count; its slot shows up as '*' in the "
+                       "weight id. When the production process itself carries a "
+                       "polarisation brace, each slot's choices are intersected with "
+                       "it (a choice with an empty intersection is dropped) and the "
+                       "denominator is the (already restricted) nominal convolution, "
+                       "so a weight stays the fraction of the sample that is written "
+                       "out.")
+        self.add_param('keep_weight_for_polarization_fermion', [], typelist=str,
+                       comment="as keep_weight_for_polarization_vector, but the list "
+                       "offered to each decaying SPIN-1/2 particle. '0' is unphysical "
+                       "for a fermion and is dropped from its choices; 'T' is its full "
+                       "helicity basis, i.e. that particle summed over.")
+        self.add_param('keep_weight_for_polarization', [], typelist=str,
+                       comment="DEPRECATED spelling of the two options above: it sets "
+                       "both keep_weight_for_polarization_vector and "
+                       "keep_weight_for_polarization_fermion to the same list. Note "
+                       "that the meaning changed: the entries are no longer applied to "
+                       "every decaying particle at once, they are combined, so the "
+                       "number of extra weights is now the product over the decaying "
+                       "particles instead of the length of the list.")
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -191,26 +214,65 @@ class MadSpinOptions(banner.ConfigFile):
                 "'set beampol [%s, 0]' for the first beam only. Got %s value(s)."
                 % (value[0] if value else 0, len(value)))
 
-    def post_set_keep_weight_for_polarization(self, value, change_userdefine,
-                                              raiseerror, *opts):
-        """Reject an unknown polarisation label at card-reading time, and store
+    @staticmethod
+    def _canonical_polarization_list(name, value):
+        """Reject an unknown polarisation label at card-reading time, and return
         the canonical spelling (so '{l}' and 'L' both become '-'). Anything but
         0/+/-/T (with L/R as aliases) has no meaning in the helicity bases the
         density spin modes use."""
-        if not value:
-            return
         canonical = []
         for entry in value:
             parsed = parse_polarization_label(entry)
             if parsed is None:
                 raise banner.InvalidCmd(
-                    "keep_weight_for_polarization: '%s' is not a polarisation. "
+                    "%s: '%s' is not a polarisation. "
                     "Use 0, +, - or T (L and R are accepted as aliases of - and +)."
-                    % entry)
+                    % (name, entry))
             if parsed[0] not in canonical:
                 canonical.append(parsed[0])
+        return canonical
+
+    def post_set_keep_weight_for_polarization_vector(self, value,
+                                                     change_userdefine,
+                                                     raiseerror, *opts):
+        if not value:
+            return
+        name = 'keep_weight_for_polarization_vector'
+        canonical = self._canonical_polarization_list(name, value)
         if canonical != list(value):
-            dict.__setitem__(self, 'keep_weight_for_polarization', canonical)
+            dict.__setitem__(self, name, canonical)
+
+    def post_set_keep_weight_for_polarization_fermion(self, value,
+                                                      change_userdefine,
+                                                      raiseerror, *opts):
+        if not value:
+            return
+        name = 'keep_weight_for_polarization_fermion'
+        canonical = self._canonical_polarization_list(name, value)
+        if canonical != list(value):
+            dict.__setitem__(self, name, canonical)
+
+    def post_set_keep_weight_for_polarization(self, value, change_userdefine,
+                                              raiseerror, *opts):
+        """Deprecated alias for the two per-species options. The list is handed
+        to both of them; the entries a species has no use for are dropped when
+        the combinations are built ('0' on a fermion), so the old spelling keeps
+        meaning something -- but it now produces the *product* over the decaying
+        particles rather than one weight per entry, which is a different (and
+        much larger) set of weights, so the warning is worth its noise."""
+        if not value:
+            return
+        canonical = self._canonical_polarization_list(
+            'keep_weight_for_polarization', value)
+        logger.warning(
+            "MadSpin: 'keep_weight_for_polarization' is deprecated; use "
+            "'set keep_weight_for_polarization_vector %s' and "
+            "'set keep_weight_for_polarization_fermion %s'. Note that the "
+            "weights are now one per COMBINATION of the per-particle "
+            "polarisations, not one per entry.", canonical, canonical)
+        dict.__setitem__(self, 'keep_weight_for_polarization', canonical)
+        self['keep_weight_for_polarization_vector'] = list(canonical)
+        self['keep_weight_for_polarization_fermion'] = list(canonical)
 
     def beampol_me(self):
         """The beam polarisations in the convention the matrix elements use.
@@ -1413,12 +1475,14 @@ class MadSpinInterface(extended_cmd.Cmd):
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
             self._production_polarization()
-            self._polarization_weight_labels()
-        elif self.options['keep_weight_for_polarization']:
+            self._polarization_weights_enabled()
+        elif (self.options['keep_weight_for_polarization_vector']
+              or self.options['keep_weight_for_polarization_fermion']):
             raise self.InvalidCmd(
-                "keep_weight_for_polarization needs a spin density matrix to "
-                "restrict, so it is only available in the density spin modes "
-                "(madspin/full, PA, onshell). Got spinmode=%s." % spinmode)
+                "keep_weight_for_polarization_vector/_fermion need a spin "
+                "density matrix to restrict, so they are only available in the "
+                "density spin modes (madspin/full, PA, onshell). Got "
+                "spinmode=%s." % spinmode)
         # The density modes decide about the '@' grouping later, in run_onshell,
         # where the production events say how many of each particle an event
         # carries. These two never can, so say it now rather than after the
@@ -2315,22 +2379,36 @@ class MadSpinInterface(extended_cmd.Cmd):
         
         # 1. Open input event file and check which particles to decay
         # - count the number of particles to be decayed.
-        to_decay = collections.defaultdict(int)	
+        to_decay = collections.defaultdict(int)
         nb_event = 0
+        # keep_weight_for_polarization_*: the set of topologies (final-state
+        # pdgs to be decayed, in production order) the file holds. The
+        # combinations -- hence the weight ids -- depend on it, and the banner
+        # is written before the first event is decayed, so it is collected here
+        # rather than discovered event by event. Only built when the option is
+        # on, so an unset option does not even allocate.
+        pol_weights = self._polarization_weights_enabled()
+        pol_layouts = set()
         for event in orig_lhe:
             if self.options['fixed_order']:
                 event = event[0]
             nb_event +=1
+            pol_sequence = [] if pol_weights else None
             for particle in event:
                 if particle.status == 1 and particle.pdg in asked_to_decay:
                     # final state and tag as to decay
                     to_decay[particle.pdg] += 1
+                    if pol_weights:
+                        pol_sequence.append(particle.pdg)
                     # Properties of decaying particle
                     width = self.banner.get('param_card', 'decay', abs(particle.pdg)).value
                     mass = self.banner.get('param_card', 'mass', abs(particle.pdg)).value
                     color = self.model.get_particle(particle.pdg).get('color')
                     spin = self.model.get_particle(particle.pdg).get('spin')
                     decay_dict[particle.pdg] = [width, mass, color, spin]
+            if pol_weights:
+                pol_layouts.add(tuple(pol_sequence))
+        self._pol_event_layouts = pol_layouts
         #print(f"to_decay = {to_decay}")
         # How many particles decay in one event -- the same multiplicity the
         # pool ladder counts. It decides which unweighting scheme 'auto' picks,
@@ -2620,11 +2698,15 @@ class MadSpinInterface(extended_cmd.Cmd):
             base_seed=int(self.seed) if self.seed else random.randint(0, 30081*30081),
         )
 
-        # keep_weight_for_polarization: the extra weights have to be declared in
-        # the header before it is written, here rather than in each writer --
+        # keep_weight_for_polarization_*: the extra weights have to be declared
+        # in the header before it is written, here rather than in each writer --
         # the parallel path forks *after* this point and its workers write
-        # bannerless fragments merged under this same banner.
-        self._declare_polarization_weights()
+        # bannerless fragments merged under this same banner. evt_decayfile is
+        # only complete now, and it is what says which of the pdgs the file
+        # holds really end up with a density slot.
+        if self._polarization_weights_enabled():
+            self._declare_polarization_weights(
+                self._polarization_layout_statics(evt_decayfile))
 
         start = time.time()
         logger.info("Start generating decays")
@@ -4777,6 +4859,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             'nchanging': nchanging,
             'position': position,
             'helicities': helicities,
+            'decaying_pdg': decaying_pdg,
             'decaying_spins': decaying_spins,
             'allowed_hel': allowed_hel,
             'hel_restriction': hel_restriction,
@@ -5001,110 +5084,264 @@ class MadSpinInterface(extended_cmd.Cmd):
         return helicities, madspin.DensityMatrix.normalize_hel_restriction(restriction)
 
     # ------------------------------------------------------------------
-    # keep_weight_for_polarization: extra LHEF v3 weights per polarisation
+    # keep_weight_for_polarization_vector / _fermion:
+    # extra LHEF v3 weights, one per polarisation COMBINATION
     # ------------------------------------------------------------------
-    # For each requested polarisation P the event carries an additional weight
+    # The card offers a list of polarisations per *species*
     #
-    #     w_P = w_nominal * <rho_dec, rho_prod>_P / <rho_dec, rho_prod>
+    #     set keep_weight_for_polarization_vector  [0, T, +, -]
+    #     set keep_weight_for_polarization_fermion [+, -]
     #
-    # i.e. the very same event reweighted to the P fraction of the density
+    # and every decaying particle draws from the list of its own spin. A
+    # combination C is one element of the cartesian product over the density
+    # basis slots -- 'p p > t t~ z' with the lists above has 2*2*4 = 16 of them
+    # -- and the event carries one extra weight per combination,
+    #
+    #     w_C = w_nominal * <rho_dec, rho_prod>_C / <rho_dec, rho_prod>
+    #
+    # i.e. the very same event reweighted to the C fraction of the density
     # convolution. Both contractions are done on the matrices that were built
     # for the nominal weight anyway -- only the row mask changes -- so N extra
     # weights cost N extra masked dot products, not N extra density matrices.
     #
-    # Conventions, all of them visible in the option's comment:
-    #  * the entry is applied to every decaying particle at once;
-    #  * a particle the polarisation is unphysical for (hel 0 on a fermion) is
-    #    left UNRESTRICTED rather than zeroed, which is what makes
-    #    'keep_weight_for_polarization = [0, T, +, -]' usable on t t~ z: the '0'
-    #    weight is then the longitudinal fraction of the Z with the tops summed
-    #    over. As a corollary a polarisation that is unphysical for *every*
-    #    decaying particle gives back the nominal weight (ratio 1);
-    #  * with a polarised production (PR #349) the restriction is intersected
-    #    with the production one and the denominator is the nominal -- already
-    #    restricted -- convolution, so w_P/w stays the fraction of what is
-    #    actually written out. An empty intersection ({L} production asked for
-    #    '+') is an impossible polarisation and gives 0.
+    # Why a product and not one weight per label (which is what the first
+    # version of this option did): a single label applied to every particle at
+    # once cannot express 't left-handed *and* Z longitudinal', and it
+    # degenerates to nothing at all on a mixed production such as
+    # 'p p > z{0} z{T}', where no single label is compatible with both slots and
+    # every weight came back exactly 0.
     #
+    # Slots and ids
+    # -------------
+    # The slot order is the density basis one -- for pdg in decays_key, and
+    # within a pdg in production order (see ``_density_basis``' ``init_part``).
+    # A combination is named after its per-slot assignment, in that order:
+    #
+    #     ms_pol_6:+_-6:-_23:0     t(+) t~(-) z(0)
+    #     ms_pol_23:0_23:T         the first Z longitudinal, the second transverse
+    #
+    # Every slot is always present, so a reader never has to guess which particle
+    # a label belongs to, even when two slots share a pdg. A slot with nothing to
+    # choose from shows up as '*', meaning "summed over its helicities":
+    #
+    #  * a scalar has a 1x1 density matrix and no polarisation, so it contributes
+    #    exactly ONE entry ('*') to the product rather than multiplying the count;
+    #  * so does a particle whose species list is empty (only
+    #    ..._vector set -> the fermions stay summed over), and
+    #  * so does a slot every label of whose list is unphysical for it
+    #    ('0' alone on a fermion).
+    #
+    # A label that is unphysical for a slot is dropped from that slot's choices
+    # rather than silently left unrestricted, so the deprecated
+    # 'keep_weight_for_polarization = [0, T, +, -]' does not emit a '0' and a 'T'
+    # copy of the same fermion weight.
+    #
+    # Production braces (PR #349, #353)
+    # ---------------------------------
+    # Each slot's choices are intersected with the production restriction of that
+    # slot, and a choice whose intersection is empty is dropped -- it is zero for
+    # every event of that topology, so it would only add a column of zeros. If
+    # that empties a slot, the slot falls back to its production restriction and
+    # a '*'. The denominator is always the nominal -- already restricted --
+    # convolution, so w_C/w stays the fraction of what is actually written out.
+    #
+    # Sum rule
+    # --------
     # The ratio is >= 0 (the numerator of a single-state restriction is a product
     # of density-matrix diagonals) but is NOT bounded by 1 event by event: the
     # denominator is the full double sum, and the interference terms a
-    # restriction drops can be negative. Measured on p p > t t~: 4 events in 100
-    # above 1, integrated fractions well inside it. For the same reason
-    # sum_P w_P = w only holds when the contraction has no off-diagonal part and
-    # a single particle is restricted -- see the sum-rule tests.
+    # restriction drops can be negative.
+    #
+    # sum_C w_C = w requires that the combinations partition the (i,j) terms that
+    # contribute, i.e. two conditions:
+    #   (a) every species list partitions its slots' helicity basis -- [+, -] for
+    #       a fermion, [0, +, -] or [0, T] for a vector. [0, T, +, -] does NOT:
+    #       T = {-1,+1} covers the same entries as + and - together, so the
+    #       weights overlap and the sum overshoots;
+    #   (b) the contraction has no off-diagonal (interference) part -- the i != j
+    #       terms of the double sum belong to no single-state block. {T} is the
+    #       exception that keeps its own (-1,+1) block, which is why [0, T] is a
+    #       partition of a vector even with interference in that block.
+    # The product form removed the *third* condition the one-label-per-weight
+    # version had ("only one particle may be restricted"): the mixed (+,-) and
+    # (-,+) assignments are now combinations of their own. See the sum-rule tests.
 
-    def _polarization_weight_labels(self):
-        """Canonical polarisation labels requested in the MadSpin card, in the
-        order the user typed them. Empty (the default) disables everything."""
-        cached = getattr(self, '_pol_weight_labels_cache', None)
-        if cached is not None:
-            return cached
+    #: species name per MG5 spin (2S+1). Only 1/2/3 have a helicity basis in
+    #: ``_density_basis``' ``hel_dict``, so nothing else can reach a slot.
+    POLARIZATION_SPECIES = {1: 'scalar', 2: 'fermion', 3: 'vector'}
+
+    #: emitting more than this many combinations per event is legal but worth a
+    #: warning: it is that many masked contractions and that many <wgt> lines per
+    #: event, and the product grows very fast (four decaying vectors with a
+    #: 4-entry list is 256).
+    POLARIZATION_COMBINATION_WARN = 32
+
+    def _polarization_weight_labels(self, species):
+        """Canonical polarisation labels requested for one species ('vector' /
+        'fermion'), in the order the user typed them. Empty (the default) leaves
+        that species summed over."""
+        cache = getattr(self, '_pol_weight_labels_cache', None)
+        if cache is None:
+            cache = self._pol_weight_labels_cache = {}
+        if species in cache:
+            return cache[species]
+        option = 'keep_weight_for_polarization_%s' % species
         out = []
-        for entry in self.options['keep_weight_for_polarization'] or []:
+        for entry in self.options.get(option) or []:
             parsed = parse_polarization_label(entry)
             if parsed is None:
                 raise self.InvalidCmd(
-                    "keep_weight_for_polarization: '%s' is not a polarisation. "
-                    "Use 0, +, - or T (L and R are accepted as aliases)." % entry)
+                    "%s: '%s' is not a polarisation. "
+                    "Use 0, +, - or T (L and R are accepted as aliases)."
+                    % (option, entry))
             if parsed[0] not in [l for l, _ in out]:
                 out.append(parsed)
-        self._pol_weight_labels_cache = out
+        cache[species] = out
         return out
 
-    @staticmethod
-    def _polarization_weight_id(label):
-        """LHEF weight id for one polarisation. Kept human readable and stable:
-        it is what an analysis has to ask the event file for."""
-        return 'ms_pol_%s' % label
+    def _polarization_weights_enabled(self):
+        """True as soon as one species list is non-empty. Both empty (the
+        default) is a complete no-op: no mask, no weight, no banner block."""
+        return bool(self._polarization_weight_labels('vector')
+                    or self._polarization_weight_labels('fermion'))
 
-    def _polarization_restrictions(self, prod_static):
-        """``[(label, restriction), ...]`` for this production event's helicity
-        basis, ``restriction`` being what ``DensityMatrix.set_hel_restriction``
-        wants -- or ``False`` for a polarisation this production can never have
-        (empty intersection with the production braces), whose weight is 0.
+    # -- which axis the projection is taken on ---------------------------
 
-        Depends on the basis only, so it is memoised on ``prod_static``, which
-        is itself built once per production event.
+    def _needs_frame_axis(self):
+        """Whether the density matrices have to be built in the ``frame_id``
+        frame (run_card ``me_frame``, the partonic CM by default) rather than in
+        the lab.
+
+        A polarised matrix element is not Lorentz invariant: the frame decides
+        which helicity ``{0}`` names. That does not matter for the *nominal*
+        weight, because the full contraction sum_ij rho_prod(i,j) rho_dec(i,j)
+        is a trace and a boost is a unitary basis change that cancels between
+        the two matrices. It matters as soon as a helicity index is
+        **projected**, which is what ``set_hel_restriction`` does -- projections
+        do not commute with a change of basis -- so the projection only means
+        what the user asked for on MG5's own quantisation axis.
+
+        Three things apply such a projection, and all three need the frame:
+
+         * polarised beams (``beampol``), which is what the guard in
+           ``_frame_boost`` tests today;
+         * a polarisation brace on the production process (PR #349/#353);
+         * a polarisation-weight request -- this branch. The weights are the
+           same projection, only used to build an extra weight rather than the
+           nominal one, so an unpolarised production with
+           ``keep_weight_for_polarization_vector/_fermion`` set still needs it.
+
+        NOT WIRED IN ON THIS BRANCH. ``_frame_boost`` still opens with the
+        beampol-only guard, and PR #355 (stacked on #349) turns that same line
+        into ``if self._beampol() is None and not self._production_polarization()``.
+        Editing it here would only collide with that. The one-line change to make
+        at merge time, replacing whichever version of the guard is in
+        ``_frame_boost`` by then, is
+
+            if not self._needs_frame_axis():
+                return None
+
+        Until that lands the polarisation weights are taken on the lab axis.
         """
-        cached = prod_static.get('pol_weight_restrictions')
+        if self._beampol() is not None:
+            return True
+        if self._production_polarization():
+            return True
+        return self._polarization_weights_enabled()
+
+    @staticmethod
+    def _polarization_weight_id(assignment):
+        """LHEF weight id of one combination.
+
+        ``assignment`` is ``[(pdg, label or None), ...]`` in density-basis slot
+        order; ``None`` (written '*') is a slot that stays summed over. Kept
+        human readable and stable -- it is what an analysis has to ask the event
+        file for -- and slot-complete, so 'ms_pol_23:0_23:T' names the two Zs of
+        'p p > z{0} z{T}' unambiguously.
+        """
+        return 'ms_pol_%s' % '_'.join('%d:%s' % (pdg, label or '*')
+                                      for pdg, label in assignment)
+
+    def _polarization_slot_choices(self, prod_static):
+        """``[[(label, restriction), ...], ...]``: the choices each density slot
+        offers, in slot order. One entry per slot, never empty -- a slot with
+        nothing to choose keeps its production restriction under the label
+        ``None``.
+
+        ``restriction`` is the helicity tuple for that slot, already intersected
+        with the production braces (``None`` = the whole basis).
+        """
+        helicities = prod_static['helicities']
+        base = prod_static.get('hel_restriction') or (None,) * len(helicities)
+        spins = prod_static.get('decaying_spins')
+        if spins is None:
+            # only the length of a basis distinguishes the three spins
+            # ``_density_basis``' hel_dict knows about
+            spins = [len(h) for h in helicities]
+
+        out = []
+        for k, basis in enumerate(helicities):
+            species = self.POLARIZATION_SPECIES.get(spins[k])
+            labels = self._polarization_weight_labels(species) if species else []
+            choices = []
+            seen = set()
+            for label, values in labels:
+                allowed = [h for h in values if h in basis]
+                if base[k] is not None:
+                    allowed = [h for h in allowed if h in base[k]]
+                if not allowed:
+                    # unphysical for this spin, or incompatible with the
+                    # production brace: zero for every event of this topology,
+                    # so not worth a column
+                    continue
+                allowed = tuple(sorted(set(allowed)))
+                if allowed in seen:
+                    continue
+                seen.add(allowed)
+                choices.append((label, allowed))
+            if not choices:
+                choices = [(None, base[k])]
+            out.append(choices)
+        return out
+
+    def _polarization_combinations(self, prod_static):
+        """``[(weight_id, restriction), ...]``, one per element of the cartesian
+        product of ``_polarization_slot_choices`` -- what
+        ``DensityMatrix.set_hel_restriction`` wants for each of them.
+
+        Empty when nothing is requested, and also when no slot has a real choice
+        (every particle would be summed over, i.e. the only combination is the
+        nominal weight again).
+
+        Depends on the basis only, so it is memoised on ``prod_static``, which is
+        itself built once per production event.
+        """
+        cached = prod_static.get('pol_weight_combinations')
         if cached is not None:
             return cached
 
-        labels = self._polarization_weight_labels()
-        helicities = prod_static['helicities']
-        base = prod_static.get('hel_restriction') or (None,) * len(helicities)
-
         out = []
-        for label, values in labels:
-            restriction = []
-            impossible = False
-            for k, basis in enumerate(helicities):
-                physical = [h for h in values if h in basis]
-                if not physical:
-                    # unphysical for this particle: skip it silently, i.e. leave
-                    # it summed over whatever the production already allows
-                    restriction.append(base[k])
-                    continue
-                if base[k] is not None:
-                    physical = [h for h in physical if h in base[k]]
-                    if not physical:
-                        impossible = True
-                        break
-                restriction.append(tuple(physical))
-            if impossible:
-                out.append((label, False))
-            else:
-                out.append((label,
-                            madspin.DensityMatrix.normalize_hel_restriction(restriction)))
+        if self._polarization_weights_enabled():
+            choices = self._polarization_slot_choices(prod_static)
+            if any(label is not None for slot in choices for label, _ in slot):
+                pdgs = prod_static.get('decaying_pdg')
+                if pdgs is None:
+                    pdgs = [0] * len(choices)
+                for combo in itertools.product(*choices):
+                    wid = self._polarization_weight_id(
+                        [(pdgs[k], label) for k, (label, _) in enumerate(combo)])
+                    restriction = madspin.DensityMatrix.normalize_hel_restriction(
+                        [allowed for _, allowed in combo])
+                    out.append((wid, restriction))
 
-        prod_static['pol_weight_restrictions'] = out
+        prod_static['pol_weight_combinations'] = out
         return out
 
     def _polarization_ratios(self, density_prod, density_dec, prod_static,
                              full=None):
-        """``{label: restricted/full}`` for the accepted chain, cached on self
-        so it does not have to be threaded through every weight return value.
+        """``{weight_id: restricted/full}`` for the accepted chain, cached on
+        self so it does not have to be threaded through every weight return
+        value.
 
         ``full`` is the nominal contraction when the caller has it already (it
         always does -- that is the event's weight); it is recomputed otherwise.
@@ -5113,7 +5350,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         refuses to combine two *different* restrictions and the production matrix
         may already carry the production-brace one.
         """
-        if not self._polarization_weight_labels():
+        if not self._polarization_weights_enabled():
+            self._pol_weight_ratios = None
+            return None
+        combinations = self._polarization_combinations(prod_static)
+        if not combinations:
             self._pol_weight_ratios = None
             return None
 
@@ -5124,38 +5365,113 @@ class MadSpinInterface(extended_cmd.Cmd):
         out = {}
         saved = density_prod.hel_restriction
         try:
-            for label, restriction in self._polarization_restrictions(prod_static):
-                if restriction is False or not full:
-                    out[label] = 0.0
+            for wid, restriction in combinations:
+                if not full:
+                    out[wid] = 0.0
                     continue
                 if restriction == saved:
-                    out[label] = 1.0
+                    out[wid] = 1.0
                     continue
                 density_prod.hel_restriction = restriction
                 value = density_dec.scalar_multiplication(density_prod)
-                out[label] = float(getattr(value, 'real', value)) / float(full)
+                out[wid] = float(getattr(value, 'real', value)) / float(full)
         finally:
             density_prod.hel_restriction = saved
 
         self._pol_weight_ratios = out
         return out
 
-    def _declare_polarization_weights(self):
-        """Declare one <weight> per requested polarisation in the banner's
+    # -- the banner declaration -----------------------------------------
+    # The combinations depend on the *topology* (which particles decay and how
+    # many of each the event holds), so the ids cannot be listed from the card
+    # alone as they could when there was one weight per label. The set of
+    # topologies is collected while run_onshell scans the input file anyway
+    # (``_pol_event_layouts``) and turned into density-basis slot layouts here.
+
+    @staticmethod
+    def _polarization_slot_layout(sequence, decaying):
+        """The density-basis slot layout of one production event.
+
+        ``sequence`` is that event's final-state pdgs in production order;
+        ``decaying`` the pdgs that actually have decay events. Reproduces
+        ``_decaying_pdgs`` (first appearance) followed by ``_density_basis``'
+        ``init_part`` (for pdg in decays_key, in production order).
+        """
+        key = []
+        for pdg in sequence:
+            if pdg in decaying and pdg not in key:
+                key.append(pdg)
+        return tuple(pdg for pdg in key for other in sequence if other == pdg)
+
+    def _polarization_layout_static(self, slot_pdgs):
+        """A ``prod_static`` stub -- helicity bases, production restriction and
+        pdgs -- for one slot layout, without a production event. Goes through
+        exactly the same ``_apply_production_polarization`` the real basis does,
+        so the declared ids cannot drift away from the emitted ones."""
+        hel_dict = {1: [0], 2: [1, -1], 3: [-1, 0, 1]}
+        spins = [self.model.get_particle(int(pdg)).get('spin')
+                 for pdg in slot_pdgs]
+        helicities = [list(hel_dict[spin]) for spin in spins]
+        helicities, restriction = self._apply_production_polarization(
+            [int(pdg) for pdg in slot_pdgs], helicities)
+        return {'helicities': helicities, 'hel_restriction': restriction,
+                'decaying_pdg': [int(pdg) for pdg in slot_pdgs],
+                'decaying_spins': spins}
+
+    def _polarization_layout_statics(self, evt_decayfile):
+        """One ``_polarization_layout_static`` per topology seen in the input
+        file, sorted so the banner is reproducible run to run."""
+        layouts = getattr(self, '_pol_event_layouts', None) or set()
+        decaying = set(pdg for pdg in evt_decayfile if len(evt_decayfile[pdg]))
+        slot_layouts = set()
+        for sequence in layouts:
+            slots = self._polarization_slot_layout(sequence, decaying)
+            if slots:
+                slot_layouts.add(slots)
+        return [self._polarization_layout_static(slots)
+                for slots in sorted(slot_layouts)]
+
+    def _declare_polarization_weights(self, statics=None):
+        """Declare one <weight> per polarisation combination in the banner's
         <initrwgt> block, in its own weightgroup, following the convention the
         reweighting and systematics modules use. No-op when nothing is
         requested, so an unset option leaves the banner byte-identical."""
-        labels = self._polarization_weight_labels()
-        if not labels:
+        if not self._polarization_weights_enabled():
             return
         if getattr(self, '_pol_weights_declared', False):
             return
+        if statics is None:
+            statics = []
+
+        entries = collections.OrderedDict()
+        biggest = 0
+        for static in statics:
+            combinations = self._polarization_combinations(dict(static))
+            biggest = max(biggest, len(combinations))
+            pdgs = static['decaying_pdg']
+            for wid, restriction in combinations:
+                if wid in entries:
+                    continue
+                base = restriction or (None,) * len(pdgs)
+                entries[wid] = ' '.join(
+                    '%s(%s)' % (self._polarization_particle_name(pdg),
+                                'sum' if hel is None
+                                else ','.join(str(h) for h in hel))
+                    for pdg, hel in zip(pdgs, base))
+        if not entries:
+            return
+        if biggest > self.POLARIZATION_COMBINATION_WARN:
+            logger.warning(
+                "MadSpin: keep_weight_for_polarization_* asks for %d "
+                "polarisation combinations, i.e. %d extra <wgt> entries and %d "
+                "extra density contractions on every event. Shorten "
+                "keep_weight_for_polarization_vector/_fermion if that is not "
+                "what you meant.", biggest, biggest, biggest)
+
         text = "\n<weightgroup name='madspin_polarization'>\n"
-        for label, values in labels:
-            text += "<weight id='%s'> MadSpin polarisation %s (helicities %s) " \
-                    "of the decaying particles </weight>\n" % (
-                        self._polarization_weight_id(label), label,
-                        ','.join(str(v) for v in values))
+        for wid, description in entries.items():
+            text += "<weight id='%s'> MadSpin polarisation %s </weight>\n" % (
+                wid, description)
         text += "</weightgroup>\n"
         # dict.get is not available: Banner.get is get_detail, which only knows
         # about a handful of card tags
@@ -5164,6 +5480,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         else:
             self.banner['initrwgt'] = text
         self._pol_weights_declared = True
+
+    def _polarization_particle_name(self, pdg):
+        """Readable name for the banner description; the pdg is what the id
+        carries, so a model that cannot be queried is not fatal."""
+        try:
+            return self.model.get_particle(int(pdg)).get_name()
+        except Exception:
+            return str(pdg)
 
     def _add_polarization_weights(self, event, ratios):
         """Write ``nominal * ratio`` into the event's LHEF v3 <rwgt> block.
@@ -5179,8 +5503,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         events = [event] if isinstance(event, lhe_parser.Event) else event
         for evt in events:
             wgts = evt.parse_reweight()
-            for label, ratio in ratios.items():
-                wgts[self._polarization_weight_id(label)] = evt.wgt * ratio
+            for wid, ratio in ratios.items():
+                wgts[wid] = evt.wgt * ratio
 
     @staticmethod
     def _decaying_pdgs(production, evt_decayfile):
@@ -6345,9 +6669,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             self._check_weight_identity(production, decays, decay_dict,
                                         w_mass_raw * w_slots, helicities, stats,
                                         offshell, keep_jac, parents)
-        if probe is None and self.options.get('keep_weight_for_polarization'):
-            # keep_weight_for_polarization: one masked contraction per requested
-            # polarisation on the accepted chain. The per-slot normalisation of
+        if probe is None and self._polarization_weights_enabled():
+            # keep_weight_for_polarization_*: one masked contraction per
+            # combination on the accepted chain. The per-slot normalisation of
             # the decay densities is an overall scalar and cancels in the ratio,
             # so this is the same number the joint path computes. Skipped in
             # probe mode (the max-weight scan writes no events).
@@ -6822,12 +7146,13 @@ class MadSpinInterface(extended_cmd.Cmd):
         # Contract production and decay density matrices
         # ------------------------------------------------------------------
         me = density_dec.scalar_multiplication(density_prod)
-        # keep_weight_for_polarization: the same contraction with a tighter row
-        # mask. Done here, on the matrices that are still alive, and stashed on
-        # self rather than added to the return tuple (which every caller unpacks
-        # positionally). The joint accept/reject tests the value computed by the
-        # last call, so the last ratios are the accepted chain's.
-        if self.options.get('keep_weight_for_polarization'):
+        # keep_weight_for_polarization_*: the same contraction with a tighter
+        # row mask, once per combination. Done here, on the matrices that are
+        # still alive, and stashed on self rather than added to the return tuple
+        # (which every caller unpacks positionally). The joint accept/reject
+        # tests the value computed by the last call, so the last ratios are the
+        # accepted chain's.
+        if self._polarization_weights_enabled():
             self._polarization_ratios(density_prod, density_dec, prod_static,
                                       full=me)
         me *= density_iden_prod * density_iden_decay

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -51,6 +51,55 @@ logger = logging.getLogger('decay.stdout') # -> stdout
 logger_stderr = logging.getLogger('decay.stderr') # ->stderr
 cmd_logger = logging.getLogger('cmdprint2') # -> print
 
+# ---------------------------------------------------------------------------
+# Polarisation labels accepted by keep_weight_for_polarization
+# ---------------------------------------------------------------------------
+# Same spelling and same meaning as MG5's polarisation braces:
+#   {L} -> [-1], {R}/{+} -> [1], {T} -> [-1,1], {0} -> [0]
+# Maps the (case-insensitive, brace-tolerant) user spelling onto
+# (canonical label, helicity values).
+POLARIZATION_ALIASES = {
+    '0': ('0', (0,)),
+    '+': ('+', (1,)),
+    'r': ('+', (1,)),
+    '-': ('-', (-1,)),
+    'l': ('-', (-1,)),
+    't': ('T', (-1, 1)),
+}
+
+
+def parse_polarization_label(label):
+    """(canonical label, helicity values) for one keep_weight_for_polarization
+    entry, or None if it is not one of 0/+/-/T (L and R aliasing - and +)."""
+    key = str(label).strip().lower()
+    if key.startswith('{') and key.endswith('}'):
+        key = key[1:-1].strip()
+    return POLARIZATION_ALIASES.get(key)
+
+
+def decay_density_tensor(slot_identity, helicities, slot_densities):
+    """The decay side of the sequential contraction: the tensor product of every
+    slot's normalised decay density, the slots still to be drawn contributing
+    I/n (``slot_identity``).
+
+    Factored out of ``_partial_density_contraction`` so the polarisation weights
+    can contract that same tensor against a differently masked production matrix
+    without rebuilding it.
+    """
+    density_dec = None
+    for slot, hel in enumerate(helicities):
+        density = slot_densities.get(slot)
+        if density is None:
+            density = slot_identity(hel)
+        else:
+            density = density.normalized()
+        if density_dec is None:
+            density_dec = density
+        else:
+            density_dec = density_dec.tensor_product(density)
+    return density_dec
+
+
 class MadSpinOptions(banner.ConfigFile):
     
     def default_setup(self):
@@ -76,6 +125,23 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
         self.add_param('beampol', [0., 0.], comment='beam polarisation of each beam in percent, -100 .. 100, exactly as the run_card polbeam1/polbeam2 (0 is unpolarised). Taken from the run_card of the production when it has one.')
+        self.add_param('keep_weight_for_polarization', [], typelist=str,
+                       comment="density spin modes only. List of polarisations "
+                       "(0, +, -, T; L/R accepted as aliases of -/+) for which an "
+                       "EXTRA weight is written in the LHEF v3 <rwgt> block of every "
+                       "event, equal to nominal_weight * (density convolution "
+                       "restricted to that polarisation) / (nominal density "
+                       "convolution). The nominal weight and the cross-section are "
+                       "untouched, and an empty list (the default) changes nothing. "
+                       "The same entry is applied to EVERY decaying particle at once, "
+                       "and is silently skipped -- i.e. that particle stays summed "
+                       "over its full helicity basis -- for the particles the "
+                       "polarisation is unphysical for, so on 'p p > t t~ z' the entry "
+                       "'0' restricts the Z only. When the production process itself "
+                       "carries a polarisation brace, the restriction is intersected "
+                       "with it and the denominator is the (already restricted) "
+                       "nominal convolution, so the weight stays the fraction of the "
+                       "sample that is written out.")
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -124,6 +190,27 @@ class MadSpinOptions(banner.ConfigFile):
                 "beampol takes the polarisation of *both* beams, in percent: "
                 "'set beampol [%s, 0]' for the first beam only. Got %s value(s)."
                 % (value[0] if value else 0, len(value)))
+
+    def post_set_keep_weight_for_polarization(self, value, change_userdefine,
+                                              raiseerror, *opts):
+        """Reject an unknown polarisation label at card-reading time, and store
+        the canonical spelling (so '{l}' and 'L' both become '-'). Anything but
+        0/+/-/T (with L/R as aliases) has no meaning in the helicity bases the
+        density spin modes use."""
+        if not value:
+            return
+        canonical = []
+        for entry in value:
+            parsed = parse_polarization_label(entry)
+            if parsed is None:
+                raise banner.InvalidCmd(
+                    "keep_weight_for_polarization: '%s' is not a polarisation. "
+                    "Use 0, +, - or T (L and R are accepted as aliases of - and +)."
+                    % entry)
+            if parsed[0] not in canonical:
+                canonical.append(parsed[0])
+        if canonical != list(value):
+            dict.__setitem__(self, 'keep_weight_for_polarization', canonical)
 
     def beampol_me(self):
         """The beam polarisations in the convention the matrix elements use.
@@ -1326,6 +1413,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
             self._production_polarization()
+            self._polarization_weight_labels()
+        elif self.options['keep_weight_for_polarization']:
+            raise self.InvalidCmd(
+                "keep_weight_for_polarization needs a spin density matrix to "
+                "restrict, so it is only available in the density spin modes "
+                "(madspin/full, PA, onshell). Got spinmode=%s." % spinmode)
         # The density modes decide about the '@' grouping later, in run_onshell,
         # where the production events say how many of each particle an event
         # carries. These two never can, so say it now rather than after the
@@ -2527,6 +2620,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             base_seed=int(self.seed) if self.seed else random.randint(0, 30081*30081),
         )
 
+        # keep_weight_for_polarization: the extra weights have to be declared in
+        # the header before it is written, here rather than in each writer --
+        # the parallel path forks *after* this point and its workers write
+        # bannerless fragments merged under this same banner.
+        self._declare_polarization_weights()
+
         start = time.time()
         logger.info("Start generating decays")
         if nb_core == 1:
@@ -3404,6 +3503,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                 wgts = full_evt.parse_reweight()
                 for key in wgts:
                     wgts[key] *= self.branching_ratio
+                self._add_polarization_weights(
+                    full_evt, getattr(self, '_pol_weight_ratios', None))
                 output_lhe.write_events(full_evt)
                 continue
 
@@ -3496,6 +3597,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                 wgts = full_evt.parse_reweight()
                 for key in wgts:
                     wgts[key] *= self.branching_ratio
+            self._add_polarization_weights(
+                full_evt, getattr(self, '_pol_weight_ratios', None))
 
             output_lhe.write_events(full_evt)
 
@@ -4807,6 +4910,188 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         return helicities, madspin.DensityMatrix.normalize_hel_restriction(restriction)
 
+    # ------------------------------------------------------------------
+    # keep_weight_for_polarization: extra LHEF v3 weights per polarisation
+    # ------------------------------------------------------------------
+    # For each requested polarisation P the event carries an additional weight
+    #
+    #     w_P = w_nominal * <rho_dec, rho_prod>_P / <rho_dec, rho_prod>
+    #
+    # i.e. the very same event reweighted to the P fraction of the density
+    # convolution. Both contractions are done on the matrices that were built
+    # for the nominal weight anyway -- only the row mask changes -- so N extra
+    # weights cost N extra masked dot products, not N extra density matrices.
+    #
+    # Conventions, all of them visible in the option's comment:
+    #  * the entry is applied to every decaying particle at once;
+    #  * a particle the polarisation is unphysical for (hel 0 on a fermion) is
+    #    left UNRESTRICTED rather than zeroed, which is what makes
+    #    'keep_weight_for_polarization = [0, T, +, -]' usable on t t~ z: the '0'
+    #    weight is then the longitudinal fraction of the Z with the tops summed
+    #    over. As a corollary a polarisation that is unphysical for *every*
+    #    decaying particle gives back the nominal weight (ratio 1);
+    #  * with a polarised production (PR #349) the restriction is intersected
+    #    with the production one and the denominator is the nominal -- already
+    #    restricted -- convolution, so w_P/w stays the fraction of what is
+    #    actually written out. An empty intersection ({L} production asked for
+    #    '+') is an impossible polarisation and gives 0.
+    #
+    # The ratio is >= 0 (the numerator of a single-state restriction is a product
+    # of density-matrix diagonals) but is NOT bounded by 1 event by event: the
+    # denominator is the full double sum, and the interference terms a
+    # restriction drops can be negative. Measured on p p > t t~: 4 events in 100
+    # above 1, integrated fractions well inside it. For the same reason
+    # sum_P w_P = w only holds when the contraction has no off-diagonal part and
+    # a single particle is restricted -- see the sum-rule tests.
+
+    def _polarization_weight_labels(self):
+        """Canonical polarisation labels requested in the MadSpin card, in the
+        order the user typed them. Empty (the default) disables everything."""
+        cached = getattr(self, '_pol_weight_labels_cache', None)
+        if cached is not None:
+            return cached
+        out = []
+        for entry in self.options['keep_weight_for_polarization'] or []:
+            parsed = parse_polarization_label(entry)
+            if parsed is None:
+                raise self.InvalidCmd(
+                    "keep_weight_for_polarization: '%s' is not a polarisation. "
+                    "Use 0, +, - or T (L and R are accepted as aliases)." % entry)
+            if parsed[0] not in [l for l, _ in out]:
+                out.append(parsed)
+        self._pol_weight_labels_cache = out
+        return out
+
+    @staticmethod
+    def _polarization_weight_id(label):
+        """LHEF weight id for one polarisation. Kept human readable and stable:
+        it is what an analysis has to ask the event file for."""
+        return 'ms_pol_%s' % label
+
+    def _polarization_restrictions(self, prod_static):
+        """``[(label, restriction), ...]`` for this production event's helicity
+        basis, ``restriction`` being what ``DensityMatrix.set_hel_restriction``
+        wants -- or ``False`` for a polarisation this production can never have
+        (empty intersection with the production braces), whose weight is 0.
+
+        Depends on the basis only, so it is memoised on ``prod_static``, which
+        is itself built once per production event.
+        """
+        cached = prod_static.get('pol_weight_restrictions')
+        if cached is not None:
+            return cached
+
+        labels = self._polarization_weight_labels()
+        helicities = prod_static['helicities']
+        base = prod_static.get('hel_restriction') or (None,) * len(helicities)
+
+        out = []
+        for label, values in labels:
+            restriction = []
+            impossible = False
+            for k, basis in enumerate(helicities):
+                physical = [h for h in values if h in basis]
+                if not physical:
+                    # unphysical for this particle: skip it silently, i.e. leave
+                    # it summed over whatever the production already allows
+                    restriction.append(base[k])
+                    continue
+                if base[k] is not None:
+                    physical = [h for h in physical if h in base[k]]
+                    if not physical:
+                        impossible = True
+                        break
+                restriction.append(tuple(physical))
+            if impossible:
+                out.append((label, False))
+            else:
+                out.append((label,
+                            madspin.DensityMatrix.normalize_hel_restriction(restriction)))
+
+        prod_static['pol_weight_restrictions'] = out
+        return out
+
+    def _polarization_ratios(self, density_prod, density_dec, prod_static,
+                             full=None):
+        """``{label: restricted/full}`` for the accepted chain, cached on self
+        so it does not have to be threaded through every weight return value.
+
+        ``full`` is the nominal contraction when the caller has it already (it
+        always does -- that is the event's weight); it is recomputed otherwise.
+        The restriction rides on ``density_prod`` for the duration of one
+        contraction rather than being passed down, because ``scalar_multiplication``
+        refuses to combine two *different* restrictions and the production matrix
+        may already carry the production-brace one.
+        """
+        if not self._polarization_weight_labels():
+            self._pol_weight_ratios = None
+            return None
+
+        if full is None:
+            full = density_dec.scalar_multiplication(density_prod)
+        full = getattr(full, 'real', full)
+
+        out = {}
+        saved = density_prod.hel_restriction
+        try:
+            for label, restriction in self._polarization_restrictions(prod_static):
+                if restriction is False or not full:
+                    out[label] = 0.0
+                    continue
+                if restriction == saved:
+                    out[label] = 1.0
+                    continue
+                density_prod.hel_restriction = restriction
+                value = density_dec.scalar_multiplication(density_prod)
+                out[label] = float(getattr(value, 'real', value)) / float(full)
+        finally:
+            density_prod.hel_restriction = saved
+
+        self._pol_weight_ratios = out
+        return out
+
+    def _declare_polarization_weights(self):
+        """Declare one <weight> per requested polarisation in the banner's
+        <initrwgt> block, in its own weightgroup, following the convention the
+        reweighting and systematics modules use. No-op when nothing is
+        requested, so an unset option leaves the banner byte-identical."""
+        labels = self._polarization_weight_labels()
+        if not labels:
+            return
+        if getattr(self, '_pol_weights_declared', False):
+            return
+        text = "\n<weightgroup name='madspin_polarization'>\n"
+        for label, values in labels:
+            text += "<weight id='%s'> MadSpin polarisation %s (helicities %s) " \
+                    "of the decaying particles </weight>\n" % (
+                        self._polarization_weight_id(label), label,
+                        ','.join(str(v) for v in values))
+        text += "</weightgroup>\n"
+        # dict.get is not available: Banner.get is get_detail, which only knows
+        # about a handful of card tags
+        if 'initrwgt' in self.banner and self.banner['initrwgt']:
+            self.banner['initrwgt'] += text
+        else:
+            self.banner['initrwgt'] = text
+        self._pol_weights_declared = True
+
+    def _add_polarization_weights(self, event, ratios):
+        """Write ``nominal * ratio`` into the event's LHEF v3 <rwgt> block.
+
+        Called *after* the nominal weight has been scaled by the branching
+        ratio, so that the extra weights are consistently normalised to the
+        weight that is actually written out.
+        """
+        if not ratios:
+            return
+        # fixed_order hands over [event] + counter-events; an Event is itself a
+        # list (of Particles), so it cannot be told apart by isinstance(list)
+        events = [event] if isinstance(event, lhe_parser.Event) else event
+        for evt in events:
+            wgts = evt.parse_reweight()
+            for label, ratio in ratios.items():
+                wgts[self._polarization_weight_id(label)] = evt.wgt * ratio
+
     @staticmethod
     def _decaying_pdgs(production, evt_decayfile):
         """The pdgs that decay, in order of first appearance among the
@@ -4902,18 +5187,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         ordering only decides which slot gets filled next -- it must never
         permute the tensor. See MADSPIN_SEQUENTIAL_PLAN.md.
         """
-        density_dec = None
-        for slot, hel in enumerate(helicities):
-            density = slot_densities.get(slot)
-            if density is None:
-                density = self._slot_identity(hel)
-            else:
-                density = density.normalized()
-            if density_dec is None:
-                density_dec = density
-            else:
-                density_dec = density_dec.tensor_product(density)
-        return density_dec.scalar_multiplication(density_prod)
+        return decay_density_tensor(self._slot_identity, helicities,
+                                    slot_densities) \
+                   .scalar_multiplication(density_prod)
 
     def _decay_reshuffle_jacobian(self, decay):
         """jac_dec: the jacobian of mapping this decay onto the virtuality just
@@ -5979,6 +6255,17 @@ class MadSpinInterface(extended_cmd.Cmd):
             self._check_weight_identity(production, decays, decay_dict,
                                         w_mass_raw * w_slots, helicities, stats,
                                         offshell, keep_jac, parents)
+        if probe is None and self.options.get('keep_weight_for_polarization'):
+            # keep_weight_for_polarization: one masked contraction per requested
+            # polarisation on the accepted chain. The per-slot normalisation of
+            # the decay densities is an overall scalar and cancels in the ratio,
+            # so this is the same number the joint path computes. Skipped in
+            # probe mode (the max-weight scan writes no events).
+            self._polarization_ratios(
+                density_prod,
+                decay_density_tensor(self._slot_identity, helicities,
+                                     slot_densities),
+                prod_static)
         return decays
 
     def get_onshell_evt_and_wgt(self, production, decays, decay_dict, prod_density_cached=None, build_event=True):
@@ -6445,6 +6732,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         # Contract production and decay density matrices
         # ------------------------------------------------------------------
         me = density_dec.scalar_multiplication(density_prod)
+        # keep_weight_for_polarization: the same contraction with a tighter row
+        # mask. Done here, on the matrices that are still alive, and stashed on
+        # self rather than added to the return tuple (which every caller unpacks
+        # positionally). The joint accept/reject tests the value computed by the
+        # last call, so the last ratios are the accepted chain's.
+        if self.options.get('keep_weight_for_polarization'):
+            self._polarization_ratios(density_prod, density_dec, prod_static,
+                                      full=me)
         me *= density_iden_prod * density_iden_decay
 
         # ------------------------------------------------------------------

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4795,8 +4795,22 @@ class MadSpinInterface(extended_cmd.Cmd):
         return self.options['spinmode'] in ['madspin', 'full', 'PA', 'onshell']
 
     def _production_polarization(self):
-        """``pdg -> tuple(allowed helicities)`` from the polarisation braces of
-        the *production* process, e.g. ``p p > t{0} t~``.
+        """``pdg -> tuple`` of the polarisation braces of the *production*
+        process, one entry per occurrence of that pdg among the final-state
+        legs, in process-line order: ``p p > t{0} t~`` gives
+        ``{6: ((0,),)}`` and ``p p > w+{0} w+{T}`` gives
+        ``{24: ((0,), (-1, 1))}``. An entry is ``None`` for an occurrence
+        that carries no brace.
+
+        A pdg whose occurrences all carry the *same* brace is collapsed to a
+        single entry, which then applies to however many of that pdg the event
+        holds ('broadcast'). That is what keeps a stack of subprocesses with
+        different multiplicities -- ``generate p p > t{0} t~`` plus
+        ``add process p p > t{0} t~ j`` -- working. A pdg with *different*
+        braces on different legs cannot be broadcast: it keeps its full
+        sequence and is matched positionally, the n-th such pdg of the event
+        taking the n-th brace (see ``_apply_production_polarization`` for why
+        that correspondence holds).
 
         MadSpin regenerates the production matrix element from the banner's
         proc_card, braces included, so the braces are exactly what MG5 saw. They
@@ -4824,7 +4838,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                   if re.search(r'^\s*add\s+process', line)]
 
         if any('{' in line for line in lines):
-            unpolarized = set()
+            # pdg -> (canonical sequence, the line it came from), so that a
+            # disagreement between two process lines can name both of them.
+            source = {}
+            multi_id = set()
             for line in lines:
                 try:
                     procdef = self.mg5cmd.extract_process(line)
@@ -4834,34 +4851,60 @@ class MadSpinInterface(extended_cmd.Cmd):
                                    'matrix convolution is left unrestricted.'
                                    % (line, error))
                     continue
+                seq = collections.OrderedDict()
                 for leg in procdef.get('legs'):
                     # initial-state polarisation is the beampol machinery, not this
                     if not leg.get('state'):
                         continue
                     pol = leg.get('polarization')
+                    pol = tuple(sorted(set(int(p) for p in pol))) if pol else None
                     ids = [int(i) for i in leg.get('ids')]
-                    if not pol:
-                        unpolarized.update(ids)
-                        continue
-                    pol = tuple(sorted(set(int(p) for p in pol)))
                     for pdg in ids:
-                        if out.setdefault(pdg, pol) != pol:
-                            raise self.InvalidCmd(
-                                'MadSpin: particle %s is produced with two different '
-                                'polarisations (%s and %s) in the production process. '
-                                'The density spin modes cannot tell which one a given '
-                                'final-state particle carries.'
-                                % (pdg, out[pdg], pol))
-            clash = unpolarized.intersection(out)
-            if clash:
-                raise self.InvalidCmd(
-                    'MadSpin: particle(s) %s are polarised in one production process '
-                    'and unpolarised in another. Please use a single, consistent '
-                    'polarisation for the particles MadSpin decays.'
-                    % ', '.join(str(p) for p in sorted(clash)))
+                        seq.setdefault(pdg, []).append(pol)
+                        if len(ids) > 1:
+                            multi_id.add(pdg)
+                for pdg, pols in seq.items():
+                    # all occurrences agree -> broadcast, the multiplicity of
+                    # the line then does not have to match the event's
+                    canonical = tuple(pols[:1]) if len(set(pols)) == 1 else tuple(pols)
+                    if pdg in source and source[pdg][0] != canonical:
+                        raise self.InvalidCmd(
+                            'MadSpin: particle %s carries the polarisation(s) %s in '
+                            'the production process "%s" and %s in "%s". The density '
+                            'spin modes have no way to tell, event by event, which of '
+                            'the two a given final-state particle follows. Please use '
+                            'one consistent polarisation pattern for the particles '
+                            'MadSpin decays.'
+                            % (pdg, self._format_polarization_sequence(source[pdg][0]),
+                               source[pdg][1],
+                               self._format_polarization_sequence(canonical), line))
+                    source[pdg] = (canonical, line)
+            for pdg, (canonical, line) in source.items():
+                if all(p is None for p in canonical):
+                    continue
+                if len(canonical) > 1 and pdg in multi_id:
+                    # 'p p > V{0} V{T}' with a multiparticle V: how many of a
+                    # given pdg an event holds is not fixed by the process line,
+                    # so the n-th brace cannot be pinned to the n-th particle.
+                    raise self.InvalidCmd(
+                        'MadSpin: particle %s appears with different polarisations '
+                        '(%s) inside a multiparticle label in the production process '
+                        '"%s". The number of %s in an event is then not fixed by the '
+                        'process line, so MadSpin cannot tell which particle carries '
+                        'which polarisation. Please spell the polarised legs out with '
+                        'explicit particle names.'
+                        % (pdg, self._format_polarization_sequence(canonical), line, pdg))
+                out[pdg] = canonical
 
         self._production_polarization_cache = out
         return out
+
+    @staticmethod
+    def _format_polarization_sequence(sequence):
+        """A polarisation sequence as it reads in a process line, for errors."""
+        names = {(0,): '{0}', (1,): '{+}', (-1,): '{-}', (-1, 1): '{T}'}
+        return ' '.join('(none)' if p is None else names.get(p, str(list(p)))
+                        for p in sequence)
 
     def _apply_production_polarization(self, decaying_pdg, helicities):
         """Turn the production polarisation into (helicity bases, restriction).
@@ -4884,15 +4927,62 @@ class MadSpinInterface(extended_cmd.Cmd):
           an allowed helicity first is what makes the spectator helicity sum
           find its rows. The order is untouched without braces, so nothing
           moves for unpolarised runs.
+
+        Same pdg, different braces ('p p > w+{0} w+{T}')
+        ------------------------------------------------
+        ``decaying_pdg`` is in slot order -- for pdg in decays_key, in
+        production-event order within a pdg -- so the slots of one pdg form a
+        contiguous block whose k-th entry is the k-th such particle of the
+        event. The k-th brace of that pdg is handed to that k-th slot, and the
+        correspondence is exact rather than a guess:
+
+        * MG5 keeps the legs of a process in the order they were typed (leg
+          number 1..n), and a leg's polarisation is part of its identity -- two
+          same-pdg legs with different braces have an ``identical_particle_factor``
+          of 1, so no symmetrisation and no momentum permutation is applied to
+          them anywhere between the amplitude and the event file;
+
+        * ``lhe_parser.Event.get_momenta`` maps the event's k-th particle of a
+          pdg onto the k-th slot of that pdg in the matrix element's leg order.
+          The momentum the matrix element sees at leg number ``position[k]`` is
+          therefore the event particle slot k stands for. The brace read off
+          leg ``position[k]`` of the process line and the density matrix
+          computed at ``position[k]`` describe the same object by construction.
+
+        A wrong assignment could not go unnoticed either: ``GET_DENSITY``
+        selects the NHEL rows of the *polarised* process by matching them
+        against the first ``ALLOW_HEL`` combination, which is built from the
+        head of each basis below. Handing '{T}' to the leg MG5 generated as
+        '{0}' asks for a helicity combination the polarised NHEL table does not
+        contain, and the production density matrix comes back identically zero
+        -- a loud failure, not a small bias.
         """
         pol_map = self._production_polarization()
         if not pol_map:
             return helicities, None
 
         helicities = list(helicities)
+        multiplicity = collections.Counter(decaying_pdg)
+        seen = collections.Counter()
         restriction = []
         for k, pdg in enumerate(decaying_pdg):
-            allowed = pol_map.get(pdg)
+            sequence = pol_map.get(pdg)
+            occurrence = seen[pdg]
+            seen[pdg] += 1
+            if not sequence:
+                allowed = None
+            elif len(sequence) == 1:
+                # one brace for every particle of that pdg
+                allowed = sequence[0]
+            elif len(sequence) != multiplicity[pdg]:
+                raise self.InvalidCmd(
+                    'MadSpin: the production process gives %d polarisation(s) (%s) '
+                    'for particle %s but the event holds %d of them. The braces can '
+                    'only be attached to the particles one by one when the two agree.'
+                    % (len(sequence), self._format_polarization_sequence(sequence),
+                       pdg, multiplicity[pdg]))
+            else:
+                allowed = sequence[occurrence]
             basis = list(helicities[k])
             if not allowed:
                 restriction.append(None)

--- a/Template/Common/Cards/madspin_card_default.dat
+++ b/Template/Common/Cards/madspin_card_default.dat
@@ -24,33 +24,11 @@
 #         - none : no spin correlation and no finite width effect
 #         legacy modes:
 #         - madspin_v1 and onshell_v1
-# set keep_weight_for_polarization_vector  [0, T, +, -]
+# set keep_weight_for_polarization_vector  [0, T] # + and - are possible choice too
 # set keep_weight_for_polarization_fermion [+, -]
 #         density spin modes only. Each decaying particle draws from the list of
 #         its own spin, and one EXTRA weight is added to the LHEF v3 <rwgt>
-#         section of every event for each COMBINATION -- one per element of the
-#         cartesian product over the decaying particles -- equal to
-#         nominal_weight * (density convolution restricted to that combination)
-#         / (nominal density convolution). The nominal weight and the
-#         cross-section are untouched, and two empty lists (the default) change
-#         nothing at all.
-#         On 'p p > t t~ z' the two lists above give 2*2*4 = 16 extra weights,
-#         named after the per-particle assignment in density-basis slot order:
-#             <wgt id='ms_pol_6:+_-6:-_23:0'>   t(+) t~(-) z(0)
-#         A particle with an empty list -- and a scalar, which has no
-#         polarisation -- is left summed over and shows up as '*' instead of a
-#         label; it does not multiply the number of weights. A label unphysical
-#         for a particle ('0' on a fermion) is dropped from its choices.
-#         With a polarised production ('p p > z{0} z{T}') each slot's choices
-#         are intersected with its own brace and the impossible ones are
-#         dropped, so the ids that survive are the ones that can be non-zero.
-#         The ratio is positive but not bounded by 1 event by event: the
-#         interference terms a polarisation drops can be negative. sum_C w_C = w
-#         only when each list partitions its helicity basis ([+, -] for a
-#         fermion, [0, +, -] or [0, T] for a vector -- [0, T, +, -] overlaps)
-#         *and* the contraction has no interference part.
-#         'set keep_weight_for_polarization [...]' is the deprecated spelling:
-#         it sets both lists at once.
+#         section of every event for each COMBINATION 
 #
 # Polarisation of the PRODUCTION process ('generate p p > w+{0} w-'):
 #         the density spin modes restrict the production/decay convolution to
@@ -59,8 +37,7 @@
 #         different braces -- 'p p > z{0} z{T}' -- in which case the n-th
 #         particle of that pdg in the event follows the n-th brace of the
 #         process line. Braces on a 'decay' line are refused instead (they
-#         would restrict the branching ratio, not the correlation); use
-#         spinmode=none or spinmode=madspin_v1 for those.
+#         would restrict the branching ratio, not the correlation); 
  set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
 
 define light = 1 2 3 4 5 -1 -2 -3 -4 -5 11 12 13 14 15 16 -11 -12 -13 -14 -15 -16

--- a/Template/Common/Cards/madspin_card_default.dat
+++ b/Template/Common/Cards/madspin_card_default.dat
@@ -24,17 +24,33 @@
 #         - none : no spin correlation and no finite width effect
 #         legacy modes:
 #         - madspin_v1 and onshell_v1
-# set keep_weight_for_polarization [0, T, +, -]
-#         density spin modes only. Adds one EXTRA weight per listed polarisation
-#         to the LHEF v3 <rwgt> section of every event, equal to
-#         nominal_weight * (density convolution restricted to that polarisation)
+# set keep_weight_for_polarization_vector  [0, T, +, -]
+# set keep_weight_for_polarization_fermion [+, -]
+#         density spin modes only. Each decaying particle draws from the list of
+#         its own spin, and one EXTRA weight is added to the LHEF v3 <rwgt>
+#         section of every event for each COMBINATION -- one per element of the
+#         cartesian product over the decaying particles -- equal to
+#         nominal_weight * (density convolution restricted to that combination)
 #         / (nominal density convolution). The nominal weight and the
-#         cross-section are untouched. The same entry applies to every decaying
-#         particle at once and is silently skipped -- that particle stays summed
-#         over its full helicity basis -- where it is unphysical, so on
-#         'p p > t t~ z' the entry '0' restricts the Z only. The ratio is
-#         positive but not bounded by 1 event by event: the interference terms
-#         a polarisation drops can be negative.
+#         cross-section are untouched, and two empty lists (the default) change
+#         nothing at all.
+#         On 'p p > t t~ z' the two lists above give 2*2*4 = 16 extra weights,
+#         named after the per-particle assignment in density-basis slot order:
+#             <wgt id='ms_pol_6:+_-6:-_23:0'>   t(+) t~(-) z(0)
+#         A particle with an empty list -- and a scalar, which has no
+#         polarisation -- is left summed over and shows up as '*' instead of a
+#         label; it does not multiply the number of weights. A label unphysical
+#         for a particle ('0' on a fermion) is dropped from its choices.
+#         With a polarised production ('p p > z{0} z{T}') each slot's choices
+#         are intersected with its own brace and the impossible ones are
+#         dropped, so the ids that survive are the ones that can be non-zero.
+#         The ratio is positive but not bounded by 1 event by event: the
+#         interference terms a polarisation drops can be negative. sum_C w_C = w
+#         only when each list partitions its helicity basis ([+, -] for a
+#         fermion, [0, +, -] or [0, T] for a vector -- [0, T, +, -] overlaps)
+#         *and* the contraction has no interference part.
+#         'set keep_weight_for_polarization [...]' is the deprecated spelling:
+#         it sets both lists at once.
 #
 # Polarisation of the PRODUCTION process ('generate p p > w+{0} w-'):
 #         the density spin modes restrict the production/decay convolution to

--- a/Template/Common/Cards/madspin_card_default.dat
+++ b/Template/Common/Cards/madspin_card_default.dat
@@ -35,6 +35,16 @@
 #         'p p > t t~ z' the entry '0' restricts the Z only. The ratio is
 #         positive but not bounded by 1 event by event: the interference terms
 #         a polarisation drops can be negative.
+#
+# Polarisation of the PRODUCTION process ('generate p p > w+{0} w-'):
+#         the density spin modes restrict the production/decay convolution to
+#         the polarisation each brace asks for, so the decay products follow
+#         that polarisation. The same particle may appear several times with
+#         different braces -- 'p p > z{0} z{T}' -- in which case the n-th
+#         particle of that pdg in the event follows the n-th brace of the
+#         process line. Braces on a 'decay' line are refused instead (they
+#         would restrict the branching ratio, not the correlation); use
+#         spinmode=none or spinmode=madspin_v1 for those.
  set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
 
 define light = 1 2 3 4 5 -1 -2 -3 -4 -5 11 12 13 14 15 16 -11 -12 -13 -14 -15 -16

--- a/Template/Common/Cards/madspin_card_default.dat
+++ b/Template/Common/Cards/madspin_card_default.dat
@@ -24,6 +24,17 @@
 #         - none : no spin correlation and no finite width effect
 #         legacy modes:
 #         - madspin_v1 and onshell_v1
+# set keep_weight_for_polarization [0, T, +, -]
+#         density spin modes only. Adds one EXTRA weight per listed polarisation
+#         to the LHEF v3 <rwgt> section of every event, equal to
+#         nominal_weight * (density convolution restricted to that polarisation)
+#         / (nominal density convolution). The nominal weight and the
+#         cross-section are untouched. The same entry applies to every decaying
+#         particle at once and is silently skipped -- that particle stays summed
+#         over its full helicity basis -- where it is unphysical, so on
+#         'p p > t t~ z' the entry '0' restricts the Z only. The ratio is
+#         positive but not bounded by 1 event by event: the interference terms
+#         a polarisation drops can be negative.
  set max_weight_ps_point 400  # number of PS to estimate the maximum for each event
 
 define light = 1 2 3 4 5 -1 -2 -3 -4 -5 11 12 13 14 15 16 -11 -12 -13 -14 -15 -16

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1306,6 +1306,53 @@ class TestDensityPolarizationRestriction(unittest.TestCase):
         self.assertIsNot(a._restriction_row_mask(a.hel_restriction),
                          a._restriction_row_mask(((-1, 1),)))
 
+    def test_restricted_paths_are_bit_identical_to_masking(self):
+        """The contractions gather the surviving rows by index instead of by
+        boolean mask. That is a speed change only: the rows come out in
+        increasing index order either way, so the sums must agree *exactly*,
+        not merely to within a tolerance."""
+        import numpy as np
+        import itertools
+        for hels in ([self.FERMION], [self.VECTOR],
+                     [self.FERMION, self.VECTOR],
+                     [self.VECTOR, self.FERMION, self.VECTOR]):
+            dim = 1
+            for h in hels:
+                dim *= len(h)
+            allowed_hel = [h for combo in itertools.product(*hels) for h in combo]
+            prod = madspin.DensityMatrix(self._packed(list(range(dim)), 101),
+                                         len(hels), allowed_hel, dim)
+            dec = None
+            for i, h in enumerate(hels):
+                d = self._density(h, 102 + i)
+                dec = d if dec is None else dec.tensor_product(d)
+            choices = [[None] + [(x,) for x in h] + [tuple(h[:2])] for h in hels]
+            for restriction in itertools.product(*choices):
+                prod.set_hel_restriction(list(restriction))
+                r = prod.hel_restriction
+                if r is None:
+                    continue
+                mask = prod._restriction_row_mask(r)
+                rows = prod._restriction_rows(r)[1]
+                self.assertTrue(np.array_equal(rows, np.flatnonzero(mask)))
+                # trace: same elements, same order
+                self.assertEqual(prod.trace(),
+                                 np.sum(prod.values[prod._diag_mask & mask]))
+                # contraction, both the map fast path (dec is prod's basis for
+                # one particle) and the sorted-alignment path
+                for lhs, rhs in ((dec, prod), (prod, dec)):
+                    m = lhs._restriction_row_mask(r)
+                    if (lhs.map_density_matrix_ind is not None and
+                            lhs.map_density_matrix_ind is rhs.map_density_matrix_ind):
+                        want = np.sum(lhs.values[m] * rhs.values[m])
+                    else:
+                        lhs._ensure_sorted_view()
+                        rhs._ensure_sorted_view()
+                        a, b = lhs._sort_order, rhs._sort_order
+                        aligned = m[a]
+                        want = np.sum(lhs.values[a][aligned] * rhs.values[b][aligned])
+                    self.assertEqual(lhs.scalar_multiplication(rhs), want)
+
     def test_contradicting_restrictions_are_refused(self):
         hel = self.FERMION
         a = self._density(hel, 81, restriction=[(1,)])

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1428,6 +1428,435 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
             self.assertFalse(self._Stub(spinmode=mode)._density_spinmode())
 
 
+class TestKeepWeightForPolarization(unittest.TestCase):
+    """keep_weight_for_polarization: one extra LHEF v3 weight per requested
+    polarisation, equal to nominal * (restricted convolution)/(full convolution).
+
+    The restriction machinery itself is PR #349's; what is tested here is the
+    vector that is built out of a *card* entry -- one entry applied to every
+    decaying particle, silently skipped where it is unphysical -- and the fact
+    that the nominal weight never moves.
+    """
+
+    MI = interface_madspin.MadSpinInterface
+
+    FERMION = [1, -1]       # pdg 6
+    VECTOR = [-1, 0, 1]     # pdg 23
+
+    class _Stub(object):
+        """Just enough MadSpinInterface for the polarisation-weight helpers."""
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        _polarization_weight_labels = \
+            interface_madspin.MadSpinInterface._polarization_weight_labels
+        _polarization_weight_id = staticmethod(
+            interface_madspin.MadSpinInterface._polarization_weight_id)
+        _polarization_restrictions = \
+            interface_madspin.MadSpinInterface._polarization_restrictions
+        _polarization_ratios = \
+            interface_madspin.MadSpinInterface._polarization_ratios
+        _declare_polarization_weights = \
+            interface_madspin.MadSpinInterface._declare_polarization_weights
+        _add_polarization_weights = \
+            interface_madspin.MadSpinInterface._add_polarization_weights
+        _slot_identity = interface_madspin.MadSpinInterface._slot_identity
+
+        def __init__(self, pols=(), banner=None):
+            self.options = {'keep_weight_for_polarization': list(pols)}
+            self.banner = {} if banner is None else banner
+
+    # ------------------------------------------------------------------
+    # matrices
+    # ------------------------------------------------------------------
+
+    def _packed(self, dim, seed):
+        """Hermitian matrix in the packed upper-triangular Fortran storage."""
+        import numpy as np
+        rng = np.random.default_rng(seed)
+        arr = (rng.normal(size=dim * (dim + 1) // 2)
+               + 1j * rng.normal(size=dim * (dim + 1) // 2)).astype('complex64')
+        for i in range(dim):
+            arr[i * (2 * dim - i + 1) // 2] = abs(arr[i * (2 * dim - i + 1) // 2])
+        return arr
+
+    def _joint(self, hels, seed, diagonal_only=False):
+        """A density matrix over the joint helicity index of ``hels``."""
+        import itertools
+        import numpy as np
+        dim = 1
+        for h in hels:
+            dim *= len(h)
+        allowed = []
+        for combo in itertools.product(*hels):
+            allowed.extend(combo)
+        arr = self._packed(dim, seed)
+        rho = madspin.DensityMatrix(arr, len(hels), allowed, dim)
+        if diagonal_only:
+            # kill every interference entry: the only configuration in which the
+            # polarisation sum rule can hold at all (see the sum-rule tests)
+            rho.values = np.where(rho._diag_mask, rho.values, 0).astype('complex64')
+        return rho
+
+    def _brute_force(self, dec, prod, restriction):
+        """sum_{(i,j) allowed} rho_dec(i,j) rho_prod(i,j), read off the helicity
+        labels -- an implementation independent of the cached row masks."""
+        table = {tuple(int(x) for x in lab): val
+                 for lab, val in zip(prod.helicities, prod.values)}
+        total = 0j
+        for lab, val in zip(dec.helicities, dec.values):
+            lab = tuple(int(x) for x in lab)
+            keep = True
+            for k, ok in enumerate(restriction or []):
+                if ok is None:
+                    continue
+                if lab[2 * k] not in ok or lab[2 * k + 1] not in ok:
+                    keep = False
+                    break
+            if keep:
+                total += complex(val) * complex(table[lab])
+        return total
+
+    def _static(self, helicities, base=None):
+        return {'helicities': [list(h) for h in helicities],
+                'hel_restriction': base}
+
+    # ------------------------------------------------------------------
+    # the option itself
+    # ------------------------------------------------------------------
+
+    def test_default_is_empty_and_changes_nothing(self):
+        """The behaviour-neutrality requirement: an unset option must not add a
+        weight, must not touch the banner, and must not even build a mask."""
+        options = interface_madspin.MadSpinOptions()
+        self.assertEqual(options['keep_weight_for_polarization'], [])
+
+        stub = self._Stub()
+        self.assertEqual(stub._polarization_weight_labels(), [])
+        stub._declare_polarization_weights()
+        self.assertEqual(stub.banner, {})
+
+        prod = self._joint([self.VECTOR], 11)
+        dec = self._joint([self.VECTOR], 12)
+        static = self._static([self.VECTOR])
+        self.assertIsNone(stub._polarization_ratios(prod, dec, static))
+        self.assertNotIn('pol_weight_restrictions', static)
+
+        event = self._event()
+        before = str(event)
+        stub._add_polarization_weights(event, None)
+        stub._add_polarization_weights(event, {})
+        self.assertEqual(str(event), before)
+        self.assertNotIn('<rwgt>', str(event))
+
+    def test_card_accepts_the_documented_spellings(self):
+        options = interface_madspin.MadSpinOptions()
+        options['keep_weight_for_polarization'] = '[0, T, +, -]'
+        self.assertEqual(options['keep_weight_for_polarization'],
+                         ['0', 'T', '+', '-'])
+        # L/R alias -/+ exactly as MG5's braces do, and the canonical spelling
+        # is what is stored (so the weight ids do not depend on the typing)
+        options['keep_weight_for_polarization'] = 'L R t'
+        self.assertEqual(options['keep_weight_for_polarization'],
+                         ['-', '+', 'T'])
+        # duplicates collapse rather than emitting the same weight twice
+        options['keep_weight_for_polarization'] = '[+, R, +]'
+        self.assertEqual(options['keep_weight_for_polarization'], ['+'])
+
+    def test_card_refuses_a_non_polarisation(self):
+        options = interface_madspin.MadSpinOptions()
+        self.assertRaises(banner.InvalidCmd, options.__setitem__,
+                          'keep_weight_for_polarization', '[0, A]')
+
+    def test_label_parsing(self):
+        parse = interface_madspin.parse_polarization_label
+        self.assertEqual(parse('0'), ('0', (0,)))
+        self.assertEqual(parse('+'), ('+', (1,)))
+        self.assertEqual(parse('R'), ('+', (1,)))
+        self.assertEqual(parse('-'), ('-', (-1,)))
+        self.assertEqual(parse('l'), ('-', (-1,)))
+        self.assertEqual(parse('T'), ('T', (-1, 1)))
+        self.assertEqual(parse('{T}'), ('T', (-1, 1)))
+        self.assertIsNone(parse('A'))
+        self.assertIsNone(parse(''))
+
+    # ------------------------------------------------------------------
+    # the restriction vector built from one card entry
+    # ------------------------------------------------------------------
+
+    def test_unphysical_states_are_skipped_per_particle(self):
+        """p p > t t~ z with [0, T, +, -]: the same entry goes to every decaying
+        particle, and the ones it is unphysical for stay *unrestricted* rather
+        than making the whole weight zero -- which is what makes '0' mean 'the
+        longitudinal fraction of the Z' on this process."""
+        stub = self._Stub(['0', 'T', '+', '-'])
+        static = self._static([self.FERMION, self.FERMION, self.VECTOR])
+        got = dict(stub._polarization_restrictions(static))
+        self.assertEqual(got['0'], (None, None, (0,)))
+        self.assertEqual(got['T'], ((-1, 1), (-1, 1), (-1, 1)))
+        self.assertEqual(got['+'], ((1,), (1,), (1,)))
+        self.assertEqual(got['-'], ((-1,), (-1,), (-1,)))
+
+    def test_a_polarisation_unphysical_everywhere_is_the_nominal_weight(self):
+        """The corollary of 'skip the particle, do not drop the event': on
+        p p > t t~ the entry '0' restricts nothing, so its weight is the nominal
+        one (ratio exactly 1) rather than 0."""
+        stub = self._Stub(['0'])
+        static = self._static([self.FERMION, self.FERMION])
+        self.assertEqual(dict(stub._polarization_restrictions(static))['0'],
+                         None)
+        prod = self._joint([self.FERMION, self.FERMION], 21)
+        dec = self._joint([self.FERMION, self.FERMION], 22)
+        self.assertEqual(stub._polarization_ratios(prod, dec, static)['0'], 1.0)
+
+    def test_restrictions_are_cached_on_the_production_static(self):
+        stub = self._Stub(['T'])
+        static = self._static([self.VECTOR])
+        first = stub._polarization_restrictions(static)
+        self.assertIs(first, stub._polarization_restrictions(static))
+        self.assertIs(first, static['pol_weight_restrictions'])
+
+    # ------------------------------------------------------------------
+    # interaction with the production polarisation (PR #349)
+    # ------------------------------------------------------------------
+
+    def test_production_braces_are_intersected(self):
+        """p p > t{+} t~ z: the nominal convolution is already restricted to a
+        right-handed top, so the polarisation weights are fractions *of that*
+        sample -- '+' keeps it, '0' leaves the (already restricted) top alone
+        and cuts the Z, and '-' is impossible and gets a zero weight."""
+        stub = self._Stub(['+', '-', '0', 'T'])
+        static = self._static([self.FERMION, self.VECTOR],
+                              base=((1,), None))
+        got = dict(stub._polarization_restrictions(static))
+        self.assertEqual(got['+'], ((1,), (1,)))
+        self.assertEqual(got['0'], ((1,), (0,)))
+        self.assertEqual(got['T'], ((1,), (-1, 1)))
+        self.assertIs(got['-'], False)
+
+    def test_an_impossible_polarisation_weighs_zero(self):
+        stub = self._Stub(['-'])
+        static = self._static([self.FERMION], base=((1,),))
+        prod = self._joint([self.FERMION], 31)
+        prod.set_hel_restriction(((1,),))
+        dec = self._joint([self.FERMION], 32)
+        self.assertEqual(stub._polarization_ratios(prod, dec, static)['-'], 0.0)
+
+    def test_the_denominator_is_the_restricted_convolution(self):
+        """With production braces the ratio must be taken against the nominal --
+        already restricted -- convolution, or it would not be the fraction of
+        what is actually written out."""
+        import numpy as np
+        stub = self._Stub(['0'])
+        hels = [self.FERMION, self.VECTOR]
+        static = self._static(hels, base=((1,), None))
+        prod = self._joint(hels, 41)
+        prod.set_hel_restriction(((1,), None))
+        dec = self._joint(hels, 42)
+        ratio = stub._polarization_ratios(prod, dec, static)['0']
+        num = self._brute_force(dec, prod, ((1,), (0,)))
+        den = self._brute_force(dec, prod, ((1,), None))
+        self.assertTrue(np.allclose(ratio, (num / den).real, atol=1e-5))
+        # and the production matrix comes back exactly as it went in
+        self.assertEqual(prod.hel_restriction, ((1,), None))
+
+    # ------------------------------------------------------------------
+    # the ratio and the emitted weight
+    # ------------------------------------------------------------------
+
+    def test_ratio_matches_an_independent_contraction(self):
+        import numpy as np
+        stub = self._Stub(['0', 'T', '+', '-'])
+        hels = [self.FERMION, self.VECTOR]
+        static = self._static(hels)
+        prod = self._joint(hels, 51)
+        dec = self._joint(hels, 52)
+        ratios = stub._polarization_ratios(prod, dec, static)
+        full = self._brute_force(dec, prod, None)
+        for label, restriction in stub._polarization_restrictions(static):
+            expected = (self._brute_force(dec, prod, restriction) / full).real
+            self.assertTrue(np.allclose(ratios[label], expected, atol=1e-5),
+                            '%s: %s != %s' % (label, ratios[label], expected))
+        # nothing was left attached to the production matrix
+        self.assertIsNone(prod.hel_restriction)
+
+    def test_nominal_contraction_is_untouched(self):
+        """The nominal weight is what the accept/reject and the cross-section
+        are built on: computing the extra weights must not perturb it."""
+        import numpy as np
+        hels = [self.FERMION, self.VECTOR]
+        prod = self._joint(hels, 61)
+        dec = self._joint(hels, 62)
+        before = dec.scalar_multiplication(prod)
+        self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
+            prod, dec, self._static(hels))
+        self.assertTrue(np.allclose(dec.scalar_multiplication(prod), before))
+
+    def test_joint_and_sequential_agree(self):
+        """The joint path contracts the raw decay tensor, the sequential one the
+        tensor of *normalised* per-slot densities (D/Tr D). Those differ by an
+        overall scalar per slot, which cancels in the ratio -- so both paths must
+        hand back the same polarisation weights for the same chain."""
+        import numpy as np
+        hels = [self.FERMION, self.VECTOR]
+        static = self._static(hels)
+        prod = self._joint(hels, 111)
+        slots = {0: self._joint([self.FERMION], 112),
+                 1: self._joint([self.VECTOR], 113)}
+        joint_dec = slots[0].tensor_product(slots[1])
+        seq_dec = interface_madspin.decay_density_tensor(
+            interface_madspin.MadSpinInterface._slot_identity.__get__(
+                TestPartialDensityContraction._Stub()), hels, slots)
+        a = self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
+            prod, joint_dec, dict(static))
+        b = self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
+            prod, seq_dec, dict(static))
+        for label in a:
+            self.assertTrue(np.allclose(a[label], b[label], atol=1e-5),
+                            '%s: %s != %s' % (label, a[label], b[label]))
+
+    def _event(self, wgt=3.5):
+        text = """<event>
+ 4  1 +%.7e 1.00000000e+02 7.54677100e-03 1.30800000e-01
+       -1 -1    0    0  501    0 +0.0000000e+00 +0.0000000e+00 +5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
+        1 -1    0    0    0  501 +0.0000000e+00 +0.0000000e+00 -5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
+       11  1    1    2    0    0 +1.0000000e+02 +0.0000000e+00 +0.0e+00 1.0e+02 0.0e+00 0.0e+00 1.0
+      -11  1    1    2    0    0 -1.0000000e+02 +0.0000000e+00 +0.0e+00 9.0e+02 0.0e+00 0.0e+00 1.0
+</event>""" % wgt
+        return lhe_parser.Event(text)
+
+    def test_emitted_weight_is_nominal_times_the_ratio(self):
+        """The value that lands in the <rwgt> block, and the fact that the
+        nominal weight of the event is not modified."""
+        import numpy as np
+        stub = self._Stub(['0', '+'])
+        event = self._event(wgt=3.5)
+        stub._add_polarization_weights(event, {'0': 0.25, '+': 0.5})
+        self.assertEqual(event.wgt, 3.5)
+        wgts = event.parse_reweight()
+        self.assertTrue(np.allclose(wgts['ms_pol_0'], 3.5 * 0.25))
+        self.assertTrue(np.allclose(wgts['ms_pol_+'], 3.5 * 0.5))
+        text = str(event)
+        self.assertIn("<wgt id='ms_pol_0'>", text)
+        self.assertIn("<wgt id='ms_pol_+'>", text)
+        # round trip through the parser
+        again = lhe_parser.Event(text).parse_reweight()
+        self.assertTrue(np.allclose(again['ms_pol_0'], 3.5 * 0.25))
+
+    def test_existing_event_weights_are_preserved(self):
+        import numpy as np
+        stub = self._Stub(['0'])
+        event = self._event(wgt=2.0)
+        event.parse_reweight()['1001'] = 7.0
+        stub._add_polarization_weights(event, {'0': 0.5})
+        wgts = lhe_parser.Event(str(event)).parse_reweight()
+        self.assertTrue(np.allclose(wgts['1001'], 7.0))
+        self.assertTrue(np.allclose(wgts['ms_pol_0'], 1.0))
+
+    def test_weights_are_declared_in_the_banner(self):
+        # a real Banner, not a dict: Banner.get is get_detail and knows about a
+        # handful of card tags only, so 'initrwgt' has to be probed with `in`
+        real = banner.Banner()
+        stub = self._Stub(['0', 'T'], banner=real)
+        real['initrwgt'] = "<weightgroup name='other'>\n</weightgroup>\n"
+        stub._declare_polarization_weights()
+        text = real['initrwgt']
+        self.assertIn("<weightgroup name='madspin_polarization'>", text)
+        self.assertIn("<weight id='ms_pol_0'>", text)
+        self.assertIn("<weight id='ms_pol_T'>", text)
+        self.assertIn("name='other'", text)
+        # idempotent: run_onshell may be re-entered, the block must not double
+        stub._declare_polarization_weights()
+        self.assertEqual(text.count("ms_pol_0"),
+                         real['initrwgt'].count("ms_pol_0"))
+
+    def test_weights_are_declared_without_a_pre_existing_block(self):
+        real = banner.Banner()
+        self.assertNotIn('initrwgt', real)
+        stub = self._Stub(['+'], banner=real)
+        stub._declare_polarization_weights()
+        self.assertIn("<weight id='ms_pol_+'>", real['initrwgt'])
+
+    # ------------------------------------------------------------------
+    # the sum rule
+    # ------------------------------------------------------------------
+    # sum_P w_P = w only when the restricted blocks *partition* the (i,j) terms
+    # that actually contribute. {+}, {-} and {0} keep one diagonal entry each, so
+    # two conditions have to hold at once:
+    #   (a) the contraction must have no off-diagonal (interference) piece --
+    #       the double sum's i != j terms belong to no single-state block;
+    #   (b) exactly one particle may be restricted -- with two, the blocks are
+    #       products (+ +) and (- -) and the mixed (+ -) diagonal entries are in
+    #       neither, so even a diagonal contraction loses them.
+    # Both are tested below, in both directions.
+
+    def test_sum_rule_holds_for_one_diagonal_particle(self):
+        import numpy as np
+        # a vector is partitioned by {+}/{-}/{0}, a fermion by {+}/{-} alone --
+        # its '0' entry is unphysical, hence unrestricted, hence a ratio of 1
+        # that must NOT be counted as a member of the partition
+        for hels, labels in (([self.VECTOR], ['+', '-', '0']),
+                             ([self.FERMION], ['+', '-'])):
+            stub = self._Stub(labels)
+            prod = self._joint(hels, 71)
+            dec = self._joint(hels, 72, diagonal_only=True)
+            ratios = stub._polarization_ratios(prod, dec, self._static(hels))
+            self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5),
+                            '%s -> %s' % (hels, ratios))
+        # and the fermion's '0' really is the whole nominal weight
+        stub = self._Stub(['0'])
+        prod = self._joint([self.FERMION], 71)
+        dec = self._joint([self.FERMION], 72, diagonal_only=True)
+        self.assertEqual(stub._polarization_ratios(
+            prod, dec, self._static([self.FERMION]))['0'], 1.0)
+
+    def test_sum_rule_holds_for_transverse_plus_longitudinal(self):
+        """{T} and {0} are the other complete, non-overlapping decomposition of
+        a vector -- and {T} keeps its own off-diagonal (-1,+1) block, so it is
+        a genuinely different partition of the same nine terms."""
+        import numpy as np
+        stub = self._Stub(['T', '0'])
+        prod = self._joint([self.VECTOR], 81)
+        dec = self._joint([self.VECTOR], 82, diagonal_only=True)
+        ratios = stub._polarization_ratios(prod, dec, self._static([self.VECTOR]))
+        self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5))
+
+    def test_sum_rule_fails_on_the_off_diagonal_terms(self):
+        """Condition (a): with interference in the contraction the single-state
+        blocks cover the diagonal only, so the sum falls short of 1. Pinned so
+        the sum rule is not mistaken for an identity."""
+        import numpy as np
+        stub = self._Stub(['+', '-', '0'])
+        prod = self._joint([self.VECTOR], 91)
+        dec = self._joint([self.VECTOR], 92)     # full, interference included
+        ratios = stub._polarization_ratios(prod, dec, self._static([self.VECTOR]))
+        self.assertFalse(np.allclose(sum(ratios.values()), 1.0, atol=1e-3))
+        # what the sum *does* reproduce is the diagonal part of the double sum
+        full = self._brute_force(dec, prod, None)
+        diag = sum(complex(v) * complex(p)
+                   for v, p, d in zip(dec.values, prod.values, dec._diag_mask)
+                   if d)
+        self.assertTrue(np.allclose(sum(ratios.values()),
+                                    (diag / full).real, atol=1e-5))
+
+    def test_sum_rule_fails_for_two_restricted_particles(self):
+        """Condition (b): the entry restricts *both* particles at once, so the
+        mixed (+,-) and (-,+) diagonal entries belong to no block."""
+        import numpy as np
+        stub = self._Stub(['+', '-'])
+        hels = [self.FERMION, self.FERMION]
+        prod = self._joint(hels, 101)
+        dec = self._joint(hels, 102, diagonal_only=True)
+        ratios = stub._polarization_ratios(prod, dec, self._static(hels))
+        self.assertFalse(np.allclose(sum(ratios.values()), 1.0, atol=1e-3))
+        # ... and it comes back as soon as one of the two is left unrestricted,
+        # which is exactly the t t~ z '0' configuration
+        stub = self._Stub(['+', '-'])
+        static = self._static(hels)
+        static['pol_weight_restrictions'] = [('+', ((1,), None)),
+                                             ('-', ((-1,), None))]
+        ratios = stub._polarization_ratios(prod, dec, static)
+        self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5))
+
+
 class TestSequentialSlots(unittest.TestCase):
     """_decaying_pdgs / _sequential_slots: which density matrix slot belongs to
     which production particle.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -253,13 +253,23 @@ class _FrameStub(object):
     """Just enough of MadSpinInterface for the frame/beampol helpers: they only
     need the options and the matrix-element ordering of the event."""
 
-    def __init__(self, frame_id, beampol):
+    def __init__(self, frame_id, beampol, prodpol=None):
         self.options = interface_madspin.MadSpinOptions()
         self.options['frame_id'] = frame_id
         self.options['beampol'] = list(beampol)
+        # what _production_polarization would have parsed out of the banner's
+        # proc_card: {} for a brace-free production process
+        self._production_polarization_cache = prodpol if prodpol else {}
 
     def get_pdir(self, event):
-        return None, None, None, None
+        # the real one returns (pdir, orig_order, prefix, pos, tag) -- five
+        # values.  _frame_boost used to unpack four, so it raised ValueError the
+        # moment it was reached; keep the arity honest here so the tests can see
+        # that again if it comes back.
+        return None, None, None, None, None
+
+    def _production_polarization(self):
+        return self._production_polarization_cache
 
     _beampol = interface_madspin.MadSpinInterface._beampol
     _frame_boost = interface_madspin.MadSpinInterface._frame_boost
@@ -286,8 +296,8 @@ class TestFrameBoost(unittest.TestCase):
                (300., 100., 50., -80.),
                (400., -100., -50., 380.)]
 
-    def _stub(self, frame_id, beampol=(80., 0.)):
-        return _FrameStub(frame_id, beampol)
+    def _stub(self, frame_id, beampol=(80., 0.), prodpol=None):
+        return _FrameStub(frame_id, beampol, prodpol)
 
     def test_polbeam_to_beampol(self):
         """the card speaks percent, like the run_card polbeam1/polbeam2, and
@@ -334,10 +344,31 @@ class TestFrameBoost(unittest.TestCase):
         self.assertEqual(options.beampol_me(), (1., 1.))
 
     def test_frame_inert_without_polarisation(self):
-        """the frame only changes the axis the initial-state helicities are
-        quantised along, so with unpolarised beams there is nothing to do"""
+        """with unpolarised beams and a brace-free production the contraction is
+        a trace: a boost acts on it as a unitary change of basis and cancels
+        between rho_prod and rho_dec, so there is nothing to do"""
         stub = self._stub(6, beampol=(0., 0.))
         self.assertIsNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
+
+    def test_frame_follows_a_production_polarisation_brace(self):
+        """a brace on the production (`p p > w+{0} w-`) is applied as a
+        *projection* on rho_prod, and a projection does not commute with the
+        change of basis a boost induces -- so the frame has to be honoured even
+        with unpolarised beams, or MadSpin would restrict a different helicity
+        than the one MadEvent generated the events with"""
+        stub = self._stub(6, beampol=(0., 0.), prodpol={24: (0,)})
+        boost = stub._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertIsNotNone(boost)
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (700., 0., 0., 300.))
+
+    def test_frame_boost_unpacks_get_pdir(self):
+        """get_pdir returns five values; unpacking four raised ValueError the
+        first time the frame was actually used (which no unpolarised run ever
+        did, so it went unnoticed)"""
+        stub = self._stub(6)
+        self.assertEqual(len(stub.get_pdir(None)), 5)
+        self.assertIsNotNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
 
     def test_frame_id_bitmask(self):
         """frame_id = sum(2**n over the selected legs), the convention mapid
@@ -1634,6 +1665,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _log_once = interface._log_once
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
+            _production_polarization = staticmethod(lambda: {})
             def __init__(self):
                 self.options = _StubOptions(
                                {'spinmode': 'onshell',
@@ -1832,11 +1864,12 @@ class TestPAUpFrontMass(unittest.TestCase):
             _log_once = interface._log_once
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
+            _production_polarization = staticmethod(lambda: {})
 
             def __init__(self):
-                # unpolarised beams and no me_frame, so _frame_boost short
-                # circuits to None: this class is about the mass stage, and the
-                # frame machinery has its own tests
+                # unpolarised beams and a brace-free production, so _frame_boost
+                # short circuits to None: this class is about the mass stage,
+                # and the frame machinery has its own tests
                 self.options = _StubOptions(
                                {'spinmode': 'PA',
                                 'sequential_spin_order': '2 3 1',

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1118,6 +1118,316 @@ class TestPartialDensityContraction(unittest.TestCase):
         self.assertTrue(np.allclose(with_scalar / without, 1.0))
 
 
+class TestDensityPolarizationRestriction(unittest.TestCase):
+    """Restricting the production/decay density-matrix convolution to the
+    polarisation written on the *production* process.
+
+    W = sum_i sum_j rho_prod(i,j) rho_dec(i,j) becomes a sum over the (i,j)
+    block the braces allow: a single-state brace ({0}, {+}/{R}, {-}/{L}) keeps
+    only the diagonal rho(X,X) term, {T} keeps the -1/+1 block and drops the 0
+    row and column, and no brace leaves the full double sum untouched.
+    """
+
+    FERMION = [1, -1]
+    VECTOR = [-1, 0, 1]
+
+    def _packed(self, hel, seed):
+        """A hermitian density matrix on that basis, in the packed
+        upper-triangular storage the Fortran side hands back."""
+        import numpy as np
+        rng = np.random.default_rng(seed)
+        n = len(hel)
+        arr = (rng.normal(size=n * (n + 1) // 2)
+               + 1j * rng.normal(size=n * (n + 1) // 2)).astype('complex64')
+        for i in range(n):
+            arr[i * (2 * n - i + 1) // 2] = abs(arr[i * (2 * n - i + 1) // 2])
+        return arr
+
+    def _density(self, hel, seed, restriction=None):
+        rho = madspin.DensityMatrix(self._packed(hel, seed), 1, hel, len(hel))
+        if restriction is not None:
+            rho.set_hel_restriction(restriction)
+        return rho
+
+    def _brute_force(self, dec, prod, allowed):
+        """Sum_{(i,j) allowed} rho_dec(i,j) rho_prod(i,j), read off the labels
+        rather than the masks -- an independent implementation of what
+        scalar_multiplication must produce."""
+        import numpy as np
+        table = {tuple(int(x) for x in lab): val
+                 for lab, val in zip(prod.helicities, prod.values)}
+        total = 0j
+        for lab, val in zip(dec.helicities, dec.values):
+            lab = tuple(int(x) for x in lab)
+            keep = True
+            for k, ok in enumerate(allowed):
+                if ok is None:
+                    continue
+                if lab[2 * k] not in ok or lab[2 * k + 1] not in ok:
+                    keep = False
+                    break
+            if keep:
+                total += complex(val) * complex(table[lab])
+        return total
+
+    # -- no braces: nothing may move ---------------------------------------
+
+    def test_no_braces_leaves_the_full_double_sum(self):
+        """The behaviour-neutrality requirement: an absent or empty restriction
+        must not touch a single value."""
+        import numpy as np
+        for hel in (self.FERMION, self.VECTOR):
+            prod = self._density(hel, seed=1)
+            dec = self._density(hel, seed=2)
+            reference = dec.scalar_multiplication(prod)
+            for empty in (None, [None], [()], [[]]):
+                other = self._density(hel, seed=1, restriction=empty)
+                self.assertIsNone(other.hel_restriction)
+                self.assertTrue(np.allclose(dec.scalar_multiplication(other),
+                                            reference))
+            self.assertTrue(np.allclose(prod.trace(), self._brute_force(
+                prod, madspin.DensityMatrix.identity(1, hel, len(hel)),
+                [None]) * len(hel)))
+
+    # -- single state -------------------------------------------------------
+
+    def test_single_state_keeps_only_the_diagonal_term(self):
+        """{0}, {+}/{R}, {-}/{L}: one helicity X survives, so the double sum
+        collapses onto rho_prod(X,X) rho_dec(X,X)."""
+        import numpy as np
+        cases = [(self.VECTOR, 0), (self.FERMION, 1), (self.FERMION, -1),
+                 (self.VECTOR, 1), (self.VECTOR, -1)]
+        for hel, x in cases:
+            prod = self._density(hel, seed=11, restriction=[(x,)])
+            dec = self._density(hel, seed=12)
+            got = dec.scalar_multiplication(prod)
+            # rho(X,X) rho(X,X): pick the two entries by label
+            pi = {tuple(int(v) for v in l): c
+                  for l, c in zip(prod.helicities, prod.values)}[(x, x)]
+            di = {tuple(int(v) for v in l): c
+                  for l, c in zip(dec.helicities, dec.values)}[(x, x)]
+            self.assertTrue(np.allclose(got, complex(di) * complex(pi)))
+            self.assertTrue(np.allclose(got, self._brute_force(dec, prod, [(x,)])))
+
+    def test_transverse_drops_the_zero_row_and_column(self):
+        """{T} = [-1,1]: the double sum survives but neither index may be 0."""
+        import numpy as np
+        prod = self._density(self.VECTOR, seed=21, restriction=[(-1, 1)])
+        dec = self._density(self.VECTOR, seed=22)
+        got = dec.scalar_multiplication(prod)
+        self.assertTrue(np.allclose(got,
+                                    self._brute_force(dec, prod, [(-1, 1)])))
+        # strictly between the single-state and the unrestricted answers: four
+        # terms out of nine, and the off-diagonal (-1,1)/(1,-1) pair kept
+        mask = prod._restriction_row_mask(prod.hel_restriction)
+        self.assertEqual(int(mask.sum()), 4)
+        kept = set(tuple(int(v) for v in l)
+                   for l, m in zip(prod.helicities, mask) if m)
+        self.assertEqual(kept, {(-1, -1), (-1, 1), (1, -1), (1, 1)})
+
+    # -- several decaying particles ----------------------------------------
+
+    def test_multi_particle_mask_is_a_per_index_product(self):
+        """t{0} t~{T}-like: the restriction is per decaying particle and the
+        masks combine multiplicatively over the tensor-product structure."""
+        import numpy as np
+        import itertools
+        hels = [self.VECTOR, self.VECTOR]
+        dim = len(hels[0]) * len(hels[1])
+        allowed_hel = [h for combo in itertools.product(*hels) for h in combo]
+        prod = madspin.DensityMatrix(self._packed(list(range(dim)), 31),
+                                     2, allowed_hel, dim)
+        dec = self._density(hels[0], 32).tensor_product(
+              self._density(hels[1], 33))
+
+        for restriction in ([(0,), (-1, 1)], [None, (0,)], [(1,), None],
+                            [(-1, 1), (-1, 1)]):
+            prod.set_hel_restriction(restriction)
+            got = dec.scalar_multiplication(prod)
+            self.assertTrue(np.allclose(
+                got, self._brute_force(dec, prod, restriction)))
+
+        # 1 (the single (0,0) pair) x 4 (the transverse block) of 9 x 9 entries
+        prod.set_hel_restriction([(0,), (-1, 1)])
+        mask = prod._restriction_row_mask(prod.hel_restriction)
+        self.assertEqual(int(mask.sum()), 4)
+        self.assertEqual(len(mask), 81)
+
+    def test_restriction_survives_the_tensor_product(self):
+        """A restricted index keeps its restriction when the matrix is tensored
+        with an unrestricted one -- the per-index masks simply concatenate."""
+        left = self._density(self.FERMION, 41, restriction=[(1,)])
+        right = self._density(self.VECTOR, 42)
+        self.assertEqual(left.tensor_product(right).hel_restriction,
+                         ((1,), None))
+        self.assertEqual(right.tensor_product(left).hel_restriction,
+                         (None, (1,)))
+
+    # -- normalisation ------------------------------------------------------
+
+    def test_trace_follows_the_restriction(self):
+        """Tr rho normalises the convolution, so it has to be restricted too:
+        it is the polarised production cross-section the events were generated
+        with. Getting this wrong would make the accept/reject weight stop
+        averaging to 1/n."""
+        import numpy as np
+        hel = self.VECTOR
+        arr = self._packed(hel, 51)
+        full = madspin.DensityMatrix(arr, 1, hel, 3)
+        diag = [complex(arr[i * (2 * 3 - i + 1) // 2]) for i in range(3)]
+        self.assertTrue(np.allclose(full.trace(), sum(diag)))
+        # labels are ordered as hel: [-1, 0, 1]
+        for x, expected in zip(hel, diag):
+            rho = madspin.DensityMatrix(arr, 1, hel, 3).set_hel_restriction([(x,)])
+            self.assertTrue(np.allclose(rho.trace(), expected))
+        transverse = madspin.DensityMatrix(arr, 1, hel, 3)
+        transverse.set_hel_restriction([(-1, 1)])
+        self.assertTrue(np.allclose(transverse.trace(), diag[0] + diag[2]))
+
+    def test_identity_contraction_still_gives_the_restricted_trace(self):
+        """<rho, I/n> restricted = (restricted Tr rho)/n, so a slot whose decay
+        has not been drawn yet contributes the same 1/n it always did and the
+        sequential accept/reject normalisation is untouched."""
+        import numpy as np
+        for hel in (self.FERMION, self.VECTOR):
+            for allowed in ([(hel[0],)], [tuple(hel[:2])]):
+                rho = self._density(hel, 61, restriction=allowed)
+                I = madspin.DensityMatrix.identity(1, hel, len(hel))
+                self.assertTrue(np.allclose(I.scalar_multiplication(rho),
+                                            rho.trace() / len(hel)))
+
+    def test_mask_is_cached_per_basis(self):
+        """Recomputed once per (basis, restriction), never per event."""
+        hel = self.VECTOR
+        a = self._density(hel, 71, restriction=[(0,)])
+        b = self._density(hel, 72, restriction=[(0,)])
+        self.assertIs(a._restriction_row_mask(a.hel_restriction),
+                      b._restriction_row_mask(b.hel_restriction))
+        self.assertIsNot(a._restriction_row_mask(a.hel_restriction),
+                         a._restriction_row_mask(((-1, 1),)))
+
+    def test_contradicting_restrictions_are_refused(self):
+        hel = self.FERMION
+        a = self._density(hel, 81, restriction=[(1,)])
+        b = self._density(hel, 82, restriction=[(-1,)])
+        self.assertRaises(ValueError, a.scalar_multiplication, b)
+
+    def test_sequential_contraction_sees_the_restriction(self):
+        """_partial_density_contraction contracts through the production matrix,
+        so attaching the restriction there is enough for the sequential
+        accept/reject -- no call site has to pass it along."""
+        import numpy as np
+        import itertools
+        hels = [self.FERMION, self.VECTOR]
+        dim = len(hels[0]) * len(hels[1])
+        allowed_hel = [h for combo in itertools.product(*hels) for h in combo]
+        rho = madspin.DensityMatrix(self._packed(list(range(dim)), 91),
+                                    2, allowed_hel, dim)
+        rho.set_hel_restriction([(1,), (0,)])
+        stub = TestPartialDensityContraction._Stub()
+        got = stub._partial_density_contraction(rho, hels, {})
+        # every slot is I/n, so this is the restricted trace over prod n_i
+        self.assertTrue(np.allclose(got, rho.trace() / dim))
+
+
+class TestProductionPolarizationPlumbing(unittest.TestCase):
+    """Reading the production polarisation and turning it into the basis /
+    restriction the density matrices are built with."""
+
+    class _Stub(object):
+        """Just enough MadSpinInterface for the polarisation helpers."""
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+
+        def __init__(self, pol_map=None, spinmode='madspin'):
+            self._pol = pol_map or {}
+            self.options = {'spinmode': spinmode}
+            self.list_branches = {}
+
+        def _production_polarization(self):
+            return self._pol
+
+        _density_spinmode = interface_madspin.MadSpinInterface._density_spinmode
+        _apply_production_polarization = \
+            interface_madspin.MadSpinInterface._apply_production_polarization
+        do_decay = interface_madspin.MadSpinInterface.do_decay
+
+    HEL = {1: [0], 2: [1, -1], 3: [-1, 0, 1]}
+
+    def test_no_braces_leaves_the_basis_untouched(self):
+        """Nothing may move for an unpolarised production process."""
+        stub = self._Stub()
+        hels = [self.HEL[2], self.HEL[3]]
+        got, restriction = stub._apply_production_polarization([6, 24], hels)
+        self.assertEqual(got, hels)
+        self.assertIsNone(restriction)
+
+    def test_single_state_puts_its_helicity_first(self):
+        """GET_DENSITY matches the process NHEL table against the *first*
+        ALLOW_HEL combination, and a polarised process has no NHEL row outside
+        its polarisation -- so the allowed helicity has to lead, or the whole
+        production density matrix comes back zero."""
+        stub = self._Stub({24: (0,)})
+        got, restriction = stub._apply_production_polarization(
+                                        [24], [list(self.HEL[3])])
+        self.assertEqual(got, [[0, -1, 1]])
+        self.assertEqual(restriction, ((0,),))
+
+        stub = self._Stub({6: (-1,)})
+        got, restriction = stub._apply_production_polarization(
+                                        [6], [list(self.HEL[2])])
+        self.assertEqual(got, [[-1, 1]])
+        self.assertEqual(restriction, ((-1,),))
+
+    def test_transverse_keeps_two_states_and_drops_zero_from_the_front(self):
+        stub = self._Stub({24: (-1, 1)})
+        got, restriction = stub._apply_production_polarization(
+                                        [24], [list(self.HEL[3])])
+        self.assertEqual(got, [[-1, 1, 0]])
+        self.assertEqual(restriction, ((-1, 1),))
+
+    def test_restriction_is_per_particle(self):
+        """t{0} t~{T}: slot 1 collapses onto its diagonal 0 entry, slot 2 keeps
+        the -1/+1 block, and an unpolarised third particle keeps everything."""
+        stub = self._Stub({24: (0,), -24: (-1, 1)})
+        got, restriction = stub._apply_production_polarization(
+                    [24, -24, 6], [list(self.HEL[3]), list(self.HEL[3]),
+                                   list(self.HEL[2])])
+        self.assertEqual(got, [[0, -1, 1], [-1, 1, 0], [1, -1]])
+        self.assertEqual(restriction, ((0,), (-1, 1), None))
+
+    def test_unsupported_polarization_is_refused(self):
+        """{A}, {G}, ... have no place in the -1/0/+1 helicity basis the density
+        matrices are built on."""
+        stub = self._Stub({24: (99,)})
+        self.assertRaises(stub.InvalidCmd,
+                          stub._apply_production_polarization,
+                          [24], [list(self.HEL[3])])
+        # a longitudinal brace on a fermion cannot be honoured either
+        stub = self._Stub({6: (0,)})
+        self.assertRaises(stub.InvalidCmd,
+                          stub._apply_production_polarization,
+                          [6], [list(self.HEL[2])])
+
+    def test_decay_side_polarization_is_an_explicit_error(self):
+        """Polarisation on a 'decay' line is not what the density modes
+        contract, so it must fail loudly rather than be silently ignored."""
+        for spinmode in ('madspin', 'full', 'PA', 'onshell'):
+            stub = self._Stub(spinmode=spinmode)
+            try:
+                stub.do_decay('t > w+{0} b')
+            except stub.InvalidCmd as error:
+                self.assertIn('not supported', str(error))
+                self.assertIn(spinmode, str(error))
+            else:
+                self.fail('decay-side polarization accepted for %s' % spinmode)
+
+    def test_density_spinmode_detection(self):
+        for mode in ('madspin', 'full', 'PA', 'onshell'):
+            self.assertTrue(self._Stub(spinmode=mode)._density_spinmode())
+        for mode in ('none', 'madspin_v1', 'onshell_v1'):
+            self.assertFalse(self._Stub(spinmode=mode)._density_spinmode())
+
+
 class TestSequentialSlots(unittest.TestCase):
     """_decaying_pdgs / _sequential_slots: which density matrix slot belongs to
     which production particle.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1605,39 +1605,55 @@ class TestSamePdgProductionPolarization(unittest.TestCase):
 
 
 class TestKeepWeightForPolarization(unittest.TestCase):
-    """keep_weight_for_polarization: one extra LHEF v3 weight per requested
-    polarisation, equal to nominal * (restricted convolution)/(full convolution).
+    """keep_weight_for_polarization_vector / _fermion: one extra LHEF v3 weight
+    per polarisation COMBINATION -- one per element of the cartesian product
+    over the decaying particles, each drawing from the list of its own species --
+    equal to nominal * (restricted convolution)/(full convolution).
 
     The restriction machinery itself is PR #349's; what is tested here is the
-    vector that is built out of a *card* entry -- one entry applied to every
-    decaying particle, silently skipped where it is unphysical -- and the fact
-    that the nominal weight never moves.
+    product built out of the *card*, the id that names it slot by slot, and the
+    fact that the nominal weight never moves.
     """
 
     MI = interface_madspin.MadSpinInterface
 
-    FERMION = [1, -1]       # pdg 6
-    VECTOR = [-1, 0, 1]     # pdg 23
+    FERMION = [1, -1]       # pdg 6,  spin 2
+    VECTOR = [-1, 0, 1]     # pdg 23, spin 3
+    SCALAR = [0]            # pdg 25, spin 1
 
     class _Stub(object):
         """Just enough MadSpinInterface for the polarisation-weight helpers."""
         InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        POLARIZATION_SPECIES = \
+            interface_madspin.MadSpinInterface.POLARIZATION_SPECIES
+        POLARIZATION_COMBINATION_WARN = \
+            interface_madspin.MadSpinInterface.POLARIZATION_COMBINATION_WARN
         _polarization_weight_labels = \
             interface_madspin.MadSpinInterface._polarization_weight_labels
+        _polarization_weights_enabled = \
+            interface_madspin.MadSpinInterface._polarization_weights_enabled
         _polarization_weight_id = staticmethod(
             interface_madspin.MadSpinInterface._polarization_weight_id)
-        _polarization_restrictions = \
-            interface_madspin.MadSpinInterface._polarization_restrictions
+        _polarization_slot_choices = \
+            interface_madspin.MadSpinInterface._polarization_slot_choices
+        _polarization_combinations = \
+            interface_madspin.MadSpinInterface._polarization_combinations
         _polarization_ratios = \
             interface_madspin.MadSpinInterface._polarization_ratios
+        _polarization_slot_layout = staticmethod(
+            interface_madspin.MadSpinInterface._polarization_slot_layout)
+        _polarization_particle_name = \
+            interface_madspin.MadSpinInterface._polarization_particle_name
         _declare_polarization_weights = \
             interface_madspin.MadSpinInterface._declare_polarization_weights
         _add_polarization_weights = \
             interface_madspin.MadSpinInterface._add_polarization_weights
         _slot_identity = interface_madspin.MadSpinInterface._slot_identity
 
-        def __init__(self, pols=(), banner=None):
-            self.options = {'keep_weight_for_polarization': list(pols)}
+        def __init__(self, vector=(), fermion=(), banner=None):
+            self.options = {
+                'keep_weight_for_polarization_vector': list(vector),
+                'keep_weight_for_polarization_fermion': list(fermion)}
             self.banner = {} if banner is None else banner
 
     # ------------------------------------------------------------------
@@ -1691,30 +1707,45 @@ class TestKeepWeightForPolarization(unittest.TestCase):
                 total += complex(val) * complex(table[lab])
         return total
 
-    def _static(self, helicities, base=None):
+    #: helicity basis and MG5 spin of the pdgs used below
+    BY_PDG = {6: ([1, -1], 2), -6: ([1, -1], 2),
+              23: ([-1, 0, 1], 3), 24: ([-1, 0, 1], 3),
+              25: ([0], 1)}
+
+    def _static(self, pdgs, base=None, helicities=None):
+        """A ``prod_static`` stub for a slot layout given by its pdgs."""
+        if helicities is None:
+            helicities = [list(self.BY_PDG[p][0]) for p in pdgs]
         return {'helicities': [list(h) for h in helicities],
-                'hel_restriction': base}
+                'hel_restriction': base,
+                'decaying_pdg': list(pdgs),
+                'decaying_spins': [self.BY_PDG[p][1] for p in pdgs]}
 
     # ------------------------------------------------------------------
     # the option itself
     # ------------------------------------------------------------------
 
     def test_default_is_empty_and_changes_nothing(self):
-        """The behaviour-neutrality requirement: an unset option must not add a
+        """The behaviour-neutrality requirement: unset options must not add a
         weight, must not touch the banner, and must not even build a mask."""
         options = interface_madspin.MadSpinOptions()
+        self.assertEqual(options['keep_weight_for_polarization_vector'], [])
+        self.assertEqual(options['keep_weight_for_polarization_fermion'], [])
         self.assertEqual(options['keep_weight_for_polarization'], [])
 
         stub = self._Stub()
-        self.assertEqual(stub._polarization_weight_labels(), [])
+        self.assertFalse(stub._polarization_weights_enabled())
+        self.assertEqual(stub._polarization_weight_labels('vector'), [])
+        self.assertEqual(stub._polarization_weight_labels('fermion'), [])
         stub._declare_polarization_weights()
         self.assertEqual(stub.banner, {})
 
         prod = self._joint([self.VECTOR], 11)
         dec = self._joint([self.VECTOR], 12)
-        static = self._static([self.VECTOR])
+        static = self._static([23])
         self.assertIsNone(stub._polarization_ratios(prod, dec, static))
-        self.assertNotIn('pol_weight_restrictions', static)
+        self.assertNotIn('pol_weight_combinations', static)
+        self.assertEqual(stub._polarization_combinations(static), [])
 
         event = self._event()
         before = str(event)
@@ -1725,22 +1756,81 @@ class TestKeepWeightForPolarization(unittest.TestCase):
 
     def test_card_accepts_the_documented_spellings(self):
         options = interface_madspin.MadSpinOptions()
-        options['keep_weight_for_polarization'] = '[0, T, +, -]'
-        self.assertEqual(options['keep_weight_for_polarization'],
+        options['keep_weight_for_polarization_vector'] = '[0, T, +, -]'
+        self.assertEqual(options['keep_weight_for_polarization_vector'],
                          ['0', 'T', '+', '-'])
         # L/R alias -/+ exactly as MG5's braces do, and the canonical spelling
         # is what is stored (so the weight ids do not depend on the typing)
-        options['keep_weight_for_polarization'] = 'L R t'
-        self.assertEqual(options['keep_weight_for_polarization'],
+        options['keep_weight_for_polarization_fermion'] = 'L R t'
+        self.assertEqual(options['keep_weight_for_polarization_fermion'],
                          ['-', '+', 'T'])
         # duplicates collapse rather than emitting the same weight twice
-        options['keep_weight_for_polarization'] = '[+, R, +]'
-        self.assertEqual(options['keep_weight_for_polarization'], ['+'])
+        options['keep_weight_for_polarization_fermion'] = '[+, R, +]'
+        self.assertEqual(options['keep_weight_for_polarization_fermion'], ['+'])
 
     def test_card_refuses_a_non_polarisation(self):
         options = interface_madspin.MadSpinOptions()
         self.assertRaises(banner.InvalidCmd, options.__setitem__,
+                          'keep_weight_for_polarization_vector', '[0, A]')
+        self.assertRaises(banner.InvalidCmd, options.__setitem__,
+                          'keep_weight_for_polarization_fermion', '[+, A]')
+        self.assertRaises(banner.InvalidCmd, options.__setitem__,
                           'keep_weight_for_polarization', '[0, A]')
+
+    def test_needs_frame_axis_covers_the_three_projections(self):
+        """A helicity *projection* does not commute with a boost, so it only
+        means what the user asked for on MG5's quantisation axis (frame_id). The
+        polarisation weights are the same projection as a production brace, so
+        the predicate _frame_boost's guard has to become must be true for them
+        too -- see _needs_frame_axis' note about wiring it to PR #355."""
+        class Frame(self._Stub):
+            _needs_frame_axis = \
+                interface_madspin.MadSpinInterface._needs_frame_axis
+
+            def __init__(self, beampol=None, braces=None, **kwargs):
+                super(Frame, self).__init__(**kwargs)
+                self._beam = beampol
+                self._braces = braces or {}
+
+            def _beampol(self):
+                return self._beam
+
+            def _production_polarization(self):
+                return self._braces
+
+        # nothing projected: the contraction is a trace and the lab will do
+        self.assertFalse(Frame()._needs_frame_axis())
+        # ... each of the three clauses on its own
+        self.assertTrue(Frame(beampol=(2.0, 1.0))._needs_frame_axis())
+        self.assertTrue(Frame(braces={23: ((0,),)})._needs_frame_axis())
+        self.assertTrue(Frame(vector=['0'])._needs_frame_axis())
+        self.assertTrue(Frame(fermion=['+'])._needs_frame_axis())
+
+    def test_the_two_species_lists_are_independent(self):
+        options = interface_madspin.MadSpinOptions()
+        options['keep_weight_for_polarization_vector'] = '[0, T]'
+        self.assertEqual(options['keep_weight_for_polarization_fermion'], [])
+        options['keep_weight_for_polarization_fermion'] = '[+, -]'
+        self.assertEqual(options['keep_weight_for_polarization_vector'],
+                         ['0', 'T'])
+
+    def test_deprecated_option_sets_both_lists(self):
+        """The old spelling is accepted, canonicalised and mapped onto both
+        species -- the name has been in a released PR, and silently ignoring it
+        would change the output of an existing card without saying so."""
+        options = interface_madspin.MadSpinOptions()
+        options['keep_weight_for_polarization'] = '[0, R, -]'
+        self.assertEqual(options['keep_weight_for_polarization_vector'],
+                         ['0', '+', '-'])
+        self.assertEqual(options['keep_weight_for_polarization_fermion'],
+                         ['0', '+', '-'])
+        # ... and the '0' it puts on the fermions is dropped when the
+        # combinations are built, so the alias does not emit a duplicate column
+        stub = self._Stub(vector=['0', '+', '-'], fermion=['0', '+', '-'])
+        self.assertEqual(
+            [wid for wid, _ in stub._polarization_combinations(
+                self._static([6]))],
+            ['ms_pol_6:+', 'ms_pol_6:-'])
 
     def test_label_parsing(self):
         parse = interface_madspin.parse_polarization_label
@@ -1755,105 +1845,183 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         self.assertIsNone(parse(''))
 
     # ------------------------------------------------------------------
-    # the restriction vector built from one card entry
+    # the product of the per-particle combinations
     # ------------------------------------------------------------------
 
-    def test_unphysical_states_are_skipped_per_particle(self):
-        """p p > t t~ z with [0, T, +, -]: the same entry goes to every decaying
-        particle, and the ones it is unphysical for stay *unrestricted* rather
-        than making the whole weight zero -- which is what makes '0' mean 'the
-        longitudinal fraction of the Z' on this process."""
-        stub = self._Stub(['0', 'T', '+', '-'])
-        static = self._static([self.FERMION, self.FERMION, self.VECTOR])
-        got = dict(stub._polarization_restrictions(static))
-        self.assertEqual(got['0'], (None, None, (0,)))
-        self.assertEqual(got['T'], ((-1, 1), (-1, 1), (-1, 1)))
-        self.assertEqual(got['+'], ((1,), (1,), (1,)))
-        self.assertEqual(got['-'], ((-1,), (-1,), (-1,)))
+    def test_ttz_is_the_full_two_by_two_by_four_product(self):
+        """The headline case: 'p p > t t~ z' with the vector list [0, T, +, -]
+        and the fermion list [+, -] is 2*2*4 = 16 weights, not 4."""
+        stub = self._Stub(vector=['0', 'T', '+', '-'], fermion=['+', '-'])
+        combos = stub._polarization_combinations(self._static([6, -6, 23]))
+        self.assertEqual(len(combos), 16)
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_6:%s_-6:%s_23:%s' % (t, tb, z)
+                          for t in '+-' for tb in '+-' for z in ['0', 'T', '+', '-']])
+        # every slot really carries its own restriction
+        got = dict(combos)
+        self.assertEqual(got['ms_pol_6:+_-6:-_23:0'], ((1,), (-1,), (0,)))
+        self.assertEqual(got['ms_pol_6:-_-6:-_23:T'], ((-1,), (-1,), (-1, 1)))
 
-    def test_a_polarisation_unphysical_everywhere_is_the_nominal_weight(self):
-        """The corollary of 'skip the particle, do not drop the event': on
-        p p > t t~ the entry '0' restricts nothing, so its weight is the nominal
-        one (ratio exactly 1) rather than 0."""
-        stub = self._Stub(['0'])
-        static = self._static([self.FERMION, self.FERMION])
-        self.assertEqual(dict(stub._polarization_restrictions(static))['0'],
-                         None)
-        prod = self._joint([self.FERMION, self.FERMION], 21)
-        dec = self._joint([self.FERMION, self.FERMION], 22)
-        self.assertEqual(stub._polarization_ratios(prod, dec, static)['0'], 1.0)
+    def test_the_product_is_deterministic_and_slot_ordered(self):
+        """The ids must be reproducible run to run: the slot order is the
+        density basis one and the label order is the one the card lists, with
+        the LAST slot varying fastest (itertools.product)."""
+        first = self._Stub(vector=['T', '0'], fermion=['-', '+'])
+        second = self._Stub(vector=['T', '0'], fermion=['-', '+'])
+        a = [wid for wid, _ in first._polarization_combinations(
+            self._static([6, 23]))]
+        b = [wid for wid, _ in second._polarization_combinations(
+            self._static([6, 23]))]
+        self.assertEqual(a, b)
+        self.assertEqual(a, ['ms_pol_6:-_23:T', 'ms_pol_6:-_23:0',
+                             'ms_pol_6:+_23:T', 'ms_pol_6:+_23:0'])
 
-    def test_restrictions_are_cached_on_the_production_static(self):
-        stub = self._Stub(['T'])
-        static = self._static([self.VECTOR])
-        first = stub._polarization_restrictions(static)
-        self.assertIs(first, stub._polarization_restrictions(static))
-        self.assertIs(first, static['pol_weight_restrictions'])
+    def test_the_id_names_every_slot_including_same_pdg_ones(self):
+        """The id has one token per slot, in slot order, so two Zs are told
+        apart by position -- which is what 'ms_pol_X' could not do."""
+        stub = self._Stub(vector=['0', 'T'])
+        combos = stub._polarization_combinations(self._static([23, 23]))
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_23:0_23:0', 'ms_pol_23:0_23:T',
+                          'ms_pol_23:T_23:0', 'ms_pol_23:T_23:T'])
+        self.assertEqual(dict(combos)['ms_pol_23:0_23:T'], ((0,), (-1, 1)))
+        # and the id builder itself, on its own
+        self.assertEqual(
+            self.MI._polarization_weight_id([(6, '+'), (-6, None), (23, '0')]),
+            'ms_pol_6:+_-6:*_23:0')
+
+    def test_a_species_with_an_empty_list_does_not_multiply_the_count(self):
+        """Only the vector list set: the tops stay summed over, contribute a
+        single '*' entry each, and the product is the Z's four choices."""
+        stub = self._Stub(vector=['0', 'T', '+', '-'])
+        combos = stub._polarization_combinations(self._static([6, -6, 23]))
+        self.assertEqual(len(combos), 4)
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_6:*_-6:*_23:%s' % z
+                          for z in ['0', 'T', '+', '-']])
+        self.assertEqual(dict(combos)['ms_pol_6:*_-6:*_23:0'],
+                         (None, None, (0,)))
+        # the mirror case
+        stub = self._Stub(fermion=['+', '-'])
+        combos = stub._polarization_combinations(self._static([6, -6, 23]))
+        self.assertEqual(len(combos), 4)
+        self.assertEqual(combos[0][0], 'ms_pol_6:+_-6:+_23:*')
+
+    def test_a_scalar_slot_contributes_one_unrestricted_entry(self):
+        """A spin-0 particle has a 1x1 density matrix and no polarisation: its
+        slot is a single '*' rather than a factor in the product."""
+        stub = self._Stub(vector=['0', 'T'], fermion=['+', '-'])
+        combos = stub._polarization_combinations(self._static([25, 23]))
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_25:*_23:0', 'ms_pol_25:*_23:T'])
+        self.assertEqual(dict(combos)['ms_pol_25:*_23:0'], (None, (0,)))
+        # a scalar has no choices of its own, so a process of scalars only asks
+        # for nothing at all -- rather than one weight equal to the nominal
+        self.assertEqual(stub._polarization_combinations(self._static([25])), [])
+        self.assertEqual(stub._polarization_combinations(
+            self._static([25, 25])), [])
+
+    def test_unphysical_labels_are_dropped_from_a_slot(self):
+        """'0' is not a fermion helicity: it is dropped from the top's choices
+        instead of being kept as an unrestricted duplicate of another weight.
+        A slot left with nothing falls back to a single '*' entry."""
+        stub = self._Stub(fermion=['0', '+', '-'])
+        combos = stub._polarization_combinations(self._static([6]))
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_6:+', 'ms_pol_6:-'])
+        # every label unphysical -> the slot is summed over, and since no slot
+        # then carries a label there is nothing to emit
+        stub = self._Stub(fermion=['0'])
+        self.assertEqual(stub._polarization_slot_choices(self._static([6])),
+                         [[(None, None)]])
+        self.assertEqual(stub._polarization_combinations(self._static([6])), [])
+        # ... but a *second* slot that does have choices keeps the '*' company
+        stub = self._Stub(fermion=['0'], vector=['0', 'T'])
+        self.assertEqual(
+            [wid for wid, _ in stub._polarization_combinations(
+                self._static([6, 23]))],
+            ['ms_pol_6:*_23:0', 'ms_pol_6:*_23:T'])
+
+    def test_duplicate_slot_restrictions_collapse(self):
+        """Two labels that end up selecting the same helicities on one slot (a
+        {+} production leg offered both 'T' and '+') must not produce two
+        identical columns."""
+        stub = self._Stub(vector=['T', '+', '0'])
+        static = self._static([23], base=((1,),))
+        self.assertEqual([wid for wid, _ in
+                          stub._polarization_combinations(static)],
+                         ['ms_pol_23:T'])
+
+    def test_combinations_are_cached_on_the_production_static(self):
+        stub = self._Stub(vector=['T'])
+        static = self._static([23])
+        first = stub._polarization_combinations(static)
+        self.assertIs(first, stub._polarization_combinations(static))
+        self.assertIs(first, static['pol_weight_combinations'])
+
+    def test_slot_species_can_be_inferred_without_the_spins(self):
+        """``prod_static`` from an older pickle may not carry decaying_spins;
+        the basis length is enough to tell the three spins apart."""
+        stub = self._Stub(vector=['0'], fermion=['+'])
+        static = self._static([6, 23])
+        del static['decaying_spins']
+        self.assertEqual([wid for wid, _ in
+                          stub._polarization_combinations(static)],
+                         ['ms_pol_6:+_23:0'])
 
     # ------------------------------------------------------------------
-    # interaction with the production polarisation (PR #349)
+    # interaction with the production polarisation (PR #349 / #353)
     # ------------------------------------------------------------------
 
-    def test_production_braces_are_intersected(self):
+    def test_production_braces_are_intersected_per_slot(self):
         """p p > t{+} t~ z: the nominal convolution is already restricted to a
-        right-handed top, so the polarisation weights are fractions *of that*
-        sample -- '+' keeps it, '0' leaves the (already restricted) top alone
-        and cuts the Z, and '-' is impossible and gets a zero weight."""
-        stub = self._Stub(['+', '-', '0', 'T'])
-        static = self._static([self.FERMION, self.VECTOR],
-                              base=((1,), None))
-        got = dict(stub._polarization_restrictions(static))
-        self.assertEqual(got['+'], ((1,), (1,)))
-        self.assertEqual(got['0'], ((1,), (0,)))
-        self.assertEqual(got['T'], ((1,), (-1, 1)))
-        self.assertIs(got['-'], False)
+        right-handed top, so the top slot keeps only the choices compatible with
+        it and the other slots are unaffected."""
+        stub = self._Stub(vector=['0', 'T', '+', '-'], fermion=['+', '-'])
+        static = self._static([6, -6, 23], base=((1,), None, None))
+        combos = stub._polarization_combinations(static)
+        # the top has one surviving choice, the anti-top two, the Z four
+        self.assertEqual(len(combos), 1 * 2 * 4)
+        self.assertTrue(all(wid.startswith('ms_pol_6:+_') for wid, _ in combos))
+        self.assertEqual(dict(combos)['ms_pol_6:+_-6:-_23:0'],
+                         ((1,), (-1,), (0,)))
 
     def test_same_pdg_mixed_production_braces_are_intersected_per_slot(self):
-        """p p > w+{0} w+{T}: the two slots carry *different* production
-        restrictions, and keep_weight_for_polarization has to intersect with
-        each of them separately -- '0' survives on slot 0 only, 'T' on slot 1
-        only, and each keeps the other slot at its production value. Only a
-        polarisation impossible for *every* slot gives a zero weight."""
-        stub = self._Stub(['0', 'T', '+', '-'])
-        static = self._static([self.VECTOR, self.VECTOR],
-                              base=((0,), (-1, 1)))
-        got = dict(stub._polarization_restrictions(static))
-        # '0': slot 0 already longitudinal, slot 1 has no 0 left -> impossible
-        self.assertIs(got['0'], False)
-        # 'T': slot 0 has no transverse state left -> impossible
-        self.assertIs(got['T'], False)
-        # '+' / '-' are impossible on the longitudinal slot too
-        self.assertIs(got['+'], False)
-        self.assertIs(got['-'], False)
-
-        # with an *unbraced* second W the picture is the interesting one: the
-        # restriction is honoured slot by slot
-        static = self._static([self.VECTOR, self.VECTOR], base=((0,), None))
-        got = dict(stub._polarization_restrictions(static))
-        self.assertEqual(got['0'], ((0,), (0,)))
-        self.assertIs(got['T'], False)
-        self.assertIs(got['+'], False)
-
-    def test_an_impossible_polarisation_weighs_zero(self):
-        stub = self._Stub(['-'])
-        static = self._static([self.FERMION], base=((1,),))
-        prod = self._joint([self.FERMION], 31)
-        prod.set_hel_restriction(((1,),))
-        dec = self._joint([self.FERMION], 32)
-        self.assertEqual(stub._polarization_ratios(prod, dec, static)['-'], 0.0)
+        """p p > z{0} z{T} (#353): the two slots carry *different* production
+        restrictions. One label applied to both slots at once was empty on
+        every choice -- all four weights came back exactly 0. The product form
+        keeps the three assignments that are compatible slot by slot."""
+        stub = self._Stub(vector=['0', 'T', '+', '-'])
+        static = self._static([23, 23], base=((0,), (-1, 1)),
+                              helicities=[[0, -1, 1], [-1, 1, 0]])
+        combos = stub._polarization_combinations(static)
+        self.assertEqual([wid for wid, _ in combos],
+                         ['ms_pol_23:0_23:T', 'ms_pol_23:0_23:+',
+                          'ms_pol_23:0_23:-'])
+        got = dict(combos)
+        self.assertEqual(got['ms_pol_23:0_23:T'], ((0,), (-1, 1)))
+        self.assertEqual(got['ms_pol_23:0_23:+'], ((0,), (1,)))
+        self.assertEqual(got['ms_pol_23:0_23:-'], ((0,), (-1,)))
+        # with an unbraced second Z the first one is still pinned
+        static = self._static([23, 23], base=((0,), None),
+                              helicities=[[0, -1, 1], [-1, 0, 1]])
+        self.assertEqual([wid for wid, _ in
+                          stub._polarization_combinations(static)],
+                         ['ms_pol_23:0_23:0', 'ms_pol_23:0_23:T',
+                          'ms_pol_23:0_23:+', 'ms_pol_23:0_23:-'])
 
     def test_the_denominator_is_the_restricted_convolution(self):
         """With production braces the ratio must be taken against the nominal --
         already restricted -- convolution, or it would not be the fraction of
         what is actually written out."""
         import numpy as np
-        stub = self._Stub(['0'])
+        stub = self._Stub(vector=['0'])
+        static = self._static([6, 23], base=((1,), None))
         hels = [self.FERMION, self.VECTOR]
-        static = self._static(hels, base=((1,), None))
         prod = self._joint(hels, 41)
         prod.set_hel_restriction(((1,), None))
         dec = self._joint(hels, 42)
-        ratio = stub._polarization_ratios(prod, dec, static)['0']
+        ratio = stub._polarization_ratios(prod, dec, static)['ms_pol_6:*_23:0']
         num = self._brute_force(dec, prod, ((1,), (0,)))
         den = self._brute_force(dec, prod, ((1,), None))
         self.assertTrue(np.allclose(ratio, (num / den).real, atol=1e-5))
@@ -1866,17 +2034,18 @@ class TestKeepWeightForPolarization(unittest.TestCase):
 
     def test_ratio_matches_an_independent_contraction(self):
         import numpy as np
-        stub = self._Stub(['0', 'T', '+', '-'])
+        stub = self._Stub(vector=['0', 'T', '+', '-'], fermion=['+', '-'])
         hels = [self.FERMION, self.VECTOR]
-        static = self._static(hels)
+        static = self._static([6, 23])
         prod = self._joint(hels, 51)
         dec = self._joint(hels, 52)
         ratios = stub._polarization_ratios(prod, dec, static)
+        self.assertEqual(len(ratios), 8)
         full = self._brute_force(dec, prod, None)
-        for label, restriction in stub._polarization_restrictions(static):
+        for wid, restriction in stub._polarization_combinations(static):
             expected = (self._brute_force(dec, prod, restriction) / full).real
-            self.assertTrue(np.allclose(ratios[label], expected, atol=1e-5),
-                            '%s: %s != %s' % (label, ratios[label], expected))
+            self.assertTrue(np.allclose(ratios[wid], expected, atol=1e-5),
+                            '%s: %s != %s' % (wid, ratios[wid], expected))
         # nothing was left attached to the production matrix
         self.assertIsNone(prod.hel_restriction)
 
@@ -1888,8 +2057,9 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         prod = self._joint(hels, 61)
         dec = self._joint(hels, 62)
         before = dec.scalar_multiplication(prod)
-        self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
-            prod, dec, self._static(hels))
+        self._Stub(vector=['0', 'T', '+', '-'],
+                   fermion=['+', '-'])._polarization_ratios(
+            prod, dec, self._static([6, 23]))
         self.assertTrue(np.allclose(dec.scalar_multiplication(prod), before))
 
     def test_joint_and_sequential_agree(self):
@@ -1899,7 +2069,7 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         hand back the same polarisation weights for the same chain."""
         import numpy as np
         hels = [self.FERMION, self.VECTOR]
-        static = self._static(hels)
+        static = self._static([6, 23])
         prod = self._joint(hels, 111)
         slots = {0: self._joint([self.FERMION], 112),
                  1: self._joint([self.VECTOR], 113)}
@@ -1907,13 +2077,16 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         seq_dec = interface_madspin.decay_density_tensor(
             interface_madspin.MadSpinInterface._slot_identity.__get__(
                 TestPartialDensityContraction._Stub()), hels, slots)
-        a = self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
+        a = self._Stub(vector=['0', 'T', '+', '-'],
+                       fermion=['+', '-'])._polarization_ratios(
             prod, joint_dec, dict(static))
-        b = self._Stub(['0', 'T', '+', '-'])._polarization_ratios(
+        b = self._Stub(vector=['0', 'T', '+', '-'],
+                       fermion=['+', '-'])._polarization_ratios(
             prod, seq_dec, dict(static))
-        for label in a:
-            self.assertTrue(np.allclose(a[label], b[label], atol=1e-5),
-                            '%s: %s != %s' % (label, a[label], b[label]))
+        self.assertEqual(sorted(a), sorted(b))
+        for wid in a:
+            self.assertTrue(np.allclose(a[wid], b[wid], atol=1e-5),
+                            '%s: %s != %s' % (wid, a[wid], b[wid]))
 
     def _event(self, wgt=3.5):
         text = """<event>
@@ -1929,107 +2102,181 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         """The value that lands in the <rwgt> block, and the fact that the
         nominal weight of the event is not modified."""
         import numpy as np
-        stub = self._Stub(['0', '+'])
+        stub = self._Stub(vector=['0'], fermion=['+'])
         event = self._event(wgt=3.5)
-        stub._add_polarization_weights(event, {'0': 0.25, '+': 0.5})
+        stub._add_polarization_weights(event, {'ms_pol_6:+_23:0': 0.25,
+                                               'ms_pol_6:+_23:T': 0.5})
         self.assertEqual(event.wgt, 3.5)
         wgts = event.parse_reweight()
-        self.assertTrue(np.allclose(wgts['ms_pol_0'], 3.5 * 0.25))
-        self.assertTrue(np.allclose(wgts['ms_pol_+'], 3.5 * 0.5))
+        self.assertTrue(np.allclose(wgts['ms_pol_6:+_23:0'], 3.5 * 0.25))
+        self.assertTrue(np.allclose(wgts['ms_pol_6:+_23:T'], 3.5 * 0.5))
         text = str(event)
-        self.assertIn("<wgt id='ms_pol_0'>", text)
-        self.assertIn("<wgt id='ms_pol_+'>", text)
-        # round trip through the parser
+        self.assertIn("<wgt id='ms_pol_6:+_23:0'>", text)
+        self.assertIn("<wgt id='ms_pol_6:+_23:T'>", text)
+        # round trip through the parser: the ':' and '*' of the id must survive
         again = lhe_parser.Event(text).parse_reweight()
-        self.assertTrue(np.allclose(again['ms_pol_0'], 3.5 * 0.25))
+        self.assertTrue(np.allclose(again['ms_pol_6:+_23:0'], 3.5 * 0.25))
+        event = self._event(wgt=2.0)
+        stub._add_polarization_weights(event, {'ms_pol_6:*_23:0': 0.5})
+        self.assertTrue(np.allclose(
+            lhe_parser.Event(str(event)).parse_reweight()['ms_pol_6:*_23:0'],
+            1.0))
 
     def test_existing_event_weights_are_preserved(self):
         import numpy as np
-        stub = self._Stub(['0'])
+        stub = self._Stub(vector=['0'])
         event = self._event(wgt=2.0)
         event.parse_reweight()['1001'] = 7.0
-        stub._add_polarization_weights(event, {'0': 0.5})
+        stub._add_polarization_weights(event, {'ms_pol_23:0': 0.5})
         wgts = lhe_parser.Event(str(event)).parse_reweight()
         self.assertTrue(np.allclose(wgts['1001'], 7.0))
-        self.assertTrue(np.allclose(wgts['ms_pol_0'], 1.0))
+        self.assertTrue(np.allclose(wgts['ms_pol_23:0'], 1.0))
+
+    # ------------------------------------------------------------------
+    # the banner declaration
+    # ------------------------------------------------------------------
+
+    def test_slot_layout_matches_the_density_basis_order(self):
+        """The banner has to enumerate the ids before a single event is decayed,
+        so the slot layout is rebuilt from the topology. It must reproduce
+        _decaying_pdgs (first appearance) then _density_basis (per pdg, in
+        production order)."""
+        layout = self.MI._polarization_slot_layout
+        self.assertEqual(layout((6, 23, -6, 23), {6, -6, 23}), (6, 23, 23, -6))
+        # a pdg with no decay events is not a slot
+        self.assertEqual(layout((6, 23, -6, 21), {6, -6}), (6, -6))
+        self.assertEqual(layout((21, 21), {6}), ())
 
     def test_weights_are_declared_in_the_banner(self):
         # a real Banner, not a dict: Banner.get is get_detail and knows about a
         # handful of card tags only, so 'initrwgt' has to be probed with `in`
         real = banner.Banner()
-        stub = self._Stub(['0', 'T'], banner=real)
+        stub = self._Stub(vector=['0', 'T'], fermion=['+', '-'], banner=real)
         real['initrwgt'] = "<weightgroup name='other'>\n</weightgroup>\n"
-        stub._declare_polarization_weights()
+        stub._declare_polarization_weights([self._static([6, 23])])
         text = real['initrwgt']
         self.assertIn("<weightgroup name='madspin_polarization'>", text)
-        self.assertIn("<weight id='ms_pol_0'>", text)
-        self.assertIn("<weight id='ms_pol_T'>", text)
+        for wid in ['ms_pol_6:+_23:0', 'ms_pol_6:+_23:T',
+                    'ms_pol_6:-_23:0', 'ms_pol_6:-_23:T']:
+            self.assertIn("<weight id='%s'>" % wid, text)
         self.assertIn("name='other'", text)
         # idempotent: run_onshell may be re-entered, the block must not double
-        stub._declare_polarization_weights()
-        self.assertEqual(text.count("ms_pol_0"),
-                         real['initrwgt'].count("ms_pol_0"))
+        stub._declare_polarization_weights([self._static([6, 23])])
+        self.assertEqual(text.count("ms_pol_6:+_23:0"),
+                         real['initrwgt'].count("ms_pol_6:+_23:0"))
+
+    def test_the_declaration_is_the_union_over_the_topologies(self):
+        """'generate p p > t t~' + 'add process p p > t t~ z' put events with
+        different slot layouts in the same file; each carries its own weights
+        and the banner has to declare both sets."""
+        real = banner.Banner()
+        stub = self._Stub(vector=['0'], fermion=['+', '-'], banner=real)
+        stub._declare_polarization_weights([self._static([6, -6]),
+                                            self._static([6, -6, 23])])
+        text = real['initrwgt']
+        for wid in ['ms_pol_6:+_-6:-', 'ms_pol_6:+_-6:-_23:0']:
+            self.assertIn("<weight id='%s'>" % wid, text)
 
     def test_weights_are_declared_without_a_pre_existing_block(self):
         real = banner.Banner()
         self.assertNotIn('initrwgt', real)
-        stub = self._Stub(['+'], banner=real)
-        stub._declare_polarization_weights()
-        self.assertIn("<weight id='ms_pol_+'>", real['initrwgt'])
+        stub = self._Stub(vector=['+'], banner=real)
+        stub._declare_polarization_weights([self._static([23])])
+        self.assertIn("<weight id='ms_pol_23:+'>", real['initrwgt'])
+
+    def test_nothing_is_declared_when_nothing_is_requested(self):
+        real = banner.Banner()
+        self._Stub(banner=real)._declare_polarization_weights(
+            [self._static([6, 23])])
+        self.assertNotIn('initrwgt', real)
+        # ... nor when the requested lists produce no combination at all
+        real = banner.Banner()
+        self._Stub(vector=['0'], banner=real)._declare_polarization_weights(
+            [self._static([25])])
+        self.assertNotIn('initrwgt', real)
+
+    def test_a_large_product_warns(self):
+        """Combinatorial growth: four decaying vectors with a 4-entry list is
+        256 extra weights *and* 256 extra contractions per event. It is legal --
+        the user asked for it -- but it is said out loud."""
+        real = banner.Banner()
+        stub = self._Stub(vector=['0', 'T', '+', '-'], banner=real)
+        with self.assertLogs('decay.stdout', level='WARNING') as caught:
+            stub._declare_polarization_weights(
+                [self._static([23, 23, 23, 24])])
+        self.assertTrue(any('256' in line for line in caught.output),
+                        caught.output)
+        # and below the threshold it stays quiet
+        real = banner.Banner()
+        stub = self._Stub(vector=['0', 'T'], banner=real)
+        stub._declare_polarization_weights([self._static([23, 23])])
+        self.assertIn("<weight id='ms_pol_23:0_23:T'>", real['initrwgt'])
 
     # ------------------------------------------------------------------
     # the sum rule
     # ------------------------------------------------------------------
-    # sum_P w_P = w only when the restricted blocks *partition* the (i,j) terms
-    # that actually contribute. {+}, {-} and {0} keep one diagonal entry each, so
-    # two conditions have to hold at once:
-    #   (a) the contraction must have no off-diagonal (interference) piece --
-    #       the double sum's i != j terms belong to no single-state block;
-    #   (b) exactly one particle may be restricted -- with two, the blocks are
-    #       products (+ +) and (- -) and the mixed (+ -) diagonal entries are in
-    #       neither, so even a diagonal contraction loses them.
-    # Both are tested below, in both directions.
+    # sum_C w_C = w only when the combinations *partition* the (i,j) terms that
+    # actually contribute. In the product form that needs two conditions (the
+    # one-label-per-weight version needed a third, "only one particle may be
+    # restricted", which the product removes):
+    #   (a) every species list must partition its slots' helicity basis --
+    #       [+, -] for a fermion, [0, +, -] or [0, T] for a vector. The default
+    #       vector list [0, T, +, -] does NOT: T = {-1,+1} covers the same
+    #       entries as + and - together, so the weights overlap;
+    #   (b) the contraction must have no off-diagonal (interference) piece --
+    #       the double sum's i != j terms belong to no single-state block. {T}
+    #       is the exception that carries its own (-1,+1) block.
+    # All of them are tested below, in both directions.
 
-    def test_sum_rule_holds_for_one_diagonal_particle(self):
+    def test_sum_rule_holds_for_a_partitioning_product(self):
         import numpy as np
         # a vector is partitioned by {+}/{-}/{0}, a fermion by {+}/{-} alone --
-        # its '0' entry is unphysical, hence unrestricted, hence a ratio of 1
-        # that must NOT be counted as a member of the partition
-        for hels, labels in (([self.VECTOR], ['+', '-', '0']),
-                             ([self.FERMION], ['+', '-'])):
-            stub = self._Stub(labels)
+        # its '0' entry is unphysical and is dropped from its choices
+        for pdgs, hels in (([23], [self.VECTOR]),
+                           ([6], [self.FERMION]),
+                           ([6, 23], [self.FERMION, self.VECTOR]),
+                           ([6, -6], [self.FERMION, self.FERMION])):
+            stub = self._Stub(vector=['+', '-', '0'], fermion=['+', '-', '0'])
             prod = self._joint(hels, 71)
             dec = self._joint(hels, 72, diagonal_only=True)
-            ratios = stub._polarization_ratios(prod, dec, self._static(hels))
+            ratios = stub._polarization_ratios(prod, dec, self._static(pdgs))
             self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5),
-                            '%s -> %s' % (hels, ratios))
-        # and the fermion's '0' really is the whole nominal weight
-        stub = self._Stub(['0'])
-        prod = self._joint([self.FERMION], 71)
-        dec = self._joint([self.FERMION], 72, diagonal_only=True)
-        self.assertEqual(stub._polarization_ratios(
-            prod, dec, self._static([self.FERMION]))['0'], 1.0)
+                            '%s -> %s' % (pdgs, ratios))
 
     def test_sum_rule_holds_for_transverse_plus_longitudinal(self):
         """{T} and {0} are the other complete, non-overlapping decomposition of
         a vector -- and {T} keeps its own off-diagonal (-1,+1) block, so it is
         a genuinely different partition of the same nine terms."""
         import numpy as np
-        stub = self._Stub(['T', '0'])
+        stub = self._Stub(vector=['T', '0'])
         prod = self._joint([self.VECTOR], 81)
         dec = self._joint([self.VECTOR], 82, diagonal_only=True)
-        ratios = stub._polarization_ratios(prod, dec, self._static([self.VECTOR]))
+        ratios = stub._polarization_ratios(prod, dec, self._static([23]))
+        self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5))
+
+    def test_the_product_restores_the_two_particle_sum_rule(self):
+        """What the one-weight-per-label form could not do: with both tops
+        restricted at once, (+,-) and (-,+) belonged to no weight and the sum
+        fell short. The cartesian product has them as combinations of their
+        own, so the sum rule comes back."""
+        import numpy as np
+        hels = [self.FERMION, self.FERMION]
+        stub = self._Stub(fermion=['+', '-'])
+        prod = self._joint(hels, 101)
+        dec = self._joint(hels, 102, diagonal_only=True)
+        ratios = stub._polarization_ratios(prod, dec, self._static([6, -6]))
+        self.assertEqual(len(ratios), 4)
         self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5))
 
     def test_sum_rule_fails_on_the_off_diagonal_terms(self):
-        """Condition (a): with interference in the contraction the single-state
+        """Condition (b): with interference in the contraction the single-state
         blocks cover the diagonal only, so the sum falls short of 1. Pinned so
         the sum rule is not mistaken for an identity."""
         import numpy as np
-        stub = self._Stub(['+', '-', '0'])
+        stub = self._Stub(vector=['+', '-', '0'])
         prod = self._joint([self.VECTOR], 91)
         dec = self._joint([self.VECTOR], 92)     # full, interference included
-        ratios = stub._polarization_ratios(prod, dec, self._static([self.VECTOR]))
+        ratios = stub._polarization_ratios(prod, dec, self._static([23]))
         self.assertFalse(np.allclose(sum(ratios.values()), 1.0, atol=1e-3))
         # what the sum *does* reproduce is the diagonal part of the double sum
         full = self._brute_force(dec, prod, None)
@@ -2039,24 +2286,25 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         self.assertTrue(np.allclose(sum(ratios.values()),
                                     (diag / full).real, atol=1e-5))
 
-    def test_sum_rule_fails_for_two_restricted_particles(self):
-        """Condition (b): the entry restricts *both* particles at once, so the
-        mixed (+,-) and (-,+) diagonal entries belong to no block."""
+    def test_sum_rule_fails_for_an_overlapping_list(self):
+        """Condition (a): the [0, T, +, -] default is not a partition -- T is
+        + and - together -- so its combinations double count and the sum
+        overshoots. Pinned because it is the list the documentation suggests."""
         import numpy as np
-        stub = self._Stub(['+', '-'])
-        hels = [self.FERMION, self.FERMION]
-        prod = self._joint(hels, 101)
-        dec = self._joint(hels, 102, diagonal_only=True)
-        ratios = stub._polarization_ratios(prod, dec, self._static(hels))
+        stub = self._Stub(vector=['0', 'T', '+', '-'])
+        prod = self._joint([self.VECTOR], 71)
+        dec = self._joint([self.VECTOR], 72, diagonal_only=True)
+        ratios = stub._polarization_ratios(prod, dec, self._static([23]))
+        self.assertEqual(len(ratios), 4)
+        # T is exactly + and - together, so the transverse part is counted twice
+        # and the sum overshoots by that fraction
+        self.assertTrue(np.allclose(ratios['ms_pol_23:T'],
+                                    ratios['ms_pol_23:+'] + ratios['ms_pol_23:-'],
+                                    atol=1e-5), ratios)
+        self.assertTrue(np.allclose(sum(ratios.values()),
+                                    1.0 + ratios['ms_pol_23:T'], atol=1e-5),
+                        ratios)
         self.assertFalse(np.allclose(sum(ratios.values()), 1.0, atol=1e-3))
-        # ... and it comes back as soon as one of the two is left unrestricted,
-        # which is exactly the t t~ z '0' configuration
-        stub = self._Stub(['+', '-'])
-        static = self._static(hels)
-        static['pol_weight_restrictions'] = [('+', ((1,), None)),
-                                             ('-', ((-1,), None))]
-        ratios = stub._polarization_ratios(prod, dec, static)
-        self.assertTrue(np.allclose(sum(ratios.values()), 1.0, atol=1e-5))
 
 
 class TestSequentialSlots(unittest.TestCase):
@@ -2253,6 +2501,10 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _sequential_spin_order = interface._sequential_spin_order
             _decay_slot_order = interface._decay_slot_order
             sequential_accept_reject = interface.sequential_accept_reject
+            _polarization_weight_labels = \
+                interface._polarization_weight_labels
+            _polarization_weights_enabled = \
+                interface._polarization_weights_enabled
             _scan_maxwgt_range = interface._scan_maxwgt_range
             _sequential_offshell = interface._sequential_offshell
             _sequential_upfront = interface._sequential_upfront
@@ -2452,6 +2704,10 @@ class TestPAUpFrontMass(unittest.TestCase):
             _sequential_spin_order = interface._sequential_spin_order
             _decay_slot_order = interface._decay_slot_order
             sequential_accept_reject = interface.sequential_accept_reject
+            _polarization_weight_labels = \
+                interface._polarization_weight_labels
+            _polarization_weights_enabled = \
+                interface._polarization_weights_enabled
             _upfront_production = interface._upfront_production
             _sequential_offshell = interface._sequential_offshell
             _sequential_upfront = interface._sequential_upfront

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1349,6 +1349,8 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
         _density_spinmode = interface_madspin.MadSpinInterface._density_spinmode
         _apply_production_polarization = \
             interface_madspin.MadSpinInterface._apply_production_polarization
+        _format_polarization_sequence = staticmethod(
+            interface_madspin.MadSpinInterface._format_polarization_sequence)
         do_decay = interface_madspin.MadSpinInterface.do_decay
 
     HEL = {1: [0], 2: [1, -1], 3: [-1, 0, 1]}
@@ -1366,20 +1368,20 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
         ALLOW_HEL combination, and a polarised process has no NHEL row outside
         its polarisation -- so the allowed helicity has to lead, or the whole
         production density matrix comes back zero."""
-        stub = self._Stub({24: (0,)})
+        stub = self._Stub({24: ((0,),)})
         got, restriction = stub._apply_production_polarization(
                                         [24], [list(self.HEL[3])])
         self.assertEqual(got, [[0, -1, 1]])
         self.assertEqual(restriction, ((0,),))
 
-        stub = self._Stub({6: (-1,)})
+        stub = self._Stub({6: ((-1,),)})
         got, restriction = stub._apply_production_polarization(
                                         [6], [list(self.HEL[2])])
         self.assertEqual(got, [[-1, 1]])
         self.assertEqual(restriction, ((-1,),))
 
     def test_transverse_keeps_two_states_and_drops_zero_from_the_front(self):
-        stub = self._Stub({24: (-1, 1)})
+        stub = self._Stub({24: ((-1, 1),)})
         got, restriction = stub._apply_production_polarization(
                                         [24], [list(self.HEL[3])])
         self.assertEqual(got, [[-1, 1, 0]])
@@ -1388,7 +1390,7 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
     def test_restriction_is_per_particle(self):
         """t{0} t~{T}: slot 1 collapses onto its diagonal 0 entry, slot 2 keeps
         the -1/+1 block, and an unpolarised third particle keeps everything."""
-        stub = self._Stub({24: (0,), -24: (-1, 1)})
+        stub = self._Stub({24: ((0,),), -24: ((-1, 1),)})
         got, restriction = stub._apply_production_polarization(
                     [24, -24, 6], [list(self.HEL[3]), list(self.HEL[3]),
                                    list(self.HEL[2])])
@@ -1398,12 +1400,12 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
     def test_unsupported_polarization_is_refused(self):
         """{A}, {G}, ... have no place in the -1/0/+1 helicity basis the density
         matrices are built on."""
-        stub = self._Stub({24: (99,)})
+        stub = self._Stub({24: ((99,),)})
         self.assertRaises(stub.InvalidCmd,
                           stub._apply_production_polarization,
                           [24], [list(self.HEL[3])])
         # a longitudinal brace on a fermion cannot be honoured either
-        stub = self._Stub({6: (0,)})
+        stub = self._Stub({6: ((0,),)})
         self.assertRaises(stub.InvalidCmd,
                           stub._apply_production_polarization,
                           [6], [list(self.HEL[2])])
@@ -1426,6 +1428,180 @@ class TestProductionPolarizationPlumbing(unittest.TestCase):
             self.assertTrue(self._Stub(spinmode=mode)._density_spinmode())
         for mode in ('none', 'madspin_v1', 'onshell_v1'):
             self.assertFalse(self._Stub(spinmode=mode)._density_spinmode())
+
+
+class TestSamePdgProductionPolarization(unittest.TestCase):
+    """'p p > w+{0} w+{T}': the same pdg twice with different braces.
+
+    The density basis lays its slots out as 'for pdg in decays_key, in
+    production-event order', so a pdg owns a contiguous block of slots whose
+    k-th entry is the k-th such particle of the event; the k-th brace of that
+    pdg in the process line goes to it.
+    """
+
+    Stub = TestProductionPolarizationPlumbing._Stub
+    HEL = TestProductionPolarizationPlumbing.HEL
+
+    class _Banner(object):
+        def __init__(self, lines):
+            self.proc_card = list(lines)
+
+    class _PolStub(object):
+        """_production_polarization on top of a banner, with the real MG5
+        process parser replaced by a minimal one: the point under test is the
+        bookkeeping, not MG5's brace syntax (which the parser owns)."""
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        _production_polarization = \
+            interface_madspin.MadSpinInterface._production_polarization
+        _format_polarization_sequence = staticmethod(
+            interface_madspin.MadSpinInterface._format_polarization_sequence)
+
+        POL = {'0': [0], 'T': [1, -1], '+': [1], '-': [-1], 'A': [99]}
+        NAMES = {'w+': [24], 'w-': [-24], 'z': [23], 't': [6], 't~': [-6],
+                 'p': [21, 2, -2], 'j': [21, 2, -2], 'V': [24, -24, 23]}
+
+        class _Leg(dict):
+            def get(self, key):
+                return self[key]
+
+        class _Proc(dict):
+            def get(self, key):
+                return self[key]
+
+        def __init__(self, lines):
+            self.banner = TestSamePdgProductionPolarization._Banner(lines)
+            self.mg5cmd = self
+
+        def extract_process(self, line):
+            legs = []
+            initial, final = line.split('>')
+            for state, part in ([(False, p) for p in initial.split()] +
+                                [(True, p) for p in final.split()]):
+                pol = []
+                if '{' in part:
+                    part, brace = part.split('{')
+                    pol = self.POL[brace.rstrip('}')]
+                legs.append(self._Leg(ids=self.NAMES[part], state=state,
+                                      polarization=pol))
+            return self._Proc(legs=legs)
+
+    def polarization(self, *lines):
+        return self._PolStub(lines)._production_polarization()
+
+    # ------------------------------------------------------------------
+    # reading the process line
+    # ------------------------------------------------------------------
+
+    def test_same_pdg_two_braces_keeps_both_in_order(self):
+        self.assertEqual(self.polarization('generate p p > w+{0} w+{T}'),
+                         {24: ((0,), (-1, 1))})
+        # ... and the order is the process line's, not sorted
+        self.assertEqual(self.polarization('generate p p > w+{T} w+{0}'),
+                         {24: ((-1, 1), (0,))})
+
+    def test_uniform_polarisation_collapses_to_one_entry(self):
+        """Same brace twice is not a positional case: one entry, broadcast to
+        however many of that pdg the event holds."""
+        self.assertEqual(self.polarization('generate p p > z{0} z{0}'),
+                         {23: ((0,),)})
+
+    def test_partially_polarised_same_pdg(self):
+        """'z{0} z': the second Z has no brace and stays summed over."""
+        self.assertEqual(self.polarization('generate p p > z{0} z'),
+                         {23: ((0,), None)})
+
+    def test_broadcast_survives_extra_subprocesses(self):
+        """The multiplicity of a broadcast pdg does not have to match between
+        subprocesses -- this is the common 'generate X; add process X j' case."""
+        self.assertEqual(
+            self.polarization('generate p p > w+{0} w-',
+                              'add process p p > w+{0} w- j'),
+            {24: ((0,),)})
+
+    def test_same_sequence_in_several_subprocesses_is_fine(self):
+        self.assertEqual(
+            self.polarization('generate p p > w+{0} w+{T}',
+                              'add process p p > w+{0} w+{T} j'),
+            {24: ((0,), (-1, 1))})
+
+    def test_subprocesses_that_disagree_are_refused(self):
+        """Two lines with the same final state but different brace patterns
+        produce indistinguishable events -- refuse rather than pick one."""
+        for lines in (('generate p p > w+{0} w+{T}',
+                       'add process p p > w+{T} w+{0}'),
+                      ('generate p p > w+{0} w+{T}',
+                       'add process p p > w+{0} w+{0}'),
+                      ('generate p p > w+{0} w-',
+                       'add process p p > w+ w-')):
+            self.assertRaises(interface_madspin.MadSpinInterface.InvalidCmd,
+                              self.polarization, *lines)
+
+    def test_multiparticle_label_with_mixed_polarisation_is_refused(self):
+        """'p p > V{0} V{T}' with V a multiparticle label: how many of a given
+        pdg an event holds is not fixed by the line, so the n-th brace cannot
+        be pinned to the n-th particle."""
+        self.assertRaises(interface_madspin.MadSpinInterface.InvalidCmd,
+                          self.polarization, 'generate p p > V{0} V{T}')
+        # uniform braces inside a multiparticle label stay fine: no positional
+        # matching is needed there
+        self.assertEqual(self.polarization('generate p p > V{0} V{0}'),
+                         {24: ((0,),), -24: ((0,),), 23: ((0,),)})
+
+    def test_no_braces_gives_an_empty_map(self):
+        self.assertEqual(self.polarization('generate p p > w+ w-'), {})
+
+    # ------------------------------------------------------------------
+    # turning it into the per-slot basis / restriction
+    # ------------------------------------------------------------------
+
+    def test_slots_of_one_pdg_take_the_braces_in_order(self):
+        stub = self.Stub({24: ((0,), (-1, 1))})
+        got, restriction = stub._apply_production_polarization(
+                        [24, 24], [list(self.HEL[3]), list(self.HEL[3])])
+        # the allowed helicity leads each basis: the first ALLOW_HEL
+        # combination is (0, -1), which the polarised NHEL table does contain
+        self.assertEqual(got, [[0, -1, 1], [-1, 1, 0]])
+        self.assertEqual(restriction, ((0,), (-1, 1)))
+
+    def test_the_other_order_gives_the_other_assignment(self):
+        stub = self.Stub({24: ((-1, 1), (0,))})
+        got, restriction = stub._apply_production_polarization(
+                        [24, 24], [list(self.HEL[3]), list(self.HEL[3])])
+        self.assertEqual(got, [[-1, 1, 0], [0, -1, 1]])
+        self.assertEqual(restriction, ((-1, 1), (0,)))
+
+    def test_a_single_entry_is_broadcast_to_every_slot(self):
+        stub = self.Stub({24: ((0,),)})
+        got, restriction = stub._apply_production_polarization(
+                        [24, 24], [list(self.HEL[3]), list(self.HEL[3])])
+        self.assertEqual(got, [[0, -1, 1], [0, -1, 1]])
+        self.assertEqual(restriction, ((0,), (0,)))
+
+    def test_unbraced_occurrence_stays_unrestricted(self):
+        stub = self.Stub({23: ((0,), None)})
+        got, restriction = stub._apply_production_polarization(
+                        [23, 23], [list(self.HEL[3]), list(self.HEL[3])])
+        self.assertEqual(got, [[0, -1, 1], [-1, 0, 1]])
+        self.assertEqual(restriction, ((0,), None))
+
+    def test_two_pdgs_each_with_their_own_sequence(self):
+        """The per-pdg counter must not leak from one pdg block to the next."""
+        stub = self.Stub({24: ((0,), (-1, 1)), 23: ((1,),)})
+        got, restriction = stub._apply_production_polarization(
+                        [24, 24, 23], [list(self.HEL[3])] * 3)
+        self.assertEqual(got, [[0, -1, 1], [-1, 1, 0], [1, -1, 0]])
+        self.assertEqual(restriction, ((0,), (-1, 1), (1,)))
+
+    def test_length_mismatch_is_refused(self):
+        """A positional sequence that does not match the number of that pdg in
+        the event cannot be attached one by one."""
+        stub = self.Stub({24: ((0,), (-1, 1))})
+        self.assertRaises(stub.InvalidCmd,
+                          stub._apply_production_polarization,
+                          [24], [list(self.HEL[3])])
+        self.assertRaises(stub.InvalidCmd,
+                          stub._apply_production_polarization,
+                          [24, 24, 24], [list(self.HEL[3])] * 3)
 
 
 class TestKeepWeightForPolarization(unittest.TestCase):
@@ -1631,6 +1807,32 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         self.assertEqual(got['0'], ((1,), (0,)))
         self.assertEqual(got['T'], ((1,), (-1, 1)))
         self.assertIs(got['-'], False)
+
+    def test_same_pdg_mixed_production_braces_are_intersected_per_slot(self):
+        """p p > w+{0} w+{T}: the two slots carry *different* production
+        restrictions, and keep_weight_for_polarization has to intersect with
+        each of them separately -- '0' survives on slot 0 only, 'T' on slot 1
+        only, and each keeps the other slot at its production value. Only a
+        polarisation impossible for *every* slot gives a zero weight."""
+        stub = self._Stub(['0', 'T', '+', '-'])
+        static = self._static([self.VECTOR, self.VECTOR],
+                              base=((0,), (-1, 1)))
+        got = dict(stub._polarization_restrictions(static))
+        # '0': slot 0 already longitudinal, slot 1 has no 0 left -> impossible
+        self.assertIs(got['0'], False)
+        # 'T': slot 0 has no transverse state left -> impossible
+        self.assertIs(got['T'], False)
+        # '+' / '-' are impossible on the longitudinal slot too
+        self.assertIs(got['+'], False)
+        self.assertIs(got['-'], False)
+
+        # with an *unbraced* second W the picture is the interesting one: the
+        # restriction is honoured slot by slot
+        static = self._static([self.VECTOR, self.VECTOR], base=((0,), None))
+        got = dict(stub._polarization_restrictions(static))
+        self.assertEqual(got['0'], ((0,), (0,)))
+        self.assertIs(got['T'], False)
+        self.assertIs(got['+'], False)
 
     def test_an_impossible_polarisation_weighs_zero(self):
         stub = self._Stub(['-'])


### PR DESCRIPTION
Restricts the production/decay density-matrix convolution according to the polarisation braces on the decaying particle in the **production** process.

Until now all density spinmodes contracted the full double sum `W = sum_i sum_j rho_prod(i,j) rho_dec(i,j)`. Now, per decaying particle:

- `{0}`, `{+}`/`{R}`, `{-}`/`{L}` — a single helicity X — keep only `rho_prod(X,X) rho_dec(X,X)`;
- `{T}` keeps the double sum over the `-1/+1` block and drops the `0` row and column;
- no brace: unchanged, bit-for-bit.

The rule is uniform — entry (i,j) of particle *k* survives iff **both** i and j are allowed for *k* — which produces the diagonal-only and transverse-block cases automatically and composes per index for several decaying particles.

## The restriction genuinely changes results

The key question was whether MadSpin's production ME already carries the polarisation projection. **It does not.** Verified at Fortran level: for `u u~ > w+{0} w-` (NCOMB=12, every NHEL row has NHEL(3)=0) the density matrix comes back **bit-identical** to the unpolarised `u u~ > w+ w-`, including the `rho(-,-)` and `rho(+,+)` entries `{0}` forbids, because `GET_ALL_INTER` overrides the polarisation at amplitude level.

Confirmed again end to end: under the **old** code a `t{R}` run was byte-identical to the unpolarised run — the brace was ignored outright.

## Two pre-existing bugs fixed

1. **A polarised production hung MadSpin indefinitely.** `GET_DENSITY` picks its NHEL rows by matching against the *first* `ALLOW_HEL` combination, and with `hel_dict = {2:[1,-1], 3:[-1,0,1]}` a `{0}`, `{L}` or `{-}` production has no matching row, so the whole production density matrix was identically zero. A zero `rho_prod` rejects *every* accept/reject trial, so MadSpin does not error — it loops forever regenerating decay pools:

   ```
   old code, p p > t{L} t~ :   killed at 600 s, 131 decay-pool regenerations, no output
   old code, p p > w+{0} w- :  exit=124 (timeout 240 s), 41 regenerations, NO DECAYED FILE
   new code, same inputs/seed: exit=0, decayed file written, seconds
   ```

   Only `{R}`/`{+}` on a fermion happened to work. Fixed by having `_density_basis` reorder each polarised particle's helicity basis so an allowed helicity leads.

2. **`adapt_production` matched the whole token**, so a polarised leg `t{L}` never received its off-shell star. Now the name before the brace is matched; the run log shows MG5 receiving `generate p p > t{L}* t~*` and producing a genuinely polarised ME (`P1_gg_tLtx` has NCOMB=8 vs 16 unpolarised, `NHEL(3)` pinned to `-1`).

## End-to-end validation

Event-block hashes (whole-file hashes differ only by banner paths/dates):

```
old_nopol    38e1065c...  new_nopol  38e1065c...   -> IDENTICAL (no-brace unchanged)
old_tR       38e1065c...  new_tR     7507ca05...   -> DIFFER (old ignored the brace)
```

Physics against the analytic distributions (theta in the parent rest frame vs the parent's lab direction — the helicity axis):

```
                e+ from t                        e- from t~ (no brace: control)
old_nopol    <cos> = +0.015 +- 0.061           <cos> = +0.011 +- 0.058
new_nopol    <cos> = +0.015 +- 0.061           <cos> = +0.011 +- 0.058
old_tR       <cos> = +0.015 +- 0.061           <cos> = +0.011 +- 0.058
new_tR       <cos> = +0.409 +- 0.045  [+1/3]   <cos> = -0.060 +- 0.055
new_tL       <cos> = -0.352 +- 0.051  [-1/3]   <cos> = +0.072 +- 0.059
```

```
W+ -> e+ ve, 2000 generated events each   <cos^2>          expected
p p > w+ w-      (madspin)                0.347 +- 0.007   SM mixture
p p > w+{T} w-   (madspin)                0.393 +- 0.007   2/5 = 0.400
p p > w+{T} w-   (onshell)                0.398 +- 0.007   2/5
p p > w+{0} w-   (madspin)                0.198 +- 0.005   1/5 = 0.200
p p > w+{0} w-   (PA)                     0.208 +- 0.005   1/5
```

`{T}` lands within 1 sigma of 2/5, `{0}` within 0.4 sigma of 1/5, and `{0}` gives `<cos> = -0.001 +- 0.010` — forward/backward symmetric, as sin^2(theta) requires. The `t~` control stays compatible with zero in every polarised run, confirming the mask is per particle. Three density spinmodes exercised: `madspin`, `PA`, `onshell`. The `t{L}` run also covers the off-shell polarised amplitude enabled by fix 2 — it behaves, not merely parses.

## Decay-side braces now error clearly

```
InvalidCmd: MadSpin: polarization (the {...} braces) is not supported on a 'decay'
line with spinmode=madspin. Only the polarization of the production process is
taken into account by the density spin modes (madspin/full/PA/onshell); use
spinmode=none or spinmode=madspin_v1 for decay-side polarization.
```

## Implementation

`MadSpin/decay.py` — the restriction rides on the `DensityMatrix` rather than on the call, so `scalar_multiplication` and `trace()` pick it up at every contraction site with no call-site change, including `_partial_density_contraction` in the sequential accept/reject. Masks are cached per `(basis_id, restriction)`, so they are built once per basis and never per event, and both existing fast paths are preserved.

`MadSpin/interface_madspin.py` — `_production_polarization()` parses the banner proc_card through `mg5cmd.extract_process`, so brace semantics cannot drift from MG5's; `_density_basis` gains a `hel_restriction` key; the three production `get_density` call sites pass it. `do_launch` validates the braces up front rather than on the first event inside a worker.

**Normalisation:** `prod_diag` is now the *restricted* trace. Required, not cosmetic: with the identity decay density the weight still averages to `1/n`, so `N_0 = Tr(rho)/prod n_i` and the accept/reject bookkeeping is untouched. Decay diagonals stay unrestricted — decay events come from the full decay ME.

`Ran 148 tests ... OK` (131 before; 17 new).

## Two things flagged, deliberately not fixed here

- **A vanishing production density matrix makes MadSpin hang rather than fail.** After this PR no polarisation input reaches that state, but any other cause would. A guard that bails out with a clear error when `Tr(rho_prod)` is zero across a whole pool regeneration is worth a follow-up; it touches the shared unweighting loop and does not belong in this diff.
- On the *first* old-code `t{L}` attempt, the runaway run also deleted sibling files in its parent directory. Not reproduced in a sandboxed layout, and never seen on any healthy run — believed to be collateral from the runaway pool regeneration rather than an independent bug, but recorded rather than asserted harmless. It only occurs on the path this PR fixes.

## Not verified

Same-pdg-different-polarisation (`p p > w+{0} w+{T}`) is refused with an explicit error rather than supported: the density basis identifies particles by pdg-and-production-order, which cannot be reliably matched to process-line order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Apply production polarisation projections consistently throughout MadSpin density calculations and expose optional per-polarisation event weights.

New Features:
- Restrict production/decay density-matrix convolutions according to per-particle production polarisation braces, including longitudinal, transverse, and multi-particle assignments.
- Add optional per-polarisation LHEF weights for vector and fermion decaying particles, with cartesian combinations, production-brace intersections, banner declarations, and deprecated-option compatibility.

Bug Fixes:
- Fix polarised production density matrices that previously became zero and caused MadSpin to loop indefinitely.
- Fix polarised production process adaptation so off-shell stars are applied to legs whose names include braces.
- Honor the production matrix-element frame for polarised density contractions and correct frame-metadata unpacking.
- Reject unsupported decay-side polarisation braces clearly in density spin modes.

Enhancements:
- Carry helicity restrictions through density-matrix contractions, tensor products, traces, and sequential accept/reject normalization with cached masks while preserving unrestricted behavior.
- Validate and parse production polarisation consistently with MG5, including same-particle assignments and incompatible subprocess patterns.

Documentation:
- Document production-polarisation restrictions, frame handling, normalization, and validation behavior in the sequential-density plan.

Tests:
- Add extensive unit coverage for density restrictions, production-polarisation plumbing, same-PDG assignments, frame handling, and optional polarisation-weight generation.