### PR TITLE
MadSpin: delete the stranded f2py cluster (get_inter_value, get_nhel, get_mymod)

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -2503,12 +2503,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.generate_all.compile()
         self.all_me = self.generate_all.all_me
         self.all_f2py = {}
-        self.all_amp = {}
-        self.all_nhel = {}
-        self.all_jamp = {}
-        self.all_inter = {}
         self.all_density = {}
-        self.all_matrix = {}
         time_me_generation = time.time() - time_me_generation
         logger.info(f"Time ME generation: {time_me_generation:.2f} sec")         
 	
@@ -6670,66 +6665,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                                                dimension)
         return density_matrix
 
-   
-    def get_inter_value(self,event,nhel):
-        """routine to return all the possible inter for an event"""
-        
-        # get_pdir returns (pdir, orig_order, prefix, pos, tag); only the first
-        # two are used here.
-        pdir, orig_order, _, _, _ = self.get_pdir(event)
 
-        if pdir in self.all_amp:
-            all_p = event.get_all_momenta(orig_order)
-            for p in all_p:
-#                print(pdir,'Momenta=',p)
-                P = rwgt_interface.ReweightInterface.invert_momenta(p)
-#               print("Momenta =",P,"\n")
-                IC = [1]*len(p)
-                amp = []
-                jamp = []
-                inter = []
-           
-                for i,hel in enumerate(nhel):
-                    #print(f"hel = {hel}")		
-                    amp.append(self.all_amp[pdir](P,hel,IC))
-                    jamp.append(self.all_jamp[pdir](amp[i]))
-                #print(f"len(jamp) = {len(jamp)}")
-                for i in range(len(jamp)): 
-                    for j in range(len(jamp)): 
-                        inter.append(self.all_inter[pdir](jamp[i],jamp[j]))
-                return inter
-        else : 
-            self.all_amp[pdir],self.all_jamp[pdir],self.all_inter[pdir],self.all_matrix[pdir]= self.get_mymod(pdir,'INTER')
-
-        return self.get_inter_value(event,nhel) 
-
-
-    def get_nhel(self,event,position):
-
-        pdir,orig_order, prefix, pos, tag = self.get_pdir(event)
-        if pdir in self.all_nhel:
-            iden,NHEL = self.all_nhel[pdir]
-            if position == -1:
-                return iden
-            nhel = rwgt_interface.ReweightInterface.invert_momenta(NHEL)
-            groups = {} 
-            nhel = sorted(nhel) 
-            for item in nhel:
-                a = item.copy()
-                del a[position]
-                t = tuple(a)
-                groups.setdefault(t, []).append(item)
-                grouped = list(groups.values())
-            return grouped,iden
-        else:
-            #transer nhel information from fortran to wrapper
-            getattr(self.f2py_module, '%sget_nhel_entry' % prefix.lower())()
-            #transer now to python dictionary
-            nhel = getattr(getattr(self.f2py_module, '%sprocess_nhel' % prefix.lower()), '%snhel' %prefix.lower())
-            iden = getattr(self.f2py_module, 'get_idens')()[pos]
-            self.all_nhel[pdir] = (iden, nhel)
-            return self.get_nhel(event,position)
-
+    # ``get_inter_value``/``get_nhel``/``get_mymod`` used to live here: the
+    # per-helicity interference loop of the original density prototype. Their
+    # last callers went away in 23409c526 (2024-08, "Caching production and
+    # decay ME using diagonal elements of density matrix") and they were
+    # unreachable ever since -- they assume the pre-e16ac171b single-module
+    # layout (``f2py_module`` a module, ``pdg2prefix`` a flat dict) while
+    # calling ``get_pdir``, which only works with the current two-module one.
+    # Removed rather than left to rot; the interference now comes from
+    # ``py_get_density`` (see ``get_density``).
 
     def get_iden(self, event):
         # DEBUGGING REMOVE
@@ -6757,14 +6702,6 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         #print(f"idens = {idens} , pos = {pos}")
         return idens[pos]
-    
-
-    def get_mymod(self,pdir,MODE): 
-        
-        all_prefix = self.f2py_module.get_prefix()
-        tag = [t for t in self.all_me if self.all_me[t]['pdir'] == pdir][0]
-        return 
-
 
 
     def get_pdir(self,event): 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3327,35 +3327,6 @@ class TestCheckWeightIdentitySlotPairing(unittest.TestCase):
                           particles, len(slot_to_index))
 
 
-class _InterStub(object):
-    """Just enough of MadSpinInterface for ``get_inter_value``: the pdir->callable
-    caches and a ``get_pdir`` with the *real* return arity."""
-
-    PDIR = 'P0_dummy'
-    ORDER = ((1, -1), (3, -3))
-
-    def __init__(self):
-        # the four caches MadSpinInterface.__init__ creates
-        self.all_amp = {self.PDIR: lambda P, hel, IC: float(sum(hel))}
-        self.all_jamp = {self.PDIR: lambda amp: [amp]}
-        self.all_inter = {self.PDIR: lambda ja, jb: ja[0] * jb[0]}
-        self.all_matrix = {}
-
-    def get_pdir(self, event):
-        # mirrors MadSpinInterface.get_pdir: (pdir, orig_order, prefix, pos, tag)
-        return self.PDIR, self.ORDER, 'pref_', 0, self.ORDER
-
-    get_inter_value = interface_madspin.MadSpinInterface.get_inter_value
-
-
-class _InterEvent(object):
-    """``get_inter_value`` only ever asks the event for its momenta."""
-
-    def get_all_momenta(self, orig_order):
-        return [[(1., 0., 0., 1.), (1., 0., 0., -1.),
-                 (1., 0., 1., 0.), (1., 0., -1., 0.)]]
-
-
 class TestGetPdirUnpackArity(unittest.TestCase):
     """``get_pdir`` grew from returning 2 values to 4 (single f2py library) to 5
     (loop-induced production) without every call site following along, and the
@@ -3427,8 +3398,10 @@ class TestGetPdirUnpackArity(unittest.TestCase):
         what get_pdir actually returns"""
         expected = self._return_arity()
         sites = self._call_sites()
-        # the sweep is worthless if the AST walk found nothing
-        self.assertTrue(len(sites) >= 4, 'no get_pdir call site found')
+        # the sweep is worthless if the AST walk found nothing. Three remain:
+        # _frame_boost, get_density and get_iden (get_inter_value/get_nhel were
+        # dead code and have been removed).
+        self.assertTrue(len(sites) >= 3, 'no get_pdir call site found')
         bad = ['%s (line %s) unpacks %s' % (name, line, nb)
                for name, line, nb in sites
                if nb != expected and name not in self.KNOWN_PENDING]
@@ -3436,10 +3409,22 @@ class TestGetPdirUnpackArity(unittest.TestCase):
                          'get_pdir returns %s value(s) but: %s'
                          % (expected, ', '.join(bad)))
 
-    def test_get_inter_value_runs(self):
-        """the regression proper: get_inter_value used to unpack 2 and died with
-        ``ValueError: too many values to unpack`` on its very first statement"""
-        nhel = [[1, -1, 1, -1], [-1, 1, -1, 1]]
-        inter = _InterStub().get_inter_value(_InterEvent(), nhel)
-        # one entry per (jamp_i, jamp_j) pair, i.e. len(nhel)**2
-        self.assertEqual(len(inter), len(nhel) ** 2)
+    def test_dead_f2py_cluster_stays_removed(self):
+        """``get_inter_value``/``get_nhel``/``get_mymod`` were the last users of
+        the pre-e16ac171b single-module f2py layout and had no caller left; they
+        are gone, and so are the caches only they touched."""
+        klass, ast = self._interface_class()
+        methods = set(m.name for m in klass.body
+                      if isinstance(m, ast.FunctionDef))
+        for name in ('get_inter_value', 'get_nhel', 'get_mymod'):
+            self.assertNotIn(name, methods)
+        for cache in ('all_amp', 'all_jamp', 'all_inter', 'all_matrix',
+                      'all_nhel'):
+            self.assertFalse(
+                hasattr(interface_madspin.MadSpinInterface, cache),
+                '%s should not come back as a class attribute' % cache)
+        with open(self.SOURCE) as fsock:
+            source = fsock.read()
+        for cache in ('all_amp', 'all_jamp', 'all_inter', 'all_matrix',
+                      'all_nhel'):
+            self.assertNotIn('self.%s' % cache, source)


### PR DESCRIPTION
Follow-up to #358 (now merged). Deletes the three methods that PR proved unreachable, and removes its `test_get_inter_value_runs` along with the method it tested.

Deletes three unreachable methods from `MadSpin/interface_madspin.py` — `get_inter_value` (31 lines), `get_nhel` (25), `get_mymod` (5) — plus five now-orphaned cache initialisations. The 9 added lines are a comment recording where the cluster lived and why it went.

## Evidence, since the point of this PR is the proof rather than the deletion

**1. Whole-repo reference sweep**, every hit attributed:

- `get_inter_value` — 2 hits in `interface_madspin.py` (its own `def`, its own tail-recursive last line) and 4 in the unit test. Nothing else anywhere.
- `get_nhel` — its own `def` and its own tail recursion. Every other repo hit is unrelated: `Template/LO/Source/PDF/pdg2pdf*.f` and `Template/MadWeight/src/setrun.f` declare a *Fortran* `get_nhel`; `madgraph/iolibs/export_v4.py` uses it as a local Python list while emitting Fortran; the `.inc` files are generated Fortran. `reweight_interface.py:2364` does `getattr(mymod, '%sget_nhel_entry' % prefix)` on **ReweightInterface's own** f2py module, not MadSpinInterface's.
- `get_mymod` — exactly 2 hits: its `def`, and the call inside `get_inter_value`'s unreachable `else`.

**Dynamic dispatch checked explicitly**: an AST sweep over every `.py` looked for these names as `Attribute`, as `Name`, *and* as substrings of string constants. Every `getattr(self, ...)` / `hasattr(self, ...)` in `MadSpin/` uses a literal name, none of them these; there is no `__getattr__`, `__getattribute__` or `eval` on a method name. They are `get_*`, not `do_*`, so `extended_cmd`'s command dispatch cannot reach them either.

**2. The `onshell_v1` / `madspin_v1` question — the premise was wrong, the conclusion holds.**

Those modes are **not** dead: `calculate_matrix_element` has a live `spinmode in ['onshell_v1','madspin_v1']` branch that still builds the old single-module layout (`f2py_module = mymod`, `pdg2prefix = {pdg_tuple: (prefix, i)}`). So "the v1 layout no longer exists" is false.

The cluster is unreachable for a sharper reason: **the v1 path never calls `get_pdir` at all.** `calculate_matrix_element` inlines its own tag/order/pdir lookup and never touches `pdg2prefix`. The complete set of `get_pdir` callers before this change was `_frame_boost`, `get_density`, `get_inter_value`, `get_nhel`, `get_iden` — all density-side. The three layout-building sites are each guarded by `if not hasattr(self, 'f2py_module')`, so whichever runs first wins for the instance's lifetime and the two layouts can never coexist. And in v1 mode `decay.py:4356` only ever calls `fill_all_me(self, "production")`, so `get_pdir` would take the `pdg2prefix[0][...]` branch against a flat dict and raise `KeyError: 0`.

**3. Historical confirmation.** `git log -S` shows real callers existed (`self.get_inter_value(production, hpair)`, `self.get_nhel(decay_event, 0)`) and were removed in `23409c526` (2024-08-28, "Caching production and decay ME using diagonal elements of density matrix"). Dead for ~2 years — *before* `e16ac171b`, not because of it.

**4. Subclass / plugin.** Nothing subclasses `MadSpinInterface` anywhere; the only definition is `class MadSpinInterface(extended_cmd.Cmd)`. It is instantiated directly by `MadSpin/madspin`, `common_run_interface.py:4346` and tests. MG5's plugin mechanism loads `new_interface` / `new_output` classes subclassing `MasterCmd` / exporters — MadSpin is never resolved through the plugin registry, so a plugin override is not a realistic path.

**5. Orphaned state.** After removal, `all_amp`, `all_jamp`, `all_inter`, `all_matrix` **and `all_nhel`** had zero readers and zero writers repo-wide, so all five initialisations are gone. (`all_nhel` was not on the original list but is in exactly the same position — written and read only by `get_nhel`.) Kept: `all_f2py`, used by `calculate_matrix_element`. No helper existed that only the deleted methods called: `get_pdir` and `rwgt_interface.invert_momenta` both have other live callers.

Found but deliberately **not** touched: `self.all_density = {}` has no reader or writer anywhere in the repo either. Independently dead, unrelated to this cluster, left out to keep the diff surgical and tracked separately.

## The arity guard

`TestGetPdirUnpackArity` still passes 3/3. `test_get_inter_value_runs` is removed with its fixtures. `KNOWN_PENDING = {'_frame_boost'}` is untouched — it still unpacks 4 and is still excluded, since it belongs to #355.

One necessary edit inside `test_every_call_site_matches`: its "sweep found nothing" sanity floor was `>= 4` and there are now 3 call sites (`_frame_boost`, `get_density`, `get_iden`), so it is `>= 3` with a comment naming them. The deleted test is replaced by `test_dead_f2py_cluster_stays_removed`, which asserts the three methods and the five caches do not come back.

## Verification

- `python3 tests/test_manager.py test_madspin -t0` — baseline re-measured on the clean base: **150 tests, OK**. After: **150 tests, OK** (one test removed, one added).
- `python3 tests/test_manager.py -p tests/unit_tests` — **927 tests, 1 error**, that error being the pre-existing unrelated `test_DensityMatrixObservables22` / `ModuleNotFoundError: No module named 'scipy'`. Honest caveat: there is **no clean re-measured full-suite baseline** — the first baseline run was still in flight when the edits were applied, so it was contaminated and discarded rather than quoted. The count is pinned by the 1-for-1 test edit and by `test_madspin` being 150 both before and after.
- `python3 -m py_compile` clean on both files.
- **End-to-end density-mode run**: `test_w_production_with_PA_decay` (`spinmode PA`, `p p > w+` / `p p > w-`, 1000 events, full MadEvent + MadSpin) — **Ran 1 test in 280.7s, OK**, including its cross-section and event-count assertions. It cannot exercise a path with no caller, but it confirms the density path and the surviving `get_pdir` / `get_iden` / `get_density` call sites are unharmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the obsolete MadSpin f2py method cluster and its unused state now that density calculations use the current live path.

Enhancements:
- Remove the unreachable MadSpin f2py interference and helicity helpers and their orphaned cache state.
- Document the historical and architectural reasons the obsolete cluster was removed.

Tests:
- Replace the obsolete interference-helper regression test with checks that the removed methods and caches remain absent, while updating the get_pdir call-site sanity check.