### PR TITLE
MadSpin: wire the frame guard to _needs_frame_axis()

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -5555,25 +5555,16 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         Three things apply such a projection, and all three need the frame:
 
-         * polarised beams (``beampol``), which is what the guard in
-           ``_frame_boost`` tests today;
+         * polarised beams (``beampol``), which reweights the initial-state
+           helicity sum;
          * a polarisation brace on the production process (PR #349/#353);
-         * a polarisation-weight request -- this branch. The weights are the
-           same projection, only used to build an extra weight rather than the
-           nominal one, so an unpolarised production with
+         * a polarisation-weight request. The weights are the same projection,
+           only used to build an extra weight rather than the nominal one, so an
+           unpolarised production with
            ``keep_weight_for_polarization_vector/_fermion`` set still needs it.
 
-        NOT WIRED IN ON THIS BRANCH. ``_frame_boost`` still opens with the
-        beampol-only guard, and PR #355 (stacked on #349) turns that same line
-        into ``if self._beampol() is None and not self._production_polarization()``.
-        Editing it here would only collide with that. The one-line change to make
-        at merge time, replacing whichever version of the guard is in
-        ``_frame_boost`` by then, is
-
-            if not self._needs_frame_axis():
-                return None
-
-        Until that lands the polarisation weights are taken on the lab axis.
+        This is ``_frame_boost``'s guard: it short-circuits to None -- leaving
+        every momentum in the lab -- exactly when this returns False.
         """
         if self._beampol() is not None:
             return True
@@ -7654,8 +7645,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         themselves (HELAS ``boostx``, exactly what ``boost_to_frame`` does in
         driver.f).
 
-        Two things switch it on, and both are cases where the frame is
-        *observable*:
+        Three things switch it on -- the three clauses of ``_needs_frame_axis``
+        -- and all of them are cases where the frame is *observable*:
 
         - polarised beams. ``beampol`` reweights the initial-state helicity sum
           and that sum is quantised along the frame's axis.
@@ -7672,13 +7663,20 @@ class MadSpinInterface(extended_cmd.Cmd):
           change of helicity basis a boost induces, so leaving the momenta in
           the lab would restrict a different helicity than the one the input
           events were generated with.
+        - a polarisation-weight request
+          (``keep_weight_for_polarization_vector`` / ``_fermion``). Those
+          weights go through the very same ``set_hel_restriction`` projection,
+          only to build an extra <wgt> line instead of the nominal weight, so
+          they need the frame for exactly the same reason -- and they can be
+          asked for on a production that carries no brace at all, which is why
+          the two clauses above do not cover them.
 
         Everything else stays in the lab, which keeps unpolarised density runs
         bit-for-bit unchanged: there the full double sum
         ``sum_ij rho_prod(i,j) rho_dec(i,j)`` is a trace, and a boost acts on it
         as a unitary change of basis that cancels between the two factors.
         """
-        if self._beampol() is None and not self._production_polarization():
+        if not self._needs_frame_axis():
             return None
         frame_id = int(self.options['frame_id'])
         if frame_id <= 0:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -63,6 +63,26 @@ def _borrow_decision_helpers(namespace):
         namespace[name] = inspect.getattr_static(
             interface_madspin.MadSpinInterface, name)
     return namespace
+
+
+def _borrow_frame_helpers(namespace):
+    """Add ``_frame_boost`` and everything its guard reaches through to a stub
+    class namespace. Call as ``_borrow_frame_helpers(locals())`` from the class
+    body of any stub that borrows ``_frame_boost``.
+
+    The guard is ``_needs_frame_axis``, which asks about the beams, the
+    production braces and the two polarisation-weight lists; going through this
+    helper is what keeps widening it from meaning an edit in every stub. The
+    caller still has to provide ``_production_polarization`` and ``options``,
+    which are what the stub is actually choosing.
+    """
+    for name in ('_beampol', '_frame_boost', '_needs_frame_axis',
+                 '_polarization_weight_labels',
+                 '_polarization_weights_enabled'):
+        namespace[name] = inspect.getattr_static(
+            interface_madspin.MadSpinInterface, name)
+    namespace['InvalidCmd'] = interface_madspin.MadSpinInterface.InvalidCmd
+    return namespace
 #
 class TestBanner(unittest.TestCase):
     """Test class for the reading of the banner"""
@@ -349,10 +369,12 @@ class _FrameStub(object):
     """Just enough of MadSpinInterface for the frame/beampol helpers: they only
     need the options and the matrix-element ordering of the event."""
 
-    def __init__(self, frame_id, beampol, prodpol=None):
+    def __init__(self, frame_id, beampol, prodpol=None, vector=(), fermion=()):
         self.options = interface_madspin.MadSpinOptions()
         self.options['frame_id'] = frame_id
         self.options['beampol'] = list(beampol)
+        self.options['keep_weight_for_polarization_vector'] = list(vector)
+        self.options['keep_weight_for_polarization_fermion'] = list(fermion)
         # what _production_polarization would have parsed out of the banner's
         # proc_card: {} for a brace-free production process
         self._production_polarization_cache = prodpol if prodpol else {}
@@ -367,8 +389,7 @@ class _FrameStub(object):
     def _production_polarization(self):
         return self._production_polarization_cache
 
-    _beampol = interface_madspin.MadSpinInterface._beampol
-    _frame_boost = interface_madspin.MadSpinInterface._frame_boost
+    _borrow_frame_helpers(locals())
     _boost_momenta = staticmethod(interface_madspin.MadSpinInterface._boost_momenta)
 
 
@@ -392,8 +413,9 @@ class TestFrameBoost(unittest.TestCase):
                (300., 100., 50., -80.),
                (400., -100., -50., 380.)]
 
-    def _stub(self, frame_id, beampol=(80., 0.), prodpol=None):
-        return _FrameStub(frame_id, beampol, prodpol)
+    def _stub(self, frame_id, beampol=(80., 0.), prodpol=None,
+              vector=(), fermion=()):
+        return _FrameStub(frame_id, beampol, prodpol, vector, fermion)
 
     def test_polbeam_to_beampol(self):
         """the card speaks percent, like the run_card polbeam1/polbeam2, and
@@ -457,6 +479,39 @@ class TestFrameBoost(unittest.TestCase):
         self.assertIsNotNone(boost)
         self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
                          (700., 0., 0., 300.))
+
+    def test_frame_follows_a_polarization_weight_request(self):
+        """keep_weight_for_polarization_vector/_fermion apply the same
+        set_hel_restriction projection as a production brace, only to build an
+        extra <wgt> line rather than the nominal weight. They can be asked for
+        on a production that carries no brace and with unpolarised beams, so
+        neither of the other two clauses sees them -- and a projection taken on
+        the lab axis restricts a different helicity than the one MG5 names.
+        Each species list switches the frame on by itself."""
+        for kwargs in [dict(vector=['0']), dict(fermion=['+']),
+                       dict(vector=['T'], fermion=['-'])]:
+            stub = self._stub(6, beampol=(0., 0.), **kwargs)
+            boost = stub._frame_boost(_MomentaEvent(self.MOMENTA))
+            self.assertIsNotNone(boost, kwargs)
+            self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
+                             (700., 0., 0., 300.), kwargs)
+
+    def test_frame_boost_matches_needs_frame_axis(self):
+        """_frame_boost's guard *is* _needs_frame_axis: the boost is taken for
+        each of the three triggers on its own and for nothing else. Pinned
+        together so the two cannot drift apart again."""
+        cases = [(dict(), False),
+                 (dict(beampol=(80., 0.)), True),
+                 (dict(prodpol={24: (0,)}), True),
+                 (dict(vector=['0']), True),
+                 (dict(fermion=['+']), True),
+                 (dict(beampol=(80., 0.), vector=['T']), True)]
+        for kwargs, wanted in cases:
+            kwargs.setdefault('beampol', (0., 0.))
+            stub = self._stub(6, **kwargs)
+            self.assertEqual(stub._needs_frame_axis(), wanted, kwargs)
+            self.assertEqual(stub._frame_boost(_MomentaEvent(self.MOMENTA))
+                             is not None, wanted, kwargs)
 
     def test_frame_boost_unpacks_get_pdir(self):
         """get_pdir returns five values; unpacking four raised ValueError the
@@ -1955,8 +2010,9 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         """A helicity *projection* does not commute with a boost, so it only
         means what the user asked for on MG5's quantisation axis (frame_id). The
         polarisation weights are the same projection as a production brace, so
-        the predicate _frame_boost's guard has to become must be true for them
-        too -- see _needs_frame_axis' note about wiring it to PR #355."""
+        the predicate that _frame_boost's guard tests has to be true for them.
+        TestFrameBoost.test_frame_boost_matches_needs_frame_axis pins the guard
+        itself onto this predicate."""
         class Frame(self._Stub):
             _needs_frame_axis = \
                 interface_madspin.MadSpinInterface._needs_frame_axis
@@ -2694,8 +2750,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
             _borrow_decision_helpers(locals())
-            _beampol = interface._beampol
-            _frame_boost = interface._frame_boost
+            _borrow_frame_helpers(locals())
             _production_polarization = staticmethod(lambda: {})
             def __init__(self):
                 self.options = _StubOptions(
@@ -2902,8 +2957,7 @@ class TestPAUpFrontMass(unittest.TestCase):
             _announce_mode = interface._announce_mode
             _log_once = interface._log_once
             _borrow_decision_helpers(locals())
-            _beampol = interface._beampol
-            _frame_boost = interface._frame_boost
+            _borrow_frame_helpers(locals())
             _production_polarization = staticmethod(lambda: {})
 
             def __init__(self):
@@ -4729,9 +4783,9 @@ class TestGetPdirUnpackArity(unittest.TestCase):
 
     SOURCE = pjoin(MG5DIR, 'MadSpin', 'interface_madspin.py')
 
-    # ``_frame_boost`` still unpacks 4 on this branch; its fix travels with the
-    # frame/beampol PR (#355). Drop this entry once that has landed.
-    KNOWN_PENDING = set(['_frame_boost'])
+    # methods knowingly left behind an arity bump, by name. Empty: every call
+    # site agrees with get_pdir today, and it stays that way.
+    KNOWN_PENDING = set()
 
     def _tree(self):
         import ast


### PR DESCRIPTION
Joins the two halves of the polarisation-axis work that were deliberately left unwired to avoid a conflict: #355 changed `_frame_boost`'s guard, and #357 added `_needs_frame_axis()` without touching that guard. Both are now in `madspin_density`, so:

```python
if not self._needs_frame_axis():
    return None
```

## Why it matters

A polarised matrix element is not Lorentz invariant, and MG5 defines the axis in `run_card: me_frame` (default the partonic CM), not the lab. That was harmless while the contraction was a full trace — a boost is a unitary basis change that cancels between `rho_prod` and `rho_dec` — but `set_hel_restriction` is a **projection**, and projections do not commute with a change of basis.

#355's guard covered production braces only. `keep_weight_for_polarization_vector` / `_fermion` apply the very same projection to build their extra LHEF weights, so on an **unpolarised** production with those options set the guard returned `None` and the weights were computed on the **lab** axis — the wrong one.

## The helper is a strict superset

The old guard proceeded iff `_beampol() is not None or _production_polarization()`. `_needs_frame_axis()` is literally those two clauses `or _polarization_weights_enabled()` — same two triggers, one added, so no existing behaviour changes.

Seam markers removed: the `NOT WIRED IN ON THIS BRANCH` paragraph in `_needs_frame_axis`, the "which is what the guard tests today" phrasing, the `#355` note in `test_needs_frame_axis_covers_the_three_projections`, and `TestGetPdirUnpackArity.KNOWN_PENDING` — which held `_frame_boost` waiting on #355 and was stale, since `_frame_boost` already unpacks 5. That set is now empty and the arity sweep covers every call site.

## Measured: the unpolarised-weight case is in the large-shift regime

Real MadSpin runs (`spinmode madspin`, seed 11) on unpolarised productions with `keep_weight_for_polarization_vector [0, T, +, -]`, same events and seed, before vs after:

| | lab (before) | partonic CM (after) |
|---|---|---|
| `p p > t t~ z`, `z > e+ e-`, 200 evts, f(Z 0) | 0.4804 | **0.4555** |
| … f(Z +) | 0.2840 | 0.2953 |
| … f(Z T) | 0.5355 | 0.5493 |
| `p p > z z`, `z > e+ e-`, 300 evts, f(T,T) | 0.3756 | **0.6942** |
| … f(0,0) | 0.0141 | **0.0616** |
| … f(+,−) | 0.1700 | **0.3354** |

`p p > z z` settles the question: individual combinations move by up to **4.4x**. The CM numbers are also the physically sensible ones — LO ZZ is transverse-dominated (f(T,T)=0.69, f(0,0)=0.06), which the lab axis smeared away entirely.

Honest caveat: the `t t~ z` shift here (f0 0.4804 -> 0.4555, −5.2% relative) is much larger than the 0.4727 vs 0.4720 that #357 reported. #357's exact setup was not reproduced (different decay chains/spinmode), so it is unclear whether that number came from a different configuration or was measured differently. With 200 events it is not a fluctuation between the two runs here, since both used identical events and seed.

## Nothing else moves

- **Control** (`p p > z z`, no braces, no weight options): decayed LHE identical apart from the harness's own `import <path>` banner line.
- **`t t~ z` with weights**: before/after differ *only* in `ms_pol_*` `<wgt>` lines — 0/200 events with different kinematics, nominal weight sum identical to 11 digits.
- **`z z` with weights**: 1/300 events got different decay kinematics, a rounding-level flip in one accept/reject decision rather than a systematic change; nominal sum identical.

## Verification

`python3 tests/test_manager.py test_madspin -t0`: **235 OK** on the pristine tree, **237 OK** after.

Wiring the guard initially broke 11 tests: two other stub classes borrow `_frame_boost` and carried only `_beampol` / `_production_polarization`. Rather than patch each, this adds `_borrow_frame_helpers(namespace)` alongside the existing `_borrow_decision_helpers`, handing a stub the guard and everything it reaches through — so the next clause added to `_needs_frame_axis` is one edit rather than one per stub. New tests: `test_frame_follows_a_polarization_weight_request` (each species list switches the frame on by itself) and `test_frame_boost_matches_needs_frame_axis` (guard pinned onto the predicate for all three triggers, and off otherwise).

## Follow-up needed when #351 lands

`_needs_frame_axis()` does **not** cover the pure-interference mode. `_pure_interference()` reads a separate card option that the helper does not consult, and #351 independently  added a third clause to `_frame_boost`'s guard. When #351 merges, `_needs_frame_axis()` needs a fourth clause returning true for `_pure_interference()`, and the merge will conflict in two places: `_frame_boost` (both sides rewrote the same guard line) and `_needs_frame_axis`'s docstring (#351 still carries the old "NOT WIRED IN" text that this PR deletes). Resolution: keep this version and add the interference clause to the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire MadSpin frame boosting to the complete frame-axis requirement predicate so all polarization projections use the correct reference frame.

Bug Fixes:
- Use the unified frame-axis predicate when boosting MadSpin events so polarization-weight projections are evaluated in the configured matrix-element frame instead of the lab frame.

Enhancements:
- Keep frame-axis decisions synchronized across beams, production polarization braces, and polarization-weight requests.
- Centralize frame-helper borrowing in tests and add coverage ensuring each trigger enables the frame and non-trigger cases do not.

Tests:
- Update arity validation to cover all current get_pdir call sites without pending exceptions.