### PR TITLE
MadSpin: gather the restricted density rows by index, not by mask

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -4699,9 +4699,17 @@ class DensityMatrix:
     # Cache tensor-product helicity tables by basis_id
     _tp_hel_cache = {}
 
-    # Cache helicity-restriction row masks.
+    # Cache helicity-restriction row selections.
     # Key: (basis_id, normalised restriction key)
+    # Value: (mask[bool], rows[int64], diag_rows[int64]) -- see _restriction_rows
     _restriction_cache = {}
+
+    # Same, but for the sorted-alignment path: the surviving positions *within*
+    # the cached sort permutation. Filled lazily, since the map-built fast path
+    # never needs a sort order at all.
+    # Key: (basis_id, normalised restriction key)
+    # Value: (keep[int64], sorted_rows[int64])
+    _restriction_sort_cache = {}
 
     def __init__(self, array, nchanging, all_helicity_combinations, dimension):
         """
@@ -4958,14 +4966,24 @@ class DensityMatrix:
         self.hel_restriction = DensityMatrix.normalize_hel_restriction(restriction)
         return self
 
-    def _restriction_row_mask(self, restriction):
-        """Boolean row mask implementing ``restriction`` on this matrix' labels.
+    def _restriction_rows(self, restriction):
+        """(mask, rows, diag_rows) implementing ``restriction`` on this matrix.
 
-        Depends only on the helicity labels, so it is cached per
-        (basis_id, restriction) and never recomputed per event.
+        ``mask`` is the boolean row mask, ``rows`` the indices of the surviving
+        rows and ``diag_rows`` the indices surviving *and* diagonal (what the
+        restricted trace sums). All three depend only on the helicity labels, so
+        they are cached per (basis_id, restriction) and never recomputed per
+        event.
+
+        The contractions use ``rows``/``diag_rows`` rather than ``mask``: a
+        restriction typically keeps a handful of rows out of hundreds, and
+        gathering with a short index array is markedly cheaper than boolean
+        indexing, which has to scan (and count) the full-length array. The rows
+        come out in increasing index order, i.e. exactly the order boolean
+        indexing would have produced, so the sums are bit-for-bit identical.
         """
         if restriction is None:
-            return None
+            return None, None, None
         cache_key = (self._basis_id, restriction)
         cached = DensityMatrix._restriction_cache.get(cache_key)
         if cached is not None:
@@ -4982,8 +5000,34 @@ class DensityMatrix:
             mask &= np.isin(h[:, 2 * k], allowed)
             mask &= np.isin(h[:, 2 * k + 1], allowed)
 
-        DensityMatrix._restriction_cache[cache_key] = mask
-        return mask
+        out = (mask, np.flatnonzero(mask), np.flatnonzero(self._diag_mask & mask))
+        DensityMatrix._restriction_cache[cache_key] = out
+        return out
+
+    def _restriction_row_mask(self, restriction):
+        """Boolean row mask implementing ``restriction`` on this matrix' labels."""
+        return self._restriction_rows(restriction)[0]
+
+    def _restriction_sorted_rows(self, restriction):
+        """(keep, sorted_rows) for the sorted-alignment path.
+
+        ``keep`` are the positions inside the cached sort permutation whose row
+        survives, and ``sorted_rows`` the rows themselves (``sort_order[keep]``).
+        Contracting ``self.values[sorted_rows]`` against
+        ``other.values[other_sort_order[keep]]`` visits exactly the entries, in
+        exactly the order, that masking the two sorted views would have.
+
+        Requires ``_ensure_sorted_view`` to have run.
+        """
+        cache_key = (self._basis_id, restriction)
+        cached = DensityMatrix._restriction_sort_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        order = self._sort_order
+        keep = np.flatnonzero(self._restriction_rows(restriction)[0][order])
+        out = (keep, order[keep])
+        DensityMatrix._restriction_sort_cache[cache_key] = out
+        return out
 
     @staticmethod
     def _combine_restrictions(a, b):
@@ -5055,14 +5099,13 @@ class DensityMatrix:
         if hel_restriction is not None:
             restriction = DensityMatrix._combine_restrictions(
                 restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
-        mask = self._restriction_row_mask(restriction)
-
         # Fastest correct path for map-built matrices
         if (self.map_density_matrix_ind is not None and
                 self.map_density_matrix_ind is other.map_density_matrix_ind):
-            if mask is None:
+            if restriction is None:
                 return np.sum(self.values * other.values)
-            return np.sum(self.values[mask] * other.values[mask])
+            rows = self._restriction_rows(restriction)[1]
+            return np.sum(self.values[rows] * other.values[rows])
 
         # Align by cached ordering for each basis
         self._ensure_sorted_view()
@@ -5070,12 +5113,13 @@ class DensityMatrix:
 
         a = self._sort_order
         b = other._sort_order
-        if mask is None:
+        if restriction is None:
             return np.sum(self.values[a] * other.values[b])
-        # the mask lives on self's rows; permuting it with the same order keeps
-        # it aligned with both sorted views
-        aligned = mask[a]
-        return np.sum(self.values[a][aligned] * other.values[b][aligned])
+        # the restriction lives on self's rows; the surviving positions inside
+        # the sort permutation are the same on both sides, so one cached gather
+        # does the masking and the alignment at once
+        keep, rows = self._restriction_sorted_rows(restriction)
+        return np.sum(self.values[rows] * other.values[b[keep]])
 
     def tensor_product(self, other):
         """
@@ -5191,10 +5235,9 @@ class DensityMatrix:
         if hel_restriction is not None:
             restriction = DensityMatrix._combine_restrictions(
                 restriction, DensityMatrix.normalize_hel_restriction(hel_restriction))
-        mask = self._restriction_row_mask(restriction)
-        if mask is None:
+        if restriction is None:
             return np.sum(self.values[self._diag_mask])
-        return np.sum(self.values[self._diag_mask & mask])
+        return np.sum(self.values[self._restriction_rows(restriction)[2]])
 
 
     def print_full_matrix(self, precision=6):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1306,6 +1306,53 @@ class TestDensityPolarizationRestriction(unittest.TestCase):
         self.assertIsNot(a._restriction_row_mask(a.hel_restriction),
                          a._restriction_row_mask(((-1, 1),)))
 
+    def test_restricted_paths_are_bit_identical_to_masking(self):
+        """The contractions gather the surviving rows by index instead of by
+        boolean mask. That is a speed change only: the rows come out in
+        increasing index order either way, so the sums must agree *exactly*,
+        not merely to within a tolerance."""
+        import numpy as np
+        import itertools
+        for hels in ([self.FERMION], [self.VECTOR],
+                     [self.FERMION, self.VECTOR],
+                     [self.VECTOR, self.FERMION, self.VECTOR]):
+            dim = 1
+            for h in hels:
+                dim *= len(h)
+            allowed_hel = [h for combo in itertools.product(*hels) for h in combo]
+            prod = madspin.DensityMatrix(self._packed(list(range(dim)), 101),
+                                         len(hels), allowed_hel, dim)
+            dec = None
+            for i, h in enumerate(hels):
+                d = self._density(h, 102 + i)
+                dec = d if dec is None else dec.tensor_product(d)
+            choices = [[None] + [(x,) for x in h] + [tuple(h[:2])] for h in hels]
+            for restriction in itertools.product(*choices):
+                prod.set_hel_restriction(list(restriction))
+                r = prod.hel_restriction
+                if r is None:
+                    continue
+                mask = prod._restriction_row_mask(r)
+                rows = prod._restriction_rows(r)[1]
+                self.assertTrue(np.array_equal(rows, np.flatnonzero(mask)))
+                # trace: same elements, same order
+                self.assertEqual(prod.trace(),
+                                 np.sum(prod.values[prod._diag_mask & mask]))
+                # contraction, both the map fast path (dec is prod's basis for
+                # one particle) and the sorted-alignment path
+                for lhs, rhs in ((dec, prod), (prod, dec)):
+                    m = lhs._restriction_row_mask(r)
+                    if (lhs.map_density_matrix_ind is not None and
+                            lhs.map_density_matrix_ind is rhs.map_density_matrix_ind):
+                        want = np.sum(lhs.values[m] * rhs.values[m])
+                    else:
+                        lhs._ensure_sorted_view()
+                        rhs._ensure_sorted_view()
+                        a, b = lhs._sort_order, rhs._sort_order
+                        aligned = m[a]
+                        want = np.sum(lhs.values[a][aligned] * rhs.values[b][aligned])
+                    self.assertEqual(lhs.scalar_multiplication(rhs), want)
+
     def test_contradicting_restrictions_are_refused(self):
         hel = self.FERMION
         a = self._density(hel, 81, restriction=[(1,)])


### PR DESCRIPTION
**Stacked on #349** — base branch is `claude/ms-density-pol-restrict`, not `madspin_density`. It should land in #349 before #349 merges, because it removes a regression #349 would otherwise ship.

## Why this exists

Benchmarking the contraction turned up that **#349's restriction made it slower, not faster** — restricted ran at 0.73–0.90x the speed of unrestricted at every basis size, up to +32% on the largest. That is backwards for a feature whose premise is that most rows are dead.

Cause: the mask was cached per basis (correct), but the per-event work still boolean-indexed the full-length values array *twice*, and boolean indexing scans and counts the whole array however few rows survive. The restricted `trace()` additionally recomputed `diag_mask & mask` on every call.

## The change

Cache the surviving row **indices** alongside the mask (`_restriction_rows` -> `(mask, rows, diag_rows)`) and gather by index. For the sorted-alignment path — the one production actually takes for >=2 decaying particles, since `density_dec` is a tensor product with no map — the restriction is folded into the cached sort permutation (`_restriction_sorted_rows`), so a single gather does masking and alignment together. `_restriction_row_mask` stays as a thin wrapper.

## Isolated benchmark, before -> after (ns/call, numpy 2.4.6)

| case | rows | kept | restr. contraction | restr. trace | unrestr. contraction (ref) |
|---|---|---|---|---|---|
| t | 4 | 1 | 1355 -> **1201** | 1126 -> **876** | 980 |
| Z | 9 | 1 | 1372 -> **1225** | 1160 -> **871** | 972 |
| t t~ | 16 | 4 | 1621 -> **1278** | 1146 -> **879** | 1158 |
| t t~ Z | 144 | 4 | 1930 -> **1350** | 1165 -> **918** | 1403 |
| t t~ t t~ | 256 | 1 | 1969 -> **1313** | 1154 -> **886** | 1539 |
| t t~ W+ W- | 1296 | 16 | 3826 -> **1310** | 1434 -> **875** | 2982 |

The restricted path is now *faster* than the unrestricted one for every basis >= 144 rows (2.25x at 1296), instead of ~30% slower.

## End-to-end measurement: no visible effect, and that is the honest answer

Measured on a real MadSpin run (`g g > t{R} t~ z`, 3000 unweighted events, `spinmode = madspin`, `nb_core 1`, 144-row density basis). The restriction is confirmed active, not silently skipped: `set_hel_restriction` called 47801x and `_restriction_sorted_rows` 182100x (unreachable when `restriction is None`).

**Wall clock**, 4 repetitions alternating base <-> optimised, same events, same seed:

| | rep0 | rep1 | rep2 | rep3 |
|---|---|---|---|---|
| base decay stage | 5.48 s | 5.96 s | 6.36 s | 5.94 s |
| new decay stage | 5.74 s | 6.12 s | 5.65 s | 5.85 s |

Spread is +/-0.9 s (~15%) against a predicted effect of ~35 ms. **The gain is ~50x smaller than the run-to-run noise and is not measurable in a real run.**

**cProfile** over the same run, identical call counts on both sides (182100 contractions, 331001 traces, 364200 tensor products), so the comparison is apples-to-apples:

| function | ncalls | tottime base -> new | cumtime base -> new |
|---|---|---|---|
| `scalar_multiplication` | 182100 | 0.491 -> 0.386 s | 1.019 -> **0.920 s** |
| `trace` | 331001 | 0.317 -> 0.256 s | 1.067 -> **1.003 s** |
| `tensor_product` | 364200 | 0.623 -> 0.652 s | 1.289 -> 1.330 s |
| `sequential_accept_reject` | 40500 | — | 46.884 -> 46.971 s |

Saving: **0.163 s off a 46.9 s accept/reject loop = 0.35%.**

To be precise about an earlier over-claim in this PR's history: the *share* estimate was right — the contraction is 0.8–2.0% of the event loop — but the *saving* is ~0.35%, not "low single-digit percent". Negligible in practice.

**So: merge this because it removes a 30–45% regression on the path #349 adds, not because it makes MadSpin faster.** Both halves of that are now measured rather than argued.

## Correctness: exact, not approximate

Same rows, same increasing order, same reduction, so the float result is bit-identical.

- Standalone harness reconstructing the verbatim base implementations and comparing with `==`: **14019 checks, 0 mismatches**, over 7 processes x 3 seeds x every restriction combination, both operand orders, both the map fast path and the sorted path, and the explicit `hel_restriction=` route.
- `test_restricted_paths_are_bit_identical_to_masking` uses `assertEqual`, not `allclose`. Confirmed not vacuous: reversing the cached row order makes it fail.

`Ran 149 tests ... OK` (148 on the base branch).

## Follow-up previously flagged, now withdrawn

An earlier revision suggested restricting the decay matrices before tensoring, on the strength of a 12.3 us vs 3.8 us gap in the 1296-row isolated benchmark. That does not carry over: on the real 144-row run `tensor_product` is 1.330 s cumulative against 0.920 s for the contraction — a ratio of 1.45, not 3.2 — and `t{R}` keeps 36 of 144 rows, so a restriction-aware tensor product could remove at most ~2% of runtime in exchange for plumbing the restriction through `interface_madspin.py`. **Not worth the risk at realistic basis sizes.**

## The finding actually worth acting on (separately)

The density layer is not where MadSpin's time goes:

- `lhe_parser.py`: **23.35 s** tottime, about half the accept/reject loop. `FourMomentum.__init__` alone is 7.0M calls / 3.2 s; `Particle.parse`, `Event.parse`, `mass_shuffle` and `reshuffle_decay` account for most of the rest.
- All of `MadSpin/decay.py`: **3.18 s** tottime (6.8%). Perfectly eliminating the entire DensityMatrix layer would buy under 7%.

If MadSpin is to be made faster, the target is LHE parsing and momentum handling.

## Caveats

- One process, one machine, single-core. Not repeated on a larger basis, where the isolated benchmark predicts a bigger contraction gain — though its *share* of runtime would have to grow too for that to show up end to end, and nothing in this profile suggests it would.
- cProfile inflates per-call Python overhead; part of the 0.163 s is the base's extra `_restriction_row_mask` call (513101 of them) that the new code avoids. The un-profiled A/B is the honest answer, and it says no visible difference.
- Bit-equality is established by the 14019-case harness and the unit test, not by diffing LHE files between the two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
