### PR TITLE
MadSpin: define the polarisation on MG5's me_frame axis, not the lab

### DIFF
--- a/MADSPIN_SEQUENTIAL_PLAN.md
+++ b/MADSPIN_SEQUENTIAL_PLAN.md
@@ -82,8 +82,9 @@ Polarisation on a **decay** line is rejected outright in the density spin modes
 defines the branching ratio, not the density matrix that is contracted.
 
 Validated end to end against the analytic decay distributions (`spinmode` in
-parentheses; theta measured in the parent rest frame against the parent's lab
-direction, which is the axis the helicity is quantised along):
+parentheses; theta measured in the parent rest frame against the parent's
+direction **in the `me_frame` frame**, which is the axis the helicity is
+quantised along -- see the next section, which is what fixed that axis):
 
 | production | observable | measured | expected |
 |---|---|---|---|
@@ -97,6 +98,112 @@ direction, which is the axis the helicity is quantised along):
 In every polarised run the *un*polarised partner in the same event (the `t~`,
 which carries no brace) stayed compatible with zero, confirming the mask is
 per particle. A no-brace run is byte-identical to the pre-change code.
+
+Those `w+` rows were measured against the parent's **lab** direction, which at
+the time was also the axis MadSpin quantised on -- self-consistent, and the
+wrong axis. See below.
+
+### Which frame the brace is defined in (`me_frame`)
+
+A polarised matrix element is **not Lorentz invariant**, so `w+{0}` is only a
+statement once a frame is named. MG5 names it in the run_card:
+
+    me_frame = 1, 2      # frame_id = sum(2**n) = 6
+
+Measured, on 200 events of `p p > w+{0} w-` (`SMATRIX` from the library MadSpin
+itself builds, evaluated on the LHE momenta and on the same momenta boosted into
+the partonic CM):
+
+    SMATRIX(lab) / SMATRIX(partonic CM)
+      {0}       min 0.512   max 7.251   mean 1.562
+      {T}       min 0.483   max 1.180   mean 0.892
+      {0}+{T}   min 1.000   max 1.000   mean 1.000   (|ratio-1| <= 1.3e-8)
+
+Each polarised piece moves by up to a factor 7 between the two frames; their sum
+-- the unpolarised `|M|^2`, which *is* invariant -- is unchanged to numerical
+precision. That is the cleanest statement of what is at stake: the frame does
+not change any physics, it changes **which helicity `{0}` names**.
+
+**MadEvent means the `me_frame` frame, and the default is the partonic CM.**
+`auto_dsig_v4.inc:134` calls `boost_to_frame(PP, frame_id, P1)` and skips it
+only for `frame_id.eq.6`, because `genps.f` (`x_to_f_arg`, `mom2cx` on
+`p(0,-nbranch) = (sqrt(shat),0,0,0)`) already builds `PP` in the partonic CM;
+`cm_rap` is carried separately for the rapidity cuts, and `unwgt.f`
+(`zboost_with_beta`) boosts to the lab only on the way out to the LHE file. So
+the momenta the polarised matrix element sees are the partonic-CM ones, and the
+lab momenta in the event file are a *later* z boost. MadSpin's own v1 Fortran
+driver agrees: `driver.f:266` calls `boost_to_frame(pfull, frame_id, P2)`
+unconditionally, and its copy of `boost_to_frame` has no `frame_id.eq.6`
+short-circuit, so it really does boost. Note also that no `me_frame` value can
+name the lab frame -- it selects the rest frame of a subset of the external
+momenta, and the lab is not one of those.
+
+**The density spin modes did not.** `_frame_boost` opened with
+
+    if self._beampol() is None:
+        return None
+
+so with unpolarised beams -- the common case, and every `p p >` run -- the
+production and decay density matrices were both built from **lab** momenta. The
+justification given when that guard was written (b231141fe) was explicit and, at
+the time, correct: *"the frame cannot change an observable here at all"*, because
+the contraction `sum_ij rho_prod(i,j) rho_dec(i,j)` is a trace and a boost acts
+on it as a unitary change of basis that cancels between the two factors.
+
+The previous section is exactly what breaks that argument. `set_hel_restriction`
+is a **projection**, not a change of basis, and a projection does not commute
+with one. The guard was safe before the restriction existed and is a live bug
+after it.
+
+Measured end to end, 10000 unweighted events per row, `p p > w+ w-` at 13 TeV,
+`spinmode madspin`, `decay w+ > e+ ve`, one MadEvent sample per polarisation
+reused by both MadSpin variants (`<|y_boost|>` = 1.57 / 1.48, so the lab and the
+partonic CM are far apart):
+
+| production | MadSpin | `<cos^2>` on the lab axis | `<cos^2>` on the me_frame axis |
+|---|---|---|---|
+| `p p > w+{0} w-` | before | **0.1977 +- 0.0021** | 0.2732 +- 0.0027 |
+| `p p > w+{0} w-` | after  | 0.2738 +- 0.0027 | **0.1974 +- 0.0021** |
+| `p p > w+{T} w-` | before | **0.4017 +- 0.0031** | 0.3783 +- 0.0031 |
+| `p p > w+{T} w-` | after  | 0.3646 +- 0.0031 | **0.4019 +- 0.0031** |
+
+(analytic: 1/5 for a pure `{0}`, 2/5 for a pure `{T}`, 1/3 for flat.)
+
+The two rows of each pair simply swap which axis carries the textbook value. The
+old code was self-consistent -- it put a clean `sin^2(theta)` on the lab axis --
+but the events it was decaying had been generated with `{0}` meaning the
+partonic-CM helicity, so it restricted the wrong one. Reading the "before" line
+as a helicity decomposition on the axis MG5 actually meant, `0.4 - 0.2 f_0`
+gives `f_0 = 0.63` for the nominally 100% longitudinal sample and `f_0 = 0.11`
+for the nominally 0% one: roughly a third of the polarisation purity the user
+asked for, thrown away by the frame alone. This is a live bug for ordinary
+`p p >` runs, not a latent trap.
+
+Two changes, both in `_frame_boost`:
+
+- the guard is now `if self._beampol() is None and not
+  self._production_polarization(): return None`. The frame is honoured when it
+  can change an observable -- polarised beams, or a brace on a final-state
+  particle of the production -- and skipped otherwise, so unpolarised density
+  runs keep the bit-for-bit behaviour b231141fe was careful to preserve. The
+  brace does not have to be on a particle MadSpin decays: a restricted helicity
+  sum over any final-state leg is frame dependent and reshapes `rho_prod`.
+- `_, orig_order, _, _ = self.get_pdir(event)` unpacked **four** values from a
+  `get_pdir` that has returned five (`pdir, orig_order, prefix, pos, tag`) since
+  6ba177c56, i.e. since well before b231141fe. `_frame_boost` therefore raised
+  `ValueError: too many values to unpack (expected 4, got 5)` the first time it
+  was ever reached. Nothing reached it, because the guard above turned it off
+  for unpolarised beams -- so **the whole `me_frame` path in the density modes
+  had never executed**, and `polbeam1`/`polbeam2` in a density spinmode crashed.
+  The unit-test stub `_FrameStub.get_pdir` returned a 4-tuple, which is why the
+  tests were green; it now returns the real 5-tuple.
+
+Cross-checks: the integrated weight is untouched (10.60038 pb for `{0}`,
+54.1049 pb for `{T}`, identical before and after and equal to the production
+cross section -- the restriction enters `N_0 = Tr(rho)` too, so the normalisation
+does not move); an unpolarised run is byte-identical to the pre-change code; and
+a brace on a particle MadSpin does *not* decay (`p p > w+{0} w-` with
+`decay w- > e- ve~`) runs through the newly-live frame path without incident.
 
 ### The partial weight
 

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6538,13 +6538,37 @@ class MadSpinInterface(extended_cmd.Cmd):
         ``Event.boost`` / ``_boost_momenta``, which negate the spatial part
         themselves (HELAS ``boostx``, exactly what ``boost_to_frame`` does in
         driver.f).
+
+        Two things switch it on, and both are cases where the frame is
+        *observable*:
+
+        - polarised beams. ``beampol`` reweights the initial-state helicity sum
+          and that sum is quantised along the frame's axis.
+        - a polarisation brace on a final-state particle of the production
+          process (``p p > w+{0} w-``). MG5 defines those braces in the
+          ``me_frame`` frame -- MadEvent evaluates the polarised matrix element
+          there (``auto_dsig_v4.inc``, ``boost_to_frame``; the default
+          ``me_frame=[1,2]`` is skipped only because ``genps.f`` already builds
+          its momenta in the partonic CM and ``unwgt.f`` boosts to the lab on
+          the way out), and MadSpin's own v1 driver does the same
+          (``boost_to_frame`` in driver.f, unconditionally). The density modes
+          apply that brace as a *projection* on rho_prod
+          (``set_hel_restriction``), and a projection does not commute with the
+          change of helicity basis a boost induces, so leaving the momenta in
+          the lab would restrict a different helicity than the one the input
+          events were generated with.
+
+        Everything else stays in the lab, which keeps unpolarised density runs
+        bit-for-bit unchanged: there the full double sum
+        ``sum_ij rho_prod(i,j) rho_dec(i,j)`` is a trace, and a boost acts on it
+        as a unitary change of basis that cancels between the two factors.
         """
-        if self._beampol() is None:
+        if self._beampol() is None and not self._production_polarization():
             return None
         frame_id = int(self.options['frame_id'])
         if frame_id <= 0:
             return None
-        _, orig_order, _, _ = self.get_pdir(event)
+        _, orig_order, _, _, _ = self.get_pdir(event)
         momenta = event.get_momenta(orig_order)
         selected = [n for n in range(1, len(momenta) + 1) if frame_id >> n & 1]
         if not selected:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -253,13 +253,23 @@ class _FrameStub(object):
     """Just enough of MadSpinInterface for the frame/beampol helpers: they only
     need the options and the matrix-element ordering of the event."""
 
-    def __init__(self, frame_id, beampol):
+    def __init__(self, frame_id, beampol, prodpol=None):
         self.options = interface_madspin.MadSpinOptions()
         self.options['frame_id'] = frame_id
         self.options['beampol'] = list(beampol)
+        # what _production_polarization would have parsed out of the banner's
+        # proc_card: {} for a brace-free production process
+        self._production_polarization_cache = prodpol if prodpol else {}
 
     def get_pdir(self, event):
-        return None, None, None, None
+        # the real one returns (pdir, orig_order, prefix, pos, tag) -- five
+        # values.  _frame_boost used to unpack four, so it raised ValueError the
+        # moment it was reached; keep the arity honest here so the tests can see
+        # that again if it comes back.
+        return None, None, None, None, None
+
+    def _production_polarization(self):
+        return self._production_polarization_cache
 
     _beampol = interface_madspin.MadSpinInterface._beampol
     _frame_boost = interface_madspin.MadSpinInterface._frame_boost
@@ -286,8 +296,8 @@ class TestFrameBoost(unittest.TestCase):
                (300., 100., 50., -80.),
                (400., -100., -50., 380.)]
 
-    def _stub(self, frame_id, beampol=(80., 0.)):
-        return _FrameStub(frame_id, beampol)
+    def _stub(self, frame_id, beampol=(80., 0.), prodpol=None):
+        return _FrameStub(frame_id, beampol, prodpol)
 
     def test_polbeam_to_beampol(self):
         """the card speaks percent, like the run_card polbeam1/polbeam2, and
@@ -334,10 +344,31 @@ class TestFrameBoost(unittest.TestCase):
         self.assertEqual(options.beampol_me(), (1., 1.))
 
     def test_frame_inert_without_polarisation(self):
-        """the frame only changes the axis the initial-state helicities are
-        quantised along, so with unpolarised beams there is nothing to do"""
+        """with unpolarised beams and a brace-free production the contraction is
+        a trace: a boost acts on it as a unitary change of basis and cancels
+        between rho_prod and rho_dec, so there is nothing to do"""
         stub = self._stub(6, beampol=(0., 0.))
         self.assertIsNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
+
+    def test_frame_follows_a_production_polarisation_brace(self):
+        """a brace on the production (`p p > w+{0} w-`) is applied as a
+        *projection* on rho_prod, and a projection does not commute with the
+        change of basis a boost induces -- so the frame has to be honoured even
+        with unpolarised beams, or MadSpin would restrict a different helicity
+        than the one MadEvent generated the events with"""
+        stub = self._stub(6, beampol=(0., 0.), prodpol={24: (0,)})
+        boost = stub._frame_boost(_MomentaEvent(self.MOMENTA))
+        self.assertIsNotNone(boost)
+        self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                         (700., 0., 0., 300.))
+
+    def test_frame_boost_unpacks_get_pdir(self):
+        """get_pdir returns five values; unpacking four raised ValueError the
+        first time the frame was actually used (which no unpolarised run ever
+        did, so it went unnoticed)"""
+        stub = self._stub(6)
+        self.assertEqual(len(stub.get_pdir(None)), 5)
+        self.assertIsNotNone(stub._frame_boost(_MomentaEvent(self.MOMENTA)))
 
     def test_frame_id_bitmask(self):
         """frame_id = sum(2**n over the selected legs), the convention mapid
@@ -1634,6 +1665,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _log_once = interface._log_once
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
+            _production_polarization = staticmethod(lambda: {})
             def __init__(self):
                 self.options = _StubOptions(
                                {'spinmode': 'onshell',
@@ -1832,11 +1864,12 @@ class TestPAUpFrontMass(unittest.TestCase):
             _log_once = interface._log_once
             _beampol = interface._beampol
             _frame_boost = interface._frame_boost
+            _production_polarization = staticmethod(lambda: {})
 
             def __init__(self):
-                # unpolarised beams and no me_frame, so _frame_boost short
-                # circuits to None: this class is about the mass stage, and the
-                # frame machinery has its own tests
+                # unpolarised beams and a brace-free production, so _frame_boost
+                # short circuits to None: this class is about the mass stage,
+                # and the frame machinery has its own tests
                 self.options = _StubOptions(
                                {'spinmode': 'PA',
                                 'sequential_spin_order': '2 3 1',


### PR DESCRIPTION
**Stacked on #349, and a prerequisite for it.** #349 should not merge without this — it is what makes the frame observable in the first place.

## 1. The frame mismatch is real

`p p > w+ w-` at 13 TeV, `spinmode madspin`, `decay w+ > e+ ve`, 10000 unweighted events per row, one MadEvent sample per polarisation reused by both MadSpin variants. `<cos^2 theta>` of the e+ in the W rest frame; `<|y_boost|>` = 1.57 / 1.48.

| production | MadSpin | lab axis | me_frame (partonic CM) axis |
|---|---|---|---|
| `p p > w+{0} w-` | before | **0.1977 +- 0.0021** | 0.2732 +- 0.0027 |
| `p p > w+{0} w-` | after | 0.2738 +- 0.0027 | **0.1974 +- 0.0021** |
| `p p > w+{T} w-` | before | **0.4017 +- 0.0031** | 0.3783 +- 0.0031 |
| `p p > w+{T} w-` | after | 0.3646 +- 0.0031 | **0.4019 +- 0.0031** |

(1/5 pure `{0}`, 2/5 pure `{T}`, 1/3 flat.) MadSpin was self-consistent on the *lab* axis before; it is now self-consistent on MG5's axis.

## 2. The partonic CM is correct — this is not a convention call

A polarised ME is **not Lorentz invariant**. On 200 events, `SMATRIX(lab)/SMATRIX(partonic CM)` runs 0.51–7.25 for `{0}` and 0.48–1.18 for `{T}`, while their **sum** — the unpolarised `|M|^2`, which *is* invariant — agrees to 1.3e-8. The frame does not change the physics; it changes *which helicity `{0}` names*.

MG5 names that frame in `run_card: me_frame`, default `[1,2]` -> `frame_id=6` -> partonic CM. MadEvent implements it (`auto_dsig_v4.inc:134`, skipping only `frame_id.eq.6` because `genps.f` already builds momenta there and `unwgt.f` boosts to lab only when writing the LHE). MadSpin's own v1 driver implements it (`driver.f:266`, unconditional). And **no `me_frame` value can name the lab frame** — so the lab basis was never a defensible alternative convention.

## 3. Severity: a live bug, not a latent trap

`_frame_boost`'s guard (`if self._beampol() is None: return None`) was *correct when written* (b231141fe): the full contraction is a trace, and a boost is a unitary basis change that cancels between `rho_prod` and `rho_dec`.

**#349 breaks exactly that argument.** `set_hel_restriction` is a **projection**, and projections do not commute with basis changes. Read as a decomposition on MG5's axis, the "before" numbers give f0 = **0.63** for a nominally 100% longitudinal sample and **0.11** for a nominally 0% one — about a third of the requested purity lost to the frame alone, on ordinary `pp` runs.

## 4. A second, independent bug found

`_frame_boost` did:

    _, orig_order, _, _ = self.get_pdir(event)

but `get_pdir` has returned **five** values since `6ba177c56` — i.e. since before the frame commit. It raised `ValueError: too many values to unpack` the first time it was reached, and nothing ever reached it because the beampol guard turned it off. So **the entire `me_frame` path in the density modes had never executed**, and `polbeam1`/`polbeam2` in a density spinmode crashed.

The tests were green because `_FrameStub.get_pdir` returned a 4-tuple. That stub now returns the real arity.

## The fix

    if self._beampol() is None and not self._production_polarization():
        return None

plus the unpack fix.

## Verification

- `python3 tests/test_manager.py test_madspin -t0` -> **`Ran 150 tests ... OK`** (baseline 148 + 2 new).
- **Unpolarised runs are byte-identical** to the pre-fix behaviour (`p p > w+ w-`, 10000 events, same seed, event blocks diffed).
- Integrated weight untouched: 10.60038 pb `{0}`, 54.1049 pb `{T}`; before = after = production cross section.
- A brace on a particle MadSpin does *not* decay (`p p > w+{0} w-` with `decay w- > e- ve~`) runs clean through the newly-live path; the unrestricted w- gives 0.3239 +- 0.0029, an SM mixture as expected.

Verified to merge cleanly with every sibling on #349 (#350, #351, #352, #353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align MadSpin polarisation handling with MG5's `me_frame` axis so production helicity restrictions are applied consistently with event generation.

Bug Fixes:
- Define MadSpin production polarisation braces in MG5's configured `me_frame`, preserving the requested helicity selection for density-matrix decays.
- Fix the density-mode frame path so it executes correctly when production polarisation is present and no longer fails due to outdated event-direction unpacking.

Enhancements:
- Preserve byte-identical behaviour for unpolarised, brace-free density runs while applying frame transformations whenever polarisation makes the frame observable.

Documentation:
- Document the `me_frame` basis used for polarisation and the conditions under which MadSpin applies frame transformations.

Tests:
- Extend frame-handling tests to cover production polarisation braces and the current `get_pdir` return shape.