### PR TITLE
MadSpin: archive the card that actually ran, including under ms_dir

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -623,7 +623,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         self.err_branching_ratio = 0
         self.me_run_name = "" # Events diretory name where to stotre the events (used by madevent) not use internally
         self.all_iden = {}
-        
+        # The card this run executes, and the directory do_import derives from
+        # the event file. Both are what madspin_card_path archives from; set
+        # before the do_import below, which fills the second one in.
+        self.ms_card_path = None
+        self.event_base_dir = None
+
         if event_path:
             logger.info("Extracting the banner ...")
             self.do_import(event_path)
@@ -731,9 +736,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         # change directory where to write the output
         self.options['curr_dir'] = os.path.realpath(os.path.dirname(inputfile))
         if os.path.basename(os.path.dirname(os.path.dirname(inputfile))) == 'Events':
-            self.options['curr_dir'] = pjoin(self.options['curr_dir'], 
+            self.options['curr_dir'] = pjoin(self.options['curr_dir'],
                                                       os.path.pardir, os.pardir)
-        
+        # Keep that directory -- the process root when the events sit in
+        # Events/<run>/, the event file's own directory otherwise -- under a
+        # name of its own. 'set ms_dir' re-points curr_dir at the gridpack
+        # (post_set_ms_dir), so curr_dir stops answering "where did these
+        # events come from" as soon as a card mentions ms_dir after the import.
+        # See madspin_card_path.
+        self.event_base_dir = self.options['curr_dir']
+
         if not os.path.exists(inputfile):
             if inputfile.endswith('.gz'):
                 if not os.path.exists(inputfile[:-3]):
@@ -1503,6 +1515,99 @@ class MadSpinInterface(extended_cmd.Cmd):
                 return tag
         return groups['tags'][-1]
 
+    ############################################################################
+    ##  Archiving the card that was actually run                              ##
+    ############################################################################
+
+    def import_command_file(self, filepath):
+        """Execute a MadSpin card, remembering which file it came from.
+
+        That file is the record of what this run did, and it is the only thing
+        that knows where the card lives: the card is handed in from outside
+        (MadEvent's ``do_decay_events`` passes
+        ``<me_dir>/Cards/madspin_card.dat``) and is under no obligation to sit
+        anywhere in particular. ``madspin_card_path`` archives it next to the
+        decayed events.
+        """
+        if isinstance(filepath, str):
+            self.ms_card_path = os.path.realpath(filepath)
+        return super(MadSpinInterface, self).import_command_file(filepath)
+
+    @property
+    def madspin_card_path(self):
+        """The MadSpin card this run executed, or None when there is no file to
+        archive (an interactive session types its commands; it has no card).
+
+        This is the single place that answers "which card was run", so that the
+        copy kept beside the events cannot name a different file from the one
+        the interface obeyed. Two sources, in order:
+
+        1. the file handed to :meth:`import_command_file` -- literally the card
+           the user edited for this run, wherever it happens to live. Every
+           driver runs MadSpin this way;
+        2. ``Cards/madspin_card.dat`` under ``event_base_dir``, the directory
+           ``do_import`` derived from the event file -- for a session driven
+           line by line that nonetheless runs inside a process directory.
+
+        What it deliberately does not use is ``self.options['curr_dir']``,
+        which is what the archiving used to be built from. ``curr_dir`` says
+        where this run's *output* goes -- that is its meaning at every other
+        use site, and what #365 pinned it to for the decayed events -- and
+        ``post_set_ms_dir`` re-points it at the gridpack. So
+        ``pjoin(curr_dir, 'Cards', 'madspin_card.dat')`` named the real card
+        only when the card happened to say ``set ms_dir`` *before* importing
+        the events, ``do_import`` then pointing curr_dir back at them. In the
+        other ordering -- the one MadEvent always produces, since it imports
+        the events in the constructor and reads the card afterwards -- it named
+        ``<ms_dir>/Cards/madspin_card.dat``, which MadSpin never creates, and
+        the archiving was skipped without a word. See
+        tests/unit_tests/madspin, class TestMadSpinCardArchive.
+        """
+        if self.ms_card_path and os.path.exists(self.ms_card_path):
+            return self.ms_card_path
+        if self.event_base_dir:
+            path = pjoin(self.event_base_dir, 'Cards', 'madspin_card.dat')
+            if os.path.exists(path):
+                return path
+        return None
+
+    def _archive_madspin_card(self, decayed_evt_file):
+        """Keep the card that produced ``decayed_evt_file`` next to it.
+
+        Shared by ``do_launch`` and ``run_from_pickle`` so that the gridpack
+        path -- the one reached on every rerun against an existing ``ms_dir``,
+        and hence the one where losing the card is most likely -- archives the
+        same file, from the same source, as a fresh run.
+
+        Returns the path written, or None when there was no card to copy.
+        """
+        ms_card_path = self.madspin_card_path
+        if not ms_card_path:
+            return None
+
+        run_dir = os.path.realpath(os.path.dirname(decayed_evt_file))
+        packed = os.path.exists(pjoin(run_dir, 'RunMaterial.tar.gz'))
+        if packed:
+            misc.call(['tar', '-xzpf', 'RunMaterial.tar.gz'], cwd=run_dir)
+            base_path = pjoin(run_dir, 'RunMaterial')
+        else:
+            base_path = run_dir
+
+        evt_name = os.path.basename(decayed_evt_file).replace('.lhe', '')
+        ms_card_to_copy = pjoin(base_path, 'madspin_card_for_%s.dat' % evt_name)
+        count = 0
+        while os.path.exists(ms_card_to_copy):
+            count += 1
+            ms_card_to_copy = pjoin(base_path, 'madspin_card_for_%s_%d.dat' %
+                                                              (evt_name, count))
+        files.cp(str(ms_card_path), str(ms_card_to_copy))
+
+        if packed:
+            misc.call(['tar', '-czpf', 'RunMaterial.tar.gz', 'RunMaterial'],
+                                                                    cwd=run_dir)
+            shutil.rmtree(pjoin(run_dir, 'RunMaterial'))
+        return ms_card_to_copy
+
     @misc.mute_logger()
     def do_launch(self, line):
         """end of the configuration launched the code"""
@@ -1667,29 +1772,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         if not self.mother:
             logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
 
-        # Now arxiv the shower card used if RunMaterial is present
-        ms_card_path = pjoin(self.options['curr_dir'],'Cards','madspin_card.dat')
-        run_dir = os.path.realpath(os.path.dirname(decayed_evt_file))
-        if os.path.exists(ms_card_path):
-            if os.path.exists(pjoin(run_dir,'RunMaterial.tar.gz')):
-                misc.call(['tar','-xzpf','RunMaterial.tar.gz'], cwd=run_dir)
-                base_path = pjoin(run_dir,'RunMaterial')
-            else:
-                base_path = pjoin(run_dir)
-
-            evt_name = os.path.basename(decayed_evt_file).replace('.lhe', '')
-            ms_card_to_copy = pjoin(base_path,'madspin_card_for_%s.dat'%evt_name)
-            count = 0    
-            while os.path.exists(ms_card_to_copy):
-                count += 1
-                ms_card_to_copy = pjoin(base_path,'madspin_card_for_%s_%d.dat'%\
-                                                               (evt_name,count))
-            files.cp(str(ms_card_path),str(ms_card_to_copy))
-            
-            if os.path.exists(pjoin(run_dir,'RunMaterial.tar.gz')):
-                misc.call(['tar','-czpf','RunMaterial.tar.gz','RunMaterial'], 
-                                                                    cwd=run_dir)
-                shutil.rmtree(pjoin(run_dir,'RunMaterial'))
+        # Now arxiv the madspin card used (inside RunMaterial if present)
+        self._archive_madspin_card(decayed_evt_file)
         self._log_lhe_timers()
 
     def run_from_pickle(self):
@@ -1783,6 +1867,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         misc.gzip(generate_all.decayed_events_path, stdout=decayed_evt_file)
         if not self.mother:
             logger.info("Decayed events have been written in %s.gz" % decayed_evt_file)
+
+        # ... and the card goes with them here too. Rerunning against an
+        # existing ms_dir is a *rerun*: it produces its own event file, from its
+        # own card, and archived nothing at all before -- do_launch returns here
+        # long before reaching its own copy of this call.
+        self._archive_madspin_card(decayed_evt_file)
     
     
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5232,6 +5232,299 @@ class TestDecayedEventsPath(unittest.TestCase):
         self.assertIn("curr_dir", code)
 
 
+class TestMadSpinCardArchive(unittest.TestCase):
+    """MadSpin keeps a copy of the card it ran next to the events it produced
+    (``madspin_card_for_<events>.dat``). That copy is the record of what was
+    actually run, and its absence is only noticed much later, by whoever tries
+    to reproduce the result.
+
+    The source used to be ``pjoin(self.options['curr_dir'], 'Cards',
+    'madspin_card.dat')``, and ``curr_dir`` does not mean that. It is where the
+    run's *output* goes (that is what #365 pinned it to for the decayed
+    events), and ``MadSpinOptions.post_set_ms_dir`` re-points it at the
+    gridpack. ``do_import`` points it back at the event file, so the card
+    *ordering* decided whether the archiving worked:
+
+      set ms_dir ... ; import events   -> curr_dir is the process dir  -> worked
+      import events ; set ms_dir ...   -> curr_dir is the ms_dir       -> silent
+
+    and the second is the ordering MadEvent always produces, because
+    ``do_decay_events`` imports the event file in the ``MadSpinInterface``
+    constructor and only then runs the card. So *every* MadEvent run whose
+    madspin_card.dat says ``set ms_dir`` lost its card, with no warning: the
+    guard was ``if os.path.exists(ms_card_path)``, and MadSpin never creates a
+    ``Cards`` directory inside an ms_dir, so the whole block was skipped.
+
+    The fix is to stop deriving the card from an output directory at all and
+    ask which card was *run* -- ``MadSpinInterface.madspin_card_path``. These
+    tests drive the real ``MadSpinOptions`` and the real ``do_import``, so the
+    ``post_set_ms_dir`` -> ``do_import`` interaction that creates the mismatch
+    is produced by production code rather than imitated here, and they pin the
+    two orderings *to each other* so neither end can drift again.
+    """
+
+    class _Interface(interface_madspin.MadSpinInterface):
+        """A MadSpinInterface carrying only the state the methods under test
+        touch. Subclassed, not faked: ``do_import``, ``import_command_file``,
+        ``madspin_card_path`` and ``_archive_madspin_card`` are the production
+        ones. ``__init__`` is skipped because building the real interface pulls
+        in a MasterCmd and a model, neither of which has any say in which card
+        gets archived."""
+
+        def __init__(self, options):
+            self.options = options
+            self.ms_card_path = None
+            self.event_base_dir = None
+            self.mother = None
+            self.child = None
+            self.stored_line = None
+            self.history = []
+            self.inputfile = None
+            self.use_rawinput = False
+
+    CARD = '# the card this run actually used\nset spinmode madspin_v1\n'
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_card_archive_')
+        self.proc = pjoin(self.tmpdir, 'PROC')
+        self.run_dir = pjoin(self.proc, 'Events', 'run_01')
+        self.ms_dir = pjoin(self.tmpdir, 'gridpack')
+        os.makedirs(pjoin(self.proc, 'Cards'))
+        os.makedirs(self.run_dir)
+        os.makedirs(self.ms_dir)
+        self.card = pjoin(self.proc, 'Cards', 'madspin_card.dat')
+        with open(self.card, 'w') as fsock:
+            fsock.write(self.CARD)
+        # the event file need not exist: do_import decides the directories
+        # before it looks at the file (see _import_events)
+        self.events = pjoin(self.run_dir, 'unweighted_events.lhe')
+        self.decayed = pjoin(self.run_dir, 'unweighted_events_decayed.lhe')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # helpers -- everything below goes through production code
+    # ------------------------------------------------------------------
+
+    def _interface(self):
+        return self._Interface(interface_madspin.MadSpinOptions())
+
+    def _import_events(self, iface):
+        """Run the *real* ``do_import`` for its directory bookkeeping.
+
+        It sets ``curr_dir``/``event_base_dir`` in its first few lines and only
+        afterwards checks that the file is there, so pointing it at a file that
+        does not exist runs exactly the part under test and stops before the
+        banner and model reading that would need a whole MadEvent output."""
+        self.assertRaises(iface.InvalidCmd, iface.do_import, self.events)
+
+    def _set_ms_dir(self, iface):
+        """`set ms_dir` as a card does it -- post_set_ms_dir carries curr_dir
+        along, which is the whole reason the orderings differ."""
+        iface.options['ms_dir'] = self.ms_dir
+
+    def _ordering_madevent(self):
+        """import first, ms_dir second: the constructor imported the events and
+        the card then says `set ms_dir`. This is what MadEvent always does."""
+        iface = self._interface()
+        self._import_events(iface)
+        self._set_ms_dir(iface)
+        return iface
+
+    def _ordering_card_first(self):
+        """`set ms_dir` first, import second -- the ordering that happened to
+        work, and which must go on working."""
+        iface = self._interface()
+        self._set_ms_dir(iface)
+        self._import_events(iface)
+        return iface
+
+    # ------------------------------------------------------------------
+    # the interaction that made this invisible really is there
+    # ------------------------------------------------------------------
+
+    def test_the_two_orderings_really_do_disagree_about_curr_dir(self):
+        """The premise of everything below, asserted rather than assumed.
+
+        It doubles as the guard against the other tempting wrong fix: making
+        ``post_set_ms_dir`` stop moving ``curr_dir``. That would silence this
+        bug and break the decayed-events path of #365, which needs curr_dir to
+        follow ms_dir when the card sets no event file after it."""
+        after = self._ordering_madevent()
+        before = self._ordering_card_first()
+        self.assertEqual(os.path.realpath(after.options['curr_dir']),
+                         os.path.realpath(self.ms_dir))
+        self.assertEqual(os.path.realpath(before.options['curr_dir']),
+                         os.path.realpath(self.proc))
+        # ...and the old expression is exactly what that breaks
+        self.assertFalse(os.path.exists(
+            pjoin(after.options['curr_dir'], 'Cards', 'madspin_card.dat')))
+
+    # ------------------------------------------------------------------
+    # the card is found whatever the ordering
+    # ------------------------------------------------------------------
+
+    def test_the_card_is_found_in_the_madevent_ordering(self):
+        """The regression: this returned a path inside the gridpack, which does
+        not exist, so nothing was archived and nothing was said."""
+        iface = self._ordering_madevent()
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    def test_the_card_is_found_in_the_card_first_ordering(self):
+        iface = self._ordering_card_first()
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    def test_the_ordering_cannot_change_the_answer(self):
+        """The pin: the two orderings are tied to each other, not each to a
+        literal, so no future edit can re-open the gap on one side only."""
+        self.assertEqual(
+            os.path.realpath(self._ordering_madevent().madspin_card_path),
+            os.path.realpath(self._ordering_card_first().madspin_card_path))
+
+    def test_without_ms_dir_the_card_is_still_found(self):
+        """The case that breaks if the fix is made at the wrong end -- by far
+        the most common way MadSpin is run."""
+        iface = self._interface()
+        self._import_events(iface)
+        self.assertEqual(iface.options['ms_dir'], '')
+        self.assertEqual(os.path.realpath(iface.madspin_card_path),
+                         os.path.realpath(self.card))
+
+    # ------------------------------------------------------------------
+    # ...and it is the card that was *run*
+    # ------------------------------------------------------------------
+
+    def test_import_command_file_records_the_card_it_runs(self):
+        """``import_command_file`` is how every driver hands MadSpin a card,
+        and the path it is given is the only thing that knows where the card
+        lives. Run the real method on an empty card so nothing is executed."""
+        elsewhere = pjoin(self.tmpdir, 'my_own_card.dat')
+        open(elsewhere, 'w').close()
+        iface = self._interface()
+        iface.import_command_file(elsewhere)
+        self.assertEqual(iface.ms_card_path, os.path.realpath(elsewhere))
+
+    def test_a_card_from_elsewhere_wins_over_the_process_directory(self):
+        """MadEvent passes ``<me_dir>/Cards/madspin_card.dat`` so the two agree
+        there, but a card handed in from anywhere else is still *the* card that
+        was run, and is what must be archived."""
+        elsewhere = pjoin(self.tmpdir, 'my_own_card.dat')
+        with open(elsewhere, 'w') as fsock:
+            fsock.write('# a card that lives somewhere else\n')
+        iface = self._ordering_madevent()
+        iface.ms_card_path = os.path.realpath(elsewhere)
+        self.assertEqual(iface.madspin_card_path, os.path.realpath(elsewhere))
+
+    def test_no_card_means_no_archive_rather_than_a_wrong_one(self):
+        """An interactive session types its commands; there is no file to keep.
+        Returning None (and archiving nothing) is the honest answer -- better
+        than reaching for whatever madspin_card.dat happens to be nearby."""
+        iface = self._interface()
+        self._import_events(iface)
+        os.remove(self.card)
+        self.assertIsNone(iface.madspin_card_path)
+        self.assertIsNone(iface._archive_madspin_card(self.decayed))
+        self.assertEqual([f for f in os.listdir(self.run_dir)
+                          if f.startswith('madspin_card_for_')], [])
+
+    # ------------------------------------------------------------------
+    # a real archiving round trip
+    # ------------------------------------------------------------------
+
+    def test_the_archive_holds_the_card_that_was_run(self):
+        """What the user goes looking for months later: the file is there, it
+        is named after the events, and its content is the card."""
+        iface = self._ordering_madevent()
+        written = iface._archive_madspin_card(self.decayed)
+        self.assertEqual(
+            os.path.realpath(written),
+            os.path.realpath(pjoin(
+                self.run_dir,
+                'madspin_card_for_unweighted_events_decayed.dat')))
+        self.assertTrue(os.path.exists(written))
+        self.assertEqual(open(written).read(), self.CARD)
+
+    def test_both_orderings_archive_the_same_bytes(self):
+        first = self._ordering_madevent()._archive_madspin_card(self.decayed)
+        second = self._ordering_card_first()._archive_madspin_card(self.decayed)
+        self.assertNotEqual(first, second)   # the counter kept them apart
+        self.assertEqual(open(first).read(), open(second).read())
+
+    def test_a_second_run_does_not_overwrite_the_first(self):
+        """Rerunning against an existing ms_dir writes a new event file into the
+        same directory; its card must not silently replace the earlier one."""
+        iface = self._ordering_madevent()
+        first = iface._archive_madspin_card(self.decayed)
+        with open(self.card, 'w') as fsock:
+            fsock.write('# a different card, second run\n')
+        second = iface._archive_madspin_card(self.decayed)
+        self.assertTrue(second.endswith(
+            'madspin_card_for_unweighted_events_decayed_1.dat'))
+        self.assertEqual(open(first).read(), self.CARD)
+        self.assertEqual(open(second).read(), '# a different card, second run\n')
+
+    def test_the_archive_goes_inside_RunMaterial_when_there_is_one(self):
+        """aMC@NLO runs keep their cards inside RunMaterial.tar.gz; the copy
+        must end up in the tarball, not loose beside it."""
+        os.makedirs(pjoin(self.run_dir, 'RunMaterial'))
+        misc.call(['tar', '-czpf', 'RunMaterial.tar.gz', 'RunMaterial'],
+                  cwd=self.run_dir)
+        shutil.rmtree(pjoin(self.run_dir, 'RunMaterial'))
+        iface = self._ordering_madevent()
+        iface._archive_madspin_card(self.decayed)
+        self.assertFalse(os.path.exists(pjoin(
+            self.run_dir, 'madspin_card_for_unweighted_events_decayed.dat')))
+        misc.call(['tar', '-xzpf', 'RunMaterial.tar.gz'], cwd=self.run_dir)
+        inside = pjoin(self.run_dir, 'RunMaterial',
+                       'madspin_card_for_unweighted_events_decayed.dat')
+        self.assertTrue(os.path.exists(inside))
+        self.assertEqual(open(inside).read(), self.CARD)
+
+    # ------------------------------------------------------------------
+    # nobody rebuilds the source by hand any more
+    # ------------------------------------------------------------------
+
+    def test_every_call_site_goes_through_the_helper(self):
+        """do_launch archived the card, run_from_pickle -- the path every rerun
+        against an existing ms_dir takes -- did not archive it at all. Both go
+        through one helper now, so they cannot disagree about what to keep or
+        about whether to keep it.
+
+        Read the module file rather than using ``inspect.getsource`` on the
+        methods: ``do_launch`` is wrapped by ``misc.mute_logger`` and getsource
+        returns the decorator's body."""
+        with open(interface_madspin.__file__.replace('.pyc', '.py')) as fsock:
+            source = fsock.read()
+        self.assertEqual(
+            source.count('self._archive_madspin_card(decayed_evt_file)'), 2,
+            'do_launch and run_from_pickle must both archive the card')
+        self.assertNotIn(
+            "pjoin(self.options['curr_dir'],'Cards','madspin_card.dat')",
+            source)
+
+    def test_the_accessor_does_not_look_at_curr_dir(self):
+        """curr_dir is an output directory. Rebuilding the card's location from
+        it is the mistake being fixed, and it is the tempting one because it
+        works in every setup that has no ms_dir."""
+        source = inspect.getsource(
+            interface_madspin.MadSpinInterface.madspin_card_path.fget)
+        code = source.split('"""')[-1]
+        self.assertNotIn('curr_dir', code)
+        self.assertIn('ms_card_path', code)
+        self.assertIn('event_base_dir', code)
+
+    def test_do_import_keeps_the_directory_under_its_own_name(self):
+        """``event_base_dir`` exists so that the answer survives a later
+        ``set ms_dir``; if do_import ever stopped setting it the fallback would
+        quietly go back to finding nothing."""
+        source = inspect.getsource(interface_madspin.MadSpinInterface.do_import)
+        self.assertIn('self.event_base_dir', source)
+
+
 class TestZeroDensityGuard(unittest.TestCase):
     """The guards that turn a MadSpin accept/reject which can never accept into
     an immediate, named failure instead of an unbounded retry loop.


### PR DESCRIPTION
**Stacked on #365**, which fixed the sibling bug in the same `curr_dir`/`path_me` family and introduced the single-accessor pattern followed here. Composes cleanly with #364.

`do_launch` archived the MadSpin card from `pjoin(curr_dir, 'Cards', 'madspin_card.dat')`. Under an `ms_dir` run `curr_dir` can point inside the gridpack, where no `Cards/` directory exists — and the block is guarded by `if os.path.exists(...)`, so the archive is skipped **in silence**. No warning, no log line (grepped a full run log for `madspin_card`/`RunMaterial`: zero hits).

## Sharper than first reported: it depends on card ordering

Not "any `ms_dir` run". The deciding factor is whether a `do_import` runs *after* `set ms_dir`. Reproduced end to end on the base (`p p > t t~`, both tops decayed, `spinmode madspin_v1`):

| how MadSpin was driven | `curr_dir` at archive time | archived card |
|---|---|---|
| MadEvent ordering (constructor imports events), no `ms_dir` | process dir | **present** |
| MadEvent ordering, card says `set ms_dir` | the gridpack | **absent** |
| card: `import` … then `set ms_dir` | the gridpack | **absent** |
| card: `set ms_dir` … then `import` | process dir | **present** |
| second run reusing the gridpack (`run_from_pickle`) | the gridpack | **absent** (never archived at all) |

The consequence that matters: **the losing ordering is the one MadEvent always produces.** `common_run_interface.do_decay_events` constructs `MadSpinInterface(args[0])`, which imports the event file in `__init__`, and only then runs `Cards/madspin_card.dat`. So every MadEvent run whose madspin card contains `set ms_dir` lost its card. Standalone cards lose it only when they import before setting `ms_dir`.

## Root cause and fix

`curr_dir` means "where this run's output goes" — its meaning at every other use site, and what #365 pinned it to for the decayed events. `post_set_ms_dir` re-points it at the gridpack; `do_import` points it back. Deriving the *card's* location from it was the same category error as #365, invisible whenever the two coincide.

Following #365, the source is now a single accessor, `MadSpinInterface.madspin_card_path`, answering "which card did this run execute": the file handed to `import_command_file` (recorded by a thin override — literally the card the user edited, and it need not live anywhere in particular), falling back to `Cards/madspin_card.dat` under `event_base_dir`, the directory `do_import` derived from the event file and now records under its own name so a later `set ms_dir` cannot move it. Nothing in the chain reads `curr_dir`.

The copying moved into `_archive_madspin_card(decayed_evt_file)`, called from `do_launch` **and** `run_from_pickle` — so the gridpack-reuse path, which archived nothing at all before, now archives the same file from the same source.

## Neighbouring archiving — surveyed

- `run_from_pickle` (every rerun against an existing `ms_dir`) had **no** archiving code. Confirmed by running the base twice against one gridpack. Fixed here.
- `run_bridge` (`spinmode none`) and `run_onshell` (`onshell`, `onshell_v1`, `PA`, and the density `madspin`/`full`) never archive the card. **Left unchanged, but worth flagging**: in upstream 3.x the default `madspin`/`full` fell through to `do_launch` and *did* archive; this fork routes it to `run_onshell`, so the default mode quietly stopped keeping the card. That is a wider behaviour change than this fix, so it is reported rather than made, and tracked separately.
- Pre-existing quirk, unchanged: the archive lands in `dirname(decayed_evt_file)`, the *production* run directory, while `do_decay_events` afterwards moves only the LHE into the new `<run>_decayed_N` directory — so the card copy stays behind with the production run.
- Mitigating context: in the MadEvent flow the card also survives in the decayed run's banner (`<madspin>` block via `banner.add(path)`, verified on an existing decayed run). The loss is total only for standalone MadSpin.

## Verification

- After the fix all four orderings archive, and the archived bytes are `diff`-identical to the card that was run; the gridpack-reuse run adds `..._decayed_1.dat` rather than overwriting.
- The **non-`ms_dir`** path still archives correctly — the case that breaks if the fix is made at the wrong end.
- `tests/test_manager.py test_madspin -t0`: baseline re-measured with `git stash` = **253 OK**; after = **268 OK** (new `TestMadSpinCardArchive`, 15 tests).
- The tests drive a real `MadSpinOptions` and the real `do_import`, so the `post_set_ms_dir` -> `do_import` interaction comes from production code rather than being simulated, and they tie the two orderings to each other rather than each to a literal.
- **Counterfactuals, all validated**: base interface + new tests -> 3 failures, 11 errors; a "fix" that shares the copying but still derives the card from `curr_dir` -> 8 failures/errors including the ordering pin; and the other tempting fix, stopping `post_set_ms_dir` from moving `curr_dir`, fails the premise test here **and** #365's `test_writer_and_reader_agree_when_ms_dir_is_curr_dir` — which is exactly why that fix is wrong.

## Not verified

The real `common_run_interface.do_decay_events` was not exercised end to end (no full MadEvent generation); its ordering was reproduced faithfully by constructing `MadSpinInterface(evt)` then `import_command_file(card)`, which is what that function does. The `RunMaterial.tar.gz` branch is covered by a unit test rather than a real aMC@NLO run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure MadSpin consistently archives the card used to generate each decayed event, including runs that use or reuse an `ms_dir` gridpack.

Bug Fixes:
- Archive the MadSpin card that was actually executed across `ms_dir` configurations, card-ordering variations, and gridpack-reuse runs.
- Preserve archived MadSpin cards inside `RunMaterial.tar.gz` when applicable and avoid overwriting cards from earlier runs.

Enhancements:
- Centralize MadSpin card discovery and archiving so the source is based on the executed card and event location rather than the mutable output directory.
- Add comprehensive regression coverage for card ordering, alternate card locations, interactive sessions, repeated runs, and packed run material.

Tests:
- Add unit tests covering MadSpin card discovery, archival behavior, reruns, and RunMaterial packaging.