### PR TITLE
MadSpin: auto picks sequential when the production is polarised

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -181,7 +181,7 @@ class MadSpinOptions(banner.ConfigFile):
                        "sequential_global_retry: as sequential, but a rejected decay redraws the virtualities too. "
                        "sequential_with_mass: one test per decaying particle with that particle's virtuality drawn *inside* its own accept/reject, so nothing is ever frozen and no stage has a conditional normalisation to divide out. Needs a per-particle mass draw, i.e. the PA spinmode; elsewhere it falls back to sequential. "
                        "two_stage, sequential and sequential_global_retry unweight the set of virtualities first; the first two then need a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
-                       "auto: sequential under PA/onshell, where it was the fastest scheme at every decay multiplicity measured; offshell joint up to two decaying particles and sequential from three, since offshell every mass set costs a production reshuffle and a production density and below three decays there are not enough of them to save to pay for it.")
+                       "auto: sequential under PA/onshell, where it was the fastest scheme at every decay multiplicity measured; offshell joint up to two decaying particles and sequential from three, since offshell every mass set costs a production reshuffle and a production density and below three decays there are not enough of them to save to pay for it; but sequential at every multiplicity when the production process carries a polarisation brace, since restricting the convolution to a polarisation subspace peaks the joint weight far below the single bound the joint test has -- measured on `p p > t t~` with both tops decayed, 112 trials per accepted event under joint for `t{+}t~{+}` and 162 for `t{+}t~{-}` against 9.1 and 8.4 under sequential, where unpolarised joint takes 3.3 (and at 50000 events, where the max-weight bound is looser still, the polarised joint columns were 204-213 and 5800-6300). An explicit 'set unweighting joint' is still honoured.")
         self.add_param('sequential_decay', 'auto',
                        comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
         self.auto_set.add('sequential_decay')
@@ -2894,10 +2894,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         spinmodes reshuffle the whole production onto the mass set at once, so
         there they fall back to ``sequential``.
 
-        ``auto`` has two branches, one per spinmode family. They were measured
-        over the number of decaying particles n on `p p > w+ j` (n=1),
-        `p p > t t~` (2), `p p > t t~ z` (3) and `p p > t t~ t t~` (4), 50000
-        events each -- see MADSPIN_SEQUENTIAL_PLAN.md section 12.
+        ``auto`` has two branches, one per spinmode family, plus an override for
+        a polarised production. They were measured over the number of decaying
+        particles n on `p p > w+ j` (n=1), `p p > t t~` (2), `p p > t t~ z` (3)
+        and `p p > t t~ t t~` (4), 50000 events each -- see
+        MADSPIN_SEQUENTIAL_PLAN.md section 12.
 
         **PA/onshell -> ``sequential``, at every n.** It was the fastest of the
         three at all four multiplicities, by 1.2x at n=1 rising to 3.8x at n=4.
@@ -2920,6 +2921,45 @@ class MadSpinInterface(extended_cmd.Cmd):
         of magnitude, no bound covers it, and the mass stage needs ~790 sets per
         accepted event. From n=3 the per-particle test wins by 2.2x and 4.3x.
 
+        **A polarised production -> ``sequential``, whatever n.** A brace on the
+        production process (``_production_polarization``) restricts the
+        production/decay convolution to a polarisation subspace, which peaks the
+        joint weight far below the bound the max-weight scan hands it -- and the
+        joint test has no way to recover, since its bound is a single number
+        over the whole chain. Measured offshell on `p p > t t~` (n=2, so the
+        multiplicity rule would say joint) with both tops decayed:
+
+        ==========================  ==============  ==============
+        production                  joint           sequential
+        ==========================  ==============  ==============
+        `t t~` (unpolarised)          3.3             6.1
+        `t{+}t~{+}`                 112               9.1
+        `t{+}t~{-}`                 162               8.4
+        ==========================  ==============  ==============
+
+        in trials per accepted event, 500 events each. The 50000-event
+        validation of all four polarised final states, where the max-weight
+        scan is longer and ``nb_sigma`` larger, saw the joint column rise to
+        4.05 unpolarised, 204-213 like-helicity and 5800-6300
+        opposite-helicity against 8.59 sequential: the gap widens with
+        statistics, because the bound the joint test must clear keeps growing
+        while the bulk of the restricted weight distribution does not.
+        Unpolarised, joint is the better of the two by ~2x and the rule above
+        stands; polarised it loses by one to three orders of magnitude, so
+        ``auto`` gives the brace priority over n.
+
+        The clause fires on any brace in the production line, including one on a
+        particle MadSpin does not decay -- such a brace leaves the restriction
+        handed to ``DensityMatrix`` empty and so cannot be the thing peaking the
+        weight. Two reasons to fire anyway. The asymmetry: taking ``sequential``
+        when joint would have done costs the ~2x above, taking joint when the
+        convolution is restricted costs 30-1500x. And the resolved mode has to
+        be the same at every call site -- it names the max-weight cache files and
+        picks which bound the accept/reject tests against -- while the set of
+        decayed pdgs is not known everywhere ``_unweighting_mode`` is called; a
+        clause that consulted it could resolve two ways in one run.
+        An explicit ``set unweighting joint`` is still honoured.
+
         ``two_stage`` is not the fastest scheme at any measured point -- joint
         beats it at n<=2 and ``sequential`` at n>=3 -- so it is reachable but
         never chosen here. It stays useful as a cross-check, being the one
@@ -2936,6 +2976,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             if self.options['spinmode'] in ['PA', 'onshell']:
                 # fastest at every multiplicity measured; rho is fixed on shell
                 # so the mass stage costs a reshuffling jacobian and nothing else
+                mode = 'sequential'
+            elif self._density_spinmode() and self._production_polarization():
+                # a polarised production restricts the convolution to a
+                # polarisation subspace, and the joint weight then sits orders
+                # of magnitude below its own bound -- see the docstring. The
+                # multiplicity rule does not apply: joint has no way to recover.
                 mode = 'sequential'
             elif nb_decaying <= 2:
                 # offshell a mass set costs a production reshuffle and a

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -56,6 +56,12 @@ def _borrow_decision_helpers(namespace):
     body of any stub that borrows one of those.
 
     getattr_static keeps the staticmethod wrappers intact.
+
+    The list is hand-kept, so a new call added inside the borrowed code hits a
+    method the stub never borrowed. The `__getattr__` installed here turns that
+    into an error naming the method (and where to add it) rather than a bare
+    AttributeError; it still *is* an AttributeError, so `getattr(self, x, d)`
+    and `hasattr` keep behaving as before.
     """
     for name in ('_auto_unweighting_mode', '_density_pole_approximation',
                  '_density_do_reshuffle', '_density_needs_reshuffle',
@@ -67,6 +73,17 @@ def _borrow_decision_helpers(namespace):
                  '_density_spinmode', '_production_polarization'):
         namespace[name] = inspect.getattr_static(
             interface_madspin.MadSpinInterface, name)
+
+    def __getattr__(self, name):
+        try:
+            inspect.getattr_static(interface_madspin.MadSpinInterface, name)
+        except AttributeError:
+            raise AttributeError(name)
+        raise AttributeError(
+            '%s does not borrow MadSpinInterface.%s: add it to the list in'
+            ' _borrow_decision_helpers, or define it on the stub'
+            % (type(self).__name__, name))
+    namespace.setdefault('__getattr__', __getattr__)
     return namespace
 #
 class TestBanner(unittest.TestCase):
@@ -4330,20 +4347,19 @@ class TestUnweightingDecisionTable(unittest.TestCase):
 
     class _Stub(object):
         """The real methods, on the smallest object that can carry them."""
-        for _name in ('_unweighting_mode', '_auto_unweighting_mode',
-                      '_announce_mode', '_log_once', '_sequential_active',
-                      '_sequential_upfront', '_sequential_offshell',
-                      '_sequential_pool_ladder', '_sequential_spin_order',
-                      '_decay_pool_ladder', '_density_pole_approximation',
-                      '_density_do_reshuffle', '_density_needs_reshuffle',
-                      '_spinmode_has_density', '_is_upfront_scheme',
-                      '_density_spinmode', '_production_polarization'):
+        _borrow_decision_helpers(locals())
+        for _name in ('_unweighting_mode', '_announce_mode', '_log_once',
+                      '_sequential_active', '_sequential_upfront',
+                      '_sequential_offshell', '_sequential_pool_ladder',
+                      '_sequential_spin_order', '_decay_pool_ladder'):
             # getattr_static keeps the staticmethod wrappers intact
             locals()[_name] = inspect.getattr_static(
                 interface_madspin.MadSpinInterface, _name)
         del _name
 
-        def __init__(self, spinmode='madspin', unweighting='auto',
+        # keyword-only: a new knob must not be able to shift the meaning of an
+        # existing argument at a call site
+        def __init__(self, *, spinmode='madspin', unweighting='auto',
                      nb_decaying=2, fixed_order=False, decay_groups=None,
                      polarization=None):
             self.options = {'spinmode': spinmode, 'unweighting': unweighting,
@@ -4357,38 +4373,54 @@ class TestUnweightingDecisionTable(unittest.TestCase):
             self.model = TestUnweightingDecisionTable._Model()
             self._logged_once = set()
 
+    # one point of the exhaustive product below. Named, so that adding a
+    # dimension cannot silently reinterpret the existing ones -- which is
+    # exactly what `polarization` would have done as a seventh tuple slot.
+    _Case = collections.namedtuple(
+        '_Case', ('spinmode', 'unweighting', 'nb_decaying', 'fixed_order',
+                  'decay_groups', 'polarization', 'density_method'))
+
     @classmethod
-    def _reference_mode(cls, spinmode, unweighting, nb_decaying, fixed_order,
-                        decay_groups, polarization, density_method):
+    def _reference_mode(cls, case):
         """The rules as documented on the `unweighting` option, restated here
         rather than read off the implementation, so this is a check and not a
         tautology."""
-        if not density_method:
+        if not case.density_method:
             return 'joint'                       # only scheme outside density
-        mode = unweighting
+        mode = case.unweighting
         if mode == 'auto':
-            if spinmode in cls.POLE_APPROXIMATION:
+            if case.spinmode in cls.POLE_APPROXIMATION:
                 mode = 'sequential'              # fastest at every measured n
-            elif polarization and spinmode in cls.DENSITY_SPINMODES:
+            elif case.polarization and case.spinmode in cls.DENSITY_SPINMODES:
                 mode = 'sequential'              # restricted convolution: the
                                                  # joint weight sits orders of
                                                  # magnitude below its bound
-            elif nb_decaying <= 2:
+            elif case.nb_decaying <= 2:
                 mode = 'joint'                   # offshell, too few decays
             else:
                 mode = 'sequential'
         if mode == 'joint':
             return 'joint'
-        if fixed_order:
+        if case.fixed_order:
             return 'joint'                       # counter-events ride along
-        if decay_groups:
+        if case.decay_groups:
             return 'joint'                       # '@' groups self-normalise
-        if spinmode not in ('PA', 'onshell', 'madspin', 'full'):
+        if case.spinmode not in ('PA', 'onshell', 'madspin', 'full'):
             return 'joint'                       # no density matrix to stage
         if (mode == 'sequential_with_mass'
-                and spinmode not in cls.POLE_APPROXIMATION):
+                and case.spinmode not in cls.POLE_APPROXIMATION):
             return 'sequential'                  # needs a per-particle mass
         return mode
+
+    def _case_stub(self, case):
+        """The stub a case describes. `density_method` stays out of it: it is
+        the argument the decision methods take, not stub state."""
+        return self._Stub(spinmode=case.spinmode,
+                          unweighting=case.unweighting,
+                          nb_decaying=case.nb_decaying,
+                          fixed_order=case.fixed_order,
+                          decay_groups=case.decay_groups,
+                          polarization=case.polarization)
 
     def _cases(self):
         for spinmode in self.SPINMODES:
@@ -4398,17 +4430,22 @@ class TestUnweightingDecisionTable(unittest.TestCase):
                         for groups in (None, {'tags': ['1', '2']}):
                             for pol in self.POLARIZATIONS:
                                 for density_method in (True, False):
-                                    yield (spinmode, unweighting, nb_decaying,
-                                           fixed_order, groups, pol,
-                                           density_method)
+                                    yield self._Case(
+                                        spinmode=spinmode,
+                                        unweighting=unweighting,
+                                        nb_decaying=nb_decaying,
+                                        fixed_order=fixed_order,
+                                        decay_groups=groups,
+                                        polarization=pol,
+                                        density_method=density_method)
 
     def test_every_combination_matches_the_documented_rules(self):
         seen = set()
         for case in self._cases():
-            stub = self._Stub(*case[:6])
-            got = stub._unweighting_mode(case[6])
+            stub = self._case_stub(case)
+            got = stub._unweighting_mode(case.density_method)
             seen.add(got)
-            self.assertEqual(got, self._reference_mode(*case), msg=str(case))
+            self.assertEqual(got, self._reference_mode(case), msg=str(case))
         # the table is not degenerate: every scheme is reachable through it
         self.assertEqual(seen, {'joint', 'two_stage', 'sequential',
                                 'sequential_global_retry',
@@ -4422,34 +4459,38 @@ class TestUnweightingDecisionTable(unittest.TestCase):
         pol = self.POLARIZATIONS[1]
         for spinmode in ('madspin', 'full', 'PA', 'onshell'):
             for nb in self.NB_DECAYING:
-                stub = self._Stub(spinmode, 'auto', nb, polarization=pol)
+                stub = self._Stub(spinmode=spinmode, unweighting='auto',
+                                  nb_decaying=nb, polarization=pol)
                 self.assertEqual(stub._auto_unweighting_mode(), 'sequential',
                                  ('polarised', spinmode, nb))
         for spinmode in ('PA', 'onshell'):
             for nb in self.NB_DECAYING:
-                self.assertEqual(
-                    self._Stub(spinmode, 'auto', nb)._auto_unweighting_mode(),
-                    'sequential', (spinmode, nb))
+                stub = self._Stub(spinmode=spinmode, unweighting='auto',
+                                  nb_decaying=nb)
+                self.assertEqual(stub._auto_unweighting_mode(),
+                                 'sequential', (spinmode, nb))
         for spinmode in ('madspin', 'full'):
             for nb, expected in ((0, 'joint'), (1, 'joint'), (2, 'joint'),
                                  (3, 'sequential'), (4, 'sequential'),
                                  (7, 'sequential')):
-                self.assertEqual(
-                    self._Stub(spinmode, 'auto', nb)._auto_unweighting_mode(),
-                    expected, (spinmode, nb))
+                stub = self._Stub(spinmode=spinmode, unweighting='auto',
+                                  nb_decaying=nb)
+                self.assertEqual(stub._auto_unweighting_mode(),
+                                 expected, (spinmode, nb))
 
     def test_auto_without_a_measured_multiplicity_assumes_two(self):
         """`_nb_decaying` is set while the decays are prepared; anything asking
         before that must not crash."""
-        stub = self._Stub('madspin', 'auto')
+        stub = self._Stub(spinmode='madspin', unweighting='auto')
         del stub._nb_decaying
         self.assertEqual(stub._unweighting_mode(), 'joint')
 
     def test_sequential_active_is_exactly_not_joint(self):
         for case in self._cases():
-            stub = self._Stub(*case[:6])
-            self.assertEqual(stub._sequential_active(case[6]),
-                             stub._unweighting_mode(case[6]) != 'joint',
+            stub = self._case_stub(case)
+            self.assertEqual(stub._sequential_active(case.density_method),
+                             stub._unweighting_mode(case.density_method)
+                                != 'joint',
                              msg=str(case))
 
     def test_upfront_is_every_scheme_but_joint_and_with_mass(self):
@@ -4460,10 +4501,10 @@ class TestUnweightingDecisionTable(unittest.TestCase):
             self.assertEqual(self._Stub()._is_upfront_scheme(mode), expected,
                              mode)
         for case in self._cases():
-            stub = self._Stub(*case[:6])
+            stub = self._case_stub(case)
             self.assertEqual(
-                stub._sequential_upfront(case[6]),
-                stub._unweighting_mode(case[6]) not in
+                stub._sequential_upfront(case.density_method),
+                stub._unweighting_mode(case.density_method) not in
                     ('joint', 'sequential_with_mass'),
                 msg=str(case))
 
@@ -4471,17 +4512,19 @@ class TestUnweightingDecisionTable(unittest.TestCase):
         """It needs a per-particle mass draw; the offshell spinmodes reshuffle
         the whole production onto the mass set at once."""
         for spinmode in ('PA', 'onshell'):
-            stub = self._Stub(spinmode, 'sequential_with_mass', 2)
+            stub = self._Stub(spinmode=spinmode, nb_decaying=2,
+                              unweighting='sequential_with_mass')
             self.assertEqual(stub._unweighting_mode(), 'sequential_with_mass')
             self.assertFalse(stub._sequential_upfront())
         for spinmode in ('madspin', 'full'):
-            stub = self._Stub(spinmode, 'sequential_with_mass', 2)
+            stub = self._Stub(spinmode=spinmode, nb_decaying=2,
+                              unweighting='sequential_with_mass')
             self.assertEqual(stub._unweighting_mode(), 'sequential')
             self.assertTrue(stub._sequential_upfront())
 
     def test_the_spinmode_family_predicates(self):
         for spinmode in self.SPINMODES:
-            stub = self._Stub(spinmode)
+            stub = self._Stub(spinmode=spinmode)
             self.assertEqual(stub._density_pole_approximation(),
                              spinmode in ('PA', 'onshell'), spinmode)
             self.assertEqual(stub._density_do_reshuffle(), spinmode == 'PA',
@@ -4495,7 +4538,7 @@ class TestUnweightingDecisionTable(unittest.TestCase):
 
     def test_needs_reshuffle_is_offshell_or_pa_inside_density_mode(self):
         for spinmode in self.SPINMODES:
-            stub = self._Stub(spinmode)
+            stub = self._Stub(spinmode=spinmode)
             self.assertFalse(stub._density_needs_reshuffle(False), spinmode)
             self.assertEqual(bool(stub._density_needs_reshuffle(True)),
                              spinmode != 'onshell', spinmode)
@@ -4503,10 +4546,10 @@ class TestUnweightingDecisionTable(unittest.TestCase):
     def test_pool_ladder_is_empty_unless_a_staged_scheme_is_in_use(self):
         to_decay, nb_event = {6: 100, -6: 100}, 100
         for case in self._cases():
-            stub = self._Stub(*case[:6])
+            stub = self._case_stub(case)
             ladder = stub._sequential_pool_ladder(dict(to_decay), nb_event,
-                                                  case[6])
-            if stub._unweighting_mode(case[6]) == 'joint':
+                                                  case.density_method)
+            if stub._unweighting_mode(case.density_method) == 'joint':
                 self.assertEqual(ladder, {}, msg=str(case))
             else:
                 self.assertEqual(sorted(ladder), [-6, 6], msg=str(case))
@@ -4514,7 +4557,8 @@ class TestUnweightingDecisionTable(unittest.TestCase):
                                  msg=str(case))
 
     def test_pool_ladder_gives_up_on_a_particle_the_model_does_not_know(self):
-        stub = self._Stub('PA', 'sequential', 2)
+        stub = self._Stub(spinmode='PA', unweighting='sequential',
+                          nb_decaying=2)
         self.assertEqual(stub._sequential_pool_ladder({6: 100, 999: 100}, 100,
                                                       True), {})
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3053,7 +3053,7 @@ class TestSequentialPoolLadder(unittest.TestCase):
         def get_particle(self, pdg):
             return TestSequentialPoolLadder._Part(self.spins[pdg])
 
-    def _stub(self, spins, **options):
+    def _stub(self, spins, polarization=None, **options):
         interface = interface_madspin.MadSpinInterface
         class Stub(object):
             _sequential_pool_ladder = interface._sequential_pool_ladder
@@ -3064,11 +3064,18 @@ class TestSequentialPoolLadder(unittest.TestCase):
             _log_once = interface._log_once
             _sequential_spin_order = interface._sequential_spin_order
             _decay_pool_ladder = staticmethod(interface._decay_pool_ladder)
+            _density_spinmode = interface._density_spinmode
+            _production_polarization = interface._production_polarization
         stub = Stub()
         stub.model = self._Model(spins)
         stub.options = {'unweighting': 'sequential', 'fixed_order': False,
                         'spinmode': 'PA', 'sequential_spin_order': '2 3 1'}
         stub.options.update(options)
+        # Seed _production_polarization's own cache rather than a banner: '{}'
+        # is what it returns for a process line without braces, and a dict of
+        # braces is what it returns for one with them. The parsing that fills
+        # it is covered by its own tests.
+        stub._production_polarization_cache = polarization or {}
         return stub
 
     NB = 1000
@@ -3145,6 +3152,83 @@ class TestSequentialPoolLadder(unittest.TestCase):
                 stub._nb_decaying = nb
                 self.assertEqual(stub._unweighting_mode(True), expected,
                                  '%s, %d decaying particles' % (spinmode, nb))
+
+    # a brace on the production, as _production_polarization returns it:
+    # 'p p > t{+} t~{+}' -> the (1,) helicity kept for both tops.
+    POL = {6: ((1,),), -6: ((1,),)}
+
+    def test_auto_is_per_particle_when_the_production_is_polarised(self):
+        """A production brace restricts the convolution to a polarisation
+        subspace, and the joint weight then sits far below the single bound the
+        max-weight scan hands it. Measured offshell on `p p > t t~` with both
+        tops decayed (500 events, so n=2 and the multiplicity rule alone would
+        say joint): `t{+}t~{+}` 112 trials per accepted event under joint
+        against 9.1 under sequential, `t{+}t~{-}` 162 against 8.4 -- while
+        unpolarised joint is the better of the two at 3.3 against 6.1. At 50000
+        events the joint column of the same three rises to 204-213, 5800-6300
+        and 4.05. So the brace overrides the multiplicity rule, at every n."""
+        for nb in (1, 2, 3, 6):
+            for spinmode in ('madspin', 'full'):
+                stub = self._stub({6: 2}, unweighting='auto', spinmode=spinmode,
+                                  polarization=self.POL)
+                stub._nb_decaying = nb
+                self.assertEqual(stub._unweighting_mode(True), 'sequential',
+                                 'polarised %s, %d decaying particles'
+                                 % (spinmode, nb))
+
+    def test_polarised_auto_leaves_the_unpolarised_resolution_alone(self):
+        """The clause keys on the brace and nothing else: the same stub without
+        one keeps the two-branch rule exactly."""
+        for nb, expected in [(1, 'joint'), (2, 'joint'),
+                             (3, 'sequential'), (6, 'sequential')]:
+            stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin')
+            stub._nb_decaying = nb
+            self.assertEqual(stub._unweighting_mode(True), expected,
+                             'unpolarised, %d decaying particles' % nb)
+
+    def test_polarised_production_does_not_override_an_explicit_joint(self):
+        """Only 'auto' looks at the brace. A user who asks for joint gets joint,
+        slow or not -- it is the cross-check the staged schemes are validated
+        against, and losing it on polarised processes would leave them
+        unvalidated exactly where they matter most."""
+        for spinmode in ('madspin', 'full', 'PA', 'onshell'):
+            stub = self._stub({6: 2}, unweighting='joint', spinmode=spinmode,
+                              polarization=self.POL)
+            self.assertEqual(stub._unweighting_mode(True), 'joint', spinmode)
+            self.assertFalse(stub._sequential_active(True), spinmode)
+        # and the other explicit schemes are untouched too
+        for mode in ('two_stage', 'sequential', 'sequential_global_retry'):
+            stub = self._stub({6: 2}, unweighting=mode, spinmode='madspin',
+                              polarization=self.POL)
+            self.assertEqual(stub._unweighting_mode(True), mode)
+
+    def test_polarised_production_leaves_pa_and_onshell_where_they_were(self):
+        """PA/onshell already resolve to sequential under auto at every
+        multiplicity, so the brace has nothing to change there -- pinned so a
+        later reshuffle of the branches cannot make the polarised case take a
+        different path from the unpolarised one."""
+        for spinmode in ('PA', 'onshell'):
+            for nb in (1, 2, 3, 6):
+                for pol in (None, self.POL):
+                    stub = self._stub({6: 2}, unweighting='auto',
+                                      spinmode=spinmode, polarization=pol)
+                    stub._nb_decaying = nb
+                    self.assertEqual(stub._unweighting_mode(True), 'sequential',
+                                     '%s, %d decaying, pol=%s'
+                                     % (spinmode, nb, bool(pol)))
+
+    def test_polarised_auto_still_yields_to_the_joint_only_gates(self):
+        """fixed_order and '@' grouping force joint whatever auto resolved to;
+        the polarisation clause must not smuggle a staged scheme past them."""
+        stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin',
+                          fixed_order=True, polarization=self.POL)
+        stub._nb_decaying = 2
+        self.assertEqual(stub._unweighting_mode(True), 'joint')
+        stub = self._stub({6: 2}, unweighting='auto', spinmode='madspin',
+                          polarization=self.POL)
+        stub._nb_decaying = 2
+        stub._decay_groups = {'1': {}, '2': {}}
+        self.assertEqual(stub._unweighting_mode(True), 'joint')
 
     def test_auto_is_per_particle_under_pa_at_every_multiplicity(self):
         """PA/onshell keep rho fixed on shell, so their mass stage costs a


### PR DESCRIPTION
Follow-up to #349. `unweighting = auto` currently resolves on the spinmode family and the decay multiplicity, so offshell at two decaying particles gives `joint` — which is between one and three **orders of magnitude** slower once the production carries a polarisation brace.

## Reproduced independently

`p p > t t~` LO, 500 production events, three separate generations, `spinmode=madspin` (offshell), `decay t > w+ b, w+ > e+ ve` + conjugate, seed 42, `nb_core 1`, defaults `Nevents_for_max_weight=75` / `nb_sigma=4.5`. Trials per accepted event:

| production | joint | sequential |
|---|---|---|
| `t t~` (unpolarised) | **3.31** (`auto`) | 6.14 |
| `t{+}t~{+}` | **111.76** | 9.10 |
| `t{+}t~{-}` | **161.85** | 8.43 |

34x and 49x worse under joint on the polarised samples — while unpolarised joint is the *better* choice by ~1.9x, which is exactly why the clause has to be conditional rather than a blanket change.

The 50000-event closure validation of all four polarised final states saw the joint column at 204–213 (like-helicity) and 5800–6300 (opposite-helicity) against 8.59 sequential. The gap **widens with statistics**: at 500 events `nb_sigma` is 4.5 over a 75-event scan, at 50k it is 5.30 over 110, so the bound the joint test must clear keeps growing while the bulk of the restricted weight distribution does not. Same mechanism, consistent numbers.

After the change: `t{+}t~{+}` **111.76 → 9.10** (12.3x), `t{+}t~{-}` **161.85 → 8.43** (19.2x).

## The clause

In `_auto_unweighting_mode()`, after the PA/onshell branch and before the multiplicity rule:

```python
if self._density_spinmode() and self._production_polarization():
    return 'sequential'
```

Gated on `_density_spinmode()` so a non-density spinmode never parses the proc card, and so a malformed brace cannot raise from a mode that ignores braces.

**A brace on a particle MadSpin does not decay still fires the clause.** Such a brace leaves the restriction handed to `DensityMatrix` empty and so cannot be what peaks the weight, but firing anyway is right for two reasons, both in the docstring: the cost asymmetry (a spurious `sequential` costs ~2x, a missed one costs 30–1500x), and the fact that the resolved mode must be identical at every call site — it names the `max_wgt_sequential_*` cache files and selects which bound the accept/reject tests against, and the decayed-pdg set is not available everywhere `_unweighting_mode` is called, so a clause consulting it could resolve two ways within one run.

An explicit `set unweighting joint` is still honoured.

## Nothing else moves — verified, not assumed

Exhaustive grid, base vs patched, over 4320 combinations (6 unweighting values x 7 spinmodes x 5 `_nb_decaying` x polarised x `fixed_order` x `_decay_groups` x `density_method`):

```
total combinations: 4320
changed: 6
  unw=auto spinmode=full    pol=1 fixed_order=0 groups=0 density=1 : joint -> sequential (nb 0,1,2)
  unw=auto spinmode=madspin pol=1 fixed_order=0 groups=0 density=1 : joint -> sequential (nb 0,1,2)
changed with pol=0: 0
```

Corroborated by runs: unpolarised `auto` still logs `joint (auto, 2 decaying particle(s))` at 3.31 trials/event; polarised `spinmode=onshell` + `auto` logs `sequential (auto, ...)` at 4.43.

**The grid is now a permanent test rather than a scratch script.** `TestUnweightingDecisionTable` (added by #346, which pins the decision table against rules restated independently of the implementation) gained `polarization=` on its stub, the new branch in `_reference_mode`, and polarisation as a seventh dimension in `_cases()`. So the before/after comparison runs on every test run.

## Documentation

Both the `unweighting` option comment and `_auto_unweighting_mode`'s docstring gained the polarised branch with the measured table, in the existing style. `two_stage` stays unadvertised — #344's wording of the schemes sentence is kept intact and only the new `auto` sentence is appended.

## Verification

`python3 tests/test_manager.py test_madspin -t0`: **235 OK on the base**, **240 OK here**.

## Negative result worth keeping

The over-maximum-weight asymmetry under offshell+`sequential` reproduces (per 500 events: unpolarised 0, `t{+}t~{+}` 6, `t{+}t~{-}` 9 — the same direction as the validation's 2 vs 82–91 per 50k; `onshell` emitted none). But one extra run settles it: `t{+}t~{+}` with `Nevents_for_max_weight=300`, `nb_sigma=5.3` gave **0 overflows** at 9.39 trials/event, against 6 at 9.10 with the 75/4.5 defaults. So it is a **max-weight-statistics problem, not a polarisation-specific one** — the existing knobs fix it for ~3% in trials, and the auto-scaling already grows both with `nevents`. Not touched; the diff stays at the `auto` clause.

## Caveats

- One measurement (`t{+}t~{+}` under joint) came from a run launched before the edit landed, whose log was truncated past the announcement line. The exhaustive grid independently proves base `auto` = `joint` for that configuration, so the row stands.
- The resolution of the merge onto the refactored `_auto_unweighting_mode` shape is a **reconstruction**: an accidental `git checkout` overwrote the first pass, and it was rebuilt deterministically from the base file and then diffed against it to confirm intent. Independently re-verified by the coordinator (clause inside `_auto_unweighting_mode`, `two_stage` text absent, #344's wording present, clean merge into `madspin_density`, 240 tests green).
- `tests/parallel_tests` not run. No physics-closure check that polarised `sequential` output matches `joint` — that identity is what `sequential_debug` and the comparator ordering tests cover, and this change touches only which scheme `auto` names, not the schemes themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Select sequential unweighting automatically for polarised density-based MadSpin production while retaining all existing explicit and non-polarised selection rules.

Bug Fixes:
- Make `unweighting = auto` choose sequential unweighting for density-based spinmodes when the production process is polarised, avoiding severe performance degradation from joint unweighting.

Enhancements:
- Preserve existing multiplicity-based and explicit unweighting decisions, including explicit requests for joint mode and existing PA/onshell behavior.

Documentation:
- Document the polarised-production auto-selection rule and its measured performance characteristics.

Tests:
- Extend MadSpin decision-table coverage across polarisation states and add regression tests for polarised, unpolarised, explicit, and gated mode-selection behavior.

Chores:
- Improve test stubs to detect missing borrowed decision helpers and use explicit case records for exhaustive decision-table validation.