### PR TITLE
MadSpin: reusing an ms_dir no longer silently zeroes the branching ratio

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2320,8 +2320,16 @@ class decay_all_events(object):
         logger.info('Decaying the events... ')
         self.outputfile = open(pjoin(self.path_me,'decayed_events.lhe'), 'w')
         self.write_banner_information()
-        
-        
+
+        # Same reasoning as the run_onshell guard (see
+        # MadSpinInterface._check_branching_ratio): this number multiplies every
+        # weight written below, so a zero one would produce a complete LHE file
+        # of +/-0.0 and report success. Skipped in 'onlyhelicity' mode, which
+        # writes the events back without applying any branching ratio.
+        if not self.options['onlyhelicity']:
+            self.mscmd._check_branching_ratio(self.branching_ratio)
+
+
         event_nb, fail_nb = 0, 0
         nb_skip = 0 
         trial_nb_all_events=0

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -115,6 +115,29 @@ class MadSpinDegenerateWeight(madspin.MadSpinError):
     pass
 
 
+class MadSpinUnknownPartialWidth(madspin.MadSpinError):
+    """A reused decay directory whose partial width can neither be read back
+    nor re-measured. Raised instead of falling back to any default, because
+    every default here is a wrong branching ratio -- i.e. a well-formed event
+    file whose every weight and whose <init> block are wrong."""
+    pass
+
+
+class MadSpinZeroBranchingRatio(madspin.MadSpinError):
+    """The branching ratio MadSpin is about to apply to every event is zero (or
+    not a number). Raised instead of writing the events.
+
+    A branching ratio multiplies every event weight and the <init> cross
+    section, so a zero one turns a completed run into a well-formed LHE file
+    full of +/-0.0 -- the failure mode a user is least likely to notice. It
+    cannot be a legitimate physics configuration either: MadSpin measures each
+    partial width by generating that decay, and a decay channel that is closed
+    makes the *generation* fail (ZeroResult) long before this point. So a zero
+    that reaches here comes from bookkeeping that did not happen, not from the
+    physics that was asked for."""
+    pass
+
+
 # How many consecutive structurally-dead trials (weight not finite and > 0) a
 # single production event may burn before the accept/reject gives up. Only
 # trials whose *matrix-element* factor is dead are counted, and any single
@@ -1424,6 +1447,55 @@ class MadSpinInterface(extended_cmd.Cmd):
             return totwidth
         return pwidth
 
+    @staticmethod
+    def _check_branching_ratio(br, gen_jobs=None):
+        """Refuse to decay with a branching ratio that is zero or not a number.
+
+        Why this cannot fire on a healthy run, however extreme the physics: the
+        branching ratio is a product of measured-partial-width / total-width
+        ratios, and MadSpin measures each partial width by actually generating
+        that decay with MadEvent. A channel so suppressed that its width
+        underflows to exactly 0 does not reach this point at all -- the
+        generation of that channel raises ZeroResult first. What a 0 (or a NaN)
+        here means is that one of those factors was never measured, i.e. a
+        bookkeeping gap, and the archetype is a reused ``ms_dir``: the decay
+        directories already exist, so nothing re-measures them.
+
+        Why it must not be a warning: this number multiplies every event weight
+        and the <init> cross-section. Left to run, MadSpin writes a complete,
+        well-formed LHE file in which every weight is +/-0.0 and the <init>
+        block is zero -- output that no downstream tool rejects and that a user
+        can easily fail to notice. Compared with that, stopping is cheap.
+        """
+        if math.isfinite(br) and br > 0:
+            return br
+        detail = ''
+        if gen_jobs:
+            detail = ("\nDecaying particles this run measured a width for: %s"
+                      % ', '.join('%s (%s)' % (pdg, job.get('kind'))
+                                  for pdg, job in gen_jobs.items()))
+        raise MadSpinZeroBranchingRatio(
+            "MadSpin computed a branching ratio of %s and will not decay the "
+            "events with it.\n"
+            "\n"
+            "The branching ratio scales every event weight and the <init> "
+            "cross-section, so MadSpin would otherwise write a complete, "
+            "well-formed event file in which every weight is zero (or not a "
+            "number) -- and report success. It stops here instead.\n"
+            "\n"
+            "It is built as a product of (partial width measured by generating "
+            "the decay) / (total width from the param_card), one factor per "
+            "decaying particle. A closed decay channel cannot produce this: "
+            "generating it fails first. A factor that was never *measured* "
+            "can. Plausible causes, most likely first:\n"
+            "  * a reused decay directory ('ms_dir', 'use_old_dir') whose "
+            "partial width could not be read back -- rerun against a fresh "
+            "'ms_dir' to confirm;\n"
+            "  * a total width of 0 in the param_card for a particle being "
+            "decayed, which makes the ratio a 0/0;\n"
+            "  * 'set cross_section' pointing at a zero cross-section.%s"
+            % (br, detail))
+
     @classmethod
     def _assignment_multiplicity(cls, branches):
         """How many *distinct* ways this multiset of decay lines can be dealt to
@@ -2173,6 +2245,92 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.mg5cmd._curr_model = self.model
         self.mg5cmd.process_model()
 
+    # File in which a decay directory records the partial width that was
+    # measured when it was built. Only the gridpack (ms_dir) path needs it: the
+    # native path regenerates -- and so re-measures -- on every run, while a
+    # gridpack is built once and merely *run* by every later run.
+    PARTIAL_WIDTH_FILE = 'ms_partial_width.dat'
+
+    @classmethod
+    def _store_partial_width(cls, decay_dir, cross):
+        """Record the measured partial width of ``decay_dir`` next to its
+        gridpack. Best effort: a read-only ms_dir must not abort a healthy
+        generation, the reader falls back to the gridpack's own banner."""
+        try:
+            with open(pjoin(decay_dir, cls.PARTIAL_WIDTH_FILE), 'w') as fsock:
+                fsock.write('%.16e\n' % float(cross))
+        except (IOError, OSError, TypeError, ValueError) as error:
+            logger.debug('could not store the partial width of %s: %s',
+                         decay_dir, error)
+
+    @classmethod
+    def _load_partial_width(cls, decay_dir, evt_file=None):
+        """The partial width of a decay directory that this run did not build.
+
+        Two sources, in order:
+
+        1. the value the run that built the gridpack measured and stored
+           (:meth:`_store_partial_width`) -- the same number that run used, so
+           reusing an ms_dir reproduces its branching ratio exactly;
+        2. failing that (an ms_dir built by an older version, which stored
+           nothing), the cross-section in the <init> block of the events the
+           gridpack has just produced. It is the same quantity measured on this
+           run's sample rather than on the grid-setup one, so it agrees to the
+           Monte Carlo error rather than to the last bit -- worth a warning, but
+           far better than the alternative.
+
+        Both failing is not recoverable, and must not be papered over with a
+        default: every "neutral" value here is a wrong branching ratio, and a
+        wrong branching ratio is a silently wrong cross-section in a
+        well-formed file. So it raises.
+        """
+        path = pjoin(decay_dir, cls.PARTIAL_WIDTH_FILE)
+        if os.path.exists(path):
+            try:
+                value = float(open(path).read().split()[0])
+            except (IOError, OSError, IndexError, ValueError) as error:
+                logger.warning('unreadable %s (%s), falling back to the '
+                               'generated events', path, error)
+            else:
+                if math.isfinite(value) and value > 0:
+                    return value
+                logger.warning('%s holds a non-physical partial width (%s), '
+                               'falling back to the generated events',
+                               path, value)
+        value = None
+        if evt_file is not None:
+            try:
+                value = float(evt_file.cross)
+            except Exception as error:
+                logger.debug('no cross-section in the events of %s: %s',
+                             decay_dir, error)
+        if value is None or not math.isfinite(value) or value <= 0:
+            raise MadSpinUnknownPartialWidth(
+                "MadSpin cannot recover the partial width of %s.\n"
+                "\n"
+                "The branching ratio MadSpin applies to every event (and to "
+                "the <init> block) is built from the partial width measured "
+                "when each decay directory was generated. This directory was "
+                "generated by an earlier run -- it is being reused through "
+                "'ms_dir'/'use_old_dir' -- and neither the record that run "
+                "should have left (%s) nor the cross-section of the events "
+                "its gridpack just produced can be read.\n"
+                "\n"
+                "MadSpin stops here rather than continue with a branching "
+                "ratio it cannot compute: that would write a perfectly "
+                "well-formed event file in which every weight is wrong.\n"
+                "\n"
+                "Remove the 'ms_dir' directory (or point 'ms_dir' at a fresh "
+                "one) and rerun: a directory generated from scratch measures "
+                "the partial widths itself."
+                % (decay_dir, cls.PARTIAL_WIDTH_FILE))
+        logger.warning('%s predates the partial-width record; using the '
+                       'cross-section of its generated events (%s) instead. '
+                       'The branching ratio will agree with the run that built '
+                       'it to the Monte Carlo error, not exactly.',
+                       decay_dir, value)
+        return value
+
     def generate_events(self, pdg, nb_event, mg5, restrict_file=None, cumul=False,
                         output_width=False, run_name='run_01'):
         """generate new events for this particle
@@ -2272,6 +2430,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                     self.seed = self.options['seed'] 
                     # actually creation
                     me5_cmd.exec_cmd("generate_events run_01 -f")
+                    # The partial width of this channel is measured HERE and
+                    # only here on the gridpack path -- a later run that finds
+                    # ``decay_dir`` already built skips this whole block. Store
+                    # it beside the gridpack so that run can read it back
+                    # (_load_partial_width); without it the branching ratio of
+                    # every ms_dir-reusing run silently collapses to 0.
+                    self._store_partial_width(decay_dir,
+                                              me5_cmd.results.current['cross'])
                     if output_width:
                         channel_widths[i] = me5_cmd.results.current['cross']
                         if cumul:
@@ -2386,6 +2552,19 @@ class MadSpinInterface(extended_cmd.Cmd):
                         "--- last run.sh/gridrun output ---\n%s"
                         % (rc, events_path, log))
                 out[i] = lhe_parser.EventFile(events_path)
+                if output_width and i not in channel_widths:
+                    # ms_dir reuse: the gridpack was built by an earlier run, so
+                    # the block above (the only place the gridpack path measures
+                    # a partial width) did not run. Recover the width that run
+                    # measured instead of leaving the accumulator at its neutral
+                    # value -- which is 0 under ``cumul``, and would zero the
+                    # branching ratio, the <init> block and every event weight.
+                    measured = self._load_partial_width(decay_dir, out[i])
+                    channel_widths[i] = measured
+                    if cumul:
+                        width += measured
+                    else:
+                        width *= measured
             if cumul:
                 break
         time_gen_dec = time.time()-time_gen_dec
@@ -2697,6 +2876,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                     max_mixed_br,
                 )
         mixed_pdgs_set = set(drop_prob_per_pdg.keys())
+
+        # Last chance to catch a branching ratio that would silently zero (or
+        # NaN) every weight of a run that otherwise completes normally.
+        self._check_branching_ratio(br, gen_jobs)
 
         self.branching_ratio = br
         self.efficiency = 1

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5173,3 +5173,209 @@ class TestZeroDensityGuard(unittest.TestCase):
         self.assertRaises(interface_madspin.MadSpinDegenerateWeight,
                           stub._combine_maxwgt,
                           [float('nan'), float('nan'), 1.0])
+
+
+class TestReusedMsDirBranchingRatio(unittest.TestCase):
+    """Reusing an ``ms_dir`` must reproduce the branching ratio of the run that
+    built it -- and a branching ratio that cannot be computed must stop the run
+    rather than scale every event to zero.
+
+    Context: ``ms_dir`` selects the gridpack decay-generation path, on which the
+    partial width of a channel is measured once, while the gridpack is being
+    built. A later run finds the ``decay_<pdg>_<i>`` directory already there,
+    skips the whole build block and only *runs* the gridpack -- so nothing
+    re-measures the width, the accumulator keeps its neutral value (0.0 under
+    ``cumul``, the common case) and the branching ratio comes out exactly 0.
+    That zero multiplies every event weight and the <init> cross-section, so
+    the run completes, writes a well-formed LHE file of +/-0.0 and reports
+    success.
+    """
+
+    _INIT_ONLY_LHE = (
+        '<LesHouchesEvents version="1.0">\n'
+        '<header>\n'
+        '</header>\n'
+        '<init>\n'
+        '2212 2212 6.500000e+03 6.500000e+03 0 0 247000 247000 -4 1\n'
+        ' 3.000000e+00 1.000000e-02 3.000000e+00 1\n'
+        '</init>\n'
+        '</LesHouchesEvents>\n'
+    )
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_dir_reuse_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # ---------------- the reuse path of generate_events ----------------
+
+    class _Particle(object):
+        def __init__(self, name):
+            self._name = name
+        def get_name(self):
+            return self._name
+
+    class _Model(object):
+        def get_particle(self, pdg):
+            return TestReusedMsDirBranchingRatio._Particle('t')
+
+    def _prebuilt_decay_dir(self, stored_width=None, gridpack_cross=True):
+        """An ``ms_dir`` holding one already-built decay directory, exactly as a
+        previous run leaves it: a run.sh, the events its gridpack produces and
+        (unless ``stored_width`` is None) the partial-width record."""
+        import gzip
+        decay_dir = pjoin(self.tmpdir, 'decay_6_0')
+        os.makedirs(decay_dir)
+        open(pjoin(decay_dir, 'run.sh'), 'w').write('#!/bin/sh\n')
+        if gridpack_cross:
+            with gzip.open(pjoin(decay_dir, 'events.lhe.gz'), 'wt') as fsock:
+                fsock.write(self._INIT_ONLY_LHE)
+        else:
+            # a file EventFile cannot get a cross-section out of
+            with gzip.open(pjoin(decay_dir, 'events.lhe.gz'), 'wt') as fsock:
+                fsock.write('<LesHouchesEvents version="1.0">\n'
+                            '</LesHouchesEvents>\n')
+        if stored_width is not None:
+            interface_madspin.MadSpinInterface._store_partial_width(
+                decay_dir, stored_width)
+        return decay_dir
+
+    def _stub(self):
+        interface = interface_madspin.MadSpinInterface
+        class Stub(object):
+            generate_events = interface.generate_events
+            _store_partial_width = interface._store_partial_width
+            _load_partial_width = interface._load_partial_width
+            PARTIAL_WIDTH_FILE = interface.PARTIAL_WIDTH_FILE
+            _DECAY_GROUP_TAG = interface._DECAY_GROUP_TAG
+            _split_group_tag = interface._split_group_tag
+            def _resolve_nb_core(self):
+                return 1
+            def _run_gridpack(self, cmd, cwd):
+                # the gridpack's events are already on disk in these tests
+                return 0, ''
+        stub = Stub()
+        stub.path_me = self.tmpdir
+        stub.options = {'ms_dir': self.tmpdir, 'seed': 7}
+        stub.seed = 7
+        stub.model = self._Model()
+        stub.list_branches = {'t': ['t > w+ b, w+ > all all']}
+        return stub
+
+    def test_reuse_recovers_the_partial_width_that_was_stored(self):
+        """The regression itself: with the record in place the reuse path
+        reports the width the building run measured -- not 0."""
+        self._prebuilt_decay_dir(stored_width=1.4594692)
+        stub = self._stub()
+        out, width, channel_widths = stub.generate_events(
+            6, 100, None, cumul=True, output_width=True)
+        self.assertEqual(width, 1.4594692)
+        self.assertEqual(channel_widths, {0: 1.4594692})
+        self.assertEqual(list(out), [0])
+
+    def test_reuse_without_the_record_falls_back_to_the_generated_events(self):
+        """An ms_dir built by a version that stored nothing must still work:
+        the cross-section of the events the gridpack just produced is the same
+        quantity, measured on this run's sample."""
+        self._prebuilt_decay_dir(stored_width=None)
+        stub = self._stub()
+        out, width, channel_widths = stub.generate_events(
+            6, 100, None, cumul=True, output_width=True)
+        self.assertEqual(width, 3.0)          # the <init> cross of the events
+        self.assertEqual(channel_widths, {0: 3.0})
+
+    def test_reuse_with_no_recoverable_width_raises(self):
+        """Neither source available: fail, never fall back to a default. Any
+        default here is a wrong branching ratio in a well-formed file."""
+        self._prebuilt_decay_dir(stored_width=None, gridpack_cross=False)
+        stub = self._stub()
+        self.assertRaises(interface_madspin.MadSpinUnknownPartialWidth,
+                          lambda: stub.generate_events(6, 100, None,
+                                                       cumul=True,
+                                                       output_width=True))
+
+    def test_the_stored_width_survives_a_round_trip(self):
+        decay_dir = self._prebuilt_decay_dir(stored_width=2.5e-3)
+        self.assertEqual(
+            interface_madspin.MadSpinInterface._load_partial_width(decay_dir),
+            2.5e-3)
+
+    def test_a_corrupt_record_falls_back_instead_of_propagating(self):
+        """A truncated/garbage record must not become the branching ratio."""
+        decay_dir = self._prebuilt_decay_dir(stored_width=1.0)
+        open(pjoin(decay_dir,
+                   interface_madspin.MadSpinInterface.PARTIAL_WIDTH_FILE),
+             'w').write('not a number\n')
+        stub = self._stub()
+        out, width, channel_widths = stub.generate_events(
+            6, 100, None, cumul=True, output_width=True)
+        self.assertEqual(width, 3.0)
+
+    def test_a_zero_record_is_not_trusted_either(self):
+        """0 is exactly the value the bug produced; reading it back from disk
+        must not resurrect it."""
+        decay_dir = self._prebuilt_decay_dir(stored_width=0.0)
+        stub = self._stub()
+        out, width, channel_widths = stub.generate_events(
+            6, 100, None, cumul=True, output_width=True)
+        self.assertEqual(width, 3.0)
+
+    def test_a_fresh_directory_is_untouched_by_the_reuse_branch(self):
+        """The recovery only ever runs for a channel this run did not measure:
+        a width already in ``channel_widths`` must never be added twice."""
+        self._prebuilt_decay_dir(stored_width=1.5)
+        stub = self._stub()
+        out, width, channel_widths = stub.generate_events(
+            6, 100, None, cumul=False, output_width=True)
+        # cumul=False multiplies into a neutral 1.0, so a double fold would
+        # square it
+        self.assertEqual(width, 1.5)
+
+    # ---------------- the branching-ratio guard ----------------
+
+    def test_a_healthy_branching_ratio_passes_through(self):
+        check = interface_madspin.MadSpinInterface._check_branching_ratio
+        self.assertEqual(check(0.543), 0.543)
+
+    def test_a_tiny_branching_ratio_is_healthy(self):
+        """A rare decay is a small BR, not a broken one: the guard keys on zero
+        and on non-finiteness, never on smallness."""
+        check = interface_madspin.MadSpinInterface._check_branching_ratio
+        self.assertEqual(check(1e-12), 1e-12)
+
+    def test_a_zero_branching_ratio_raises_and_names_the_cause(self):
+        check = interface_madspin.MadSpinInterface._check_branching_ratio
+        try:
+            check(0.0, {6: {'kind': 'simple'}})
+        except interface_madspin.MadSpinZeroBranchingRatio as error:
+            msg = str(error)
+        else:
+            self.fail('a zero branching ratio must raise')
+        # what would have happened
+        self.assertIn('every weight is zero', msg)
+        self.assertIn('<init>', msg)
+        # the plausible causes, the first of which is this bug
+        self.assertIn('ms_dir', msg)
+        self.assertIn('use_old_dir', msg)
+        self.assertIn('param_card', msg)
+        self.assertIn('cross_section', msg)
+        # and what the run was actually doing
+        self.assertIn('simple', msg)
+
+    def test_a_non_finite_branching_ratio_raises(self):
+        check = interface_madspin.MadSpinInterface._check_branching_ratio
+        for bad in (float('nan'), float('inf'), -1.0):
+            self.assertRaises(interface_madspin.MadSpinZeroBranchingRatio,
+                              check, bad)
+
+    def test_run_onshell_checks_before_it_decays(self):
+        """The guard has to sit on the branching ratio *before* the events are
+        written, not after; pin the call site so it cannot drift below the
+        decay loop."""
+        source = inspect.getsource(
+            interface_madspin.MadSpinInterface.run_onshell)
+        self.assertIn('_check_branching_ratio(br', source)
+        self.assertLess(source.index('_check_branching_ratio(br'),
+                        source.index('self.branching_ratio = br'))


### PR DESCRIPTION
Reusing an `ms_dir` across MadSpin runs silently produced `branching_ratio = 0`: every event weight `+/-0.0`, a zero `<init>` cross section, exit code 0 and **no warning**. A well-formed LHE full of zeros is the worst failure mode available — the run looks like it worked.

Independent of the interference work; merges cleanly alongside it.

## Reproduced

30-event `g g > t t~` sample, `spinmode madspin`, seed 12345, `decay t > w+ b, w+ > all all` and conjugate:

| run | `<init>` cross | event weights | exit |
|---|---|---|---|
| fresh `ms_dir` | `+4.2220215e+02` | `+4.2138806e+02` | 0 |
| **same `ms_dir` reused (base)** | **`+0.0000000e+00`** | **`+0.0000000e+00`** | **0, no warning** |

## Root cause

In `generate_events`, `ms_dir` selects the gridpack path. On that path the channel's partial width is measured in exactly one place — `me5_cmd.results.current['cross']` right after `generate_events run_01 -f` — and that statement sits **inside `if not os.path.exists(decay_dir):`**, the grid-*building* block. A reuse run finds `decay_<pdg>_<i>` already present, skips the block entirely, and takes the `else:` branch that only *runs* `run.sh`. Nothing re-measures anything, so `width` keeps the value it was initialised with 200 lines earlier:

```python
if cumul:
    width = 0.
else:
    width = 1.
```

The common `kind='simple'` job (one particle of that pdg per event) sets `cumul: True`, so `pwidth` comes back **0.0**, and `br *= pwidth / totwidth` in `run_onshell` gives `br = 0`. That zero then scales `self.cross`, `banner.scale_init_cross(...)` and every `event.wgt *= self.branching_ratio`.

The legacy decay-chain path is **not** affected: its BRs are computed at `add_decay` time and stored in `madspin.pkl`, so they survive the round trip (verified end to end).

## Fix: make reuse work

- A run that builds a gridpack writes its measured width to `decay_dir/ms_partial_width.dat`.
- A run that reuses the directory reads it back and folds it in, guarded so a directory this run built is never double-counted.
- An `ms_dir` built by an **older version** has no record: it falls back to the `<init>` cross of the events the gridpack just produced, **with a warning** that this agrees only to the MC error.
- Neither readable: `MadSpinUnknownPartialWidth`, naming the directory and telling the user to use a fresh `ms_dir`. No silent default — every default here is a wrong BR in a well-formed file.

## Guard, independent of the cause

`_check_branching_ratio` raises `MadSpinZeroBranchingRatio` on a BR that is not finite-and-positive, called before any event is written, from both `run_onshell` and the legacy `decaying_events`. Modelled on the existing `_raise_degenerate_weight`: it names what would otherwise have happened, and lists the plausible causes with `ms_dir`/`use_old_dir` first.

**A genuinely zero BR is not legitimate here** — each factor is a partial width MadSpin measures by *generating* that decay, and a closed channel makes the generation fail (`ZeroResult`) long before this point. A rare-but-open channel is a small positive number, and the guard keys on zero, never on smallness (pinned by a test at 1e-12).

## Verification

- **The guard is a real backstop**: with the recovery block disabled, the same reuse run aborts with `MadSpinZeroBranchingRatio` and exit 1 instead of writing zeros.
- **Reuse of an `ms_dir` built before the fix**: `+4.2401105e+02` against the fresh `+4.2220215e+02` — 0.43%, i.e. the MC error, with the fallback warning printed for both decay directories.
- **Fresh run unaffected**: decayed LHE **byte-identical** (`cmp`) to the pre-fix fresh run.
- **Reuse of an `ms_dir` built with the fix**: `<init>` exactly `+4.2220215e+02` and first event weight exactly `+4.2138806e+02` — identical to the fresh run, no warning.
- **Tests**: baseline re-measured on the untouched base = **242 OK**; with the change = **254 OK** (12 new).

## Honest caveats

- The 12 new tests drive `generate_events` through the reuse branch with a stub (real files on disk, stubbed `_run_gridpack`/model) rather than a full MadEvent round trip, which is far too slow for the unit suite. The full round trip was done by hand, above.
- A **separate, pre-existing** bug was hit in passing: legacy `spinmode madspin_v1` + `ms_dir` decays correctly (BR=1, 30/30 events, correct `<init>`) and then dies with `FileNotFoundError` gzipping `curr_dir/decayed_events.lhe` — `decaying_events` writes it into `path_me`, which *is* the `ms_dir`. Confirmed identical on the untouched base, so not introduced here; left alone to keep this diff tight and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve MadSpin branching ratios when reusing gridpack directories and stop runs that cannot compute a valid branching ratio.

Bug Fixes:
- Prevent reused MadSpin gridpack directories from silently producing zero branching ratios, event weights, and cross sections.
- Recover partial widths from stored measurements or generated-event cross sections, and fail explicitly when neither source is available.

Enhancements:
- Add validation that rejects zero, negative, or non-finite branching ratios before events are written, including legacy decay handling.

Tests:
- Add unit coverage for partial-width persistence, reuse recovery and fallback behavior, invalid records, branching-ratio validation, and pre-write guard placement.