### PR TITLE
MadSpin: write decayed_events.lhe where the caller reads it

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2161,6 +2161,42 @@ class decay_all_events(object):
     
         self.ending_run()
         
+    # Name of the intermediate LHE file the legacy (madspin_v1) decay writes and
+    # that MadSpinInterface then gzips into <events>_decayed.lhe.gz.
+    DECAYED_EVENTS_NAME = 'decayed_events.lhe'
+
+    @property
+    def decayed_events_path(self):
+        """The one place that decides where the decayed events are written.
+
+        Both ends of the write/read pair must go through this property --
+        ``decaying_events`` opens it, ``MadSpinInterface.do_launch`` and
+        ``run_from_pickle`` gzip it -- because they used to compute it
+        separately and disagreed (see tests/unit_tests/madspin, class
+        TestDecayedEventsPath).
+
+        It is ``curr_dir``, the run's output directory, and deliberately *not*
+        ``path_me``:
+
+        * ``path_me`` means "where the matrix-element directories live"
+          everywhere else it is used (production_me/full_me/decay_me,
+          decay_<pdg>_<i>, ms_wstatus_*, param_card.dat). Under ``ms_dir`` it is
+          a directory that is built once and reused -- and possibly shared --
+          by later runs, so per-run event output has no business there.
+        * without ``ms_dir`` the two coincide (``path_me`` is *defined* as
+          ``realpath(curr_dir)``), which is why the mismatch stayed hidden: it
+          only bites when ``ms_dir`` is set *and* ``curr_dir`` is not the
+          ms_dir, i.e. whenever the event file is imported after ``set ms_dir``
+          (``post_set_ms_dir`` points ``curr_dir`` at the ms_dir, and
+          ``do_import`` points it back at the event file's directory).
+
+        The value is read off the *live* interface rather than ``self.options``
+        on purpose: under ``ms_dir`` this object is restored from
+        ``madspin.pkl``, so its own ``options`` -- pickled with the gridpack --
+        still describe the run that *built* it, ``curr_dir`` included.
+        """
+        return pjoin(self.mscmd.options['curr_dir'], self.DECAYED_EVENTS_NAME)
+
     def ending_run(self):
         """launch the unweighting and deal with final information"""    
         # launch the decay and reweighting
@@ -2318,7 +2354,7 @@ class decay_all_events(object):
 
         logger.info(' ' )
         logger.info('Decaying the events... ')
-        self.outputfile = open(pjoin(self.path_me,'decayed_events.lhe'), 'w')
+        self.outputfile = open(self.decayed_events_path, 'w')
         self.write_banner_information()
         
         

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -1659,8 +1659,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             pass
         misc.gzip(evt_path)
         decayed_evt_file=evt_path.replace('.lhe', '_decayed.lhe')
-        misc.gzip(pjoin(self.options['curr_dir'],'decayed_events.lhe'),
-                  stdout=decayed_evt_file)
+        # Ask the writer where it put the file rather than rebuilding the path
+        # here: the two used to be spelled out separately and disagreed as soon
+        # as ms_dir was set and curr_dir was not the ms_dir (see
+        # decay_all_events.decayed_events_path).
+        misc.gzip(generate_all.decayed_events_path, stdout=decayed_evt_file)
         if not self.mother:
             logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
 
@@ -1775,10 +1778,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             pass
         misc.gzip(evt_path)
         decayed_evt_file=evt_path.replace('.lhe', '_decayed.lhe')
-        misc.gzip(pjoin(self.options['curr_dir'],'decayed_events.lhe'),
-                  stdout=decayed_evt_file)
+        # Same shared accessor as do_launch -- and this path is *only* reachable
+        # with ms_dir set, so it was the one always exposed to the mismatch.
+        misc.gzip(generate_all.decayed_events_path, stdout=decayed_evt_file)
         if not self.mother:
-            logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)    
+            logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
     
     
 

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -623,7 +623,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.err_branching_ratio = 0
         self.me_run_name = "" # Events diretory name where to stotre the events (used by madevent) not use internally
         self.all_iden = {}
-        
+        # The card this run executes, and the directory do_import derives from
+        # the event file. Both are what madspin_card_path archives from; set
+        # before the do_import below, which fills the second one in.
+        self.ms_card_path = None
+        self.event_base_dir = None
+
         if event_path:
             logger.info("Extracting the banner ...")
             self.do_import(event_path)
@@ -731,9 +736,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         # change directory where to write the output
         self.options['curr_dir'] = os.path.realpath(os.path.dirname(inputfile))
         if os.path.basename(os.path.dirname(os.path.dirname(inputfile))) == 'Events':
-            self.options['curr_dir'] = pjoin(self.options['curr_dir'], 
+            self.options['curr_dir'] = pjoin(self.options['curr_dir'],
                                                       os.path.pardir, os.pardir)
-        
+        # Keep that directory -- the process root when the events sit in
+        # Events/<run>/, the event file's own directory otherwise -- under a
+        # name of its own. 'set ms_dir' re-points curr_dir at the gridpack
+        # (post_set_ms_dir), so curr_dir stops answering "where did these
+        # events come from" as soon as a card mentions ms_dir after the import.
+        # See madspin_card_path.
+        self.event_base_dir = self.options['curr_dir']
+
         if not os.path.exists(inputfile):
             if inputfile.endswith('.gz'):
                 if not os.path.exists(inputfile[:-3]):
@@ -1503,6 +1515,99 @@ class MadSpinInterface(extended_cmd.Cmd):
                 return tag
         return groups['tags'][-1]
 
+    ############################################################################
+    ##  Archiving the card that was actually run                              ##
+    ############################################################################
+
+    def import_command_file(self, filepath):
+        """Execute a MadSpin card, remembering which file it came from.
+
+        That file is the record of what this run did, and it is the only thing
+        that knows where the card lives: the card is handed in from outside
+        (MadEvent's ``do_decay_events`` passes
+        ``<me_dir>/Cards/madspin_card.dat``) and is under no obligation to sit
+        anywhere in particular. ``madspin_card_path`` archives it next to the
+        decayed events.
+        """
+        if isinstance(filepath, str):
+            self.ms_card_path = os.path.realpath(filepath)
+        return super(MadSpinInterface, self).import_command_file(filepath)
+
+    @property
+    def madspin_card_path(self):
+        """The MadSpin card this run executed, or None when there is no file to
+        archive (an interactive session types its commands; it has no card).
+
+        This is the single place that answers "which card was run", so that the
+        copy kept beside the events cannot name a different file from the one
+        the interface obeyed. Two sources, in order:
+
+        1. the file handed to :meth:`import_command_file` -- literally the card
+           the user edited for this run, wherever it happens to live. Every
+           driver runs MadSpin this way;
+        2. ``Cards/madspin_card.dat`` under ``event_base_dir``, the directory
+           ``do_import`` derived from the event file -- for a session driven
+           line by line that nonetheless runs inside a process directory.
+
+        What it deliberately does not use is ``self.options['curr_dir']``,
+        which is what the archiving used to be built from. ``curr_dir`` says
+        where this run's *output* goes -- that is its meaning at every other
+        use site, and what #365 pinned it to for the decayed events -- and
+        ``post_set_ms_dir`` re-points it at the gridpack. So
+        ``pjoin(curr_dir, 'Cards', 'madspin_card.dat')`` named the real card
+        only when the card happened to say ``set ms_dir`` *before* importing
+        the events, ``do_import`` then pointing curr_dir back at them. In the
+        other ordering -- the one MadEvent always produces, since it imports
+        the events in the constructor and reads the card afterwards -- it named
+        ``<ms_dir>/Cards/madspin_card.dat``, which MadSpin never creates, and
+        the archiving was skipped without a word. See
+        tests/unit_tests/madspin, class TestMadSpinCardArchive.
+        """
+        if self.ms_card_path and os.path.exists(self.ms_card_path):
+            return self.ms_card_path
+        if self.event_base_dir:
+            path = pjoin(self.event_base_dir, 'Cards', 'madspin_card.dat')
+            if os.path.exists(path):
+                return path
+        return None
+
+    def _archive_madspin_card(self, decayed_evt_file):
+        """Keep the card that produced ``decayed_evt_file`` next to it.
+
+        Shared by ``do_launch`` and ``run_from_pickle`` so that the gridpack
+        path -- the one reached on every rerun against an existing ``ms_dir``,
+        and hence the one where losing the card is most likely -- archives the
+        same file, from the same source, as a fresh run.
+
+        Returns the path written, or None when there was no card to copy.
+        """
+        ms_card_path = self.madspin_card_path
+        if not ms_card_path:
+            return None
+
+        run_dir = os.path.realpath(os.path.dirname(decayed_evt_file))
+        packed = os.path.exists(pjoin(run_dir, 'RunMaterial.tar.gz'))
+        if packed:
+            misc.call(['tar', '-xzpf', 'RunMaterial.tar.gz'], cwd=run_dir)
+            base_path = pjoin(run_dir, 'RunMaterial')
+        else:
+            base_path = run_dir
+
+        evt_name = os.path.basename(decayed_evt_file).replace('.lhe', '')
+        ms_card_to_copy = pjoin(base_path, 'madspin_card_for_%s.dat' % evt_name)
+        count = 0
+        while os.path.exists(ms_card_to_copy):
+            count += 1
+            ms_card_to_copy = pjoin(base_path, 'madspin_card_for_%s_%d.dat' %
+                                                              (evt_name, count))
+        files.cp(str(ms_card_path), str(ms_card_to_copy))
+
+        if packed:
+            misc.call(['tar', '-czpf', 'RunMaterial.tar.gz', 'RunMaterial'],
+                                                                    cwd=run_dir)
+            shutil.rmtree(pjoin(run_dir, 'RunMaterial'))
+        return ms_card_to_copy
+
     @misc.mute_logger()
     def do_launch(self, line):
         """end of the configuration launched the code"""
@@ -1667,29 +1772,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         if not self.mother:
             logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
 
-        # Now arxiv the shower card used if RunMaterial is present
-        ms_card_path = pjoin(self.options['curr_dir'],'Cards','madspin_card.dat')
-        run_dir = os.path.realpath(os.path.dirname(decayed_evt_file))
-        if os.path.exists(ms_card_path):
-            if os.path.exists(pjoin(run_dir,'RunMaterial.tar.gz')):
-                misc.call(['tar','-xzpf','RunMaterial.tar.gz'], cwd=run_dir)
-                base_path = pjoin(run_dir,'RunMaterial')
-            else:
-                base_path = pjoin(run_dir)
-
-            evt_name = os.path.basename(decayed_evt_file).replace('.lhe', '')
-            ms_card_to_copy = pjoin(base_path,'madspin_card_for_%s.dat'%evt_name)
-            count = 0    
-            while os.path.exists(ms_card_to_copy):
-                count += 1
-                ms_card_to_copy = pjoin(base_path,'madspin_card_for_%s_%d.dat'%\
-                                                               (evt_name,count))
-            files.cp(str(ms_card_path),str(ms_card_to_copy))
-            
-            if os.path.exists(pjoin(run_dir,'RunMaterial.tar.gz')):
-                misc.call(['tar','-czpf','RunMaterial.tar.gz','RunMaterial'], 
-                                                                    cwd=run_dir)
-                shutil.rmtree(pjoin(run_dir,'RunMaterial'))
+        # Now arxiv the madspin card used (inside RunMaterial if present)
+        self._archive_madspin_card(decayed_evt_file)
         self._log_lhe_timers()
 
     def run_from_pickle(self):
@@ -1783,6 +1867,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         misc.gzip(generate_all.decayed_events_path, stdout=decayed_evt_file)
         if not self.mother:
             logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
+
+        # ... and the card goes with them here too. Rerunning against an
+        # existing ms_dir is a *rerun*: it produces its own event file, from its
+        # own card, and archived nothing at all before -- do_launch returns here
+        # long before reaching its own copy of this call.
+        self._archive_madspin_card(decayed_evt_file)
     
     
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5232,6 +5232,299 @@ class TestDecayedEventsPath(unittest.TestCase):
         self.assertIn("curr_dir", code)
 
 
+class TestMadSpinCardArchive(unittest.TestCase):
+    """MadSpin keeps a copy of the card it ran next to the events it produced
+    (``madspin_card_for_<events>.dat``). That copy is the record of what was
+    actually run, and its absence is only noticed much later, by whoever tries
+    to reproduce the result.
+
+    The source used to be ``pjoin(self.options['curr_dir'], 'Cards',
+    'madspin_card.dat')``, and ``curr_dir`` does not mean that. It is where the
+    run's *output* goes (that is what #365 pinned it to for the decayed
+    events), and ``MadSpinOptions.post_set_ms_dir`` re-points it at the
+    gridpack. ``do_import`` points it back at the event file, so the card
+    *ordering* decided whether the archiving worked:
+
+      set ms_dir ... ; import events   -> curr_dir is the process dir  -> worked
+      import events ; set ms_dir ...   -> curr_dir is the ms_dir       -> silent
+
+    and the second is the ordering MadEvent always produces, because
+    ``do_decay_events`` imports the event file in the ``MadSpinInterface``
+    constructor and only then runs the card. So *every* MadEvent run whose
+    madspin_card.dat says ``set ms_dir`` lost its card, with no warning: the
+    guard was ``if os.path.exists(ms_card_path)``, and MadSpin never creates a
+    ``Cards`` directory inside an ms_dir, so the whole block was skipped.
+
+    The fix is to stop deriving the card from an output directory at all and
+    ask which card was *run* -- ``MadSpinInterface.madspin_card_path``. These
+    tests drive the real ``MadSpinOptions`` and the real ``do_import``, so the
+    ``post_set_ms_dir`` -> ``do_import`` interaction that creates the mismatch
+    is produced by production code rather than imitated here, and they pin the
+    two orderings *to each other* so neither end can drift again.
+    """
+
+    class _Interface(interface_madspin.MadSpinInterface):
+        """A MadSpinInterface carrying only the state the methods under test
+        touch. Subclassed, not faked: ``do_import``, ``import_command_file``,
+        ``madspin_card_path`` and ``_archive_madspin_card`` are the production
+        ones. ``__init__`` is skipped because building the real interface pulls
+        in a MasterCmd and a model, neither of which has any say in which card
+        gets archived."""
+
+        def __init__(self, options):
+            self.options = options
+            self.ms_card_path = None
+            self.event_base_dir = None
+            self.mother = None
+            self.child = None
+            self.stored_line = None
+            self.history = []
+            self.inputfile = None
+            self.use_rawinput = False
+
+    CARD = '# the card this run actually used\nset spinmode madspin_v1\n'
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_card_archive_')
+        self.proc = pjoin(self.tmpdir, 'PROC')
+        self.run_dir = pjoin(self.proc, 'Events', 'run_01')
+        self.ms_dir = pjoin(self.tmpdir, 'gridpack')
+        os.makedirs(pjoin(self.proc, 'Cards'))
+        os.makedirs(self.run_dir)
+        os.makedirs(self.ms_dir)
+        self.card = pjoin(self.proc, 'Cards', 'madspin_card.dat')
+        with open(self.card, 'w') as fsock:
+            fsock.write(self.CARD)
+        # the event file need not exist: do_import decides the directories
+        # before it looks at the file (see _import_events)
+        self.events = pjoin(self.run_dir, 'unweighted_events.lhe')
+        self.decayed = pjoin(self.run_dir, 'unweighted_events_decayed.lhe')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # helpers -- everything below goes through production code
+    # ------------------------------------------------------------------
+
+    def _interface(self):
+        return self._Interface(interface_madspin.MadSpinOptions())
+
+    def _import_events(self, iface):
+        """Run the *real* ``do_import`` for its directory bookkeeping.
+
+        It sets ``curr_dir``/``event_base_dir`` in its first few lines and only
+        afterwards checks that the file is there, so pointing it at a file that
+        does not exist runs exactly the part under test and stops before the
+        banner and model reading that would need a whole MadEvent output."""
+        self.assertRaises(iface.InvalidCmd, iface.do_import, self.events)
+
+    def _set_ms_dir(self, iface):
+        """`set ms_dir` as a card does it -- post_set_ms_dir carries curr_dir
+        along, which is the whole reason the orderings differ."""
+        iface.options['ms_dir'] = self.ms_dir
+
+    def _ordering_madevent(self):
+        """import first, ms_dir second: the constructor imported the events and
+        the card then says `set ms_dir`. This is what MadEvent always does."""
+        iface = self._interface()
+        self._import_events(iface)
+        self._set_ms_dir(iface)
+        return iface
+
+    def _ordering_card_first(self):
+        """`set ms_dir` first, import second -- the ordering that happened to
+        work, and which must go on working."""
+        iface = self._interface()
+        self._set_ms_dir(iface)
+        self._import_events(iface)
+        return iface
+
+    # ------------------------------------------------------------------
+    # the interaction that made this invisible really is there
+    # ------------------------------------------------------------------
+
+    def test_the_two_orderings_really_do_disagree_about_curr_dir(self):
+        """The premise of everything below, asserted rather than assumed.
+
+        It doubles as the guard against the other tempting wrong fix: making
+        ``post_set_ms_dir`` stop moving ``curr_dir``. That would silence this
+        bug and break the decayed-events path of #365, which needs curr_dir to
+        follow ms_dir when the card sets no event file after it."""
+        after = self._ordering_madevent()
+        before = self._ordering_card_first()
+        self.assertEqual(os.path.realpath(after.options['curr_dir']),
+                         os.path.realpath(self.ms_dir))
+        self.assertEqual(os.path.realpath(before.options['curr_dir']),
+                         os.path.realpath(self.proc))
+        # ...and the old expression is exactly what that breaks
+        self.assertFalse(os.path.exists(
+            pjoin(after.options['curr_dir'], 'Cards', 'madspin_card.dat')))
+
+    # ------------------------------------------------------------------
+    # the card is found whatever the ordering
+    # ------------------------------------------------------------------
+
+    def test_the_card_is_found_in_the_madevent_ordering(self):
+        """The regression: this returned a path inside the gridpack, which does
+        not exist, so nothing was archived and nothing was said."""
+        iface = self._ordering_madevent()
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    def test_the_card_is_found_in_the_card_first_ordering(self):
+        iface = self._ordering_card_first()
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    def test_the_ordering_cannot_change_the_answer(self):
+        """The pin: the two orderings are tied to each other, not each to a
+        literal, so no future edit can re-open the gap on one side only."""
+        self.assertEqual(
+            os.path.realpath(self._ordering_madevent().madspin_card_path),
+            os.path.realpath(self._ordering_card_first().madspin_card_path))
+
+    def test_without_ms_dir_the_card_is_still_found(self):
+        """The case that breaks if the fix is made at the wrong end -- by far
+        the most common way MadSpin is run."""
+        iface = self._interface()
+        self._import_events(iface)
+        self.assertEqual(iface.options['ms_dir'], '')
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    # ------------------------------------------------------------------
+    # ...and it is the card that was *run*
+    # ------------------------------------------------------------------
+
+    def test_import_command_file_records_the_card_it_runs(self):
+        """``import_command_file`` is how every driver hands MadSpin a card,
+        and the path it is given is the only thing that knows where the card
+        lives. Run the real method on an empty card so nothing is executed."""
+        elsewhere = pjoin(self.tmpdir, 'my_own_card.dat')
+        open(elsewhere, 'w').close()
+        iface = self._interface()
+        iface.import_command_file(elsewhere)
+        self.assertEqual(iface.ms_card_path, os.path.realpath(elsewhere))
+
+    def test_a_card_from_elsewhere_wins_over_the_process_directory(self):
+        """MadEvent passes ``<me_dir>/Cards/madspin_card.dat`` so the two agree
+        there, but a card handed in from anywhere else is still *the* card that
+        was run, and is what must be archived."""
+        elsewhere = pjoin(self.tmpdir, 'my_own_card.dat')
+        with open(elsewhere, 'w') as fsock:
+            fsock.write('# a card that lives somewhere else\n')
+        iface = self._ordering_madevent()
+        iface.ms_card_path = os.path.realpath(elsewhere)
+        self.assertEqual(iface.madspin_card_path, os.path.realpath(elsewhere))
+
+    def test_no_card_means_no_archive_rather_than_a_wrong_one(self):
+        """An interactive session types its commands; there is no file to keep.
+        Returning None (and archiving nothing) is the honest answer -- better
+        than reaching for whatever madspin_card.dat happens to be nearby."""
+        iface = self._interface()
+        self._import_events(iface)
+        os.remove(self.card)
+        self.assertIsNone(iface.madspin_card_path)
+        self.assertIsNone(iface._archive_madspin_card(self.decayed))
+        self.assertEqual([f for f in os.listdir(self.run_dir)
+                          if f.startswith('madspin_card_for_')], [])
+
+    # ------------------------------------------------------------------
+    # a real archiving round trip
+    # ------------------------------------------------------------------
+
+    def test_the_archive_holds_the_card_that_was_run(self):
+        """What the user goes looking for months later: the file is there, it
+        is named after the events, and its content is the card."""
+        iface = self._ordering_madevent()
+        written = iface._archive_madspin_card(self.decayed)
+        self.assertEqual(
+            os.path.realpath(written),
+            os.path.realpath(pjoin(
+                self.run_dir,
+                'madspin_card_for_unweighted_events_decayed.dat')))
+        self.assertTrue(os.path.exists(written))
+        self.assertEqual(open(written).read(), self.CARD)
+
+    def test_both_orderings_archive_the_same_bytes(self):
+        first = self._ordering_madevent()._archive_madspin_card(self.decayed)
+        second = self._ordering_card_first()._archive_madspin_card(self.decayed)
+        self.assertNotEqual(first, second)   # the counter kept them apart
+        self.assertEqual(open(first).read(), open(second).read())
+
+    def test_a_second_run_does_not_overwrite_the_first(self):
+        """Rerunning against an existing ms_dir writes a new event file into the
+        same directory; its card must not silently replace the earlier one."""
+        iface = self._ordering_madevent()
+        first = iface._archive_madspin_card(self.decayed)
+        with open(self.card, 'w') as fsock:
+            fsock.write('# a different card, second run\n')
+        second = iface._archive_madspin_card(self.decayed)
+        self.assertTrue(second.endswith(
+            'madspin_card_for_unweighted_events_decayed_1.dat'))
+        self.assertEqual(open(first).read(), self.CARD)
+        self.assertEqual(open(second).read(), '# a different card, second run\n')
+
+    def test_the_archive_goes_inside_RunMaterial_when_there_is_one(self):
+        """aMC@NLO runs keep their cards inside RunMaterial.tar.gz; the copy
+        must end up in the tarball, not loose beside it."""
+        os.makedirs(pjoin(self.run_dir, 'RunMaterial'))
+        misc.call(['tar', '-czpf', 'RunMaterial.tar.gz', 'RunMaterial'],
+                  cwd=self.run_dir)
+        shutil.rmtree(pjoin(self.run_dir, 'RunMaterial'))
+        iface = self._ordering_madevent()
+        iface._archive_madspin_card(self.decayed)
+        self.assertFalse(os.path.exists(pjoin(
+            self.run_dir, 'madspin_card_for_unweighted_events_decayed.dat')))
+        misc.call(['tar', '-xzpf', 'RunMaterial.tar.gz'], cwd=self.run_dir)
+        inside = pjoin(self.run_dir, 'RunMaterial',
+                       'madspin_card_for_unweighted_events_decayed.dat')
+        self.assertTrue(os.path.exists(inside))
+        self.assertEqual(open(inside).read(), self.CARD)
+
+    # ------------------------------------------------------------------
+    # nobody rebuilds the source by hand any more
+    # ------------------------------------------------------------------
+
+    def test_every_call_site_goes_through_the_helper(self):
+        """do_launch archived the card, run_from_pickle -- the path every rerun
+        against an existing ms_dir takes -- did not archive it at all. Both go
+        through one helper now, so they cannot disagree about what to keep or
+        about whether to keep it.
+
+        Read the module file rather than using ``inspect.getsource`` on the
+        methods: ``do_launch`` is wrapped by ``misc.mute_logger`` and getsource
+        returns the decorator's body."""
+        with open(interface_madspin.__file__.replace('.pyc', '.py')) as fsock:
+            source = fsock.read()
+        self.assertEqual(
+            source.count('self._archive_madspin_card(decayed_evt_file)'), 2,
+            'do_launch and run_from_pickle must both archive the card')
+        self.assertNotIn(
+            "pjoin(self.options['curr_dir'],'Cards','madspin_card.dat')",
+            source)
+
+    def test_the_accessor_does_not_look_at_curr_dir(self):
+        """curr_dir is an output directory. Rebuilding the card's location from
+        it is the mistake being fixed, and it is the tempting one because it
+        works in every setup that has no ms_dir."""
+        source = inspect.getsource(
+            interface_madspin.MadSpinInterface.madspin_card_path.fget)
+        code = source.split('"""')[-1]
+        self.assertNotIn('curr_dir', code)
+        self.assertIn('ms_card_path', code)
+        self.assertIn('event_base_dir', code)
+
+    def test_do_import_keeps_the_directory_under_its_own_name(self):
+        """``event_base_dir`` exists so that the answer survives a later
+        ``set ms_dir``; if do_import ever stopped setting it the fallback would
+        quietly go back to finding nothing."""
+        source = inspect.getsource(interface_madspin.MadSpinInterface.do_import)
+        self.assertIn('self.event_base_dir', source)
+
+
 class TestZeroDensityGuard(unittest.TestCase):
     """The guards that turn a MadSpin accept/reject which can never accept into
     an immediate, named failure instead of an unbounded retry loop.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5000,6 +5000,238 @@ class TestGetPdirUnpackArity(unittest.TestCase):
             self.assertNotIn('self.%s' % cache, source)
 
 
+class TestDecayedEventsPath(unittest.TestCase):
+    """The legacy (madspin_v1) decay writes its events to an intermediate
+    ``decayed_events.lhe`` and the interface then gzips that file into
+    ``<events>_decayed.lhe.gz``. Writer and reader used to spell the directory
+    out separately -- ``decay_all_events.decaying_events`` used ``path_me``,
+    ``MadSpinInterface.do_launch``/``run_from_pickle`` used ``curr_dir`` -- and
+    disagreed whenever those two differ.
+
+    They differ exactly when ``ms_dir`` is set *and* ``curr_dir`` is not the
+    ms_dir. That is not exotic: ``post_set_ms_dir`` points ``curr_dir`` at the
+    ms_dir, so a card that says ``set ms_dir`` and *then* imports the event file
+    gets ``curr_dir`` pointed back at the event file's directory by
+    ``do_import``. The whole (expensive) decay then completes -- correct
+    branching ratio, all events written, correct <init> -- and the run dies on
+    the very last step with FileNotFoundError on a file that is sitting in the
+    ms_dir. Without ``ms_dir`` the two coincide by construction (``path_me`` is
+    *defined* as ``realpath(curr_dir)``), which is why this never showed up in
+    the common case.
+
+    ``curr_dir`` is the correct end: it is the run's output directory, whereas
+    ``path_me`` means "where the matrix-element directories live" everywhere
+    else it is used, and under ``ms_dir`` it is a directory built once and
+    reused by later runs.
+
+    These tests pin the two ends *together* rather than each to a literal, so a
+    future edit to either side cannot re-open the gap without failing here. No
+    MadEvent round trip is needed: the disagreement is entirely about paths.
+    """
+
+    NAME = 'decayed_events.lhe'
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_decayed_path_')
+        self.evt_dir = pjoin(self.tmpdir, 'events')
+        self.ms_dir = pjoin(self.tmpdir, 'gridpack')
+        os.makedirs(self.evt_dir)
+        os.makedirs(self.ms_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    class _Interface(object):
+        """Stands in for the live MadSpinInterface: the accessor only needs its
+        ``options``."""
+        def __init__(self, options):
+            self.options = options
+
+    def _options(self, ms_dir=None, curr_dir=None):
+        """A real MadSpinOptions, driven the way a card drives it -- so the
+        ``set ms_dir`` -> ``import`` interaction that creates the mismatch is
+        reproduced by the production code, not imitated here."""
+        options = interface_madspin.MadSpinOptions()
+        if ms_dir:
+            options['ms_dir'] = ms_dir          # post_set_ms_dir moves curr_dir
+        if curr_dir:
+            options['curr_dir'] = curr_dir      # ...and do_import moves it back
+        return options
+
+    def _writer(self, options):
+        """A ``decay_all_events`` with only what the accessor touches. Built
+        without ``__init__`` on purpose: constructing the real thing needs a
+        banner, a model and a compiled matrix element, none of which has any say
+        in where the output goes."""
+        writer = object.__new__(madspin.decay_all_events)
+        writer.options = options
+        writer.mscmd = self._Interface(options)
+        # path_me exactly as decay_all_events.__init__ computes it
+        writer.path_me = os.path.realpath(options['curr_dir'])
+        if options['ms_dir']:
+            writer.path_me = os.path.realpath(options['ms_dir'])
+        return writer
+
+    @staticmethod
+    def _reader_path(writer):
+        """What the interface gzips. Kept as a named indirection so it is
+        obvious that ``test_both_gzip_call_sites_use_the_accessor`` is what
+        makes this stand for the real read sites."""
+        return writer.decayed_events_path
+
+    # ------------------------------------------------------------------
+    # the two ends agree
+    # ------------------------------------------------------------------
+
+    def test_writer_and_reader_agree_without_ms_dir(self):
+        writer = self._writer(self._options(curr_dir=self.evt_dir))
+        self.assertEqual(os.path.realpath(writer.decayed_events_path),
+                         os.path.realpath(self._reader_path(writer)))
+        self.assertEqual(os.path.realpath(os.path.dirname(
+                             writer.decayed_events_path)),
+                         os.path.realpath(self.evt_dir))
+
+    def test_writer_and_reader_agree_with_ms_dir(self):
+        """The regression: ms_dir set, curr_dir left pointing at the event file
+        (a card that imports after ``set ms_dir``)."""
+        options = self._options(ms_dir=self.ms_dir, curr_dir=self.evt_dir)
+        # the setup really is the mismatching one
+        self.assertNotEqual(os.path.realpath(options['curr_dir']),
+                            os.path.realpath(options['ms_dir']))
+        writer = self._writer(options)
+        self.assertEqual(os.path.realpath(writer.decayed_events_path),
+                         os.path.realpath(self._reader_path(writer)))
+
+    def test_writer_and_reader_agree_when_ms_dir_is_curr_dir(self):
+        """The historically working case -- a card that sets ms_dir and lets
+        post_set_ms_dir carry curr_dir with it -- must stay working."""
+        options = self._options(ms_dir=self.ms_dir)
+        self.assertEqual(os.path.realpath(options['curr_dir']),
+                         os.path.realpath(self.ms_dir))
+        writer = self._writer(options)
+        self.assertEqual(os.path.realpath(writer.decayed_events_path),
+                         os.path.realpath(self._reader_path(writer)))
+        self.assertEqual(os.path.realpath(os.path.dirname(
+                             writer.decayed_events_path)),
+                         os.path.realpath(self.ms_dir))
+
+    # ------------------------------------------------------------------
+    # ...and agree on the *right* directory
+    # ------------------------------------------------------------------
+
+    def test_the_output_goes_to_curr_dir_and_not_into_the_ms_dir(self):
+        """Fixing this at the other end -- teaching the reader to look in
+        path_me -- would also have silenced the traceback, and would have been
+        wrong: it would leave per-run event output inside a gridpack directory
+        that later runs reuse and may share."""
+        writer = self._writer(self._options(ms_dir=self.ms_dir,
+                                            curr_dir=self.evt_dir))
+        self.assertEqual(os.path.realpath(os.path.dirname(
+                             writer.decayed_events_path)),
+                         os.path.realpath(self.evt_dir))
+        self.assertNotEqual(os.path.realpath(writer.decayed_events_path),
+                            os.path.realpath(pjoin(writer.path_me, self.NAME)))
+
+    def test_without_ms_dir_path_me_and_curr_dir_still_coincide(self):
+        """The no-ms_dir case is the one most likely to break if the fix is made
+        at the wrong end, so pin that the file lands where it always did."""
+        writer = self._writer(self._options(curr_dir=self.evt_dir))
+        self.assertEqual(os.path.realpath(writer.decayed_events_path),
+                         os.path.realpath(pjoin(writer.path_me, self.NAME)))
+
+    # ------------------------------------------------------------------
+    # the accessor reads the live run, not the pickled one
+    # ------------------------------------------------------------------
+
+    def test_the_path_follows_the_live_interface_not_the_stored_options(self):
+        """Under ms_dir the writer is restored from ``madspin.pkl``, so its own
+        ``options`` are those of the run that *built* the gridpack -- including
+        that run's curr_dir. ``run_from_pickle`` re-points ``mscmd`` at the live
+        interface, so the accessor must read the location from there."""
+        stale_dir = pjoin(self.tmpdir, 'the_run_that_built_the_gridpack')
+        os.makedirs(stale_dir)
+        writer = self._writer(self._options(ms_dir=self.ms_dir,
+                                            curr_dir=stale_dir))
+        # what run_from_pickle does: hand the restored object the live interface
+        live = self._options(ms_dir=self.ms_dir, curr_dir=self.evt_dir)
+        writer.mscmd = self._Interface(live)
+        self.assertEqual(os.path.realpath(os.path.dirname(
+                             writer.decayed_events_path)),
+                         os.path.realpath(self.evt_dir))
+        self.assertNotIn('the_run_that_built_the_gridpack',
+                         writer.decayed_events_path)
+
+    # ------------------------------------------------------------------
+    # a real write/read round trip
+    # ------------------------------------------------------------------
+
+    def _round_trip(self, options):
+        """Write at the writer's path, gzip from the reader's path, exactly as
+        decaying_events and do_launch do."""
+        writer = self._writer(options)
+        with open(writer.decayed_events_path, 'w') as fsock:
+            fsock.write('<LesHouchesEvents version="1.0">\n'
+                        '</LesHouchesEvents>\n')
+        out = pjoin(self.tmpdir, 'events_decayed.lhe')
+        misc.gzip(self._reader_path(writer), stdout=out)
+        return out + '.gz'
+
+    def test_round_trip_without_ms_dir(self):
+        import gzip as gziplib
+        out = self._round_trip(self._options(curr_dir=self.evt_dir))
+        self.assertTrue(os.path.exists(out))
+        self.assertIn('LesHouchesEvents', gziplib.open(out, 'rt').read())
+
+    def test_round_trip_with_ms_dir(self):
+        """On the buggy code this raised FileNotFoundError -- after the whole
+        decay had already been done."""
+        import gzip as gziplib
+        out = self._round_trip(self._options(ms_dir=self.ms_dir,
+                                             curr_dir=self.evt_dir))
+        self.assertTrue(os.path.exists(out))
+        self.assertIn('LesHouchesEvents', gziplib.open(out, 'rt').read())
+
+    # ------------------------------------------------------------------
+    # nobody rebuilds the path by hand any more
+    # ------------------------------------------------------------------
+
+    def test_the_writer_opens_the_accessor(self):
+        source = inspect.getsource(madspin.decay_all_events.decaying_events)
+        self.assertIn('self.decayed_events_path', source)
+        self.assertNotIn(self.NAME, source)
+
+    def test_both_gzip_call_sites_use_the_accessor(self):
+        """This is what lets the round-trip tests above stand for the real read
+        sites: neither of them may rebuild the path from an option.
+
+        Read from the module file rather than through ``inspect.getsource`` on
+        the methods: ``do_launch`` is wrapped by ``misc.mute_logger`` and
+        getsource returns the decorator's body."""
+        with open(interface_madspin.__file__.replace('.pyc', '.py')) as fsock:
+            source = fsock.read()
+        self.assertEqual(
+            source.count('misc.gzip(generate_all.decayed_events_path'), 2,
+            'do_launch and run_from_pickle must both ask the writer where the '
+            'decayed events are')
+        self.assertNotIn("pjoin(self.options['curr_dir'],'%s')" % self.NAME,
+                         source)
+
+    def test_the_accessor_is_not_derived_from_path_me(self):
+        """path_me is the matrix-element directory; the guard is here because
+        making the traceback go away by pointing the *reader* at path_me is the
+        tempting wrong fix."""
+        source = inspect.getsource(
+            madspin.decay_all_events.decayed_events_path.fget)
+        code = source.split('"""')[-1]
+        self.assertNotIn('path_me', code)
+        self.assertIn("curr_dir", code)
+
+
 class TestZeroDensityGuard(unittest.TestCase):
     """The guards that turn a MadSpin accept/reject which can never accept into
     an immediate, named failure instead of an unbounded retry loop.


### PR DESCRIPTION
`spinmode madspin_v1` with `ms_dir` decayed correctly — BR = 1, every event written, correct `<init>` — and then died at the very last step:

```
File "MadSpin/interface_madspin.py", line 1663, in do_launch
    misc.gzip(pjoin(self.options['curr_dir'],'decayed_events.lhe'), ...)
FileNotFoundError: .../dbg2/decayed_events.lhe
```

with the file sitting in `gridpack/decayed_events.lhe`. Loud rather than dangerous — no wrong number ever reaches a result — but it wastes the whole run and makes `madspin_v1` + `ms_dir` unusable.

## The trigger is narrower than first reported

The first reproduction attempt **failed**: `madspin_v1` + `ms_dir` completed cleanly. The reason is `MadSpinOptions.post_set_ms_dir`, which sets `curr_dir := ms_dir` as a side effect, so with the usual card ordering (`import` first, then `set ms_dir`) the two agree and there is no bug.

It reproduces when the event file is imported **after** `set ms_dir`, because `do_import` points `curr_dir` back at the event file's directory:

```
DEBUG-WRITE path_me='.../dbg2/gridpack'  curr_dir_opt='.../dbg2'
DEBUG-READ  curr_dir='.../dbg2'          exists=False
```

`run_from_pickle` has the same defect and is reachable **only** with `ms_dir` set, so it is permanently one card-ordering away from it. Confirmed failing on base too, via a second run against an existing gridpack.

## Which end is correct

`decaying_events` opened `pjoin(self.path_me, 'decayed_events.lhe')`; both callers gzipped `pjoin(self.options['curr_dir'], 'decayed_events.lhe')`. **`curr_dir` is right, so the writer is what changed:**

- `path_me` means "where the matrix-element directories live" at every one of its ~40 other uses (`production_me`/`full_me`/`decay_me`, `decay_<pdg>_<i>`, `ms_wstatus_*`, `param_card.dat`, `seeds.dat`). Under `ms_dir` it is built once and reused — possibly shared — by later runs; per-run event output does not belong there.
- `do_import`'s own comment calls `curr_dir` "directory where to write the output".
- In the **non-`ms_dir`** case `path_me` is *defined* as `realpath(curr_dir)`, so the change is a no-op there. That coincidence is exactly why this stayed hidden.
- Pointing the *reader* at `path_me` would have silenced the traceback and left events inside the gridpack — the tempting wrong fix.

Both ends now go through one accessor, `decay_all_events.decayed_events_path`, so they cannot drift again. It reads the location off `self.mscmd.options` (the **live** interface) rather than `self.options`, because under `ms_dir` the writer is restored from `madspin.pkl` and its own options — pickled with the gridpack — still describe the run that *built* it, `curr_dir` included. `run_from_pickle` re-points `mscmd` at the live interface before `ending_run()`, so this is sound.

## Neighbouring paths — checked, no change needed

- **Density spinmodes (`PA`/`onshell`/`madspin`) and `onshell_v1`** go through `run_onshell`, which constructs `decay_all_events_density`/`_onshell` only as ME evaluators — `run()`/`decaying_events()` is never called, so `decayed_events.lhe` never exists for them. Output is written to and gzipped from the same local `base_out`. No mismatch possible.
- **`spinmode none`** (`run_bridge`) writes `orig_lhe.name.replace(...)` directly as `.gz`, no intermediate file.
- Dead code noted, not touched: `decay_all_events.__init__` sets `self.curr_dir = os.getcwd()`, never read (and not the same thing as `options['curr_dir']`).
- **One genuine latent issue found in passing, not fixed and tracked separately**: `do_launch` archives the MadSpin card from `pjoin(curr_dir, 'Cards', 'madspin_card.dat')`, which under any `ms_dir` run points inside the gridpack — so `madspin_card_for_<run>.dat` is silently never archived.

## Verification

`p p > t t~`, both tops decayed:

| case | base | fixed |
|---|---|---|
| `madspin_v1` + ms_dir, import after `set ms_dir` (`do_launch`) | `FileNotFoundError` | exit 0, 100/100, BR 1 |
| same, second run reusing the gridpack (`run_from_pickle`) | `FileNotFoundError`, file left in `gridpack/` | exit 0, 100/100, BR 1 |
| `madspin_v1`, **no** ms_dir | exit 0 | exit 0, output **byte-identical** |
| `spinmode madspin` (density) | exit 0 | exit 0, output **byte-identical** |

Both byte-comparisons are exact apart from the one banner line recording the input file's path, which differs only because the runs live in different directories.

## Regression test

New `TestDecayedEventsPath` (11 tests), no MadEvent round trip. It drives a real `MadSpinOptions` so the `post_set_ms_dir` -> `do_import` interaction that creates the mismatch is produced by production code rather than simulated, and asserts writer path == reader path for the non-`ms_dir` case, the `ms_dir == curr_dir` case and the broken `ms_dir != curr_dir` case; that the file lands in `curr_dir` and not in `path_me`; that the path follows the live interface rather than pickled options; a real write-then-`misc.gzip` round trip for both cases; and source pins that neither gzip site rebuilds the path.

Not vacuous, checked both ways:
- against base code (fix stashed, tests kept): **9 errors + 2 failures**;
- against a counterfactual "wrong end" fix (accessor returning `path_me`): **3 failures**, including `test_the_output_goes_to_curr_dir_and_not_into_the_ms_dir`.

`tests/test_manager.py test_madspin -t0`: baseline re-measured with `git stash` = **242 OK**; with the change = **253 OK**.

## Relation to #364

Merges cleanly. #364 inserts its `_check_branching_ratio` call immediately after the line changed here, and the composed `decaying_events` contains both correctly. The two are orthogonal — #364 is about the branching-ratio *value*, this is about the output *location*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure MadSpin writes, packages, and archives per-run outputs in the directories associated with the active run.

Bug Fixes:
- Write and read legacy MadSpin decayed events from the run output directory, preventing failures when `ms_dir` and `curr_dir` differ.
- Archive the MadSpin card used by both fresh runs and gridpack reruns, including runs with packaged material.

Enhancements:
- Centralize decayed-event path resolution and MadSpin card discovery to keep output and archival call sites consistent.

Tests:
- Add regression coverage for decayed-event locations, live-versus-pickled run state, gzip round trips, card discovery, and card archival across run configurations.