### PR TITLE
MadSpin: fix the get_pdir unpack in get_inter_value, and guard the arity

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6674,8 +6674,10 @@ class MadSpinInterface(extended_cmd.Cmd):
     def get_inter_value(self,event,nhel):
         """routine to return all the possible inter for an event"""
         
-        pdir,orig_order = self.get_pdir(event)
-        	
+        # get_pdir returns (pdir, orig_order, prefix, pos, tag); only the first
+        # two are used here.
+        pdir, orig_order, _, _, _ = self.get_pdir(event)
+
         if pdir in self.all_amp:
             all_p = event.get_all_momenta(orig_order)
             for p in all_p:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3325,3 +3325,121 @@ class TestCheckWeightIdentitySlotPairing(unittest.TestCase):
         decays = self._build_decays(particles, slot_to_index, slot_decays)
         self.assertRaises(AssertionError, self._run_check, production, decays,
                           particles, len(slot_to_index))
+
+
+class _InterStub(object):
+    """Just enough of MadSpinInterface for ``get_inter_value``: the pdir->callable
+    caches and a ``get_pdir`` with the *real* return arity."""
+
+    PDIR = 'P0_dummy'
+    ORDER = ((1, -1), (3, -3))
+
+    def __init__(self):
+        # the four caches MadSpinInterface.__init__ creates
+        self.all_amp = {self.PDIR: lambda P, hel, IC: float(sum(hel))}
+        self.all_jamp = {self.PDIR: lambda amp: [amp]}
+        self.all_inter = {self.PDIR: lambda ja, jb: ja[0] * jb[0]}
+        self.all_matrix = {}
+
+    def get_pdir(self, event):
+        # mirrors MadSpinInterface.get_pdir: (pdir, orig_order, prefix, pos, tag)
+        return self.PDIR, self.ORDER, 'pref_', 0, self.ORDER
+
+    get_inter_value = interface_madspin.MadSpinInterface.get_inter_value
+
+
+class _InterEvent(object):
+    """``get_inter_value`` only ever asks the event for its momenta."""
+
+    def get_all_momenta(self, orig_order):
+        return [[(1., 0., 0., 1.), (1., 0., 0., -1.),
+                 (1., 0., 1., 0.), (1., 0., -1., 0.)]]
+
+
+class TestGetPdirUnpackArity(unittest.TestCase):
+    """``get_pdir`` grew from returning 2 values to 4 (single f2py library) to 5
+    (loop-induced production) without every call site following along, and the
+    result is a ``ValueError: too many values to unpack`` that only shows up when
+    the call is actually made. These tests turn that into a test failure instead:
+    change ``get_pdir``'s return and the arity check below goes red."""
+
+    SOURCE = pjoin(MG5DIR, 'MadSpin', 'interface_madspin.py')
+
+    # ``_frame_boost`` still unpacks 4 on this branch; its fix travels with the
+    # frame/beampol PR (#355). Drop this entry once that has landed.
+    KNOWN_PENDING = set(['_frame_boost'])
+
+    def _tree(self):
+        import ast
+        with open(self.SOURCE) as fsock:
+            return ast.parse(fsock.read()), ast
+
+    def _interface_class(self):
+        tree, ast = self._tree()
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and node.name == 'MadSpinInterface':
+                return node, ast
+        self.fail('MadSpinInterface not found in %s' % self.SOURCE)
+
+    def _return_arity(self):
+        """number of values ``MadSpinInterface.get_pdir`` returns"""
+        klass, ast = self._interface_class()
+        for meth in klass.body:
+            if isinstance(meth, ast.FunctionDef) and meth.name == 'get_pdir':
+                arities = [len(n.value.elts) for n in ast.walk(meth)
+                           if isinstance(n, ast.Return) and n.value is not None
+                           and isinstance(n.value, ast.Tuple)]
+                self.assertTrue(arities, 'get_pdir returns no tuple')
+                self.assertEqual(len(set(arities)), 1,
+                                 'get_pdir returns tuples of differing length: %s'
+                                 % arities)
+                return arities[0]
+        self.fail('MadSpinInterface.get_pdir not found')
+
+    def _call_sites(self):
+        """[(method name, line, number of targets)] for every ``... = self.get_pdir(...)``"""
+        klass, ast = self._interface_class()
+        out = []
+        for meth in klass.body:
+            if not isinstance(meth, ast.FunctionDef):
+                continue
+            for node in ast.walk(meth):
+                if not isinstance(node, ast.Assign):
+                    continue
+                call = node.value
+                if not isinstance(call, ast.Call):
+                    continue
+                fct = call.func
+                if not (isinstance(fct, ast.Attribute) and fct.attr == 'get_pdir'):
+                    continue
+                target = node.targets[0]
+                nb = len(target.elts) if isinstance(target, ast.Tuple) else 1
+                out.append((meth.name, node.lineno, nb))
+        return out
+
+    def test_get_pdir_return_arity(self):
+        """the arity the call sites are checked against -- a bump here is the
+        signal to update them all"""
+        self.assertEqual(self._return_arity(), 5)
+
+    def test_every_call_site_matches(self):
+        """every ``self.get_pdir(...)`` unpack in MadSpinInterface agrees with
+        what get_pdir actually returns"""
+        expected = self._return_arity()
+        sites = self._call_sites()
+        # the sweep is worthless if the AST walk found nothing
+        self.assertTrue(len(sites) >= 4, 'no get_pdir call site found')
+        bad = ['%s (line %s) unpacks %s' % (name, line, nb)
+               for name, line, nb in sites
+               if nb != expected and name not in self.KNOWN_PENDING]
+        self.assertEqual(bad, [],
+                         'get_pdir returns %s value(s) but: %s'
+                         % (expected, ', '.join(bad)))
+
+    def test_get_inter_value_runs(self):
+        """the regression proper: get_inter_value used to unpack 2 and died with
+        ``ValueError: too many values to unpack`` on its very first statement"""
+        nhel = [[1, -1, 1, -1], [-1, 1, -1, 1]]
+        inter = _InterStub().get_inter_value(_InterEvent(), nhel)
+        # one entry per (jamp_i, jamp_j) pair, i.e. len(nhel)**2
+        self.assertEqual(len(inter), len(nhel) ** 2)


### PR DESCRIPTION
`get_inter_value` did `pdir, orig_order = self.get_pdir(event)`, but `get_pdir` returns **five** values (`pdir, orig_order, prefix, pos, tag`), so the call raised `ValueError: too many values to unpack` — the third instance of the same arity drift found in this batch, after `_frame_boost` (#355) and a `NameError` in dead code (#356).

## The path is dead code — proof, since that was the open question

1. `get_inter_value` has exactly **two** references in the whole tree: its own `def`, and its own tail-recursive retry on the last line of its own body. There is no wrapper and no external caller.
2. No dynamic dispatch reaches it — the only `getattr(self, 'get_…')` patterns in the tree are `extended_cmd.py`'s `get_allowed_%s` / `get_cardcmd_for_%s`, which cannot produce this name.
3. Its caches (`all_amp` / `all_jamp` / `all_inter` / `all_matrix`, initialised empty) are written at exactly one place — inside its own dead `else` branch — so they are permanently empty and even a hypothetical call would take that branch every time.
4. That branch could not work anyway: `get_mymod` ends in a bare `return`, so the 4-target unpack would raise `TypeError: cannot unpack non-iterable NoneType` and then infinitely recurse. And `get_mymod`'s first statement `self.f2py_module.get_prefix()` would `AttributeError` first, because wherever `get_pdir` works `f2py_module` is a **list**.

Point 4 is the structural clincher. Two incompatible layouts coexist in this file:

- **density modes**: `f2py_module = [prod, decay]`, `pdg2prefix = [prod_dict, decay_dict]`
- **`onshell_v1` / `madspin_v1`**: `f2py_module = <single module>`, `pdg2prefix = {pdg_tuple: ...}`

`get_pdir` indexes `pdg2prefix[0]`/`[1]`, so it only works in the density world, while `get_inter_value`'s `get_mymod` and `get_nhel`'s `getattr(self.f2py_module, ...)` assume the single-module world. The two can never hold at once. `get_inter_value`, `get_nhel` and `get_mymod` are a stranded legacy cluster.

So this is neither "a configuration nobody exercises" nor a swallowed exception — there is simply no caller.

**Dating the drift** (`git log -L` on `get_pdir`'s return):

| commit | date | returns |
|---|---|---|
| `94d5782d5` | 2023-08-12 | 2 |
| `e16ac171b` | 2026-01-09, "single library for f2py" | **4** |
| `6ba177c56` | 2026-07-07, loop-induced production | **5** |

`get_inter_value` was last touched 2024-06-25 and was correct until `e16ac171b` — so it has been broken for ~7 months, unnoticed because nothing calls it. `_frame_boost` was written against the 4-tuple era and broke at `6ba177c56`.

## Full sweep of `get_pdir` call sites

| site | unpacks | status |
|---|---|---|
| `_frame_boost` | 4 | **broken — left for #355 deliberately**, fixing it here would conflict |
| `get_density` | 5 | OK (live) |
| `get_inter_value` | 5 | **fixed here** (was 2) |
| `get_nhel` | 5 | OK (arity fine; method itself dead) |
| `get_iden` | 5 | OK (live) |

Plus the test stub `_FrameStub.get_pdir`, which returns 4 to mirror `_frame_boost` — also left to #355.

## Fix

```python
# get_pdir returns (pdir, orig_order, prefix, pos, tag); only the first
# two are used here.
pdir, orig_order, _, _, _ = self.get_pdir(event)
```

`prefix`/`pos`/`tag` are genuinely unused downstream.

## Tests

New `TestGetPdirUnpackArity`, appended at the end of the file to minimise conflict surface:

- `test_get_pdir_return_arity` — pins the return at 5, so a bump becomes a deliberate signal.
- `test_every_call_site_matches` — **the generic guard**: AST-walks `interface_madspin.py` and asserts every `... = self.get_pdir(...)` unpack matches the real return arity. `_frame_boost` sits in a documented `KNOWN_PENDING` set with a comment to drop it once #355 lands; it is an exclusion rather than an expected-failure assertion, so this stays green whichever order the two PRs merge in.
- `test_get_inter_value_runs` — runtime regression: a stub with a correct 5-value `get_pdir` calls the real `get_inter_value` and asserts `len(nhel)**2` entries.

Both new tests confirmed **red on the unfixed source** (stashing the source file only): `test_every_call_site_matches` reported `get_inter_value (line 6677) unpacks 2`, and `test_get_inter_value_runs` errored.

## Verification

Baseline re-measured via `git stash`: **147 tests, OK**. After: **150 tests, OK**. Before/after shown concretely with a stub harness — `ValueError: too many values to unpack (expected 2, got 5)` on the base, `[0, 0, 0, 0]` with the fix.

No end-to-end run: the path has no caller, so a run could not exercise it and would have proved nothing.

## Flagged, not touched

`get_mymod` is a stub ending in a bare `return` after two statements, one of which is incompatible with the current list-valued `f2py_module`. `get_inter_value`, `get_nhel` and `get_mymod` are all dead and all assume the pre-`e16ac171b` single-module layout while depending on `get_pdir`, which assumes the post-change one. **Deleting the three together would be a cleaner resolution than keeping them compiling** — but that is a judgement call, not a minimal-diff change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Keep MadSpin interaction-value calculation compatible with the current `get_pdir` interface and protect the contract with automated tests.

Bug Fixes:
- Fix `get_inter_value` to handle the current five-value return from `get_pdir` without raising an unpacking error.

Enhancements:
- Add regression coverage that verifies `get_pdir` return arity, checks its call sites, and exercises `get_inter_value`.

Tests:
- Add tests guarding `get_pdir` arity consistency and preventing regressions in `get_inter_value`.