### PR TITLE
MadSpin: unweighted-up-to-a-sign interference, and a general weighted-output option

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -3900,9 +3900,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         pure_interference_c = ctx.get('pure_interference_c')
         pi_unweighted = pure_interference and bool(
             ctx.get('pure_interference_unweighted'))
-        # every trial is kept and carries W/c
-        keep_every_trial = weighted_decay or (pure_interference
-                                              and not pi_unweighted)
+        # No ordinary accept/reject is made below in any of these modes: the
+        # two weighted paths keep every trial outright, and the 'unweighted'
+        # interference path has ALREADY made its own decision (on |W|, one
+        # draw) by the time the test is reached, so falling through to the
+        # signed test there would reject every negative weight a second time.
+        no_joint_test = pure_interference or weighted_decay
         if (pure_interference or weighted_decay) and not pure_interference_c:
             raise self.InvalidCmd(
                 "MadSpin: the normalisation constant c = <W> is missing; the "
@@ -4121,7 +4124,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     dead_trials = self._dead_trial(dead_trials, wgt,
                                                    'the joint accept/reject')
 
-                if keep_every_trial or random.random()*maxwgt < test:
+                if no_joint_test or random.random()*maxwgt < test:
                     if offshell_density:
                         # prod_trial has already been reshuffled internally (its
                         # jacobian is in wgt); build the event to write out from the

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -160,6 +160,36 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
         self.add_param('beampol', [0., 0.], comment='beam polarisation of each beam in percent, -100 .. 100, exactly as the run_card polbeam1/polbeam2 (0 is unpolarised). Taken from the run_card of the production when it has one.')
+        self.add_param('decay_output', 'unweighted',
+                       allowed=['unweighted', 'weighted'],
+                       comment="whether MadSpin unweights its decays at all. 'unweighted' "
+                       "(default, and what MadSpin has always done): draw decay "
+                       "configurations until one is accepted, so every production event "
+                       "yields exactly one output event and every event of a given "
+                       "production process carries the same weight. 'weighted': NO "
+                       "accept/reject -- draw ONE decay configuration per production event, "
+                       "keep it, and put the convolution on the weight, "
+                       "w = w_prod * BR * W / c, with W this trial's production/decay "
+                       "density convolution and c = <W> its decay-phase-space mean (a "
+                       "constant, measured by the same probe that estimates the maximum "
+                       "weight). Under MG5's IDWTUP = -4 convention the cross-section is "
+                       "the MEAN of the weights, and mean(w) = sigma*BR exactly as before, "
+                       "so <init> is unchanged and the file is self-normalising. WHY, "
+                       "measured on p p > t t~ with spinmode = onshell and 50 000 events: "
+                       "the ordinary accept/reject burned 4.13 decay trials per written "
+                       "event, each one a matrix-element evaluation, and this mode burns "
+                       "exactly 1; the price is only a 6-13% larger variance per "
+                       "production event (the weights have sd/mean = 0.28), so per unit "
+                       "of CPU in the unweighting loop it is about a 3.7-3.9x variance "
+                       "reduction. WHAT YOU GIVE UP: the output is a WEIGHTED LHE "
+                       "file. Anything downstream that assumes MadSpin events carry a "
+                       "constant weight -- unit-weight event counting, simple histogram "
+                       "entry counts -- is wrong on it. Density spin modes only "
+                       "(madspin/full, PA, onshell): the v1 modes and spinmode = none "
+                       "build no density matrix and have no W. Ignored under "
+                       "pure_interference, which is always weighted and has its own "
+                       "pure_interference_output. See doc/madspin_sequential_plan.md "
+                       "section 13.18.")
         self.add_param('pure_interference', '',
                        comment="pure-interference mode: keep ONLY the interference between two "
                        "polarisations of a decaying particle in the production/decay density "
@@ -1641,6 +1671,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.options['spinmode'] = spinmode
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
+        # decay_output is refused outside the density modes too, so it is
+        # checked before the branch rather than inside it
+        self._validate_weighted_decay()
         if self._density_spinmode():
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
@@ -2870,6 +2903,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             # by the fully weighted default.
             pure_interference_absw=getattr(self, '_pi_absw', None),
             pure_interference_unweighted=self._pure_interference_unweighted(),
+            # decay_output = weighted: the same 'keep every trial and put W/c
+            # on the weight' path, for an ordinary (non-interference) run
+            weighted_decay=self._weighted_decay(),
             sequential=sequential,
             decay_dict=decay_dict,
             drop_prob_per_pdg=drop_prob_per_pdg,
@@ -3244,6 +3280,15 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "MadSpin: pure_interference forces the joint "
                            "accept/reject (every partial weight of a staged "
                            "scheme is identically zero in this mode)")
+            return self._announce_mode('joint', self.options['unweighting'])
+        if self._weighted_decay():
+            # There is no accept/reject at all in this mode, so there is no
+            # scheme to choose: the staged schemes exist only to split a test
+            # that is not being made. The joint branch is the one that carries
+            # the weighted path.
+            self._log_once('weighted_decay_joint',
+                           "MadSpin: decay_output = weighted takes the joint "
+                           "path (there is no accept/reject to stage)")
             return self._announce_mode('joint', self.options['unweighting'])
         asked = mode = self.options['unweighting']
         if mode == 'auto':
@@ -3845,14 +3890,24 @@ class MadSpinInterface(extended_cmd.Cmd):
         # historical redraw-until-accept, which would force one event per
         # production point and divide <|W|> out altogether.
         pure_interference = bool(self._pure_interference())
+        # decay_output = weighted rides the SAME path as the fully weighted
+        # pure-interference output: one draw per production event, no
+        # accept/reject, w = w_prod * BR * W / c.  The only differences are
+        # that W is not restricted to an interference block (so <W> = c rather
+        # than 0, and mean(w) = sigma*BR rather than 0), that <init> keeps its
+        # ordinary cross-section, and that nothing here is signed.
+        weighted_decay = bool(ctx.get('weighted_decay'))
         pure_interference_c = ctx.get('pure_interference_c')
         pi_unweighted = pure_interference and bool(
             ctx.get('pure_interference_unweighted'))
-        if pure_interference and not pure_interference_c:
+        # every trial is kept and carries W/c
+        keep_every_trial = weighted_decay or (pure_interference
+                                              and not pi_unweighted)
+        if (pure_interference or weighted_decay) and not pure_interference_c:
             raise self.InvalidCmd(
-                "MadSpin: the pure-interference normalisation constant c is "
-                "missing; the weights cannot be normalised. This is an "
-                "internal error -- the maximum-weight scan measures it.")
+                "MadSpin: the normalisation constant c = <W> is missing; the "
+                "weights cannot be normalised. This is an internal error -- "
+                "the maximum-weight scan measures it.")
         pi_w0_factor = 0.0     # <|W|>/c: the constant |w|/(sigma*BR) of the
                                # 'unweighted' output
         if pi_unweighted:
@@ -4017,9 +4072,24 @@ class MadSpinInterface(extended_cmd.Cmd):
                     jac = full_evt.reshuffle_production()
 
                 test = wgt*jac
-                if pure_interference:
+                if pure_interference or weighted_decay:
                     signed = float(getattr(test, 'real', test))
-                    if not math.isfinite(signed):
+                    dead = not math.isfinite(signed)
+                    if weighted_decay and signed <= 0:
+                        # Outside the interference mode W is a contraction of
+                        # two positive-semidefinite matrices and cannot be
+                        # negative; a non-positive one means jac <= 0, i.e. a
+                        # mass set the production could not be reshuffled onto.
+                        # The accept/reject treats that as a rejection and
+                        # redraws. There is no redraw here, and the event that
+                        # would be written carries the FAILED reshuffle's
+                        # kinematics -- so it is written with weight 0 (which
+                        # is also what that region contributes to the integral)
+                        # and counted, rather than given the negative weight
+                        # that would make the bookkeeping add up on an
+                        # unphysical event.
+                        dead = True
+                    if dead:
                         nb_pi_dead += 1
                         signed = 0.0
                     if not pi_unweighted:
@@ -4051,7 +4121,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     dead_trials = self._dead_trial(dead_trials, wgt,
                                                    'the joint accept/reject')
 
-                if pure_interference or random.random()*maxwgt < test:
+                if keep_every_trial or random.random()*maxwgt < test:
                     if offshell_density:
                         # prod_trial has already been reshuffled internally (its
                         # jacobian is in wgt); build the event to write out from the
@@ -4101,7 +4171,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             # the event weight and every entry of the multi-weight block through
             # the same multiplication. pi_factor is 1.0 in every other mode, so
             # nothing else moves.
-            br = self.branching_ratio * pi_factor if pure_interference \
+            br = self.branching_ratio * pi_factor \
+                if (pure_interference or weighted_decay) \
                 else self.branching_ratio
             if self.options['fixed_order']:
                 for evt in full_evt:
@@ -4110,7 +4181,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     wgts = evt.parse_reweight()
                     for key in wgts:
                         wgts[key] *= br
-                if pure_interference:
+                if pure_interference or weighted_decay:
                     sum_w += full_evt[0].wgt
                     sum_w2 += full_evt[0].wgt ** 2
             else:
@@ -4119,7 +4190,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 wgts = full_evt.parse_reweight()
                 for key in wgts:
                     wgts[key] *= br
-                if pure_interference:
+                if pure_interference or weighted_decay:
                     sum_w += full_evt.wgt
                     sum_w2 += full_evt.wgt ** 2
             self._add_polarization_weights(
@@ -4498,6 +4569,85 @@ class MadSpinInterface(extended_cmd.Cmd):
         # does hold that many fewer events.
         self.efficiency = keep
 
+    def _weighted_decay_note(self, base_out, stats_list, n_written,
+                             br_correction=1.0):
+        """The ``<MGWeightedDecay>`` banner block, and the log line that goes
+        with it: what ``decay_output = weighted`` wrote, and the one check it
+        can make on itself.
+
+        The check is ``mean(w)`` against ``sigma_ref * BR``. Under MG5's
+        ``IDWTUP = -4`` the cross-section is the mean of the event weights, so
+        that equality is not a convention here -- it is the statement that
+        ``c = <W>`` was measured correctly, since ``mean(w) = sigma*BR*<W>/c``
+        by construction. It is the exact analogue of the interference mode's
+        ``z`` test (there ``<W> = 0``, so the target is 0 instead of 1).
+        """
+        S = sum(s.get('sum_w', 0.0) for s in stats_list)
+        sum_w2 = sum(s.get('sum_w2', 0.0) for s in stats_list)
+        nb_dead = sum(s.get('nb_pi_dead', 0) for s in stats_list)
+        mean_w = S / n_written if n_written else 0.0
+        # the MC error on the mean, from the second moment of the weights
+        var = max(sum_w2 / n_written - mean_w * mean_w, 0.0) if n_written else 0.0
+        mean_err = math.sqrt(var / n_written) if n_written else 0.0
+        # read before the block is (possibly) rescaled by the same pass, and
+        # corrected by hand so the comparison is against what <init> will say
+        reference = self._read_lhe_init_cross(base_out) * br_correction
+        c_value = getattr(self, '_pi_c', 0.0) or 0.0
+        c_err = getattr(self, '_pi_c_err', 0.0) or 0.0
+        n_c = (getattr(self, '_pi_c_stats', None) or {}).get('n', 0)
+        ratio = (mean_w / reference) if reference else 0.0
+        pull = ((mean_w - reference) / mean_err) if mean_err else 0.0
+        if nb_dead:
+            logger.warning(
+                "MadSpin decay_output = weighted: %d/%d trial(s) had a "
+                "non-positive or non-finite convolution -- normally a mass set "
+                "the production could not be reshuffled onto, which the "
+                "accept/reject would have redrawn. They were written with "
+                "weight 0, so they contribute nothing, but they do dilute the "
+                "sample by that fraction.", nb_dead, n_written)
+        logger.info(
+            "MadSpin decay_output = weighted: wrote %d weighted events; "
+            "mean(w) = %.6e +- %.2e against the reference sigma*BR = %.6e "
+            "(ratio %.6f, %.2f sigma). Under IDWTUP = -4 that mean IS the "
+            "cross-section, so the agreement is the check that c = <W> = "
+            "%.6e was measured right.",
+            n_written, mean_w, mean_err, reference, ratio, pull, c_value)
+        if mean_err and abs(pull) > 5.0:
+            logger.critical(
+                "MadSpin decay_output = weighted: mean(w) = %.6e is %.2f "
+                "sigma from the reference sigma*BR = %.6e (ratio %.4f). Under "
+                "IDWTUP = -4 the sample's cross-section is the mean of its "
+                "weights, so this file does not carry the rate its <init> "
+                "block claims. The likely cause is a mis-measured c = <W>: "
+                "raise Nevents_for_max_weight / max_weight_ps_point.",
+                mean_w, pull, reference, ratio)
+        return [
+            '#  WEIGHTED MadSpin sample (decay_output = weighted): no',
+            '#  accept/reject was done. One decay configuration was drawn per',
+            '#  production event and kept, carrying',
+            '#      w = w_prod * BR * W / c',
+            '#  with W that trial\'s production/decay density convolution and',
+            '#  c = <W> its decay-phase-space mean (a constant, below). MG5',
+            '#  writes LHE with IDWTUP = -4, i.e. the cross-section is the MEAN',
+            '#  of the event weights, so <init> is the ordinary sigma*BR and',
+            '#  sum_bin(w) / N_file is that bin in pb -- but the per-event',
+            '#  weights are NOT constant. Any consumer that assumes unit-weight',
+            '#  MadSpin output (counting events, unweighted histograms) is',
+            '#  wrong on this file.',
+            '#  Normalisation constant     c : %+.8e  +- %.4f%%' % (
+                c_value, (100 * c_err / abs(c_value)) if c_value else 0.0),
+            '#     (measured by the maximum-weight scan over %d trials)' % n_c,
+            '#  Reference sigma * BR   (pb)  : %+.8e' % reference,
+            '#  mean(w), the sample XSECUP   : %+.8e  +- %.4e' % (
+                mean_w, mean_err),
+            '#  mean(w) / reference          : %.6f   (%.2f sigma)' % (
+                ratio, pull),
+            '#  Events written               : %d' % n_written,
+            '#  Trials with a dead weight    : %d' % nb_dead,
+            '#     (non-positive or non-finite W -- a failed production',
+            '#      reshuffle -- written with weight 0)',
+        ]
+
     @staticmethod
     def _read_lhe_init_cross(path):
         """Sum of the XSECUP column of an already-written LHE ``<init>`` block."""
@@ -4552,21 +4702,32 @@ class MadSpinInterface(extended_cmd.Cmd):
         if self._pure_interference():
             self._report_pure_interference(base_out, stats_list,
                                            n_processed, n_written)
-        elif nb_loose_skip > 0:
+        elif nb_loose_skip > 0 or self._weighted_decay():
             # Rewrite the banner with the corrected cross-section so it
             # matches the actual sum of kept-event weights. Each kept event
             # already has wgt = orig_wgt * max_br; we need the banner to read
             # σ * max_br * (n_written / n_processed) ≈ σ * <br>.
+            #
+            # decay_output = weighted goes through the same rewrite even with
+            # nothing dropped (br_correction = 1), because it is the pass that
+            # inserts the <MGWeightedDecay> note: <init> stays right, but a
+            # weighted MadSpin file is not what a consumer expects and the
+            # file has to say so.
             br_correction = float(n_written) / n_processed if n_processed else 1.0
-            self._rewrite_lhe_banner_cross(base_out, br_correction,
-                                           n_written=n_written)
+            note = (self._weighted_decay_note(base_out, stats_list, n_written,
+                                              br_correction)
+                    if self._weighted_decay() else None)
+            self._rewrite_lhe_banner_cross(
+                base_out, br_correction, n_written=n_written, note=note,
+                note_tag='MGWeightedDecay' if note else 'MGGenerationInfo')
             self.branching_ratio *= br_correction
             self.cross *= br_correction
             self.error *= br_correction
-            logger.info(
-                "BR equalization: dropped %d/%d events (effective BR rescale = %.4g).",
-                nb_loose_skip, n_processed, br_correction,
-            )
+            if nb_loose_skip:
+                logger.info(
+                    "BR equalization: dropped %d/%d events (effective BR "
+                    "rescale = %.4g).", nb_loose_skip, n_processed,
+                    br_correction)
             # Downstream sets nb_event = int(original_nb_event * efficiency)
             # so the kept-fraction needs to be communicated as the efficiency.
             self.efficiency = br_correction
@@ -5099,9 +5260,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         #print(f"decay_dict = {decay_dict} - length = {len(decay_dict)}")
         # event_decay is a dict pdg -> list of event file (contain the decay)
                 
-        pure_interference = bool(self._pure_interference())
+        # both the pure-interference mode and decay_output = weighted need the
+        # decay-side constant c, which only this scan measures
+        pure_interference = bool(self._pure_interference()) or self._weighted_decay()
         if self.options['ms_dir'] and os.path.exists(pjoin(self.options['ms_dir'], 'max_wgt')):
-            # in pure-interference mode this scan also measures c, so a cached
+            # in those modes this scan also measures c, so a cached
             # bound may only be reused when the matching c is cached too
             if not pure_interference:
                 return float(open(pjoin(self.options['ms_dir'], 'max_wgt'),'r').read())
@@ -5433,8 +5596,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         signed = bool(self._pure_interference())
         # ... and the same scan measures c = <W_full>, the decay-side constant
         # the fully weighted output divides by. One extra contraction per draw
-        # on matrices that are alive anyway (section 13.13).
-        self._pi_probe_c = signed
+        # on matrices that are alive anyway (section 13.13). decay_output =
+        # weighted needs the same constant, and gets it from the same place --
+        # there the "unrestricted" contraction IS the ordinary one (the trace
+        # restriction defaults to the contraction restriction), so the swap in
+        # _pi_unrestricted_contraction is a no-op and c = <W>, exactly the
+        # quantity that makes mean(w) = sigma*BR.
+        probe_c = signed or self._weighted_decay()
+        self._pi_probe_c = probe_c
         pi_c_sum = 0.0
         pi_c_sumsq = 0.0
         pi_c_n = 0
@@ -5497,7 +5666,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     full_evt = full_evt.add_decays(decays)
                     jac = full_evt.reshuffle_production()
                 maxwgt = max(abs(wgt*jac) if signed else wgt*jac, maxwgt)
-                if signed:
+                if probe_c:
                     restricted = wgt*jac
                     restricted = float(getattr(restricted, 'real', restricted))
                     if math.isfinite(restricted):
@@ -5516,13 +5685,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                             pi_c_sum += sample
                             pi_c_sumsq += sample * sample
                             pi_c_n += 1
-            if signed and ev_absw_n:
+            if probe_c and ev_absw_n:
                 ev_mean = ev_absw_sum / ev_absw_n
                 pi_absw_ev_sum += ev_mean
                 pi_absw_ev_sumsq += ev_mean * ev_mean
                 pi_absw_ev_n += 1
             per_event.append(float(getattr(maxwgt, 'real', maxwgt)))
-        if signed:
+        if probe_c:
             self._pi_probe_c = False
             stats = getattr(self, '_pi_c_stats', None) or {'sum': 0.0,
                                                            'sumsq': 0.0, 'n': 0}
@@ -6477,6 +6646,59 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         self._pure_interference_cache = out
         return out
+
+    def _weighted_decay(self):
+        """True when the ordinary (non-interference) decay output is to be
+        written WEIGHTED -- no accept/reject, one draw per production event,
+        ``w = w_prod * BR * W / c``.
+
+        False in the pure-interference mode: that mode is always weighted (or
+        unweighted up to a sign) on its own terms and answers to
+        ``pure_interference_output`` instead, so the two options never both
+        apply. Also false outside the density spin modes, where there is no
+        ``W`` -- ``_validate_weighted_decay`` refuses that combination at
+        launch rather than silently ignoring it, so this is belt and braces.
+        """
+        try:
+            asked = self.options['decay_output']
+        except (KeyError, TypeError):
+            # option sets built by hand (unit-test stubs, older cards): the
+            # same fallback _pure_interference makes, and the same reason
+            return False
+        return (asked == 'weighted'
+                and not self._pure_interference()
+                and self._density_spinmode())
+
+    def _validate_weighted_decay(self):
+        """Card-level checks for ``decay_output = weighted``, run once at
+        launch. Refuses rather than ignores: an option that silently does
+        nothing is how a user ends up quoting statistics they never got."""
+        if self.options['decay_output'] != 'weighted':
+            return
+        if self._pure_interference():
+            logger.warning(
+                "MadSpin: decay_output = weighted has no effect under "
+                "pure_interference, which writes a signed sample on its own "
+                "terms. Use pure_interference_output (currently '%s') to "
+                "choose that mode's output shape.",
+                self.options['pure_interference_output'])
+            return
+        if not self._density_spinmode():
+            raise self.InvalidCmd(
+                "MadSpin: decay_output = weighted needs one of the density "
+                "spin modes (madspin/full, PA, onshell). spinmode = %s builds "
+                "no production/decay spin-density convolution, so there is no "
+                "W to put on the weight and nothing to gain by not "
+                "unweighting. Drop decay_output, or switch spinmode."
+                % self.options['spinmode'])
+        logger.warning(
+            "MadSpin: decay_output = weighted. No accept/reject is done -- one "
+            "decay configuration is drawn per production event and kept, with "
+            "w = w_prod * BR * W / c. The output LHE is therefore WEIGHTED: "
+            "mean(w) = sigma*BR (MG5 writes IDWTUP = -4, so that is the "
+            "cross-section and <init> is unchanged), but the per-event weights "
+            "are NOT constant. Anything downstream that assumes MadSpin events "
+            "carry a constant weight will be wrong on this file.")
 
     def _pure_interference_unweighted(self):
         """True when the pure-interference mode must write the 'unweighted'

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4265,9 +4265,42 @@ class MadSpinInterface(extended_cmd.Cmd):
         sum_w2 = sum(s.get('sum_w2', 0.0) for s in stats_list)
         nb_pi_dead = sum(s.get('nb_pi_dead', 0) for s in stats_list)
         nb_pi_overflow = sum(s.get('nb_pi_overflow', 0) for s in stats_list)
+        nb_loose_skip = sum(s.get('nb_loose_skip', 0) for s in stats_list)
+        unweighted = self._pure_interference_unweighted()
+        absw = getattr(self, '_pi_absw', 0.0) or 0.0
+        max_weight = getattr(self, '_pi_max_weight', 0.0) or 0.0
+
+        # --------------------------------------------------------------
+        # 'unweighted': replace the probe's <|W|> by the one the run itself
+        # realised, which is exact rather than merely well-measured.
+        #
+        # The written magnitude is w0 = sigma_ref*BR*<|W|>/c, and the file
+        # normalises by N_file.  Since N_file = N_drawn*<|W|>/M, putting the
+        # RUN's own <|W|> = (N_file/N_drawn)*M into w0 makes N_file cancel out
+        # of the estimator entirely:
+        #
+        #     (1/N_file) sum w O  =  (M sigma_ref BR / (c N_drawn))
+        #                            * sum_accepted sign(W) O
+        #
+        # whose expectation is sigma_ref*BR*<W O>/c exactly, with no estimate
+        # of <|W|> in it anywhere.  The probe's <|W|> is a poor substitute:
+        # unlike c it is not a decay-side constant, so it is only as good as
+        # the handful of production events the probe sees -- measured 9.5%
+        # spread over the 110 events of the default probe on p p > t t~,
+        # which would be a 9.5% flat error on every weight.  The correction is
+        # a single constant, applied to every event in the pass that writes
+        # the banner note (which rewrites the whole file anyway).
+        n_drawn = n_processed - nb_loose_skip
+        event_scale = None
+        if unweighted and absw and n_drawn:
+            absw_run = (float(n_written) / n_drawn) * max_weight
+            event_scale = absw_run / absw
+            S *= event_scale
+            sum_w2 *= event_scale * event_scale
+        else:
+            absw_run = absw
         delta = math.sqrt(sum_w2)
         z = (S / delta) if delta else 0.0
-        unweighted = self._pure_interference_unweighted()
         if nb_pi_dead:
             logger.critical(
                 "MadSpin pure_interference: %d/%d trial(s) had a non-finite "
@@ -4299,11 +4332,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         c_value = getattr(self, '_pi_c', 0.0) or 0.0
         c_err = getattr(self, '_pi_c_err', 0.0) or 0.0
         analytic_c = getattr(self, '_pi_analytic_c', 0.0) or 0.0
-        max_weight = getattr(self, '_pi_max_weight', 0.0) or 0.0
-        absw = getattr(self, '_pi_absw', 0.0) or 0.0
         absw_err = getattr(self, '_pi_absw_err', 0.0) or 0.0
         n_c = (getattr(self, '_pi_c_stats', None) or {}).get('n', 0)
         n_absw = (getattr(self, '_pi_absw_stats', None) or {}).get('n', 0)
+        n_absw_ev = (getattr(self, '_pi_absw_stats', None) or {}).get('ev_n', 0)
         mean_w = S / n_written if n_written else 0.0
         if unweighted:
             note = [
@@ -4320,13 +4352,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                 '#  unrestricted decay-side constant, both below. One decay draw was',
                 '#  made per production event and kept with probability |W|/max|W|,',
                 '#  so the file holds FEWER events than were read and the local size',
-                '#  of the interference is carried by the keep rate. The bound the',
-                '#  acceptance used cancels out of the weight above, so it is not a',
-                '#  normalisation constant. MG5 writes LHE with IDWTUP = -4, i.e. the',
-                '#  cross-section is the MEAN of the weights, so this sample is',
-                '#  self-normalising: mean(w) = 0 (its rate) and sum_bin(w) / N_file',
-                '#  is the interference contribution to that bin, in pb, with N_file',
-                '#  the number of events WRITTEN (the first number below).',
+                '#  of the interference is carried by the keep rate. <|W|> is taken',
+                '#  from the run itself -- (N_file/N_drawn) * max|W| -- not from the',
+                '#  maximum-weight probe, which sees too few production events to',
+                '#  know it; that also makes the accept/reject bound cancel out of',
+                '#  the weight EXACTLY rather than on average. MG5 writes LHE with',
+                '#  IDWTUP = -4, i.e. the cross-section is the MEAN of the weights,',
+                '#  so this sample is self-normalising: mean(w) = 0 (its rate) and',
+                '#  sum_bin(w) / N_file is the interference contribution to that',
+                '#  bin, in pb, with N_file the number of events WRITTEN (the first',
+                '#  number below).',
             ]
         else:
             note = [
@@ -4359,28 +4394,28 @@ class MadSpinInterface(extended_cmd.Cmd):
                 analytic_c, (c_value / analytic_c) if analytic_c else 0.0),
             '#     (1/(prod_denominators * sym_decay); exact only where the chain',
             '#      carries no reshuffling jacobian -- a cross-check, not the value used)',
-            '#  Mean absolute conv.   <|W|>  : %+.8e  +- %.4f%%' % (
+            '#  <|W|> from the probe         : %+.8e  +- %.4f%%' % (
                 absw, (100 * absw_err / absw) if absw else 0.0),
-            '#     (the decay-phase-space mean of |W|, over %d probe trials.' % n_absw,
-            '#      It normalises the "unweighted" output; for the fully weighted',
-            '#      one it is a diagnostic only)',
+            '#     (the decay-phase-space mean of |W|, over %d trials on %d' % (
+                n_absw, n_absw_ev),
+            '#      production events. The error is the spread over THOSE events,',
+            '#      not over the trials: <|W|> is not a decay-side constant the way',
+            '#      c is, so a handful of production events does not pin it down)',
             '#  Maximum weight max|W| probed : %+.8e' % max_weight,
         ]
         if unweighted:
-            expected_absw = keep * max_weight
             note += [
                 '#     (the bound the accept/reject used. It cancels out of the',
-                '#      weight, but it does bound it: see the overflow count below)',
+                '#      weight exactly, but it does bound it: see the overflow count)',
+                '#  <|W|> the run realised       : %+.8e  (probe x %.4f)' % (
+                    absw_run, event_scale or 1.0),
+                '#     ( = (N_file/N_drawn) * max|W| , over every production event',
+                '#      of this run rather than the probe\'s few. THIS is what the',
+                '#      written weights carry; the probe value above was the',
+                '#      provisional one and has been divided out)',
                 '#  Weight magnitude |w| (pb)    : %+.8e' % (
-                    reference * absw / c_value if c_value else 0.0),
+                    reference * absw_run / c_value if c_value else 0.0),
                 '#     ( = sigma_ref * <|W|> / c ; every event carries +- this)',
-                '#  keep rate x max|W|           : %+.8e  (ratio to <|W|> %.4f)' % (
-                    expected_absw,
-                    (expected_absw / absw) if absw else 0.0),
-                '#     (free consistency check: the realised keep rate is',
-                '#      <|W|>/max|W| by construction, so this must reproduce <|W|>.',
-                '#      A ratio away from 1 means the probe events were not',
-                '#      representative of the full sample)',
                 '#  Trials above max|W|          : %d' % nb_pi_overflow,
                 '#     (accepted with probability 1 instead of |W|/max|W|, which',
                 '#      biases the sample. Non-zero means max_weight is',
@@ -4400,7 +4435,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             '#  Trials with a dead weight    : %d' % nb_pi_dead,
         ]
         self._rewrite_lhe_banner_cross(base_out, 0.0, n_written=n_written,
-                                       note=note, note_tag='MGPureInterference')
+                                       note=note, note_tag='MGPureInterference',
+                                       event_scale=event_scale)
 
         logger.info("MadSpin pure_interference: sum of weights S = %+.6e, "
                     "sqrt(sum w^2) = %.6e, z = %+.3f, mean(w) = %+.6e "
@@ -4408,30 +4444,26 @@ class MadSpinInterface(extended_cmd.Cmd):
                     "recorded in the <MGPureInterference> banner block)",
                     S, delta, z, mean_w, reference, c_value)
         if unweighted:
-            # The keep rate IS <|W|>/max|W| by construction, so this reproduces
-            # the probe's <|W|> for free -- and it is the only in-run handle on
-            # whether the probe's production events were representative, which
-            # is the one extra scale uncertainty this variant carries over the
-            # fully weighted one (<|W|>, unlike c, is not a decay-side
-            # constant).
-            expected = keep * max_weight
-            ratio = (expected / absw) if absw else 0.0
             logger.info(
-                "MadSpin pure_interference: |w| = %.6e pb on every event, and "
-                "the realised keep rate x max|W| = %.6e reproduces the probe's "
-                "<|W|> = %.6e to %.4f -- the accept/reject bound cancels out "
-                "of the normalisation, this is its consistency check.",
-                (reference * absw / c_value) if c_value else 0.0,
-                expected, absw, ratio)
-            if absw and abs(ratio - 1.0) > 0.10:
+                "MadSpin pure_interference: every event carries |w| = %.6e pb, "
+                "from the run's own <|W|> = (N_file/N_drawn) x max|W| = %.6e. "
+                "The maximum-weight probe had said %.6e +- %.1f%%, so the "
+                "written weights were rescaled by %.4f -- the probe sees too "
+                "few production events to normalise with, and using the run's "
+                "own keep rate instead makes the accept/reject bound cancel "
+                "exactly rather than on average.",
+                (reference * absw_run / c_value) if c_value else 0.0,
+                absw_run, absw, 100 * (absw_err / absw if absw else 0.0),
+                event_scale or 1.0)
+            if event_scale and abs(event_scale - 1.0) > 0.25:
                 logger.warning(
-                    "MadSpin pure_interference: the realised keep rate implies "
-                    "<|W|> = %.6e, %.1f%% away from the %.6e the maximum-weight "
-                    "probe measured. <|W|> is a flat scale on every written "
-                    "weight, so the sample is normalised to that accuracy. The "
-                    "probe's production events are not representative of the "
-                    "sample -- raise Nevents_for_max_weight.",
-                    expected, 100 * (ratio - 1.0), absw)
+                    "MadSpin pure_interference: the probe's <|W|> was off by "
+                    "%.0f%%, which is a lot even for a quantity it only sees a "
+                    "handful of production events of. The written weights use "
+                    "the run's own value and are right, but a probe that far "
+                    "out means the maximum weight it produced may be poor too "
+                    "-- check the overweight count and consider raising "
+                    "Nevents_for_max_weight.", 100 * (event_scale - 1.0))
             if nb_pi_overflow:
                 logger.critical(
                     "MadSpin pure_interference: %d trial(s) had |W| above the "
@@ -4800,8 +4832,12 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         self._apply_accounting(base_out, stats_list)
 
+    # <wgt id='...'>value</wgt>, the LHEF v3 multi-weight entry
+    _RWGT_LINE = re.compile(r'^(\s*<wgt\b[^>]*>)\s*([-+0-9.eEdD]+)\s*(</wgt>\s*)$')
+
     def _rewrite_lhe_banner_cross(self, path, ratio, n_written=None,
-                                  note=None, note_tag='MGGenerationInfo'):
+                                  note=None, note_tag='MGGenerationInfo',
+                                  event_scale=None):
         """Rewrite an already-written LHE file, multiplying every <init> line
         cross-section / error / xmax by ``ratio`` and (optionally) replacing
         the ``Number of Events`` entry in the MGGenerationInfo block with
@@ -4811,16 +4847,63 @@ class MadSpinInterface(extended_cmd.Cmd):
         ``note``, when given, is a list of already-formatted comment lines
         inserted as a ``<note_tag>`` block just before ``</header>`` -- the
         pure-interference mode uses it to record the reference normalisation
-        that its zeroed ``<init>`` block no longer carries."""
+        that its zeroed ``<init>`` block no longer carries.
+
+        ``event_scale``, when given, additionally multiplies every event's
+        ``XWGTUP`` and every ``<wgt>`` entry of its ``<rwgt>`` block by that
+        constant. Only the 'unweighted' pure-interference output uses it, and
+        only to replace the maximum-weight probe's estimate of ``<|W|>`` by
+        the one the run itself realised -- a number that is not known until
+        the loop has finished, hence the second pass. ``None`` (the default)
+        leaves every event byte-for-byte as written."""
 
         tmp_path = path + '.tmp_brfix'
         shutil.move(path, tmp_path)
         with open(tmp_path, 'r') as src, open(path, 'w') as dst:
             in_init = False
             in_mggen = False
+            in_event = False
+            want_event_head = False
             for line in src:
                 stripped = line.strip()
                 lstripped = stripped.lower()
+                if event_scale is not None:
+                    if lstripped.startswith('<event'):
+                        in_event = True
+                        want_event_head = True
+                        dst.write(line)
+                        continue
+                    if in_event:
+                        if lstripped.startswith('</event'):
+                            in_event = False
+                            dst.write(line)
+                            continue
+                        if want_event_head:
+                            # NUP IDPRUP XWGTUP SCALUP AQEDUP AQCDUP
+                            parts = stripped.split()
+                            if len(parts) == 6:
+                                try:
+                                    wgt = float(parts[2].replace('d', 'e'))
+                                except ValueError:
+                                    pass
+                                else:
+                                    want_event_head = False
+                                    parts[2] = '%.7e' % (wgt * event_scale)
+                                    dst.write('%s\n' % ' '.join(parts))
+                                    continue
+                        match = self._RWGT_LINE.match(line.rstrip('\n'))
+                        if match:
+                            try:
+                                wgt = float(match.group(2).replace('d', 'e'))
+                            except ValueError:
+                                pass
+                            else:
+                                dst.write('%s%.7e%s\n' % (match.group(1),
+                                                          wgt * event_scale,
+                                                          match.group(3)))
+                                continue
+                        dst.write(line)
+                        continue
                 if note and lstripped.startswith('</header'):
                     dst.write('<%s>\n' % note_tag)
                     for entry in note:
@@ -5180,13 +5263,28 @@ class MadSpinInterface(extended_cmd.Cmd):
                     "this case." % ('zero' if n else 'nothing', n))
             return
         mean = stats['sum'] / n
-        # sumsq holds sum(W^2) = sum(|W|^2), the right second moment for <|W|>
-        var = max(stats['sumsq'] / n - mean * mean, 0.0)
         self._pi_absw = mean
-        self._pi_absw_err = math.sqrt(var / n)
+        # The error is the spread of the PER-PRODUCTION-EVENT means, not of the
+        # individual trials: the nb_ps_point draws of one production point all
+        # carry its own |W| scale, so the trial-level error is not an error on
+        # <|W|> at all. Measured on p p > t t~: 0.46% trial-level against a
+        # 9.5% production-event spread over the 110 probed events. Only the
+        # second number says how well <|W|> is known -- which is why the run
+        # does not trust it for the normalisation (see _report_pure_
+        # interference: the realised keep rate replaces it).
+        ev_n = stats.get('ev_n', 0)
+        if ev_n > 1:
+            ev_mean = stats['ev_sum'] / ev_n
+            ev_var = max(stats['ev_sumsq'] / ev_n - ev_mean * ev_mean, 0.0)
+            self._pi_absw_err = math.sqrt(ev_var / ev_n)
+        else:
+            var = max(stats['sumsq'] / n - mean * mean, 0.0)
+            self._pi_absw_err = math.sqrt(var / n)
         rel = (self._pi_absw_err / mean) if mean else 0.0
         logger.info("MadSpin pure_interference: <|W|> = %.6e +- %.2f%% over %d "
-                    "trials", mean, 100 * rel, n)
+                    "trials on %d production events (the error is the spread "
+                    "over those events, which is what <|W|> is an average of)",
+                    mean, 100 * rel, n, ev_n)
 
     def _write_pi_c_cache(self, path):
         """Persist the c and <|W|> measurements beside ``max_wgt`` in
@@ -5351,6 +5449,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         pi_absw_sum = 0.0
         pi_absw_sumsq = 0.0
         pi_absw_n = 0
+        # ... and the same thing BLOCKED by production event. The nb_ps_point
+        # draws of one production point share its a_p, so treating all
+        # nevents*nb_ps_point trials as independent understates the error on
+        # <|W|> by more than an order of magnitude (measured: 0.46% claimed
+        # against a 9.5% production-event spread). The honest error is the
+        # spread of the per-production-event means over the probe's production
+        # events, which is what these three accumulate.
+        pi_absw_ev_sum = 0.0
+        pi_absw_ev_sumsq = 0.0
+        pi_absw_ev_n = 0
         per_event = []
         for i in range(start, stop):
             if (i - start) % 5 == 1 and getattr(self, '_shard_tag', None) in (None, 0):
@@ -5359,6 +5467,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             if self.options['fixed_order']:
                 base_event = base_event[0]
             maxwgt = 0
+            ev_absw_sum = 0.0     # this production event's own |W| draws
+            ev_absw_n = 0
             density_matrix_prod = None
             offshell_density = (self.generate_all.mode == 'density'
                                 and not density_pole_approximation)
@@ -5394,6 +5504,8 @@ class MadSpinInterface(extended_cmd.Cmd):
                         pi_absw_sum += abs(restricted)
                         pi_absw_sumsq += restricted * restricted
                         pi_absw_n += 1
+                        ev_absw_sum += abs(restricted)
+                        ev_absw_n += 1
                     sample = getattr(self, '_pi_unrestricted_wgt', None)
                     if sample is not None:
                         # the outer jacobian (PA with density_keep_jacobian) is
@@ -5404,6 +5516,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                             pi_c_sum += sample
                             pi_c_sumsq += sample * sample
                             pi_c_n += 1
+            if signed and ev_absw_n:
+                ev_mean = ev_absw_sum / ev_absw_n
+                pi_absw_ev_sum += ev_mean
+                pi_absw_ev_sumsq += ev_mean * ev_mean
+                pi_absw_ev_n += 1
             per_event.append(float(getattr(maxwgt, 'real', maxwgt)))
         if signed:
             self._pi_probe_c = False
@@ -5419,6 +5536,9 @@ class MadSpinInterface(extended_cmd.Cmd):
             astats['sum'] += pi_absw_sum
             astats['sumsq'] += pi_absw_sumsq
             astats['n'] += pi_absw_n
+            astats['ev_sum'] = astats.get('ev_sum', 0.0) + pi_absw_ev_sum
+            astats['ev_sumsq'] = astats.get('ev_sumsq', 0.0) + pi_absw_ev_sumsq
+            astats['ev_n'] = astats.get('ev_n', 0) + pi_absw_ev_n
             self._pi_absw_stats = astats
         return per_event
 
@@ -5527,10 +5647,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                 self._pi_c_stats = merged
             pi_absw = r.get('pi_absw')
             if pi_absw:
-                merged = getattr(self, '_pi_absw_stats', None) or {
-                    'sum': 0.0, 'sumsq': 0.0, 'n': 0}
-                for key in ('sum', 'sumsq', 'n'):
-                    merged[key] += pi_absw.get(key, 0)
+                merged = getattr(self, '_pi_absw_stats', None) or {}
+                for key in ('sum', 'sumsq', 'n',
+                            'ev_sum', 'ev_sumsq', 'ev_n'):
+                    merged[key] = merged.get(key, 0) + pi_absw.get(key, 0)
                 self._pi_absw_stats = merged
             if r.get('pi_analytic_c'):
                 self._pi_analytic_c = r['pi_analytic_c']

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -175,8 +175,27 @@ class MadSpinOptions(banner.ConfigFile):
                        "UNPOLARISED on the legs given an I block (the interference between two "
                        "polarisations does not exist in a sample generated with a brace on that "
                        "leg). The sample then has zero total cross-section by construction, and "
-                       "its event weights are SIGNED and fully weighted, w = sigma*BR*W/c; see "
-                       "doc/madspin_sequential_plan.md section 13.")
+                       "its event weights are SIGNED; see pure_interference_output for their "
+                       "value and doc/madspin_sequential_plan.md section 13.")
+        self.add_param('pure_interference_output', 'weighted',
+                       allowed=['weighted', 'unweighted'],
+                       comment="how the pure-interference mode writes its (always signed) event "
+                       "weights. Ignored unless pure_interference is set. 'weighted' (default): "
+                       "no accept/reject at all, every trial is kept and carries the fully "
+                       "weighted w = sigma_ref*BR*W/c, with W the signed convolution of that "
+                       "trial and c = <W> the unrestricted decay-side constant. 'unweighted': "
+                       "unweight on |W| against the probed maximum, ONE draw per production "
+                       "event and nothing written on rejection, and give each accepted event "
+                       "w = +- sigma_ref*BR*<|W|>/c -- i.e. exactly two weight magnitudes, so "
+                       "the sample is unweighted up to a sign. Both give mean(w) = 0 and "
+                       "sum_bin(w)/N_file = the interference contribution to that bin in pb "
+                       "(N_file = the number of events IN THE FILE, which is N_read only for "
+                       "'weighted'), and in neither does the accept/reject bound enter the "
+                       "normalisation. 'weighted' is the default because it uses every "
+                       "production event instead of the few percent an accept/reject keeps: "
+                       "measured ~6x less variance per production event on <C_nn>, "
+                       "<cos phi_ll> and <Delta phi> (section 13.17). Choose 'unweighted' only "
+                       "when a downstream tool needs near-constant |w|.")
         self.add_param('keep_weight_for_polarization_vector', [], typelist=str,
                        comment="density spin modes only. Polarisations (0, +, -, T; "
                        "L/R accepted as aliases of -/+) offered to each decaying "
@@ -2847,6 +2866,10 @@ class MadSpinInterface(extended_cmd.Cmd):
             # pure interference: the decay-side constant every written weight is
             # divided by, measured by the same scan that produced ``maxwgt``
             pure_interference_c=getattr(self, '_pi_c', None),
+            # ... and <|W|>, which normalises the 'unweighted' output. Unused
+            # by the fully weighted default.
+            pure_interference_absw=getattr(self, '_pi_absw', None),
+            pure_interference_unweighted=self._pure_interference_unweighted(),
             sequential=sequential,
             decay_dict=decay_dict,
             drop_prob_per_pdg=drop_prob_per_pdg,
@@ -3807,16 +3830,56 @@ class MadSpinInterface(extended_cmd.Cmd):
         # i.e. the file normalises itself, max_weight leaves the normalisation
         # entirely, and every production event is used instead of the 3-9% an
         # accept/reject kept. See doc/madspin_sequential_plan.md section 13.13.
+        #
+        # ``pure_interference_output = unweighted`` selects the other
+        # representation of the same estimator (section 13.17): keep the
+        # accept/reject, but on |W| and with ONE draw -- nothing is written on
+        # rejection, so the keep rate carries <|W|> -- and give each accepted
+        # event the constant magnitude
+        #
+        #     w = +- sigma_parent * BR * <|W|> / c
+        #
+        # The bound M the acceptance uses cancels between the acceptance
+        # probability |W|/M and the resulting file size N_file = N*<|W|>/M, so
+        # this normalisation contains no max_weight either. It is *not* the
+        # historical redraw-until-accept, which would force one event per
+        # production point and divide <|W|> out altogether.
         pure_interference = bool(self._pure_interference())
         pure_interference_c = ctx.get('pure_interference_c')
+        pi_unweighted = pure_interference and bool(
+            ctx.get('pure_interference_unweighted'))
         if pure_interference and not pure_interference_c:
             raise self.InvalidCmd(
                 "MadSpin: the pure-interference normalisation constant c is "
                 "missing; the weights cannot be normalised. This is an "
                 "internal error -- the maximum-weight scan measures it.")
+        pi_w0_factor = 0.0     # <|W|>/c: the constant |w|/(sigma*BR) of the
+                               # 'unweighted' output
+        if pi_unweighted:
+            absw = ctx.get('pure_interference_absw')
+            if not absw:
+                raise self.InvalidCmd(
+                    "MadSpin: pure_interference_output = unweighted needs "
+                    "<|W|>, the decay-phase-space mean of the absolute "
+                    "convolution, and the maximum-weight scan produced none. "
+                    "This is an internal error -- the scan measures it beside "
+                    "c.")
+            if not maxwgt:
+                raise self.InvalidCmd(
+                    "MadSpin: pure_interference_output = unweighted needs a "
+                    "positive maximum weight to unweight |W| against, and the "
+                    "scan produced %r." % (maxwgt,))
+            pi_w0_factor = absw / pure_interference_c
         nb_pi_dead = 0     # trials whose convolution was not a finite number:
                            # they are written with weight 0, and an all-dead
                            # sample is a bug rather than a physics statement
+        nb_pi_reject = 0   # 'unweighted' only: production events whose single
+                           # decay draw failed the |W|/M test and wrote nothing
+        nb_pi_overflow = 0 # 'unweighted' only: |W| above the bound. Unlike the
+                           # fully weighted output the bound is live again here
+                           # -- the acceptance probability clips at 1 -- so an
+                           # under-estimated max_weight biases the sample and
+                           # has to be counted and reported.
         sum_w = 0.0        # signed weight sum, for the zero-cross-section check
         sum_w2 = 0.0       # its second moment: no cancellation, so the MC error
         nb_try = 0
@@ -3905,7 +3968,10 @@ class MadSpinInterface(extended_cmd.Cmd):
 
             # Per-production-event cache reused across rejection retries.
             prod_density_cached = None
-            pi_factor = 1.0   # W / c in the pure-interference mode, 1 elsewhere
+            pi_factor = 1.0   # W/c ('weighted') or +-<|W|>/c ('unweighted') in
+                              # the pure-interference mode, 1 elsewhere
+            pi_rejected = False  # 'unweighted': the single draw failed, so this
+                                 # production event writes nothing at all
             # Consecutive trials whose matrix-element weight was not a finite
             # positive number. This `while 1` has no other exit than an
             # acceptance, so without it a structurally zero weight loops for
@@ -3952,13 +4018,31 @@ class MadSpinInterface(extended_cmd.Cmd):
 
                 test = wgt*jac
                 if pure_interference:
-                    # no accept/reject: the signed convolution goes onto the
-                    # weight, scaled by the decay-side constant c
                     signed = float(getattr(test, 'real', test))
                     if not math.isfinite(signed):
                         nb_pi_dead += 1
                         signed = 0.0
-                    pi_factor = signed / pure_interference_c
+                    if not pi_unweighted:
+                        # no accept/reject: the signed convolution goes onto
+                        # the weight, scaled by the decay-side constant c
+                        pi_factor = signed / pure_interference_c
+                    else:
+                        # unweighted up to a sign. ONE draw, accepted with
+                        # probability |W|/M; nothing is written on rejection,
+                        # so the keep rate carries <|W|>. The magnitude is the
+                        # same for every accepted event and M cancels out of
+                        # it. A negative weight is normal here, which is why
+                        # the test and the overflow count are both on |W| --
+                        # and why _dead_trial, whose whole premise is that a
+                        # non-positive weight is structurally dead, is not on
+                        # this path at all (nb_pi_dead counts the genuinely
+                        # dead, non-finite trials instead).
+                        if abs(signed) > maxwgt:
+                            nb_pi_overflow += 1
+                        if random.random() * maxwgt >= abs(signed):
+                            pi_rejected = True
+                            break
+                        pi_factor = math.copysign(pi_w0_factor, signed)
                 else:
                     # ``wgt`` alone, not ``wgt*jac``: a zero/-1 jacobian is an
                     # ordinary rejection (a mass set the production cannot be
@@ -4001,6 +4085,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                     break
                 #else:
                 #    misc.sprint('fail-> retry')
+            if pi_rejected:
+                # 'unweighted' pure interference: one draw, and it failed. Write
+                # nothing and move to the next production event -- redrawing
+                # here would force one output per production point and divide
+                # out <|W|>, which is precisely the quantity the keep rate is
+                # carrying (section 13.7b).
+                nb_pi_reject += 1
+                continue
             # Efficiency = accepted / trials (+1 because current event is already accepted)
             self.efficiency = float(curr_event + 1) / nb_try
             #if density_method:
@@ -4044,9 +4136,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                            time.time()-start))
         n_processed = curr_event + 1
         return dict(n_processed=n_processed,
-                    n_written=n_processed - nb_loose_skip,
+                    n_written=n_processed - nb_loose_skip - nb_pi_reject,
                     nb_try=nb_try,
                     nb_loose_skip=nb_loose_skip,
+                    nb_pi_reject=nb_pi_reject,
+                    nb_pi_overflow=nb_pi_overflow,
                     # picklable and merged additively over the forked shards, so
                     # one shard or many gives the identical zero-cross-section
                     # test (section 13.8)
@@ -4170,8 +4264,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         S = sum(s.get('sum_w', 0.0) for s in stats_list)
         sum_w2 = sum(s.get('sum_w2', 0.0) for s in stats_list)
         nb_pi_dead = sum(s.get('nb_pi_dead', 0) for s in stats_list)
+        nb_pi_overflow = sum(s.get('nb_pi_overflow', 0) for s in stats_list)
         delta = math.sqrt(sum_w2)
         z = (S / delta) if delta else 0.0
+        unweighted = self._pure_interference_unweighted()
         if nb_pi_dead:
             logger.critical(
                 "MadSpin pure_interference: %d/%d trial(s) had a non-finite "
@@ -4179,14 +4275,24 @@ class MadSpinInterface(extended_cmd.Cmd):
                 "matrix element, not physics -- the sample is incomplete.",
                 nb_pi_dead, n_processed)
 
-        # Fully weighted: every production event is kept, so this is 1 unless
-        # some *other* mechanism (BR equalization) dropped events.
         keep = float(n_written) / n_processed if n_processed else 0.0
-        logger.info(
-            "MadSpin pure_interference: wrote %d/%d production events "
-            "(%.4f). The mode does not accept/reject: every trial is kept and "
-            "the local size of the interference is carried by the magnitude of "
-            "the signed weight instead.", n_written, n_processed, keep)
+        if unweighted:
+            logger.info(
+                "MadSpin pure_interference: wrote %d/%d production events "
+                "(%.4f). pure_interference_output = unweighted: one decay "
+                "draw per production event, accepted with probability "
+                "|W|/max|W|, so the keep rate -- not the weight magnitude -- "
+                "carries the local size of the interference.",
+                n_written, n_processed, keep)
+        else:
+            # Fully weighted: every production event is kept, so this is 1
+            # unless some *other* mechanism (BR equalization) dropped events.
+            logger.info(
+                "MadSpin pure_interference: wrote %d/%d production events "
+                "(%.4f). The mode does not accept/reject: every trial is kept "
+                "and the local size of the interference is carried by the "
+                "magnitude of the signed weight instead.",
+                n_written, n_processed, keep)
 
         # The reference normalisation has to be read before the block is zeroed.
         reference = self._read_lhe_init_cross(base_out)
@@ -4194,23 +4300,50 @@ class MadSpinInterface(extended_cmd.Cmd):
         c_err = getattr(self, '_pi_c_err', 0.0) or 0.0
         analytic_c = getattr(self, '_pi_analytic_c', 0.0) or 0.0
         max_weight = getattr(self, '_pi_max_weight', 0.0) or 0.0
+        absw = getattr(self, '_pi_absw', 0.0) or 0.0
+        absw_err = getattr(self, '_pi_absw_err', 0.0) or 0.0
         n_c = (getattr(self, '_pi_c_stats', None) or {}).get('n', 0)
+        n_absw = (getattr(self, '_pi_absw_stats', None) or {}).get('n', 0)
         mean_w = S / n_written if n_written else 0.0
-        note = [
-            '#  Pure-interference sample: it keeps ONLY the interference between',
-            '#  the polarisations listed below, so its total cross-section is zero',
-            '#  by construction and <init> is written with XSECUP = 0. That also',
-            '#  zeroes XERRUP/XMAXUP, so the file cannot be showered as-is.',
-            '#',
-            '#  The event weights are SIGNED and fully weighted:',
-            '#      w = sigma_ref * BR * W / c',
-            '#  with W the signed production/decay convolution of this event and',
-            '#  c = <W> the decay-side constant below. MG5 writes LHE with',
-            '#  IDWTUP = -4, i.e. the cross-section is the MEAN of the weights,',
-            '#  so this sample is self-normalising: mean(w) = 0 (its rate) and',
-            '#  sum_bin(w) / N_read is the interference contribution to that',
-            '#  bin, in pb. N_read is the "Events written / read" count below.',
-        ]
+        if unweighted:
+            note = [
+                '#  Pure-interference sample: it keeps ONLY the interference between',
+                '#  the polarisations listed below, so its total cross-section is zero',
+                '#  by construction and <init> is written with XSECUP = 0. That also',
+                '#  zeroes XERRUP/XMAXUP, so the file cannot be showered as-is.',
+                '#',
+                '#  The event weights are SIGNED and unweighted UP TO A SIGN -- the',
+                '#  file holds exactly two weight magnitudes:',
+                '#      w = +- sigma_ref * BR * <|W|> / c',
+                '#  with W the signed production/decay convolution, <|W|> its',
+                '#  decay-phase-space mean absolute value and c = <W> the',
+                '#  unrestricted decay-side constant, both below. One decay draw was',
+                '#  made per production event and kept with probability |W|/max|W|,',
+                '#  so the file holds FEWER events than were read and the local size',
+                '#  of the interference is carried by the keep rate. The bound the',
+                '#  acceptance used cancels out of the weight above, so it is not a',
+                '#  normalisation constant. MG5 writes LHE with IDWTUP = -4, i.e. the',
+                '#  cross-section is the MEAN of the weights, so this sample is',
+                '#  self-normalising: mean(w) = 0 (its rate) and sum_bin(w) / N_file',
+                '#  is the interference contribution to that bin, in pb, with N_file',
+                '#  the number of events WRITTEN (the first number below).',
+            ]
+        else:
+            note = [
+                '#  Pure-interference sample: it keeps ONLY the interference between',
+                '#  the polarisations listed below, so its total cross-section is zero',
+                '#  by construction and <init> is written with XSECUP = 0. That also',
+                '#  zeroes XERRUP/XMAXUP, so the file cannot be showered as-is.',
+                '#',
+                '#  The event weights are SIGNED and fully weighted:',
+                '#      w = sigma_ref * BR * W / c',
+                '#  with W the signed production/decay convolution of this event and',
+                '#  c = <W> the decay-side constant below. MG5 writes LHE with',
+                '#  IDWTUP = -4, i.e. the cross-section is the MEAN of the weights,',
+                '#  so this sample is self-normalising: mean(w) = 0 (its rate) and',
+                '#  sum_bin(w) / N_read is the interference contribution to that',
+                '#  bin, in pb. N_read is the "Events written / read" count below.',
+            ]
         for pdg, (prod, dec) in sorted(self._pure_interference().items()):
             note.append('#  interference  pdg %-6s : production %s  x  decay %s'
                         % (pdg, list(prod), list(dec)))
@@ -4226,9 +4359,39 @@ class MadSpinInterface(extended_cmd.Cmd):
                 analytic_c, (c_value / analytic_c) if analytic_c else 0.0),
             '#     (1/(prod_denominators * sym_decay); exact only where the chain',
             '#      carries no reshuffling jacobian -- a cross-check, not the value used)',
+            '#  Mean absolute conv.   <|W|>  : %+.8e  +- %.4f%%' % (
+                absw, (100 * absw_err / absw) if absw else 0.0),
+            '#     (the decay-phase-space mean of |W|, over %d probe trials.' % n_absw,
+            '#      It normalises the "unweighted" output; for the fully weighted',
+            '#      one it is a diagnostic only)',
             '#  Maximum weight max|W| probed : %+.8e' % max_weight,
-            '#     (diagnostic only: the mode does not accept/reject, so this',
-            '#      number no longer enters the normalisation anywhere)',
+        ]
+        if unweighted:
+            expected_absw = keep * max_weight
+            note += [
+                '#     (the bound the accept/reject used. It cancels out of the',
+                '#      weight, but it does bound it: see the overflow count below)',
+                '#  Weight magnitude |w| (pb)    : %+.8e' % (
+                    reference * absw / c_value if c_value else 0.0),
+                '#     ( = sigma_ref * <|W|> / c ; every event carries +- this)',
+                '#  keep rate x max|W|           : %+.8e  (ratio to <|W|> %.4f)' % (
+                    expected_absw,
+                    (expected_absw / absw) if absw else 0.0),
+                '#     (free consistency check: the realised keep rate is',
+                '#      <|W|>/max|W| by construction, so this must reproduce <|W|>.',
+                '#      A ratio away from 1 means the probe events were not',
+                '#      representative of the full sample)',
+                '#  Trials above max|W|          : %d' % nb_pi_overflow,
+                '#     (accepted with probability 1 instead of |W|/max|W|, which',
+                '#      biases the sample. Non-zero means max_weight is',
+                '#      under-estimated: raise nb_sigma or Nevents_for_max_weight)',
+            ]
+        else:
+            note += [
+                '#     (diagnostic only: the mode does not accept/reject, so this',
+                '#      number no longer enters the normalisation anywhere)',
+            ]
+        note += [
             '#  Sum of written weights     S : %+.8e' % S,
             '#  MC error   sqrt(sum w^2)     : %+.8e' % delta,
             '#  z = S / error                : %+.4f' % z,
@@ -4244,24 +4407,63 @@ class MadSpinInterface(extended_cmd.Cmd):
                     "(reference normalisation %.6e pb, c = %.6e, both "
                     "recorded in the <MGPureInterference> banner block)",
                     S, delta, z, mean_w, reference, c_value)
+        if unweighted:
+            # The keep rate IS <|W|>/max|W| by construction, so this reproduces
+            # the probe's <|W|> for free -- and it is the only in-run handle on
+            # whether the probe's production events were representative, which
+            # is the one extra scale uncertainty this variant carries over the
+            # fully weighted one (<|W|>, unlike c, is not a decay-side
+            # constant).
+            expected = keep * max_weight
+            ratio = (expected / absw) if absw else 0.0
+            logger.info(
+                "MadSpin pure_interference: |w| = %.6e pb on every event, and "
+                "the realised keep rate x max|W| = %.6e reproduces the probe's "
+                "<|W|> = %.6e to %.4f -- the accept/reject bound cancels out "
+                "of the normalisation, this is its consistency check.",
+                (reference * absw / c_value) if c_value else 0.0,
+                expected, absw, ratio)
+            if absw and abs(ratio - 1.0) > 0.10:
+                logger.warning(
+                    "MadSpin pure_interference: the realised keep rate implies "
+                    "<|W|> = %.6e, %.1f%% away from the %.6e the maximum-weight "
+                    "probe measured. <|W|> is a flat scale on every written "
+                    "weight, so the sample is normalised to that accuracy. The "
+                    "probe's production events are not representative of the "
+                    "sample -- raise Nevents_for_max_weight.",
+                    expected, 100 * (ratio - 1.0), absw)
+            if nb_pi_overflow:
+                logger.critical(
+                    "MadSpin pure_interference: %d trial(s) had |W| above the "
+                    "maximum weight and were accepted with probability 1 "
+                    "instead of |W|/max|W|. Unlike the fully weighted output, "
+                    "this variant DOES accept/reject, so that bound is live "
+                    "and an under-estimated one biases the sample. Raise "
+                    "nb_sigma or Nevents_for_max_weight.", nb_pi_overflow)
         if abs(z) > 5.0:
+            cause = (
+                "either a genuine fluctuation, an under-estimated max_weight "
+                "(the overweight count above is the monitor for that), or a bug"
+                if unweighted else
+                "either a genuine fluctuation or a bug (the mode no longer "
+                "accept/rejects, so an under-estimated max_weight can no "
+                "longer be the cause)")
             message = (
                 "MadSpin pure_interference: the sum of the event weights is "
                 "NOT compatible with zero -- S = %+.6e, sqrt(sum w^2) = %.6e, "
                 "z = %+.3f (over 5 sigma). The interference term must "
-                "integrate to zero over the decay phase space, so this is "
-                "either a genuine fluctuation or a bug (the mode no longer "
-                "accept/rejects, so an under-estimated max_weight can no "
-                "longer be the cause)."
-                % (S, delta, z))
+                "integrate to zero over the decay phase space, so this is %s."
+                % (S, delta, z, cause))
             logger.critical(message)
             if self.options['density_debug']:
                 raise RuntimeError(message)
         # The banner cross-section is NOT rescaled (it is zero anyway) and
-        # neither is the branching ratio. Fully weighted, n_written ==
-        # n_processed, so the efficiency downstream sizes nb_event with is 1 --
-        # but it is still taken from the counts rather than hard-coded, so a BR
-        # equalization drop in the same run is still reported honestly.
+        # neither is the branching ratio -- in this mode a low keep rate is
+        # physics, not a correction to undo. The efficiency downstream sizes
+        # nb_event with is taken from the counts: 1 for the fully weighted
+        # output (n_written == n_processed, up to a BR-equalization drop), and
+        # the genuine keep rate for the unweighted one, where the file really
+        # does hold that many fewer events.
         self.efficiency = keep
 
     @staticmethod
@@ -4821,8 +5023,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             if not pure_interference:
                 return float(open(pjoin(self.options['ms_dir'], 'max_wgt'),'r').read())
             c_cache = pjoin(self.options['ms_dir'], 'pure_interference_c')
-            if os.path.exists(c_cache):
-                self._read_pi_c_cache(c_cache)
+            if os.path.exists(c_cache) and self._read_pi_c_cache(c_cache):
                 cached = float(open(pjoin(self.options['ms_dir'], 'max_wgt'),'r').read())
                 self._pi_max_weight = cached
                 return cached
@@ -4875,6 +5076,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         base_max_weight = self._combine_maxwgt(all_maxwgt)
         if pure_interference:
             self._finalize_pi_c()
+            self._finalize_pi_absw()
         if self.options['ms_dir']:
             open(pjoin(self.options['ms_dir'], 'max_wgt'),'w').write(str(base_max_weight))
             if pure_interference:
@@ -4934,25 +5136,93 @@ class MadSpinInterface(extended_cmd.Cmd):
                 "is a flat scale error on every written weight. Raise "
                 "Nevents_for_max_weight or max_weight_ps_point.", 100 * rel)
 
+    def _finalize_pi_absw(self):
+        """Turn the raw sum/sumsq/n of ``|W|`` the max-weight scan collected
+        into ``self._pi_absw`` (the estimate) and ``self._pi_absw_err``.
+
+        ``<|W|>`` is what the 'unweighted' output normalises with:
+
+            w = +- sigma_ref * BR * <|W|> / c
+
+        Derivation (section 13.17). Unweight one draw per production event on
+        ``|W|/M`` for any bound ``M >= max|W|`` and write ``w = sign(W) * w0``.
+        Then ``N_file = N_read * <|W|>/M`` and, for any observable ``O``,
+
+            (1/N_file) sum_written w O = w0 * <W O> / <|W|>
+
+        because ``|W| sign(W) = W``, and the ``M`` of the acceptance
+        probability cancels against the ``M`` of ``N_file``. Matching the
+        interference contribution ``sigma*BR*<W O>/c`` -- the same target the
+        'weighted' output hits per read event -- gives ``w0 = sigma*BR*<|W|>/c``
+        with **no ``M`` in it**: the accept/reject bound leaves the
+        normalisation in this variant too. ``mean(w) = w0 <W>/<|W|> = 0``
+        still, since ``<W> = 0`` for a pure-interference sample.
+
+        Unlike ``c`` this is *not* a decay-side constant -- ``<|W|>`` is the
+        local size of the interference and varies from production point to
+        production point -- so the probe average is over its production events
+        as well, and is only as representative as they are. That is a genuine
+        extra scale uncertainty of this variant over the fully weighted one,
+        and it is why the run cross-checks it against the realised keep rate
+        (``N_file/N_read * M``, see _report_pure_interference).
+        """
+        stats = getattr(self, '_pi_absw_stats', None)
+        n = (stats or {}).get('n', 0)
+        if not n or not stats['sum']:
+            self._pi_absw = 0.0
+            self._pi_absw_err = 0.0
+            if self._pure_interference_unweighted():
+                raise self.InvalidCmd(
+                    "MadSpin: pure_interference_output = unweighted needs "
+                    "<|W|>, the decay-phase-space mean of |W|, and the "
+                    "maximum-weight scan measured %s over %d trials. Raise "
+                    "Nevents_for_max_weight / max_weight_ps_point, or report "
+                    "this case." % ('zero' if n else 'nothing', n))
+            return
+        mean = stats['sum'] / n
+        # sumsq holds sum(W^2) = sum(|W|^2), the right second moment for <|W|>
+        var = max(stats['sumsq'] / n - mean * mean, 0.0)
+        self._pi_absw = mean
+        self._pi_absw_err = math.sqrt(var / n)
+        rel = (self._pi_absw_err / mean) if mean else 0.0
+        logger.info("MadSpin pure_interference: <|W|> = %.6e +- %.2f%% over %d "
+                    "trials", mean, 100 * rel, n)
+
     def _write_pi_c_cache(self, path):
-        """Persist the c measurement beside ``max_wgt`` in ``ms_dir``."""
+        """Persist the c and <|W|> measurements beside ``max_wgt`` in
+        ``ms_dir``. Five fields; a three-field file is one written before
+        <|W|> existed and is rejected by the reader when the run needs it."""
         try:
             with open(path, 'w') as fsock:
-                fsock.write('%r %r %r\n' % (self._pi_c, self._pi_c_err,
-                                            getattr(self, '_pi_analytic_c', 0.0)))
+                fsock.write('%r %r %r %r %r\n' % (
+                    self._pi_c, self._pi_c_err,
+                    getattr(self, '_pi_analytic_c', 0.0) or 0.0,
+                    getattr(self, '_pi_absw', 0.0) or 0.0,
+                    getattr(self, '_pi_absw_err', 0.0) or 0.0))
         except Exception as exc:
             logger.warning('MadSpin: could not cache the pure-interference '
                            'constant c in %s (%s)', path, exc)
 
     def _read_pi_c_cache(self, path):
-        """Read back what ``_write_pi_c_cache`` wrote."""
+        """Read back what ``_write_pi_c_cache`` wrote. Returns False when the
+        cache predates ``<|W|>`` and this run needs it, so the caller can fall
+        through to a fresh scan rather than run on a missing normalisation."""
         values = open(path).read().split()
         self._pi_c = float(values[0])
         self._pi_c_err = float(values[1]) if len(values) > 1 else 0.0
         if len(values) > 2 and float(values[2]):
             self._pi_analytic_c = float(values[2])
+        if len(values) > 4:
+            self._pi_absw = float(values[3])
+            self._pi_absw_err = float(values[4])
+        elif self._pure_interference_unweighted():
+            logger.info("MadSpin pure_interference: the cached constants in %s "
+                        "predate <|W|>, which the 'unweighted' output needs; "
+                        "re-running the maximum-weight scan.", path)
+            return False
         logger.info("MadSpin pure_interference: c = %.6e read from the ms_dir "
                     "cache", self._pi_c)
+        return True
 
     def _scan_maxwgt_range(self, events, start, stop, evt_decayfile,
                            nevents, nb_ps_point):
@@ -5070,6 +5340,17 @@ class MadSpinInterface(extended_cmd.Cmd):
         pi_c_sum = 0.0
         pi_c_sumsq = 0.0
         pi_c_n = 0
+        # ... and, on the same draws, <|W|>: the decay-phase-space mean of the
+        # ABSOLUTE restricted convolution. It is what normalises the
+        # 'unweighted' output (w = +- sigma*BR*<|W|>/c, section 13.17), and a
+        # free diagnostic for the 'weighted' one, so it is always collected
+        # when the mode is on. Unlike c it is not a decay-side constant -- it
+        # varies from production point to production point -- so what the probe
+        # measures is its average over the probe's production events, which is
+        # exactly the global mean the derivation needs.
+        pi_absw_sum = 0.0
+        pi_absw_sumsq = 0.0
+        pi_absw_n = 0
         per_event = []
         for i in range(start, stop):
             if (i - start) % 5 == 1 and getattr(self, '_shard_tag', None) in (None, 0):
@@ -5107,6 +5388,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                     jac = full_evt.reshuffle_production()
                 maxwgt = max(abs(wgt*jac) if signed else wgt*jac, maxwgt)
                 if signed:
+                    restricted = wgt*jac
+                    restricted = float(getattr(restricted, 'real', restricted))
+                    if math.isfinite(restricted):
+                        pi_absw_sum += abs(restricted)
+                        pi_absw_sumsq += restricted * restricted
+                        pi_absw_n += 1
                     sample = getattr(self, '_pi_unrestricted_wgt', None)
                     if sample is not None:
                         # the outer jacobian (PA with density_keep_jacobian) is
@@ -5126,6 +5413,13 @@ class MadSpinInterface(extended_cmd.Cmd):
             stats['sumsq'] += pi_c_sumsq
             stats['n'] += pi_c_n
             self._pi_c_stats = stats
+            astats = getattr(self, '_pi_absw_stats', None) or {'sum': 0.0,
+                                                               'sumsq': 0.0,
+                                                               'n': 0}
+            astats['sum'] += pi_absw_sum
+            astats['sumsq'] += pi_absw_sumsq
+            astats['n'] += pi_absw_n
+            self._pi_absw_stats = astats
         return per_event
 
     def _joint_maxwgt_shard_entry(self, shard_id, nb_core, events, start, stop,
@@ -5151,6 +5445,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                 # so one shard or many gives the identical estimate)
                 json.dump({'per_event': per_event,
                            'pi_c': getattr(self, '_pi_c_stats', None),
+                           'pi_absw': getattr(self, '_pi_absw_stats', None),
                            'pi_analytic_c': getattr(self, '_pi_analytic_c', None)}, f)
         except Exception as exc:
             import traceback
@@ -5230,6 +5525,13 @@ class MadSpinInterface(extended_cmd.Cmd):
                 for key in ('sum', 'sumsq', 'n'):
                     merged[key] += pi_c.get(key, 0)
                 self._pi_c_stats = merged
+            pi_absw = r.get('pi_absw')
+            if pi_absw:
+                merged = getattr(self, '_pi_absw_stats', None) or {
+                    'sum': 0.0, 'sumsq': 0.0, 'n': 0}
+                for key in ('sum', 'sumsq', 'n'):
+                    merged[key] += pi_absw.get(key, 0)
+                self._pi_absw_stats = merged
             if r.get('pi_analytic_c'):
                 self._pi_analytic_c = r['pi_analytic_c']
         for outp in out_paths:
@@ -6056,11 +6358,28 @@ class MadSpinInterface(extended_cmd.Cmd):
         self._pure_interference_cache = out
         return out
 
+    def _pure_interference_unweighted(self):
+        """True when the pure-interference mode must write the 'unweighted'
+        (up to a sign) output instead of the fully weighted default.
+
+        Only meaningful when the mode is on -- ``pure_interference_output`` is
+        ignored otherwise, which ``_validate_pure_interference`` says out loud.
+        """
+        return (bool(self._pure_interference())
+                and self.options['pure_interference_output'] == 'unweighted')
+
     def _validate_pure_interference(self):
         """Card-level checks for the pure-interference mode, run once at launch
         rather than on the first event inside a worker process."""
         pure = self._pure_interference()
         if not pure:
+            if self.options['pure_interference_output'] != 'weighted':
+                logger.warning(
+                    "MadSpin: pure_interference_output = %s has no effect "
+                    "because pure_interference is not set. It only chooses "
+                    "how the pure-interference mode writes its signed "
+                    "weights; ordinary runs are unweighted as always.",
+                    self.options['pure_interference_output'])
             return
         if not self._density_spinmode():
             raise self.InvalidCmd(
@@ -6158,20 +6477,33 @@ class MadSpinInterface(extended_cmd.Cmd):
                        'y' if len(missing) == 1 else 'ies',
                        ', '.join(str(h) for h in missing)))
 
+        if self._pure_interference_unweighted():
+            shape = ("UNWEIGHTED UP TO A SIGN: one decay draw per production "
+                     "event, unweighted on |W| against the probed maximum and "
+                     "dropped on rejection, so the file holds fewer events "
+                     "than it read and each carries "
+                     "w = +- sigma_ref * BR * <|W|> / c -- exactly two weight "
+                     "magnitudes. The accept/reject bound cancels out of that "
+                     "normalisation (section 13.17)")
+        else:
+            shape = ("FULLY WEIGHTED: every trial is kept and carries "
+                     "w = sigma_ref * BR * W / c")
         logger.warning(
             "MadSpin: pure_interference is ON for particle(s) %s. The decayed "
             "sample keeps ONLY the interference between the polarisations "
             "named, so its total cross-section is zero by construction and its "
-            "events are FULLY WEIGHTED with a SIGNED weight, "
-            "w = sigma_ref * BR * W / c. Under MG5's IDWTUP = -4 convention "
-            "(cross-section = mean of the weights) that makes the file "
-            "self-normalising: mean(w) = 0 and sum_bin(w)/N is the "
-            "interference contribution to that bin in pb. The <init> block is "
+            "events carry a SIGNED weight. Output shape "
+            "(pure_interference_output = %s) -- %s. Under MG5's IDWTUP = -4 "
+            "convention (cross-section = mean of the weights) the file is "
+            "self-normalising either way: mean(w) = 0 and sum_bin(w)/N_file is "
+            "the interference contribution to that bin in pb, with N_file the "
+            "number of events IN THE FILE. The <init> block is "
             "written with XSECUP = 0, so the file is NOT directly showerable "
             "and any tool that assumes unit weights will be wrong on it -- see "
             "the <MGPureInterference> banner block for the reference "
-            "cross-section, c, and the zero-cross-section check.",
-            ', '.join(str(p) for p in sorted(pure)))
+            "cross-section, c, <|W|>, and the zero-cross-section check.",
+            ', '.join(str(p) for p in sorted(pure)),
+            self.options['pure_interference_output'], shape)
 
     def _apply_pure_interference(self, decaying_pdg, helicities, restriction):
         """Overlay the pure-interference cross restriction on the (symmetric)

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2647,7 +2647,8 @@ the base branch and against this one. The fully weighted run's event stream is
 byte-identical too (`event_scale` is `None` there, so
 `_rewrite_lhe_banner_cross` does not touch an event).
 
-`tests/test_manager.py test_madspin -t0`: **308 tests, OK** (291 before).
+`tests/test_manager.py test_madspin -t0`: **325 tests, OK** (291 before this
+work, counting 13.18's).
 
 Caveats:
 
@@ -2777,8 +2778,23 @@ generation is the bottleneck. That is why the default stays `unweighted`.
 the same 90 368 979-byte file, SHA-256
 `767da240c5221ecc0d7193a3031044b3304a457f909212158728c2ab7f242855`.
 
-`tests/test_manager.py test_madspin -t0`: **319 tests, OK** (291 before this
+`tests/test_manager.py test_madspin -t0`: **325 tests, OK** (291 before this
 work).
+
+**One regression, and what caught it.** Adding this option replaced
+`_unweight_range`'s exit condition `if pure_interference or
+random.random()*maxwgt < test` by a flag that was true only for the paths
+keeping *every* trial. 13.17's 'unweighted' path does not keep every trial --
+but it has already decided, on `|W|`, further up -- so it fell through to the
+signed test and had every negative weight rejected a second time: 356 events
+instead of 3764, z = +18.9. The condition is "no ordinary joint test is made
+below", which is true for all three paths.
+
+The mode's own `z` check did catch it (far past the 5-sigma
+`logger.critical`, a `RuntimeError` under `density_debug`) -- but only after a
+full run. Six tests now drive the real `_unweight_range` through all three
+shapes with the matrix element stubbed out; two of them fail on the bad
+condition.
 
 Caveats, stated rather than glossed:
 

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2503,3 +2503,161 @@ Caveats:
 * the analytic cross-check is confirmed only in the `<jac> = 1` case, which is
   exactly where the derivation says it should hold. It has **not** been checked
   offshell, where the derivation says it should *not* hold.
+
+### 13.17 The unweighted-up-to-a-sign output -- `pure_interference_output`
+
+**Status: implemented and validated end to end.** The fully weighted output of
+13.13 stays the **default**; `set pure_interference_output = unweighted`
+selects the other representation of the same estimator, in which the sample
+carries exactly two weight magnitudes.
+
+**The derivation.** Unweight on `|W|` against any bound `M >= max|W|`, ONE
+decay draw per production event, nothing written on rejection, and give each
+accepted event `w = sign(W) * w0`. Then `N_file = N_read * <|W|>/M` and, for
+any observable `O`,
+
+    sum_written w O = N_read * w0 * <W O> / M         (because |W| sign(W) = W)
+
+    (1/N_file) sum_written w O = w0 * <W O> / <|W|>
+
+The `M` of the acceptance probability cancels against the `M` of the file
+size. Matching the interference contribution `sigma*BR*<W O>/c` -- the same
+target the fully weighted output hits, per read event -- gives
+
+    w0 = sigma_ref * BR * <|W|> / c
+
+with **no `max_weight` in it**. `mean(w) = w0 <W>/<|W|> = 0` still holds,
+because `<W> = 0`, so `XSECUP = 0` remains correct and both variants obey the
+same `IDWTUP = -4` rule: `sum_bin(w) / N_file` is the contribution in pb, with
+`N_file` the number of events *in the file* (which is `N_read` only for the
+fully weighted output).
+
+**The design notes' `w = +- sigma*BR*maxwgt/c` is not wrong physics; it is
+normalised per event READ.** `maxwgt/c = (<|W|>/c) * (N_read/N_file)`, so the
+two differ by exactly `N_read/N_file`. An LHE file carries no `N_read`, and
+`IDWTUP = -4` says the cross-section is the mean of the weights over the file,
+so a consumer that divides by `N_file` -- the only count it has -- would be off
+by `M/<|W|>` (a factor 13 in the run below), and the factor depends on the
+internal bound. That is what made `maxwgt` look load-bearing. It is not.
+
+**`<|W|>` must NOT come from the maximum-weight probe.** This is the one thing
+the derivation does not tell you and the run does. Unlike `c`, `<|W|>` is not
+a decay-side constant -- it is the *local size of the interference* and varies
+from production point to production point, which is the whole content of
+13.7b. The probe sees `Nevents_for_max_weight` production events (112 in the
+run below) and its `max_weight_ps_point` draws on each are all correlated
+through that point's `|W|` scale, so:
+
+* the trial-level error is meaningless here. The probe claimed
+  `<|W|> = 3.168e-11 +- 0.46%`; blocked by production event the error is
+  **5.0%**, and the truth was `2.895e-11`, i.e. the probe was **9.4% high**;
+* it is not an ordering bias -- 2000 random 110-event subsamples of the same
+  file have a 9.5% spread and the probe's value sits 0.8 sigma inside it. It
+  is simply the wrong sample size for the quantity;
+* a 9.4% error on `<|W|>` is a 9.4% error on every physics number the file
+  produces, because the estimator is linear in `w0`.
+
+**The run normalises with its own keep rate instead, which is exact.** Putting
+`<|W|> = (N_file/N_drawn) * M` into `w0` makes `N_file` cancel out of the
+estimator altogether:
+
+    (1/N_file) sum w O = (M sigma_ref BR / (c N_drawn)) sum_accepted sign(W) O
+
+whose expectation is `sigma_ref*BR*<W O>/c` exactly, with no estimate of
+`<|W|>` in it anywhere and no residual `M` dependence even in principle. The
+run therefore writes the probe's provisional magnitude during the loop and
+divides it out afterwards, in the same pass that inserts the
+`<MGPureInterference>` note (`_rewrite_lhe_banner_cross(event_scale=...)`);
+`S`, `sqrt(sum w^2)` and `mean(w)` are rescaled with it and `z` is invariant.
+The probe's `<|W|>`, its blocked error and the correction factor are all in
+the banner block, and a correction beyond 25% warns.
+
+**What comes back that the fully weighted output had lost:** the bound is live
+again -- the acceptance probability clips at 1 when `|W| > M` -- so
+`nb_pi_overflow` and its `logger.critical` are back on this path (and only on
+it). `_dead_trial` is still not on the pure-interference path at all: a
+negative weight is normal here, and `nb_pi_dead` counts the genuinely
+non-finite trials.
+
+**End-to-end validation.** Same setup as 13.16 -- `p p > t t~` at 13 TeV,
+NNPDF23LO, `me_frame = [1,2]`, 50 000 production events (`iseed = 4321`),
+`spinmode = onshell`, `BW_cut = 15`, `max_weight_ps_point = 400`, `l = e, mu`,
+8 cores, the `(I, I)` block -- run four times on the **same** parent file:
+fully weighted, and unweighted against three bounds set by `nb_sigma`.
+
+| | weighted | `nb_sigma = 0` | `nb_sigma = 10` | `nb_sigma = 40` |
+|---|---|---|---|---|
+| `M = max\|W\|` used | (none) | 3.845e-10 | 6.351e-10 (1.65x) | 2.235e-09 (5.81x) |
+| events written / read | 50000 / 50000 | 3764 / 50000 | 2305 / 50000 | 620 / 50000 |
+| distinct \|w\| magnitudes | 49985 | **1** | **1** | **1** |
+| positive / negative | 24921 / 25079 | 1855 / 1909 | 1135 / 1170 | 326 / 294 |
+| `\|w\|` (pb) | -- | 3.05767 | 3.09265 | 2.92710 |
+| `<\|W\|>` realised | 2.928e-11 | 2.895e-11 | 2.928e-11 | 2.771e-11 |
+| `S` | -4.4436e+02 | -1.6511e+02 | -1.0824e+02 | +9.3667e+01 |
+| `sqrt(sum w^2)` | 9.8358e+02 | 1.8759e+02 | 1.4848e+02 | 7.2884e+01 |
+| `z` | **-0.452** | **-0.880** | **-0.729** | **+1.285** |
+| `mean(w)` | -8.887e-03 | -4.387e-02 | -4.696e-02 | +1.511e-01 |
+| trials above `M` | -- | 0 | 0 | 0 |
+
+**`M` cancels.** The three bounds span 5.8x and the files they produce span
+6.1x in size, and the physics is the same:
+
+| observable | weighted | `M` | `1.65 M` | `5.81 M` |
+|---|---|---|---|---|
+| `<C_nn>` | +0.037286 +- 0.000366 | +0.036567 +- 0.000859 | +0.037049 +- 0.001111 | +0.035850 +- 0.002011 |
+| `<C_rr>` | +0.001744 +- 0.000375 | +0.002458 +- 0.000830 | +0.003282 +- 0.001073 | +0.004786 +- 0.001952 |
+| `<C_kk>` | +0.000108 +- 0.000165 | -0.000273 +- 0.000530 | -0.000605 +- 0.000690 | +0.000543 +- 0.001247 |
+| `<cos phi_ll>` | +0.039139 +- 0.000564 | +0.038753 +- 0.001328 | +0.039726 +- 0.001716 | +0.041178 +- 0.003132 |
+| `<Delta phi>` | -0.065226 +- 0.001768 | -0.066889 +- 0.004384 | -0.068263 +- 0.005661 | -0.047423 +- 0.010122 |
+| `<pT(t)>` (null) | +0.04 +- 0.12 | -0.24 +- 0.30 | -0.38 +- 0.39 | +0.40 +- 0.68 |
+
+Every unweighted entry is within one sigma of the fully weighted one on the
+same events (largest pull -0.88, on the `pT(t)` null test). The three
+independent measurements of `<|W|>` the runs realise -- 2.895, 2.928,
+2.771e-11 -- agree to their own 1.6% / 2.1% / 4.0% counting errors, which is
+the same statement one level down.
+
+**The closure.** Against the committed `interference_closure_v2` numbers
+(`RESULTS.md` section 4), for the `nb_sigma = 0` run:
+
+| | closure v2 | closure v1 | this run, unweighted | pull vs v2 | pull vs v1 |
+|---|---|---|---|---|---|
+| `<C_nn>` | +0.03657 +- 0.00059 | +0.03626 +- 0.00090 | **+0.036567 +- 0.000859** | **-0.00** | +0.25 |
+| `<C_rr>` | +0.00104 +- 0.00066 | +0.00247 +- 0.00091 | +0.002458 +- 0.000830 | +1.34 | -0.01 |
+
+**The variance penalty is confirmed at 5.5-6.2x, from the other direction.**
+Same 50 000 production events, ratio of the errors squared, unweighted over
+fully weighted:
+
+| observable | error ratio | variance ratio |
+|---|---|---|
+| `<C_nn>` | 2.35 | **5.5** |
+| `<cos phi_ll>` | 2.35 | **5.5** |
+| `<Delta phi>` | 2.48 | **6.2** |
+| `<C_rr>` | 2.21 | 4.9 |
+
+13.16 measured 5.8 / 5.7 / 6.1 by comparing against a different (5x larger)
+reference; this is a direct like-for-like measurement on identical events and
+it agrees. That is why the default stays `weighted`.
+
+**Unchanged elsewhere.** A run with `pure_interference` unset produces the
+identical 90 368 979-byte file, SHA-256
+`767da240c5221ecc0d7193a3031044b3304a457f909212158728c2ab7f242855`, against
+the base branch and against this one. The fully weighted run's event stream is
+byte-identical too (`event_scale` is `None` there, so
+`_rewrite_lhe_banner_cross` does not touch an event).
+
+`tests/test_manager.py test_madspin -t0`: **308 tests, OK** (291 before).
+
+Caveats:
+
+* only `spinmode = onshell` was exercised for this variant;
+* the normalisation is exact in expectation but `N_file` is itself random, so
+  `w0` carries a `1/sqrt(N_file)` relative error (1.6% at 3764 events). It is
+  a *self-normalisation* error of the ratio estimator, not a bias, and it is
+  small next to the 5.5x variance penalty;
+* an `ms_dir` reused across MadSpin runs gave `branching_ratio = 0` (hence
+  zero weights and a zero reference cross-section) on a card that ran
+  correctly with a fresh `ms_dir`. That is **pre-existing** -- nothing in this
+  work touches the branching-ratio path -- but it was hit while validating and
+  is recorded here.

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2661,3 +2661,141 @@ Caveats:
   correctly with a fresh `ms_dir`. That is **pre-existing** -- nothing in this
   work touches the branching-ratio path -- but it was hit while validating and
   is recorded here.
+
+### 13.18 `decay_output = weighted` -- the same trick for an ordinary run
+
+**Status: implemented and validated end to end.** `set decay_output =
+weighted` drops the accept/reject for an ordinary (non-interference) MadSpin
+run: one decay configuration is drawn per production event and kept, with
+
+    w = w_prod * BR * W / c
+
+exactly the fully weighted path of 13.13, only with `W` unrestricted. Default
+`unweighted`, i.e. every existing card is untouched.
+
+**The normalisation needs nothing new.** `c = <W>` is a decay-side constant --
+that is the 13.7b argument, and it is what makes redraw-until-accept unbiased
+in the first place -- so
+
+    mean(w) = sigma_ref * BR * <W> / c = sigma_ref * BR
+
+MG5 writes `IDWTUP = -4`, under which the cross-section *is* the mean of the
+event weights, so `<init>` keeps its ordinary value and nothing downstream has
+to be told a new rule. That is the whole difference from the interference
+mode, where `<W> = 0` forces `XSECUP = 0`.
+
+It also gives the mode a free self-check with no analogue elsewhere: `mean(w)`
+against `sigma_ref * BR` **is** the statement that `c` was measured right,
+because `mean(w)/(sigma*BR) = <W>/c` by construction. It is the exact
+analogue of the interference mode's `z` test, with the target at 1 instead of
+0, and it is reported in the log and in the `<MGWeightedDecay>` banner block,
+`logger.critical` beyond 5 sigma.
+
+**`c` is available on every path this covers**, from the same probe: it is
+measured in `_joint_maxwgt_range` with the cross restriction swapped for
+`hel_restriction_trace`, and outside the interference mode those two are the
+same object, so the swap is a no-op and what comes out is `<W>` itself. The
+probe is *not* skipped when the option is on -- `max_weight` goes unused, but
+`c` does not, and the probe is the only thing that measures it. (`<|W|>` is
+collected on the same draws and is unused here.)
+
+**Scope: the density spin modes only.** `madspin`/`full`, `PA`, `onshell`.
+`madspin_v1`, `onshell_v1` and `spinmode = none` build no density matrix and
+have no `W`; the option raises `InvalidCmd` there rather than being ignored.
+Under `pure_interference` it warns and steps aside -- that mode is always
+weighted on its own terms and answers to `pure_interference_output`, so the
+two never both apply.
+
+**It forces the joint path**, for the plain reason that there is no
+accept/reject left to stage: the sequential and two-stage schemes exist to
+split a test that is not being made.
+
+**Interactions.** `fixed_order`: the counter-event group already rides along
+through the same `br` multiplication, unchanged -- implemented, not validated,
+exactly as in 13.9. `keep_weight_for_polarization_*`: allowed and still
+meaningful, unlike in the interference mode -- the ratios multiply a nominal
+weight that is now weighted, and the ratio itself is untouched. BR
+equalization: unchanged, and it now shares the banner-rewrite pass with the
+note. `_dead_trial` is **not** on this path: it exists to break a `while 1`
+that no longer runs. In its place, a trial with `W <= 0` or non-finite is
+written with **weight 0** and counted. `W < 0` outside the interference mode
+means `jac <= 0`, i.e. a mass set the production could not be reshuffled onto,
+which the accept/reject would have redrawn; there is no redraw here and the
+event would carry the failed reshuffle's kinematics, so it gets the weight
+that region contributes to the integral (zero) rather than the negative one
+that would make the bookkeeping add up on an unphysical event. Zero such
+trials occurred in the run below.
+
+**End-to-end validation.** `p p > t t~` at 13 TeV, 50 000 production events
+(`iseed = 4321`), `spinmode = onshell`, `BW_cut = 15`,
+`max_weight_ps_point = 400`, `decay t > b w+, w+ > l+ vl` and the conjugate,
+`l = e, mu`, 8 cores -- the same parent file as 13.17, run once with the card
+default and once with `set decay_output weighted`.
+
+| | default | `decay_output = weighted` |
+|---|---|---|
+| scheme taken | `sequential` (`auto`) | `joint` (forced) |
+| decay trials per written event | **4.13** (206 289 / 50 000) | **1** |
+| events written | 50 000 | 50 000 |
+| `<init>` XSECUP | 23.779781 | 23.779781 (unchanged) |
+| `sd(w)/mean(w)` | 0.0000 | 0.2779 |
+| `mean(w)` | 23.779781 | **23.783611 +- 0.029563** |
+| `mean(w)` / `sigma_ref*BR` | 1 | **1.000161 (0.13 sigma)** |
+| `c` measured | -- | 2.251356e-10 +- 0.13% |
+| trials with a dead weight | -- | 0 |
+
+`c` is the same 2.251356e-10 the interference runs of 13.17 measured on the
+same parent, which it has to be: it is the unrestricted convolution's mean
+either way.
+
+**The physics is the same and the variance penalty is small.**
+
+| observable | default | weighted | var ratio | pull |
+|---|---|---|---|---|
+| `<C_nn>` | +0.037409 +- 0.001479 | +0.036763 +- 0.001520 | 1.06 | -0.30 |
+| `<C_rr>` | +0.000651 +- 0.001485 | +0.000982 +- 0.001540 | 1.07 | +0.15 |
+| `<C_kk>` | +0.036655 +- 0.001481 | +0.035017 +- 0.001576 | 1.13 | -0.76 |
+| `<cos phi_ll>` | +0.074716 +- 0.002554 | +0.072762 +- 0.002671 | 1.09 | -0.53 |
+| `<Delta phi>` | +1.749616 +- 0.004042 | +1.748802 +- 0.004232 | 1.10 | -0.14 |
+| `<pT(t)>` | 119.864 +- 0.348 | 120.045 +- 0.367 | 1.11 | +0.36 |
+
+**So: 4.13x fewer decay trials for a 6-13% larger variance per production
+event, i.e. roughly a 3.7-3.9x variance reduction per unit of CPU spent in
+the unweighting loop.**
+
+Note this is a *different*, and much smaller, effect than the interference
+mode's ~6x **per production event** (13.17). There the accept/reject discards
+whole production events, so the weighted output buys statistics outright;
+here the accept/reject redraws and every production event yields an output
+event either way, so the weighted output is strictly noisier per event -- it
+is importance sampling against exact sampling -- and the win is entirely in
+CPU. Which of the two matters depends on whether MadSpin or the parent
+generation is the bottleneck. That is why the default stays `unweighted`.
+
+**Byte-identical with the option off.** The same card without
+`decay_output`, run against the base branch and against this one, produces
+the same 90 368 979-byte file, SHA-256
+`767da240c5221ecc0d7193a3031044b3304a457f909212158728c2ab7f242855`.
+
+`tests/test_manager.py test_madspin -t0`: **319 tests, OK** (291 before this
+work).
+
+Caveats, stated rather than glossed:
+
+* only `spinmode = onshell` was exercised end to end; `madspin`/`full` and
+  `PA` go through the same `_unweight_range` and the same `c`, but were not
+  run. `PA` in particular is the one path where the outer reshuffling
+  jacobian is live, i.e. where the `W <= 0` handling above can actually fire,
+  and it has **not** been exercised;
+* `fixed_order` is implemented but unvalidated;
+* **no downstream consumer was checked.** A weighted LHE is not what most
+  tooling expects from MadSpin, and I have not run Pythia8, Delphes or any
+  analysis framework on one of these files. `IDWTUP = -4` with non-constant
+  `XWGTUP` is legal LHEF and Pythia8's reader does take the per-event
+  `XWGTUP`, but I did not verify it, and anything that counts events instead
+  of summing weights will be wrong. The option comment and the banner block
+  both say so;
+* `c` carries a flat scale error on every weight (0.13% here). Unlike the
+  interference mode's `<|W|>`, `c` really is a decay-side constant, so the
+  probe's few production events are enough for it -- and `mean(w)` against
+  `sigma*BR` is the direct measurement of whether that held.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -37,6 +37,7 @@ import array
 import collections
 import inspect
 import math
+import random
 
 import madgraph.core.base_objects as MG
 import madgraph.various.misc as misc
@@ -1901,6 +1902,8 @@ class TestPureInterferenceMode(unittest.TestCase):
             interface_madspin.MadSpinInterface._apply_pure_interference
         _validate_pure_interference = \
             interface_madspin.MadSpinInterface._validate_pure_interference
+        _pure_interference_unweighted = \
+            interface_madspin.MadSpinInterface._pure_interference_unweighted
         _density_spinmode = interface_madspin.MadSpinInterface._density_spinmode
         _unweighting_mode = interface_madspin.MadSpinInterface._unweighting_mode
         _announce_mode = interface_madspin.MadSpinInterface._announce_mode
@@ -1911,9 +1914,10 @@ class TestPureInterferenceMode(unittest.TestCase):
 
         def __init__(self, spec='', spinmode='madspin', pol_map=None,
                      branches=('w+', 'w-'), unweighting='sequential',
-                     pol_weights=False):
+                     pol_weights=False, output='weighted'):
             self.options = interface_madspin.MadSpinOptions()
             self.options['pure_interference'] = spec
+            self.options['pure_interference_output'] = output
             self.options['spinmode'] = spinmode
             self.options['unweighting'] = unweighting
             self.options['fixed_order'] = False
@@ -2094,6 +2098,38 @@ class TestPureInterferenceMode(unittest.TestCase):
         # ... and without the mode the two are unrelated
         self._Stub('w+ = 0 T', pol_weights=False)._validate_pure_interference()
 
+    # -- pure_interference_output ------------------------------------------
+
+    def test_the_output_option_defaults_to_the_fully_weighted_mode(self):
+        """The fully weighted output stays the default: it uses every
+        production event and measures ~6x less variance per production event
+        (section 13.17)."""
+        stub = self._Stub('w+ = 0 T')
+        self.assertEqual(stub.options['pure_interference_output'], 'weighted')
+        self.assertFalse(stub._pure_interference_unweighted())
+
+    def test_the_output_option_selects_the_unweighted_variant(self):
+        stub = self._Stub('w+ = 0 T', output='unweighted')
+        self.assertTrue(stub._pure_interference_unweighted())
+        stub._validate_pure_interference()
+
+    def test_the_output_option_is_inert_without_the_mode(self):
+        """It only chooses how the interference mode writes its signed
+        weights, so an ordinary run must not be touched by it."""
+        stub = self._Stub('', output='unweighted')
+        self.assertFalse(stub._pure_interference_unweighted())
+        # and validation is a no-op (it only warns)
+        stub._validate_pure_interference()
+
+    def test_the_output_option_rejects_an_unknown_value(self):
+        """ConfigFile keeps the previous value and warns rather than raising,
+        so the check is that an unknown spelling does not silently become the
+        active one."""
+        options = interface_madspin.MadSpinOptions()
+        options['pure_interference_output'] = 'unweighted'
+        options['pure_interference_output'] = 'signed'
+        self.assertEqual(options['pure_interference_output'], 'unweighted')
+
 
 class TestPureInterferenceCardSyntax(unittest.TestCase):
     """The card spelling of a multi-particle pure_interference request.
@@ -2239,6 +2275,148 @@ class TestPureInterferenceNormalisation(unittest.TestCase):
         self.assertRaises(stub.InvalidCmd, stub._finalize_pi_c)
         stub._pi_c_stats = {'sum': 0.0, 'sumsq': 4.0, 'n': 2}
         self.assertRaises(stub.InvalidCmd, stub._finalize_pi_c)
+
+
+class TestPureInterferenceUnweightedOutput(unittest.TestCase):
+    """``pure_interference_output = unweighted``: ``<|W|>``, its plumbing, and
+    the estimator identity that says the accept/reject bound cancels out of
+    the weight (section 13.17)."""
+
+    class _Stub(object):
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        _finalize_pi_absw = \
+            interface_madspin.MadSpinInterface._finalize_pi_absw
+        _write_pi_c_cache = \
+            interface_madspin.MadSpinInterface._write_pi_c_cache
+        _read_pi_c_cache = interface_madspin.MadSpinInterface._read_pi_c_cache
+
+        def __init__(self, unweighted=False):
+            self._unweighted = unweighted
+
+        def _pure_interference_unweighted(self):
+            return self._unweighted
+
+    # -- <|W|> -------------------------------------------------------------
+
+    def test_finalize_turns_the_raw_moments_into_absw_and_its_error(self):
+        """sumsq holds sum(W^2) = sum(|W|^2), so the population variance of
+        |W| comes straight out of it."""
+        stub = self._Stub()
+        values = [-1.0, 2.0, -3.0, 4.0]
+        stub._pi_absw_stats = {'sum': sum(abs(v) for v in values),
+                               'sumsq': sum(v * v for v in values),
+                               'n': len(values)}
+        stub._finalize_pi_absw()
+        self.assertAlmostEqual(stub._pi_absw, 2.5)
+        self.assertAlmostEqual(stub._pi_absw_err, math.sqrt(1.25 / 4.0))
+
+    def test_a_missing_absw_is_fatal_only_for_the_unweighted_output(self):
+        empty = {'sum': 0.0, 'sumsq': 0.0, 'n': 0}
+        weighted = self._Stub(unweighted=False)
+        weighted._pi_absw_stats = dict(empty)
+        weighted._finalize_pi_absw()          # a diagnostic there, so tolerated
+        self.assertEqual(weighted._pi_absw, 0.0)
+        unweighted = self._Stub(unweighted=True)
+        unweighted._pi_absw_stats = dict(empty)
+        self.assertRaises(unweighted.InvalidCmd, unweighted._finalize_pi_absw)
+
+    # -- the ms_dir cache --------------------------------------------------
+
+    def test_the_cache_round_trips_c_and_absw(self):
+        import tempfile
+        stub = self._Stub()
+        stub._pi_c, stub._pi_c_err = 2.3e-10, 3.1e-13
+        stub._pi_analytic_c = 2.25e-10
+        stub._pi_absw, stub._pi_absw_err = 1.7e-11, 4.0e-14
+        path = os.path.join(tempfile.mkdtemp(), 'pure_interference_c')
+        stub._write_pi_c_cache(path)
+        back = self._Stub(unweighted=True)
+        self.assertTrue(back._read_pi_c_cache(path))
+        self.assertAlmostEqual(back._pi_c, 2.3e-10)
+        self.assertAlmostEqual(back._pi_absw, 1.7e-11)
+        self.assertAlmostEqual(back._pi_absw_err, 4.0e-14)
+
+    def test_a_cache_written_before_absw_is_rejected_when_it_is_needed(self):
+        """A three-field file is one the fully weighted mode wrote. Reusing it
+        for the unweighted output would run on a missing normalisation, so the
+        reader says no and the caller re-scans."""
+        import tempfile
+        path = os.path.join(tempfile.mkdtemp(), 'pure_interference_c')
+        with open(path, 'w') as fsock:
+            fsock.write('2.3e-10 3.1e-13 2.25e-10\n')
+        self.assertFalse(self._Stub(unweighted=True)._read_pi_c_cache(path))
+        # ... but the fully weighted mode does not need it and reads on
+        weighted = self._Stub(unweighted=False)
+        self.assertTrue(weighted._read_pi_c_cache(path))
+        self.assertAlmostEqual(weighted._pi_c, 2.3e-10)
+
+    # -- the estimator identity -------------------------------------------
+
+    def _toy(self, seed, bound_factor, w0_rule):
+        """A pure-python stand-in for the unweighting loop.
+
+        ``W(p, u) = a_p cos(2 pi u)`` with ``u`` uniform, so ``<W> = 0`` for
+        every production point (the defining property of the mode) while
+        ``<|W|>`` varies with ``a_p`` -- the local size of the interference.
+        The observable is ``O(u) = cos(2 pi u)``, so everything is closed form:
+
+            <W O>  = <a> / 2        <|W|> = <a> * 2/pi
+
+        ``w0_rule(absw, c)`` supplies the weight magnitude under test.
+        """
+        rng = random.Random(seed)
+        a = [1.0 + 3.0 * (k % 7) / 6.0 for k in range(500)]   # a_p in [1, 4]
+        c, ref, n = 0.5, 12.0, 400000
+        absw = (sum(a) / len(a)) * 2.0 / math.pi
+        bound = max(a) * bound_factor
+        w0 = w0_rule(absw, c)
+        total, n_file = 0.0, 0
+        for _ in range(n):
+            a_p = a[rng.randrange(len(a))]
+            u = rng.random()
+            obs = math.cos(2 * math.pi * u)
+            W = a_p * obs
+            if rng.random() * bound >= abs(W):
+                continue
+            n_file += 1
+            total += math.copysign(w0, W) * obs
+        return total / n_file, n_file, n
+
+    def test_the_unweighted_weight_reproduces_the_interference_and_M_cancels(self):
+        """The claim being tested, end to end on a toy:
+
+            (1/N_file) sum w O  =  w0 <W O> / <|W|>
+
+        so ``w0 = sigma*BR*<|W|>/c`` makes it the interference contribution
+        ``sigma*BR*<W O>/c`` the fully weighted output writes -- with no
+        ``M`` in it. Two bounds a factor 4 apart must therefore give the same
+        physics from very different file sizes.
+        """
+        a = [1.0 + 3.0 * (k % 7) / 6.0 for k in range(500)]
+        mean_a = sum(a) / len(a)
+        target = 12.0 * (mean_a / 2.0) / 0.5          # ref * <W O> / c
+        rule = lambda absw, c: 12.0 * absw / c        # noqa: E731
+        tight, n_tight, n_read = self._toy(11, 1.0, rule)
+        loose, n_loose, _ = self._toy(11, 4.0, rule)
+        # the two runs keep very different numbers of events ...
+        self.assertGreater(n_tight, 3.0 * n_loose)
+        self.assertAlmostEqual(n_tight / float(n_read),
+                               mean_a * 2.0 / math.pi / max(a), delta=0.01)
+        # ... and agree with each other and with the analytic answer
+        self.assertAlmostEqual(tight, target, delta=0.02 * target)
+        self.assertAlmostEqual(loose, target, delta=0.03 * target)
+
+    def test_the_design_notes_weight_would_be_wrong_per_file_event(self):
+        """The superseded proposal ``w = +- sigma*BR*maxwgt/c`` normalises per
+        event READ, not per event in the file, so a consumer dividing by
+        N_file -- the only count an LHE file carries, and what IDWTUP = -4
+        means -- is off by exactly ``M/<|W|>``, a bound-dependent factor."""
+        a = [1.0 + 3.0 * (k % 7) / 6.0 for k in range(500)]
+        target = 12.0 * ((sum(a) / len(a)) / 2.0) / 0.5
+        got, _, _ = self._toy(11, 1.0, lambda absw, c: 12.0 * max(a) / c)
+        absw = (sum(a) / len(a)) * 2.0 / math.pi
+        self.assertAlmostEqual(got / target, max(a) / absw, delta=0.03)
+        self.assertGreater(got / target, 1.5)
 
 
 class TestProductionPolarizationPlumbing(unittest.TestCase):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2299,8 +2299,7 @@ class TestPureInterferenceUnweightedOutput(unittest.TestCase):
     # -- <|W|> -------------------------------------------------------------
 
     def test_finalize_turns_the_raw_moments_into_absw_and_its_error(self):
-        """sumsq holds sum(W^2) = sum(|W|^2), so the population variance of
-        |W| comes straight out of it."""
+        """Without per-event blocking it falls back to the trial-level error."""
         stub = self._Stub()
         values = [-1.0, 2.0, -3.0, 4.0]
         stub._pi_absw_stats = {'sum': sum(abs(v) for v in values),
@@ -2309,6 +2308,31 @@ class TestPureInterferenceUnweightedOutput(unittest.TestCase):
         stub._finalize_pi_absw()
         self.assertAlmostEqual(stub._pi_absw, 2.5)
         self.assertAlmostEqual(stub._pi_absw_err, math.sqrt(1.25 / 4.0))
+
+    def test_the_absw_error_is_blocked_by_production_event(self):
+        """The nb_ps_point draws of one production point share its |W| scale,
+        so the trial-level spread is not an error on <|W|>. Measured on
+        p p > t t~: 0.46% trial-level against 5.0% blocked, and the blocked
+        one is the honest number -- the probe's <|W|> came out 9% away from
+        the run's."""
+        stub = self._Stub()
+        # four production events, ten near-identical draws each: the trials
+        # look extremely well determined, the production events do not
+        per_event = [1.0, 2.0, 3.0, 4.0]
+        trials = [m for m in per_event for _ in range(10)]
+        stub._pi_absw_stats = {
+            'sum': sum(trials), 'sumsq': sum(v * v for v in trials),
+            'n': len(trials),
+            'ev_sum': sum(per_event),
+            'ev_sumsq': sum(v * v for v in per_event),
+            'ev_n': len(per_event)}
+        stub._finalize_pi_absw()
+        self.assertAlmostEqual(stub._pi_absw, 2.5)
+        # the blocked error: sd of [1,2,3,4] over sqrt(4)
+        self.assertAlmostEqual(stub._pi_absw_err, math.sqrt(1.25 / 4.0))
+        # ... and it is much larger than the trial-level one would have been
+        naive = math.sqrt((sum(v * v for v in trials) / 40.0 - 6.25) / 40.0)
+        self.assertGreater(stub._pi_absw_err, 3.0 * naive)
 
     def test_a_missing_absw_is_fatal_only_for_the_unweighted_output(self):
         empty = {'sum': 0.0, 'sumsq': 0.0, 'n': 0}
@@ -2406,6 +2430,38 @@ class TestPureInterferenceUnweightedOutput(unittest.TestCase):
         self.assertAlmostEqual(tight, target, delta=0.02 * target)
         self.assertAlmostEqual(loose, target, delta=0.03 * target)
 
+    def test_a_mis_measured_absw_biases_the_result_by_exactly_that_factor(self):
+        """Why the run does not normalise with the maximum-weight probe's
+        <|W|>. Unlike c it is not a decay-side constant, so the probe's
+        handful of production events knows it only to ~10% -- and the
+        estimator is linear in it, so a 10% error is a 10% error on every
+        physics number. Feeding the toy an inflated <|W|> shows the bias is
+        exactly the ratio."""
+        a = [1.0 + 3.0 * (k % 7) / 6.0 for k in range(500)]
+        absw = (sum(a) / len(a)) * 2.0 / math.pi
+        target = 12.0 * ((sum(a) / len(a)) / 2.0) / 0.5
+        got, _, _ = self._toy(11, 1.0, lambda _absw, c: 12.0 * (1.1 * absw) / c)
+        self.assertAlmostEqual(got / target, 1.1, delta=0.03)
+
+    def test_the_realised_keep_rate_normalisation_needs_no_absw_estimate(self):
+        """What the run actually writes. Taking <|W|> = (N_file/N_read) * M
+        from the run itself makes N_file cancel out of the estimator, so the
+        answer is right whatever the probe said and whatever M was. Two very
+        different bounds, and a deliberately wrong probe value, all land on
+        the same physics."""
+        a = [1.0 + 3.0 * (k % 7) / 6.0 for k in range(500)]
+        target = 12.0 * ((sum(a) / len(a)) / 2.0) / 0.5
+        for bound_factor in (1.0, 4.0):
+            # a first pass with a deliberately silly provisional magnitude ...
+            _, n_file, n_read = self._toy(11, bound_factor,
+                                          lambda absw, c: 1.0)
+            # ... and the correction the run applies from its own keep rate
+            absw_run = (n_file / float(n_read)) * max(a) * bound_factor
+            got, n2, _ = self._toy(11, bound_factor,
+                                   lambda absw, c: 12.0 * absw_run / c)
+            self.assertEqual(n2, n_file)
+            self.assertAlmostEqual(got, target, delta=0.02 * target)
+
     def test_the_design_notes_weight_would_be_wrong_per_file_event(self):
         """The superseded proposal ``w = +- sigma*BR*maxwgt/c`` normalises per
         event READ, not per event in the file, so a consumer dividing by
@@ -2417,6 +2473,98 @@ class TestPureInterferenceUnweightedOutput(unittest.TestCase):
         absw = (sum(a) / len(a)) * 2.0 / math.pi
         self.assertAlmostEqual(got / target, max(a) / absw, delta=0.03)
         self.assertGreater(got / target, 1.5)
+
+
+class TestBannerEventWeightRescale(unittest.TestCase):
+    """``_rewrite_lhe_banner_cross(event_scale=...)``: the second pass that
+    replaces the provisional weight magnitude of the 'unweighted'
+    pure-interference output by the one the run realised."""
+
+    LHE = """<LesHouchesEvents version="3.0">
+<header>
+<MGGenerationInfo>
+#  Number of Events        :       2
+#  Integrated weight (pb)   : 7.0
+</MGGenerationInfo>
+</header>
+<init>
+2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1
+5.0e+02 2.8e-01 5.0e+02 1
+</init>
+<event>
+ 4 1 -3.0000000e+00 1.8e+02 7.5e-03 1.1e-01
+       21 -1    0    0  503  502 +0.0 +0.0 +1.0 1.0 0.0 0.0e+00 1.0e+00
+<rwgt>
+<wgt id='r1'> -6.0000000e+00 </wgt>
+</rwgt>
+</event>
+<event>
+ 4 1 +3.0000000e+00 1.8e+02 7.5e-03 1.1e-01
+       21 -1    0    0  503  502 +0.0 +0.0 +1.0 1.0 0.0 0.0e+00 1.0e+00
+</event>
+</LesHouchesEvents>
+"""
+
+    class _Stub(object):
+        _RWGT_LINE = interface_madspin.MadSpinInterface._RWGT_LINE
+        _rewrite_lhe_banner_cross = \
+            interface_madspin.MadSpinInterface._rewrite_lhe_banner_cross
+
+    def _run(self, **kwargs):
+        import tempfile
+        path = os.path.join(tempfile.mkdtemp(), 'out.lhe')
+        with open(path, 'w') as f:
+            f.write(self.LHE)
+        self._Stub()._rewrite_lhe_banner_cross(path, 0.0, **kwargs)
+        return open(path).read()
+
+    def _weights(self, text):
+        out = []
+        in_event = want = False
+        for line in text.split('\n'):
+            low = line.strip().lower()
+            if low.startswith('<event'):
+                in_event, want = True, True
+                continue
+            if low.startswith('</event'):
+                in_event = False
+                continue
+            if in_event and want and len(line.split()) == 6:
+                want = False
+                out.append(float(line.split()[2]))
+            match = interface_madspin.MadSpinInterface._RWGT_LINE.match(line)
+            if match:
+                out.append(float(match.group(2)))
+        return out
+
+    def test_without_event_scale_the_events_are_untouched(self):
+        """Every other caller passes nothing, so no event may move."""
+        text = self._run()
+        self.assertEqual(self._weights(text), [-3.0, -6.0, 3.0])
+        # the <init> block is still zeroed by ratio, as before
+        self.assertIn('+0.0000000e+00 +0.0000000e+00 +0.0000000e+00 1', text)
+
+    def test_event_scale_multiplies_xwgtup_and_the_rwgt_entries(self):
+        text = self._run(event_scale=0.5)
+        self.assertEqual(self._weights(text), [-1.5, -3.0, 1.5])
+
+    def test_event_scale_leaves_the_particle_lines_and_the_banner_alone(self):
+        """The particle lines have 13 fields, not 6, and nothing outside an
+        <event> is an event at all."""
+        text = self._run(event_scale=0.5)
+        self.assertIn('21 -1    0    0  503  502 +0.0 +0.0 +1.0 1.0 0.0 '
+                      '0.0e+00 1.0e+00', text)
+        self.assertIn('2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1', text)
+        self.assertEqual(text.count('<event>'), 2)
+        self.assertEqual(text.count('</event>'), 2)
+
+    def test_the_note_block_still_goes_in_with_a_scale(self):
+        text = self._run(event_scale=2.0, note=['#  hello'],
+                         note_tag='MGPureInterference', n_written=7)
+        self.assertIn('<MGPureInterference>\n#  hello\n'
+                      '</MGPureInterference>', text)
+        self.assertIn('#  Number of Events        :       7', text)
+        self.assertEqual(self._weights(text), [-6.0, -12.0, 6.0])
 
 
 class TestProductionPolarizationPlumbing(unittest.TestCase):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2607,6 +2607,154 @@ class TestWeightedDecayOutput(unittest.TestCase):
         self.assertIn('mean(w) / reference          : 1.000000', note)
 
 
+class TestUnweightRangeWeightPaths(unittest.TestCase):
+    """The three shapes ``_unweight_range`` can write, driven through the real
+    loop with the matrix element stubbed out.
+
+    This exists because the interference and weighted paths all leave the
+    ``while 1`` through the same ``if <no ordinary test> or random()*maxwgt <
+    test`` line, and getting that condition wrong is silent: the 'unweighted'
+    interference path, which has already made its own decision on |W|, once
+    fell through to the signed test and had every negative weight rejected a
+    second time. The z check caught it end to end, but only after a run.
+    """
+
+    EVENT = """<event>
+ 4  1 +%.7e 1.00000000e+02 7.54677100e-03 1.30800000e-01
+       -1 -1    0    0  501    0 +0.0000000e+00 +0.0000000e+00 +5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
+        1 -1    0    0    0  501 +0.0000000e+00 +0.0000000e+00 -5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
+       11  1    1    2    0    0 +1.0000000e+02 +0.0000000e+00 +0.0e+00 1.0e+02 0.0e+00 0.0e+00 1.0
+      -11  1    1    2    0    0 -1.0000000e+02 +0.0000000e+00 +0.0e+00 9.0e+02 0.0e+00 0.0e+00 1.0
+</event>"""
+
+    class _Sink(object):
+        def __init__(self):
+            self.events = []
+
+        def write_events(self, evt):
+            self.events.append(evt)
+
+    class _Stub(object):
+        """Enough MadSpinInterface for the joint branch of _unweight_range."""
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        _unweight_range = interface_madspin.MadSpinInterface._unweight_range
+        _dead_trial = interface_madspin.MadSpinInterface._dead_trial
+        _POL_TOKENS = interface_madspin.MadSpinInterface._POL_TOKENS
+        _parse_pol_side = interface_madspin.MadSpinInterface._parse_pol_side
+        _pure_interference = \
+            interface_madspin.MadSpinInterface._pure_interference
+
+        def __init__(self, weights, pure_interference=''):
+            self.options = interface_madspin.MadSpinOptions()
+            self.options['pure_interference'] = pure_interference
+            self.model = _PIModelStub()
+            self.options['fixed_order'] = False
+            self.options['density_keep_jacobian'] = False
+            self.branching_ratio = 2.0
+            self.efficiency = 1.0
+            self._weights = list(weights)
+            self._draw = 0
+
+        # -- the pieces the loop calls out to -----------------------------
+        def get_decay_from_file(self, production, evt_decayfile, nb_remain):
+            return {}
+
+        def get_onshell_evt_and_wgt(self, prod, decays, decay_dict,
+                                    cached=None, build_event=False):
+            wgt = self._weights[self._draw % len(self._weights)]
+            self._draw += 1
+            return None, wgt, 'density'
+
+        def _add_polarization_weights(self, evt, ratios):
+            pass
+
+    def _ctx(self, **over):
+        ctx = dict(maxwgt=1.0, maxwgts=[], sequential=False, decay_dict={},
+                   drop_prob_per_pdg={}, mixed_pdgs_set=set(),
+                   density_method=True, density_pole_approximation=True,
+                   density_needs_reshuffle=False, shard_nb_event=10,
+                   branching_ratio=2.0, base_seed=1,
+                   pure_interference_c=0.5, pure_interference_absw=0.25,
+                   pure_interference_unweighted=False, weighted_decay=False)
+        ctx.update(over)
+        return ctx
+
+    def _run(self, stub, ctx, nb_events=4):
+        source = [lhe_parser.Event(self.EVENT % 1.0) for _ in range(nb_events)]
+        sink = self._Sink()
+        stats = stub._unweight_range(source, {}, sink, ctx)
+        return [e.wgt for e in sink.events], stats
+
+    # ------------------------------------------------------------------
+
+    def test_the_ordinary_path_still_accepts_and_rejects(self):
+        """A weight of 0.5 against maxwgt 1.0 keeps roughly half the trials,
+        and every written event carries w_prod * BR with no W on it."""
+        random.seed(7)
+        stub = self._Stub([0.5])
+        wgts, stats = self._run(stub, self._ctx(), nb_events=50)
+        self.assertEqual(len(wgts), 50)          # redraw-until-accept
+        self.assertEqual(set(round(w, 9) for w in wgts), {2.0})
+        self.assertGreater(stats['nb_try'], 60)  # ... and it did redraw
+
+    def test_the_fully_weighted_interference_path_keeps_every_trial(self):
+        random.seed(7)
+        stub = self._Stub([0.5, -0.25], pure_interference='w+ = 0 T')
+        wgts, stats = self._run(stub, self._ctx(), nb_events=4)
+        self.assertEqual(stats['nb_try'], 4)     # one draw per event, no redraw
+        # w = w_prod * BR * W / c, c = 0.5
+        self.assertEqual([round(w, 9) for w in wgts],
+                         [2.0, -1.0, 2.0, -1.0])
+
+    def test_the_weighted_decay_path_keeps_every_trial(self):
+        random.seed(7)
+        stub = self._Stub([0.5, 0.25])
+        wgts, stats = self._run(stub, self._ctx(weighted_decay=True),
+                                nb_events=4)
+        self.assertEqual(stats['nb_try'], 4)
+        self.assertEqual([round(w, 9) for w in wgts], [2.0, 1.0, 2.0, 1.0])
+
+    def test_the_weighted_decay_path_zeroes_a_failed_reshuffle(self):
+        """W <= 0 outside the interference mode means jac <= 0, i.e. a mass
+        set the production could not be reshuffled onto: weight 0, counted."""
+        random.seed(7)
+        stub = self._Stub([0.5, -0.5])
+        wgts, stats = self._run(stub, self._ctx(weighted_decay=True),
+                                nb_events=4)
+        self.assertEqual([round(w, 9) for w in wgts], [2.0, 0.0, 2.0, 0.0])
+        self.assertEqual(stats['nb_pi_dead'], 2)
+
+    def test_the_unweighted_interference_path_does_not_test_twice(self):
+        """THE regression. Every trial here has |W| = maxwgt, so the |W| test
+        accepts all of them; a second, signed test would throw away every
+        negative one. Both signs must survive, with one magnitude."""
+        random.seed(7)
+        stub = self._Stub([1.0, -1.0], pure_interference='w+ = 0 T')
+        wgts, stats = self._run(
+            stub, self._ctx(pure_interference_unweighted=True), nb_events=20)
+        self.assertEqual(len(wgts), 20)
+        # w = +- w_prod * BR * <|W|> / c = +- 2.0 * 0.25/0.5
+        self.assertEqual(sorted(set(round(w, 9) for w in wgts)), [-1.0, 1.0])
+        self.assertEqual(sum(1 for w in wgts if w > 0), 10)
+        self.assertEqual(sum(1 for w in wgts if w < 0), 10)
+        self.assertEqual(stats['nb_pi_reject'], 0)
+
+    def test_the_unweighted_interference_path_drops_on_rejection(self):
+        """|W| = maxwgt/4 keeps about a quarter, and writes nothing for the
+        rest -- one draw, no redraw."""
+        random.seed(11)
+        stub = self._Stub([0.25, -0.25], pure_interference='w+ = 0 T')
+        wgts, stats = self._run(
+            stub, self._ctx(pure_interference_unweighted=True), nb_events=400)
+        self.assertEqual(stats['nb_try'], 400)          # exactly one each
+        self.assertEqual(len(wgts) + stats['nb_pi_reject'], 400)
+        self.assertGreater(len(wgts), 60)
+        self.assertLess(len(wgts), 140)
+        self.assertEqual(sorted(set(round(abs(w), 9) for w in wgts)), [1.0])
+        self.assertTrue(any(w > 0 for w in wgts))
+        self.assertTrue(any(w < 0 for w in wgts))
+
+
 class TestBannerEventWeightRescale(unittest.TestCase):
     """``_rewrite_lhe_banner_cross(event_scale=...)``: the second pass that
     replaces the provisional weight magnitude of the 'unweighted'

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -72,9 +72,10 @@ def _borrow_decision_helpers(namespace):
                  # _production_polarization_cache gets '{}' out of it, since
                  # there is no banner to read a proc_card from.
                  '_density_spinmode', '_production_polarization',
-                 # _unweighting_mode consults this first: the interference mode
-                 # forces joint, so a stub that borrows the resolver needs it
-                 '_pure_interference'):
+                 # _unweighting_mode consults these first: the interference
+                 # mode and decay_output = weighted both force joint, so a stub
+                 # that borrows the resolver needs them
+                 '_pure_interference', '_weighted_decay'):
         namespace[name] = inspect.getattr_static(
             interface_madspin.MadSpinInterface, name)
 
@@ -2473,6 +2474,137 @@ class TestPureInterferenceUnweightedOutput(unittest.TestCase):
         absw = (sum(a) / len(a)) * 2.0 / math.pi
         self.assertAlmostEqual(got / target, max(a) / absw, delta=0.03)
         self.assertGreater(got / target, 1.5)
+
+
+class TestWeightedDecayOutput(unittest.TestCase):
+    """``decay_output = weighted``: the option that drops the accept/reject
+    for an ORDINARY (non-interference) run and writes
+    ``w = w_prod * BR * W / c`` instead (section 13.18)."""
+
+    class _Stub(object):
+        InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
+        _weighted_decay = interface_madspin.MadSpinInterface._weighted_decay
+        _validate_weighted_decay = \
+            interface_madspin.MadSpinInterface._validate_weighted_decay
+        _weighted_decay_note = \
+            interface_madspin.MadSpinInterface._weighted_decay_note
+        _read_lhe_init_cross = inspect.getattr_static(
+            interface_madspin.MadSpinInterface, '_read_lhe_init_cross')
+        _unweighting_mode = interface_madspin.MadSpinInterface._unweighting_mode
+        _announce_mode = interface_madspin.MadSpinInterface._announce_mode
+        _log_once = interface_madspin.MadSpinInterface._log_once
+        _POL_TOKENS = interface_madspin.MadSpinInterface._POL_TOKENS
+        _parse_pol_side = interface_madspin.MadSpinInterface._parse_pol_side
+        _borrow_decision_helpers(locals())
+
+        def __init__(self, output='unweighted', spinmode='onshell',
+                     pure_interference='', unweighting='auto'):
+            self.options = interface_madspin.MadSpinOptions()
+            self.options['decay_output'] = output
+            self.options['spinmode'] = spinmode
+            self.options['pure_interference'] = pure_interference
+            self.options['unweighting'] = unweighting
+            self.options['fixed_order'] = False
+            self.model = _PIModelStub()
+            self._production_polarization_cache = {}
+
+    # -- the predicate ------------------------------------------------------
+
+    def test_off_by_default(self):
+        stub = self._Stub()
+        self.assertEqual(stub.options['decay_output'], 'unweighted')
+        self.assertFalse(stub._weighted_decay())
+
+    def test_on_when_asked_for_in_a_density_mode(self):
+        for spinmode in ('madspin', 'full', 'PA', 'onshell'):
+            stub = self._Stub(output='weighted', spinmode=spinmode)
+            self.assertTrue(stub._weighted_decay(), spinmode)
+
+    def test_the_two_output_options_do_not_both_apply(self):
+        """pure_interference is always weighted (or unweighted up to a sign)
+        on its own terms, so decay_output steps aside there rather than
+        contradicting pure_interference_output."""
+        stub = self._Stub(output='weighted', pure_interference='t = + -')
+        self.assertFalse(stub._weighted_decay())
+        stub._validate_weighted_decay()          # warns, does not raise
+
+    def test_refused_outside_the_density_modes(self):
+        for spinmode in ('madspin_v1', 'onshell_v1', 'none'):
+            stub = self._Stub(output='weighted', spinmode=spinmode)
+            self.assertFalse(stub._weighted_decay(), spinmode)
+            self.assertRaises(stub.InvalidCmd, stub._validate_weighted_decay)
+
+    def test_an_unweighted_card_validates_silently_everywhere(self):
+        for spinmode in ('madspin', 'PA', 'onshell', 'madspin_v1', 'none'):
+            self._Stub(spinmode=spinmode)._validate_weighted_decay()
+
+    def test_the_option_rejects_an_unknown_value(self):
+        options = interface_madspin.MadSpinOptions()
+        options['decay_output'] = 'weighted'
+        options['decay_output'] = 'signed'
+        self.assertEqual(options['decay_output'], 'weighted')
+
+    # -- it forces the joint path ------------------------------------------
+
+    def test_it_takes_the_joint_path(self):
+        """There is no accept/reject to stage, and the joint branch is the one
+        that carries the weighted path."""
+        for unweighting in ('auto', 'sequential', 'two_stage'):
+            stub = self._Stub(output='weighted', unweighting=unweighting)
+            self.assertEqual(stub._unweighting_mode(True), 'joint', unweighting)
+
+    def test_it_does_not_touch_the_scheme_when_off(self):
+        stub = self._Stub(unweighting='sequential')
+        self.assertNotEqual(stub._unweighting_mode(True), 'joint')
+
+    # -- the banner note and its self-check ---------------------------------
+
+    INIT = """<LesHouchesEvents version="3.0">
+<header>
+</header>
+<init>
+2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1
+2.0e+01 1.0e-02 2.0e+01 1
+</init>
+</LesHouchesEvents>
+"""
+
+    def _note(self, weights, br_correction=1.0):
+        import tempfile
+        path = os.path.join(tempfile.mkdtemp(), 'out.lhe')
+        with open(path, 'w') as f:
+            f.write(self.INIT)
+        stub = self._Stub(output='weighted')
+        stub._pi_c, stub._pi_c_err = 2.25e-10, 3.0e-13
+        stub._pi_c_stats = {'n': 44016}
+        stats = [{'sum_w': sum(weights),
+                  'sum_w2': sum(w * w for w in weights),
+                  'nb_pi_dead': 0}]
+        return '\n'.join(stub._weighted_decay_note(
+            path, stats, len(weights), br_correction))
+
+    def test_the_note_compares_mean_w_against_the_reference_sigma_br(self):
+        """Under IDWTUP = -4 the cross-section IS the mean of the weights, so
+        mean(w) == sigma*BR is the check that c = <W> was measured right --
+        the exact analogue of the interference mode's z test, with the target
+        at 1 instead of 0."""
+        note = self._note([19.0, 20.0, 21.0])
+        self.assertIn('Reference sigma * BR   (pb)  : +2.00000000e+01', note)
+        self.assertIn('mean(w), the sample XSECUP   : +2.00000000e+01', note)
+        self.assertIn('mean(w) / reference          : 1.000000', note)
+        self.assertIn('Events written               : 3', note)
+        self.assertIn('Normalisation constant     c : +2.25000000e-10', note)
+
+    def test_the_note_reports_a_mis_normalised_sample_as_a_ratio(self):
+        note = self._note([22.0, 22.0, 22.0, 22.0])
+        self.assertIn('mean(w) / reference          : 1.100000', note)
+
+    def test_the_note_follows_a_br_equalization_rescale(self):
+        """<init> is rescaled by the same pass, so the reference the note
+        quotes has to be the post-rescale one."""
+        note = self._note([10.0, 10.0], br_correction=0.5)
+        self.assertIn('Reference sigma * BR   (pb)  : +1.00000000e+01', note)
+        self.assertIn('mean(w) / reference          : 1.000000', note)
 
 
 class TestBannerEventWeightRescale(unittest.TestCase):


### PR DESCRIPTION
**Stacked on #351.** Two related options, both defaulting to current behaviour.

## 1. `pure_interference_output = weighted | unweighted` (default `weighted`)

An **unweighted-up-to-a-sign** interference sample: unweight on `|W|` (one draw, accept on `|W|/M`, nothing written on rejection), carry the sign onto the event weight, and write `w = ± sigma*BR*<|W|>/c`. The file then has exactly **two** weight magnitudes.

The derivation, re-done independently: accepting with probability `|W|/M` gives `N_file = N*<|W|>/M`, and since `|W|*sign(W) = W`,

```
(1/N_file) * sum_written w*O  =  w0 * <W O> / <|W|>        <- M cancels
```

Matching `sigma*BR*<W O>/c` gives `w0 = sigma*BR*<|W|>/c`, with **no `max_weight`**. `mean(w) = 0` since `<W> = 0`.

Worth recording: the earlier `w = ± sigma*BR*maxwgt/c` formula in the design notes is **not wrong physics** — it is the same estimator normalised per event *read* rather than per event *in the file*, since `maxwgt/c = (<|W|>/c) * (N_read/N_file)`. But an LHE carries no `N_read`, and `IDWTUP = -4` means the mean over the file, so a consumer dividing by `N_file` would be off by `M/<|W|>` — a factor 13 here. That is what made `maxwgt` look load-bearing.

### The trap the algebra does not warn you about

**`<|W|>` must not be taken from the max-weight probe.** Unlike `c` it is *not* a decay-side constant (that is exactly the point of plan §13.7b), so the probe's ~110 production events do not pin it down and its 400 draws per event are correlated through that point's `|W|` scale. Measured: probe `3.168e-11 ± 0.46%` against a truth of `2.895e-11` — **9.4% high**, and 5.0% when blocked by production event. Not an ordering artefact: random 110-event subsamples show a 9.5% spread. A 9.4% error on `w0` is 9.4% on every physics number the sample produces.

The fix is exact and free: use the run's own `<|W|> = (N_file/N_drawn)*M`, which makes `N_file` cancel out of the estimator entirely.

### `M` cancels — demonstrated

`p p > t t~`, 50k events, `spinmode onshell`, the `(I,I)` block, one parent file, three bounds spanning 5.8x via `nb_sigma`:

| | weighted | M | 1.65M | 5.81M |
|---|---|---|---|---|
| events written | 50000 | 3764 | 2305 | 620 |
| distinct `\|w\|` | 49985 | **1** | **1** | **1** |
| +/− | 24921/25079 | 1855/1909 | 1135/1170 | 326/294 |
| `z` | −0.452 | −0.880 | −0.729 | +1.285 |
| `<C_nn>` | +0.037286±0.000366 | +0.036567±0.000859 | +0.037049±0.001111 | +0.035850±0.002011 |

**Closure**: `<C_nn>` committed +0.03657±0.00059 (v2) and +0.03626±0.00090 (v1); this run **+0.036567±0.000859**, pulls **−0.00 / +0.25**. `<C_rr>` +0.002458±0.000830, pulls +1.34 / −0.01.

**Variance penalty 5.5–6.2x** on identical events (5.5x `<C_nn>`, 5.5x `<cos phi_ll>`, 6.2x `<Delta phi>`) — consistent with the 5.8/5.7/6.1 measured from the other direction, which is why `weighted` stays the default.

## 2. `decay_output = weighted | unweighted` (default `unweighted`)

Skips the accept/reject for the ordinary density modes. Density spinmodes only — `madspin_v1`, `onshell_v1` and `none` raise; under `pure_interference` it warns and steps aside.

The normalisation falls out: `w = sigma*BR*W/c` gives `mean(w) = sigma*BR*<W>/c = sigma*BR`, exactly MG5's `IDWTUP = -4` convention, so `XSECUP` keeps its ordinary value. Measured rather than assumed: `mean(w) = 23.783611 ± 0.029563` against `sigma*BR = 23.779781` — **ratio 1.000161, 0.13 sigma**.

**4.13 decay trials per event -> 1**, for 6–13% more variance per event, i.e. **~3.7–3.9x less variance per unit CPU**. Note this is a *different and smaller* effect than the interference mode's 6x: there the accept/reject discards production events, here it only redraws decays, so weighted output is strictly noisier per event and the entire win is CPU.

## Caveats, stated plainly

- **A regression was introduced in feature 2 and caught by re-running, not by the tests**: the unweighted interference path fell through to a second, signed accept/reject (356 events instead of 3764, `z = +18.9`). Fixed, output byte-identical again, and six new tests now drive the real `_unweight_range` and fail on the bad condition. The mode's own `z` check did catch it — but only after a full run.
- **No downstream consumer was checked** for `decay_output = weighted`. Pythia8, Delphes and the rest were not run. The output is legal LHEF, but anything counting events rather than summing weights will be wrong. This is said in the option comment and in the banner.
- `<|W|>`-from-the-run is exact in expectation, but `N_file` is random, so `w0` carries a `1/sqrt(N_file)` self-normalisation error (1.6% here) — small next to the 5.5x variance penalty.
- Only `spinmode = onshell` was exercised end to end for both new paths. `PA` — the one place the `W <= 0` failed-reshuffle handling can fire — and `fixed_order` are implemented but unvalidated.

## Verification

Byte-identity with both options at their defaults: same 90,368,979-byte file, SHA-256 `767da240…f2855`, against the base branch. `test_madspin -t0`: **325 tests, OK** (291 on the base). Plan §13.17 and §13.18 record both features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional weighted decay output and signed-unweighted pure-interference output while preserving MadSpin's existing defaults.

New Features:
- Add configurable pure-interference output that supports signed, constant-magnitude event weights through |W|-based unweighting.
- Add configurable weighted decay output for density spin modes, retaining one decay draw per production event with the convolution carried by event weights.

Bug Fixes:
- Prevent pure-interference unweighted events from undergoing a second signed accept/reject decision.
- Normalize unweighted interference weights using the run-realized keep rate instead of the maximum-weight probe's potentially biased absolute-convolution estimate.
- Handle failed non-interference reshuffles as zero-weight events in weighted decay output.

Enhancements:
- Extend normalization scans, caching, accounting, LHE banner reporting, and output metadata for weighted and signed-unweighted modes.
- Preserve existing default behavior and byte-identical output when the new options are not enabled.

Documentation:
- Document the estimator normalization, supported modes, performance trade-offs, validation results, and caveats for both output options in the MadSpin sequential plan.

Tests:
- Add unit coverage for option validation, normalization estimates and caches, estimator behavior across bounds, weighted decay accounting, event-weight rescaling, and all output paths through the unweighting loop.