### PR TITLE
MadSpin: make the density weight real at the source, not at the comparison

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -148,6 +148,61 @@ class MadSpinZeroBranchingRatio(madspin.MadSpinError):
 # positive weights, which do not count) is nil.
 MS_MAX_DEAD_TRIALS = 20000
 
+# How large the imaginary part of a density contraction may be, relative to its
+# real part, before it is reported. The contraction is real *by construction*
+# (see ms_density_real), so anything above float32 rounding is a bug and not a
+# tolerance to be widened: the density matrices are complex64, the packed index
+# set is closed under (h1,h2) -> (h2,h1), and the imaginary parts of the two
+# members of each pair are computed by the same operations in the opposite
+# order, so what survives the sum is the residue of an exact cancellation. On
+# `p p > t t~` with both tops decayed (53655 contractions) the largest ratio
+# measured was 1.5e-7, i.e. exactly float32 epsilon; 1e-3 leaves four orders of
+# margin over that and still catches an imaginary part that means anything.
+MS_DENSITY_IMAG_TOL = 1e-3
+
+# Reported once per site: a violation is a property of the setup (a non-hermitian
+# density matrix, a helicity basis mismatched between the two sides of the
+# contraction), so it repeats on every trial of every event once it happens.
+_MS_IMAG_REPORTED = set()
+
+
+def ms_density_real(value, what):
+    """The real part of a spin-density contraction, with its reality checked.
+
+    Contracting two hermitian density matrices over an index set closed under
+    (h1,h2) -> (h2,h1) -- which is what ``DensityMatrix`` stores, and what a
+    polarisation restriction preserves, since it masks the bra *and* the ket
+    helicity with the same set -- pairs every term with its own complex
+    conjugate. The sum is therefore real by construction, and what is discarded
+    here is float32 rounding, not physics.
+
+    That argument is only as good as its premises, so it is checked rather than
+    assumed: an imaginary part above ``MS_DENSITY_IMAG_TOL`` of the real part
+    means one of the two matrices is not hermitian, or the two are not in the
+    same helicity basis, and the number this returns is then not the matrix
+    element. Reported at CRITICAL (once per site) rather than raised, following
+    the weight-identity and ``density_debug`` checks: the run does produce
+    events, they are just not to be trusted, and silently dropping the evidence
+    is the one thing that must not happen.
+    """
+    imag = getattr(value, 'imag', None)
+    if imag is None:
+        return value              # not a number with a real/imaginary split
+    real = value.real             # a float/np.float32 keeps its own value here
+    if abs(imag) > MS_DENSITY_IMAG_TOL * abs(real) and what not in _MS_IMAG_REPORTED:
+        _MS_IMAG_REPORTED.add(what)
+        logger.critical(
+            "MadSpin: %s came out with a significant imaginary part "
+            "(%.6g + %.6gj, |Im|/|Re| = %.3g > %.3g). A contraction of two "
+            "hermitian density matrices in a common helicity basis is real by "
+            "construction, so this is not a rounding effect: the value used as "
+            "the accept/reject weight from here on is its real part only, and "
+            "the decayed events are not reliable.",
+            what, real, imag, abs(imag) / abs(real) if real else float('inf'),
+            MS_DENSITY_IMAG_TOL)
+    return real
+
+
 class MadSpinOptions(banner.ConfigFile):
 
     # Unweighting schemes that still work but are no longer offered to the
@@ -5342,6 +5397,16 @@ class MadSpinInterface(extended_cmd.Cmd):
         positive weights, occasionally accepted -- from ever reaching the bound.
         This catches the causes ``_check_production_density`` does not, e.g. a
         decay density matrix that is structurally zero.
+
+        ``math.isfinite`` and not ``numpy.isfinite``, deliberately: every weight
+        that reaches here is a real scalar (the density contraction has its real
+        part taken by ``ms_density_real``, and the sequential stages take theirs
+        at ``(n_k / n_prev).real``), so the coercion ``math.isfinite`` performs
+        is free -- and if a complex weight is ever reintroduced upstream this is
+        the line that says so, with a ComplexWarning naming the file and the
+        line. ``numpy.isfinite`` would accept it in silence, and ``wgt.real``
+        would discard the imaginary part without anyone finding out; neither is
+        an improvement on being told.
         """
         try:
             ok = math.isfinite(wgt) and wgt > 0
@@ -7756,8 +7821,17 @@ class MadSpinInterface(extended_cmd.Cmd):
                     dec_diag *= density_dec_tmp.trace().real
                 density_iden_decay *= color * spin
                 prod_color *= color
-                D = complex(0, mass * width)
-                prod_denominators *= (D * D.conjugate())
+                # |D|^2 of the propagator denominator D = i*m*Gamma at the pole.
+                # Written as the real number it is: D * conj(D) has the same
+                # value bit for bit, but it is a Python *complex*, and that type
+                # then rides through `denominator` into the accept/reject weight
+                # -- which is the whole reason the weight was ever complex.
+                # Nothing else in the chain introduces one: the density
+                # contraction below has its real part taken explicitly. Note
+                # `mw * mw` and not `mw ** 2`: pow() re-rounds, and the two
+                # differ in the last bit for about one value in 700.
+                mw = mass * width
+                prod_denominators *= mw * mw
             
 
             decaying_idx += N
@@ -7781,7 +7855,15 @@ class MadSpinInterface(extended_cmd.Cmd):
         # include production identical-final-state symmetry factor
         # ------------------------------------------------------------------
         denominator = iden_p * sym_factor_prod_ident * prod_color * prod_denominators * sym_factor_decay
-        me = me.real / denominator
+        # The bare `.real` this replaces was right but silent; ms_density_real
+        # returns the same number and says so if the premise it rests on -- two
+        # hermitian matrices contracted in one helicity basis -- ever fails.
+        # `denominator` is real now, so the weight this feeds is a real scalar
+        # all the way to the accept/reject rather than a complex one every
+        # consumer has to coerce back (which is what emitted the ComplexWarning
+        # from _dead_trial's math.isfinite).
+        me = ms_density_real(me, 'the production/decay density contraction') \
+             / denominator
 
         #print(f"production = {production}")
         #print(f"decays = {decays}")

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5379,3 +5379,259 @@ class TestReusedMsDirBranchingRatio(unittest.TestCase):
         self.assertIn('_check_branching_ratio(br', source)
         self.assertLess(source.index('_check_branching_ratio(br'),
                         source.index('self.branching_ratio = br'))
+
+
+
+class TestDensityContractionIsReal(unittest.TestCase):
+    """The accept/reject weight of the density spin modes is a *real* number,
+    and the code now says so.
+
+    Background. Every weight is built from ``rho_dec . rho_prod``, a sum over
+    the packed (h1,h2) index set of products of complex64 entries. That sum is
+    real by construction -- the index set is closed under (h1,h2) -> (h2,h1),
+    both matrices are hermitian, so each term appears together with its own
+    complex conjugate -- and what survives it is float32 rounding. Measured on
+    `p p > t t~` with both tops decayed (53655 contractions, joint unweighting):
+    24% of them had a non-zero imaginary part, and the largest |Im|/|Re| was
+    1.5e-7, i.e. float32 epsilon.
+
+    The weight that reached the accept/reject was nevertheless a *complex*
+    scalar with an exactly zero imaginary part, because the propagator
+    denominator was built as ``complex(0, m*Gamma) * conj(...)`` -- a real
+    number written in complex form -- and that type rode through the division.
+    ``math.isfinite`` in ``_dead_trial`` then coerced it back and emitted
+    "ComplexWarning: Casting complex values to real discards the imaginary
+    part" on every run of every density mode using the joint scheme.
+    """
+
+    # ---------------- the reality check itself ----------------
+
+    def test_a_negligible_imaginary_part_passes_through_as_the_real_part(self):
+        """The physical case: rounding residue of an exact cancellation. The
+        real part comes back unchanged and nothing is reported."""
+        import numpy as np
+        value = np.complex64(complex(43065.3125, -0.00048828125))  # measured
+        with _CaptureCritical() as reported:
+            got = interface_madspin.ms_density_real(value, 'a contraction')
+        self.assertEqual(got, value.real)
+        self.assertFalse(hasattr(got, 'imag') and got.imag)
+        self.assertEqual(reported.messages, [])
+
+    def test_an_exactly_real_value_passes_through(self):
+        with _CaptureCritical() as reported:
+            self.assertEqual(
+                interface_madspin.ms_density_real(complex(2.5, 0.0), 'x'), 2.5)
+        self.assertEqual(reported.messages, [])
+
+    def test_a_plain_float_is_returned_unchanged(self):
+        """The helper has to be safe on the paths whose weight is already real
+        (the sequential stages take their own ``.real``)."""
+        import numpy as np
+        with _CaptureCritical() as reported:
+            self.assertEqual(interface_madspin.ms_density_real(1.25, 'x'), 1.25)
+            self.assertEqual(
+                interface_madspin.ms_density_real(np.float32(0.5), 'x'), 0.5)
+        self.assertEqual(reported.messages, [])
+
+    def test_a_large_imaginary_part_is_reported_loudly(self):
+        """The part that must not be silent. A contraction with a real
+        imaginary part means a non-hermitian density matrix or two sides in
+        different helicity bases -- a bug, not a tolerance to widen."""
+        with _CaptureCritical() as reported:
+            got = interface_madspin.ms_density_real(complex(1.0, 0.5),
+                                                    'the test contraction')
+        self.assertEqual(got, 1.0)
+        self.assertEqual(len(reported.messages), 1)
+        msg = reported.messages[0]
+        self.assertIn('imaginary part', msg)
+        self.assertIn('the test contraction', msg)
+        self.assertIn('real by construction', msg)
+
+    def test_a_reported_imaginary_part_does_not_abort_the_run(self):
+        """Reported, not raised: the run still produces events (they are just
+        not to be trusted), which is what the weight-identity and
+        ``density_debug`` checks in this file do as well."""
+        with _CaptureCritical():
+            interface_madspin.ms_density_real(complex(1.0, 1.0), 'no-raise')
+
+    def test_a_vanishing_real_part_with_an_imaginary_one_is_reported(self):
+        """No ZeroDivisionError on the way to the message: a zero weight is
+        exactly the state the dead-trial guards are watching for, so this path
+        has to survive it."""
+        with _CaptureCritical() as reported:
+            got = interface_madspin.ms_density_real(complex(0.0, 1e-30), 'z')
+        self.assertEqual(got, 0.0)
+        self.assertEqual(len(reported.messages), 1)
+
+    def test_the_tolerance_leaves_room_over_float32_rounding(self):
+        """The measured worst case was 1.5e-7 (float32 epsilon). The bound has
+        to sit far above that and far below anything that means something."""
+        self.assertGreater(interface_madspin.MS_DENSITY_IMAG_TOL, 1e-5)
+        self.assertLess(interface_madspin.MS_DENSITY_IMAG_TOL, 1e-1)
+        with _CaptureCritical() as reported:
+            for exponent in range(7, 12):
+                interface_madspin.ms_density_real(complex(1.0, 10.0 ** -exponent),
+                                                  'tol %d' % exponent)
+        self.assertEqual(reported.messages, [])
+
+    def test_each_site_is_reported_once(self):
+        """A broken basis repeats on every trial of every event; one line, not
+        millions."""
+        with _CaptureCritical() as reported:
+            for _ in range(50):
+                interface_madspin.ms_density_real(complex(1.0, 1.0), 'one site')
+        self.assertEqual(len(reported.messages), 1)
+
+    # ---------------- the propagator denominator ----------------
+
+    def test_the_real_propagator_denominator_is_bit_identical(self):
+        """``prod_denominators`` used to be accumulated as
+        ``complex(0, m*Gamma) * conj(complex(0, m*Gamma))``: the value |D|^2 of
+        a real number written in complex form. Replacing it by ``mw * mw`` is
+        what makes the weight real, and it is only a legitimate replacement if
+        it changes no bit of any weight -- which is why the decayed output of a
+        real run is byte-identical across the change. Pin that.
+
+        ``mw ** 2`` is NOT the same thing: pow() re-rounds and differs from the
+        product in the last bit for roughly one value in 700, which would move
+        weights and so move the accepted events."""
+        import struct
+        bits = lambda x: struct.pack('<d', x)
+        differs_under_pow = 0
+        values = [173.0 * 1.5, 80.379 * 2.085, 91.1876 * 2.4952,
+                  1e-30, 1e12, 4.7, 0.0, 1.0]
+        import random as _random
+        random_ = _random.Random(20250819)
+        values += [random_.uniform(1e-12, 1e6) for _ in range(20000)]
+        for mw in values:
+            old = (complex(0, mw) * complex(0, mw).conjugate())
+            self.assertEqual(old.imag, 0.0)
+            self.assertEqual(bits(old.real), bits(mw * mw))
+            if bits(old.real) != bits(mw ** 2):
+                differs_under_pow += 1
+        self.assertGreater(differs_under_pow, 0,
+                           'if pow() ever becomes exact here the comment above '
+                           'is stale, but mw*mw stays the safe spelling')
+
+    def test_the_denominator_is_no_longer_built_as_a_complex(self):
+        """The single ``complex(...)`` construction in the density weight was
+        the only reason it was ever complex; keep it gone."""
+        source = inspect.getsource(
+            interface_madspin.MadSpinInterface.calculate_matrix_element_from_density)
+        self.assertNotIn('complex(0,', source.replace(' ', ''))
+        self.assertIn('mw * mw', source)
+        self.assertIn('ms_density_real(me', source)
+
+    # ---------------- what _dead_trial accepts ----------------
+
+    def _dead_trial_stub(self):
+        interface = interface_madspin.MadSpinInterface
+        class Stub(object):
+            _dead_trial = interface._dead_trial
+            _raise_degenerate_weight = interface._raise_degenerate_weight
+        return Stub()
+
+    def test_dead_trial_verdicts_are_unchanged_by_the_weight_becoming_real(self):
+        """The invariant the fix must not disturb: exactly the weights that
+        reset the counter before still reset it, and exactly those that were
+        counted as dead still are -- whether they arrive as a python float, as
+        the numpy real scalar the density path now produces, or as the numpy
+        complex scalar with a negligible imaginary part it used to produce."""
+        import numpy as np
+        import warnings
+        stub = self._dead_trial_stub()
+        alive = [1.0, 1e-12, 1e30, 3.5]
+        dead = [0.0, -0.0, -1.0, float('nan'), float('inf'), -float('inf')]
+        # the complex entries below coerce on purpose; that they do is the
+        # subject of the two tests underneath, not noise this one has to print
+        cm = warnings.catch_warnings()
+        cm.__enter__()
+        self.addCleanup(cm.__exit__, None, None, None)
+        warnings.simplefilter('ignore')
+        for value in alive:
+            for wgt in (value, np.float32(value), np.float64(value),
+                        np.complex64(complex(value, 0.0)),
+                        np.complex64(complex(value, 1e-9 * value))):
+                self.assertEqual(stub._dead_trial(17, wgt, 'x'), 0,
+                                 'a positive weight must reset: %r' % (wgt,))
+        for value in dead:
+            for wgt in (value, np.float32(value), np.float64(value),
+                        np.complex64(complex(value, 0.0))):
+                self.assertEqual(stub._dead_trial(0, wgt, 'x'), 1,
+                                 'a dead weight must count: %r' % (wgt,))
+
+    def test_a_python_complex_weight_would_be_counted_as_dead(self):
+        """A sharp edge worth knowing about rather than discovering. A *numpy*
+        complex scalar defines ``__float__`` and so survives ``math.isfinite``
+        (with the ComplexWarning); a plain python ``complex`` does not, the
+        ``except TypeError`` branch takes over, and the trial is scored dead --
+        which after MS_MAX_DEAD_TRIALS in a row would abort a healthy run.
+
+        It is unreachable today, and the fix makes it more so: the weight is
+        built from numpy scalars, so a python complex never wins the mixed
+        arithmetic. Pinned so that a future change which does hand one over is
+        seen for what it is instead of surfacing as a mystery
+        MadSpinDegenerateWeight."""
+        stub = self._dead_trial_stub()
+        self.assertEqual(stub._dead_trial(17, complex(1.0, 0.0), 'x'), 18)
+
+    def test_dead_trial_does_not_coerce_the_weights_the_code_now_produces(self):
+        """The warning the user saw, pinned from the other side: the real
+        scalars the density path hands over must reach ``math.isfinite``
+        without any complex-to-real cast at all."""
+        import warnings
+        import numpy as np
+        stub = self._dead_trial_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            for wgt in (1.0, np.float32(2.5), np.float64(0.0), -1.0):
+                stub._dead_trial(0, wgt, 'x')
+        self.assertEqual([w for w in caught
+                          if 'ComplexWarning' in w.category.__name__], [])
+
+    def test_dead_trial_still_reports_a_complex_weight_rather_than_hiding_it(self):
+        """``math.isfinite`` was kept on purpose over ``numpy.isfinite`` or an
+        explicit ``.real``: if a complex weight is ever reintroduced upstream,
+        this is the line that says so."""
+        import warnings
+        import numpy as np
+        stub = self._dead_trial_stub()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            stub._dead_trial(0, np.complex64(complex(1.0, 0.0)), 'x')
+        self.assertTrue([w for w in caught
+                         if 'ComplexWarning' in w.category.__name__],
+                        'a complex weight must not pass in silence')
+        source = inspect.getsource(interface_madspin.MadSpinInterface._dead_trial)
+        self.assertIn('math.isfinite(wgt)', source)
+
+
+class _CaptureCritical(object):
+    """Collect the CRITICAL records ``ms_density_real`` emits, and reset its
+    once-per-site memory so the tests do not shadow one another."""
+
+    def __enter__(self):
+        import logging
+        self.messages = []
+        capture = self
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                capture.messages.append(record.getMessage())
+
+        interface_madspin._MS_IMAG_REPORTED.clear()
+        self._handler = _Handler(level=logging.CRITICAL)
+        self._logger = interface_madspin.logger
+        self._level = self._logger.level
+        self._propagate = self._logger.propagate
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.CRITICAL)
+        self._logger.propagate = False
+        return self
+
+    def __exit__(self, *args):
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._level)
+        self._logger.propagate = self._propagate
+        interface_madspin._MS_IMAG_REPORTED.clear()
+        return False


### PR DESCRIPTION
A run log showed:

```
MadSpin/interface_madspin.py: ComplexWarning: Casting complex values to real discards the imaginary part
  ok = math.isfinite(wgt) and wgt > 0
```

(in `_dead_trial`). Two questions: is it *correct* that `wgt` is complex there, and if so what is the better way to write the check.

## Is it correct? Yes — but not for the expected reason, and the imaginary part is bit-exact zero

The natural suspicion is the density contraction: `DensityMatrix.scalar_multiplication` sums `complex64`, so a weight built from it would be complex by storage type. **That is not the source** — `calculate_matrix_element_from_density` already takes `me.real`.

The complexness came entirely from one line:

```python
D = complex(0, mass * width)
prod_denominators *= (D * D.conjugate())
```

`(m*Gamma)^2`, a real number, written as a Python `complex`. That type rode through `denominator` into `me.real / denominator` and out to the weight. It is the only `complex(` construction in `MadSpin/interface_madspin.py` or `MadSpin/decay.py` outside numpy dtypes.

Only the **joint** accept/reject is affected. The sequential slot stages already do `(n_k / n_prev).real` and the mass stage `density_prod.trace().real / ...`; `spinmode onshell` is plain floats. Reachable via `auto` for `madspin`/`full` with <=2 decaying particles, or explicitly under PA.

**Guaranteed real, or just numerically small?** Both, at different layers. The contraction *is* real by construction — the hermitian/transposition-closure argument holds: `get_map_density_matrix` stores the full n^2 label set (direct for i<=j, conjugated for i>j), and `_restriction_rows` masks bra and ket with the same allowed set, so a polarisation restriction preserves the closure. Numerically it is real only up to the rounding residue of `np.sum` over complex64. After `.real`, the residual complexness was a pure storage artifact with an **exactly +0.0** imaginary part.

**Measured**, instrumented `p p > t t~`, both tops decayed, `spinmode madspin` + `unweighting joint`, 100 events:

| quantity | n | non-zero imag | max abs(imag)/abs(real) |
|---|---|---|---|
| raw contraction `rho_dec . rho_prod` | 53655 | 12824 (24%) | **1.54e-7** (p99 2.2e-8, median 0) |
| `me` from `calculate_matrix_element_from_density` | 53655 | **0** | 0 |
| `wgt` at `_dead_trial` | 16155 | **0** | 0 |

float32 epsilon is 1.19e-7, so the contraction residue is exactly at rounding level. **Nothing upstream is wrong; the warning carried zero information.**

## The fix: upstream, not at the call site

1. `prod_denominators *= mw * mw` (real). Bit-identical to the real part of the complex form, verified over 20007 sampled values plus the physical ones. Note `mw ** 2` is **not** an acceptable substitute — `pow()` re-rounds and differs in the last bit for ~1 value in 700, which would move weights and hence accepted events.
2. New module-level `ms_density_real(value, what)` replaces the bare `.real`: same number, but reports at CRITICAL (once per site) if `abs(imag) > MS_DENSITY_IMAG_TOL * abs(real)`, tol = 1e-3 — four orders above the measured worst case and still catching anything meaningful. Reported rather than raised, matching the weight-identity / `density_debug` precedent in the same file.
3. `_dead_trial` **keeps** `math.isfinite`, now documented: `numpy.isfinite` would swallow a complex weight silently and `wgt.real` would discard it unseen. The coercion is free on real scalars, and it stays the line that speaks up if complexity is ever reintroduced.

## Other latent coercions found

All fixed by the upstream change; none needed touching directly.

- `if random.random()*maxwgt < wgt*jac:` in the joint accept/reject — **silent**, and the more interesting one. numpy orders complex scalars lexicographically (real, then imag), so it gave the right answer only because the imaginary part was zero. No warning, so it was invisible.
- The joint max-weight scan does `max(wgt*jac, maxwgt)` then `float(getattr(maxwgt, 'real', maxwgt))` — someone had already worked around this defensively.
- `_check_weight_identity` (`sequential_debug` only): complex `w_joint` -> complex `identity_ratio_sum`/`sqsum` -> `math.sqrt(...)` and `'%.10g' %`, both coercing.
- `_polarization_ratios` — already defensive.

Also pinned in a test: **`math.isfinite` raises `TypeError` on a plain Python `complex`** (no `__float__`), so `_dead_trial`'s `except TypeError: ok = False` would score such a weight *dead* — 20000 in a row would abort a healthy run with `MadSpinDegenerateWeight`. Unreachable today (numpy wins the mixed arithmetic) and more so after this change, but worth knowing.

## Verification

- Warning present on base, **gone** after: `madspin`+joint and `PA`+joint each emitted it; both now emit 0. Plain PA (sequential) never did.
- **Byte-identical decayed output** across the change on all three configurations, with an identical trial count (16155 for 100 events) — so every individual accept/reject decision was unchanged, not merely the final sample.
- `tests/test_manager.py test_madspin -t0`: baseline re-measured = **254 OK** -> **268 OK**. 14 new tests in `TestDensityContractionIsReal`, including that `_dead_trial` returns the same verdict for every alive/dead value across float / np.float32 / np.float64 / np.complex64-with-negligible-imag.

## Caveats

All runs were tree-level `p p > t t~` with 2 decays, 100 events. Not exercised: loop-induced, polarisation braces, `spinmode full`, multi-core, offshell with >=3 decays. The imaginary-part distribution is measured on that one process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make MadSpin density weights real at their source and detect meaningful imaginary components before they reach accept/reject logic.

Bug Fixes:
- Ensure MadSpin density-mode accept/reject weights remain real by constructing propagator denominator factors as real values.
- Report significant imaginary components in density contractions instead of silently discarding them.

Enhancements:
- Preserve the existing finite-weight checks while making complex-weight regressions visible.
- Add comprehensive coverage for density-contraction reality, denominator bit stability, diagnostic reporting, and dead-trial behavior.

Tests:
- Add unit tests covering real and complex density weights, diagnostic thresholds, one-time reporting, bit-identical denominator calculations, and unchanged trial verdicts.