### PR TITLE
MadSpin: fix a raise that raised NameError instead of MadSpinError

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6884,7 +6884,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 try:
                     proc_nb = int(proc_nb)
                 except ValueError:
-                    raise MadSpinError('MadSpin didn\'t allow order restriction after the @ comment: \"%s\" not valid' % proc_nb)
+                    raise madspin.MadSpinError('MadSpin didn\'t allow order restriction after the @ comment: \"%s\" not valid' % proc_nb)
                 proc_nb = '@ %i' % proc_nb 
                 if self.options['global_order_coupling']:
                     proc_nb = '%s %s' % (proc_nb, self.options['global_order_coupling'])

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -45,7 +45,7 @@ import MadSpin.interface_madspin as interface_madspin
 import models.import_ufo as import_ufo
 
 
-from madgraph import MG5DIR
+from madgraph import MG5DIR, MadGraph5Error
 #
 class TestBanner(unittest.TestCase):
     """Test class for the reading of the banner"""
@@ -185,6 +185,85 @@ class TestBanner(unittest.TestCase):
                          out.split(';')[:-1])       
 
           
+
+class _ProcCardBanner(object):
+    """Minimal banner stand-in exposing only the proc_card lines."""
+
+    def __init__(self, proc_card):
+        self.proc_card = proc_card
+
+
+class _ProcCardInterface(object):
+    """Minimal MadSpinInterface stand-in.
+
+    generate_all_matrix_element only reads banner.proc_card, list_branches and
+    options, so a full interface (which needs an event file and a model) is not
+    required to reach the '@' order-restriction check.
+    """
+
+    def __init__(self, proc_card):
+        self.banner = _ProcCardBanner(proc_card)
+        self.list_branches = {}
+        self.options = {'global_order_coupling': ''}
+
+
+class TestOrderRestrictionError(unittest.TestCase):
+    """An invalid order restriction after '@' must report what is wrong.
+
+    interface_madspin.generate_all_matrix_element used to raise a bare
+    'MadSpinError', a name that module never imports.  The int(proc_nb)
+    ValueError therefore led to 'NameError: name MadSpinError is not defined'
+    raised *during* the handling of that ValueError, and the intended
+    diagnostic was lost.
+    """
+
+    bad_line = 'generate p p > t t~ @NLO'
+
+    def test_interface_reports_the_invalid_order_restriction(self):
+        """the interface copy of the check raises MadSpinError, not NameError"""
+
+        cmd = _ProcCardInterface([self.bad_line])
+        gen = interface_madspin.MadSpinInterface.generate_all_matrix_element
+
+        self.assertRaises(madspin.MadSpinError, gen, cmd)
+
+        try:
+            gen(cmd)
+        except madspin.MadSpinError as error:
+            # the offending token has to be in the message, otherwise the user
+            # cannot tell which process line to fix
+            self.assertIn('NLO', str(error))
+            self.assertIn('order restriction after the @ comment', str(error))
+            # raised from inside 'except ValueError', so the int() failure is
+            # the chained context; what matters is that the *raised* error is
+            # the MadSpin one and not a NameError from the handler itself
+            self.assertNotIsInstance(error, NameError)
+            self.assertIsInstance(error, MadGraph5Error)
+
+    def test_decay_path_reports_the_same_error(self):
+        """the decay.py copy of the same check stays consistent with it"""
+
+        # no '[' in the process, so the model is never looked at before the
+        # order-restriction check
+        self.assertRaises(madspin.MadSpinError,
+                          madspin.decay_all_events.get_proc_with_decay,
+                          self.bad_line, 't > w+ b', None)
+
+    def test_valid_order_restriction_passes_the_check(self):
+        """a numeric '@' tag is accepted: the guard does not fire"""
+
+        cmd = _ProcCardInterface(['generate p p > t t~ @1'])
+        gen = interface_madspin.MadSpinInterface.generate_all_matrix_element
+
+        # the method is still unfinished further down, so it raises something
+        # else; the point is that it is no longer the order-restriction error
+        try:
+            gen(cmd)
+        except madspin.MadSpinError as error:
+            self.fail('valid order restriction rejected: %s' % error)
+        except Exception:
+            pass
+
 
 class TestDensity(unittest.TestCase):
     """Test class for the reading of the lhe input file"""


### PR DESCRIPTION
`MadSpin/interface_madspin.py:6887` raised a bare `MadSpinError`, a name never imported into that module (the class lives at `MadSpin/decay.py:76`). Since the `raise` sits inside an `except ValueError:` handler, it produced `NameError: name 'MadSpinError' is not defined` chained to the original `ValueError`, hiding the real diagnostic.

Fixed by qualifying it through the module's existing `import MadSpin.decay as madspin` alias (already used 12 times in the file), so no new import.

## Scope, stated up front

**This is a latent bug, not one users hit today.** `generate_all_matrix_element` in `interface_madspin.py` is dead code — no callers anywhere in the repository — and its body is unfinished (it ends in a literal `raise Exception` and calls `ReweightInterface.get_LO_definition_from_NLO()` with zero arguments on a method taking `(proc, model)`). The copy users actually reach is `decay.py:3038`, which already raised `MadSpinError` correctly. The fix makes the diagnostic right if and when this method is wired up; the surrounding WIP was left alone to keep the diff minimal.

## Why `MadSpinError` rather than `InvalidCmd`

- The **identical check with the identical message** already exists at `decay.py:3038` and raises `MadSpinError`. Making this copy raise a different class would give the same user mistake two different exception types depending on which copy runs.
- The `InvalidCmd` convention in this file is specifically `self.InvalidCmd` inside `do_*` handlers, where `extended_cmd.Cmd.error_handling` catches it for the clean `nice_user_error` path. `generate_all_matrix_element` is not a command handler, and `self.InvalidCmd` there resolves to `extended_cmd.Cmd.InvalidCmd`, a plain `Exception` subclass unrelated to `MadGraph5Error`.
- Git history confirms intent: the line was `raise MadSpinError, '...'` since Python 2, and the 2to3 modernisation only added parentheses. The name was never in scope in this module.

## Before / after, measured

Driving `generate_all_matrix_element` with the proc-card line `generate p p > t t~ @NLO`:

- **Before:** `NameError: name 'MadSpinError' is not defined`, `__context__` = the `ValueError`. MRO: `NameError -> Exception`.
- **After:** `MadSpinError: MadSpin didn't allow order restriction after the @ comment: "NLO" not valid`, `__context__` still the `ValueError`. MRO: `MadSpinError -> MadGraph5Error -> Exception`.

## Sibling sweep

`pyflakes` installed into a scratch venv and run over all of `MadSpin/*.py`. Neither file uses `import *`, so undefined-name analysis was fully active. Complete results:

| location | name | action |
|---|---|---|
| `interface_madspin.py:6887` | `MadSpinError` | **fixed** |
| `interface_madspin.py:6423, 6424` | `label_to_index` | **left deliberately** |
| `decay.py` | — | none found |

`label_to_index` is defined **nowhere in the repository**, so there is no unambiguous fix without inventing the mapping. Its method `get_density_matrix_element_from_label` is also dead (zero callers) and independently malformed — declared as an instance method whose first parameter is `matrix`, not `self`, so it could not be called as a bound method even with the name defined. Deleting it would be defensible but widens the diff, and it plausibly belongs to in-flight density-matrix work on the stacked branches. Flagged rather than touched.

The remaining pyflakes output is unused locals and one shadowed import (`interface_madspin.py:240`, loop variable `files` shadowing the module imported at line 41) — pre-existing hygiene, out of scope.

## Tests

New `TestOrderRestrictionError` with two small module-level stubs matching the file's existing convention (the method only reads `banner.proc_card`, `list_branches` and `options`, so no event file, model or f2py build is needed):

1. asserts `MadSpinError`, that the message names the offending token, that it is not a `NameError`, and that it is a `MadGraph5Error`;
2. locks the `decay.get_proc_with_decay` copy to the same class so the two cannot drift apart again;
3. `@1` must not trip the guard.

**The test was verified to fail before the fix**, not merely assumed: stashing only `interface_madspin.py` gives `Ran 3 tests ... FAILED (errors=1)` with the traceback ending in `NameError` at line 6887.

Baseline re-measured on a confirmed-clean tree: `Ran 137 tests ... OK`. After: **`Ran 140 tests ... OK`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct MadSpin order-restriction error reporting and keep its validation behavior consistent across code paths.

Bug Fixes:
- Fix invalid MadSpin order-restriction handling so it raises the intended MadSpinError instead of a NameError and preserves the actionable diagnostic.

Tests:
- Add coverage for invalid and valid order restrictions and ensure the interface and decay paths use the same exception type.