### PR TITLE
MG5: stop the standalone Source 'make' fallback from hiding real failures

### DIFF
--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -2622,9 +2622,42 @@ class ProcessExporterFortranSA(ProcessExporterFortran):
         logger.info("Running make for Source directory")
         try:
             misc.compile(cwd=source_dir, mode='fortran')
-        except:
-            misc.compile(arg=['../lib/libdhelas.a'], cwd=source_dir, mode='fortran')
-            misc.compile(arg=['../lib/libmodel.a'], cwd=source_dir, mode='fortran')
+        except Exception as error:
+            # This fallback was added in 129c8386 (May 2022), a few days after
+            # deabc60d switched this method from building the two libraries
+            # explicitly to a plain 'make' (i.e. the 'all' target). It rebuilds
+            # only the two libraries a standalone output strictly needs, and so
+            # it also silently rescues an 'all' target that carries a
+            # prerequisite which cannot be satisfied in this output. That is
+            # how the unconditional libcts.a prerequisite of the MadLoop
+            # standalone Source/makefile stayed unnoticed for years: under the
+            # default output_dependencies='external' the first 'make' failed on
+            # *every* MadLoop standalone output and nobody ever saw it.
+            # Warn instead of hiding it. Note that the bare 'except' this
+            # replaces also swallowed KeyboardInterrupt and SystemExit.
+            logger.warning(
+                "Running 'make' in %s failed; falling back to building "
+                "libdhelas and libmodel individually. This normally indicates "
+                "a problem in Source/makefile and should be reported. The "
+                "failure was:\n%s", source_dir, error)
+            try:
+                misc.compile(arg=['../lib/libdhelas.a'], cwd=source_dir, mode='fortran')
+                misc.compile(arg=['../lib/libmodel.a'], cwd=source_dir, mode='fortran')
+            except Exception as fallback_error:
+                # '../lib/libXXX.a' is only a valid target when the makefile was
+                # configured with the default static libext. When 'dynamic' is
+                # set (make_opts), libext is 'so'/'dylib', the makefile only
+                # knows about '../lib/libdhelas.$(libext)' and these two targets
+                # do not exist at all -- make then stops with
+                #     No rule to make target `../lib/libdhelas.a'
+                # Retry through the libext-agnostic phony targets that both
+                # Source/makefile templates provide before giving up, and
+                # re-raise the original error if that does not help either.
+                try:
+                    misc.compile(arg=['libdhelas'], cwd=source_dir, mode='fortran')
+                    misc.compile(arg=['libmodel'], cwd=source_dir, mode='fortran')
+                except Exception:
+                    raise fallback_error
 
     #===========================================================================
     # Create proc_card_mg5.dat for Standalone directory

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -2623,18 +2623,6 @@ class ProcessExporterFortranSA(ProcessExporterFortran):
         try:
             misc.compile(cwd=source_dir, mode='fortran')
         except Exception as error:
-            # This fallback was added in 129c8386 (May 2022), a few days after
-            # deabc60d switched this method from building the two libraries
-            # explicitly to a plain 'make' (i.e. the 'all' target). It rebuilds
-            # only the two libraries a standalone output strictly needs, and so
-            # it also silently rescues an 'all' target that carries a
-            # prerequisite which cannot be satisfied in this output. That is
-            # how the unconditional libcts.a prerequisite of the MadLoop
-            # standalone Source/makefile stayed unnoticed for years: under the
-            # default output_dependencies='external' the first 'make' failed on
-            # *every* MadLoop standalone output and nobody ever saw it.
-            # Warn instead of hiding it. Note that the bare 'except' this
-            # replaces also swallowed KeyboardInterrupt and SystemExit.
             logger.warning(
                 "Running 'make' in %s failed; falling back to building "
                 "libdhelas and libmodel individually. This normally indicates "


### PR DESCRIPTION
**Stacked on #368**, which fixes the bug this `except:` was hiding — the two need to be read together.

`ProcessExporterFortranSA.make` ran `make` in `Source/` and, on failure, swallowed it with a **bare `except:`** and retried `../lib/libdhelas.a` / `../lib/libmodel.a`. That masking is why #368's broken template makefile went unnoticed: the primary `make` failed on *every* MadLoop standalone output and nobody ever saw it.

## What the fallback was actually for

`git log -L` on the block gives a clean two-step story:

- `deabc60d5` (2022-04-29) replaced two explicit `make ../lib/libdhelas.a` / `libmodel.a` calls with a plain `make` (the `all:` target).
- `129c83868` (2022-05-04, five days later, *"fixing Davide + issue"*) put those calls back as a `try/except:` fallback — **and in the same commit** fixed `models/template_files/fortran/makefile_standalone`, adding a missing `../cuts.inc` prerequisite for `couplings.f`.

So the fallback is the pre-`deabc60d5` behaviour restored as a safety net for exactly the failure that commit had just been bitten by: an `all:` target carrying a prerequisite that cannot be satisfied in a given output, while the two libraries standalone actually needs build fine individually. That is precisely the #368 CutTools shape, which is why it hid it so well.

## The `libext` gap in #368's account — now closed

`libext` is defined in `Template/LO/Source/.make_opts` and `Template/NLO/Source/make_opts.inc`: `ifdef dynamic` -> `libext=dylib` (Darwin) / `so` (Linux), else `libext=a`. `dynamic` is an ordinary make/env variable, and `Template/LO/bin/internal/Gridpack/compile` does `export dynamic=true`, so it is a real configuration. Both `all:` targets use `$(libext)`; the fallback hardcodes `.a`.

The subtlety that explains why #368 could not reproduce the second CI error line: `make ../lib/libdhelas.a` errors with *"No rule to make target"* only when the file **does not exist** — if it exists, make says "Nothing to be done" and returns 0. So it needs `libext != a` **and** a fresh output.

**Reproduced end to end**: pre-#368 template makefile + `dynamic=true` + a fresh MadLoop SA export gives exactly

```
make: *** No rule to make target `../lib/libdhelas.a'.  Stop.
```

with no mention of CutTools anywhere — confirming the CI error was primary-fails-on-CutTools followed by fallback-fails-on-libext, with the first cause swallowed.

**Honest caveat**: `libext != a` was forced via the `dynamic` env var. That reproduces the *mechanism*, not CI's cause — it was not established that CI sets it, and any other route to a non-`a` or empty `libext` gives the identical message. Separately, `dynamic=true` is independently broken on macOS (DHELAS links `-shared` while LDFLAGS carries `-bundle`), so the dynamic path cannot complete here regardless.

## The change

- `except:` -> `except Exception:`, so `KeyboardInterrupt` and `SystemExit` are no longer swallowed.
- Log a **warning naming the directory and quoting make's output** before falling back.
- Only *if* the `.a` fallback also fails, retry the libext-agnostic phony `libdhelas` / `libmodel` targets (present in both the loop standalone template and the generated `madevent_makefile_source`), re-raising the original `.a` error if that does not help either.

Every path that succeeds today is untouched.

## What it now reports in the #368 scenario — demonstrated

Pre-#368 template checked into the tree, fresh MadLoop SA export:

```
WARNING: Running 'make' in .../SA_LOOP_PRE/Source failed; falling back to building
libdhelas and libmodel individually. ... The failure was:
    make: *** No rule to make target `.../Source/CutTools', needed by `../lib/libcts.a'.  Stop.
```

and the export **still completes** (full `lib/`, zero hard errors). This would have surfaced #368 years earlier at no cost.

## Verification

- Standalone `e+ e- > mu+ mu-`: exit 0, `lib/{libdhelas.a,libmodel.a}`, no fallback warning.
- MadLoop standalone `g g > t t~ [virt=QCD]`: exit 0, full lib set, no fallback warning (the primary make succeeds thanks to #368).
- `test_madspin -t0`: **254 OK** baseline -> **254 OK** after.
- `tests/unit_tests/loop`: identical before and after.
- `test_madspin_loop_induced`: **Ran 1 test, OK**, 148.8s.
- A 5-case synthetic harness run against **both** the base and this commit in separate worktrees. Differences appear only where intended: normal build identical; `.a`-rescue case gains a warning with the same result; libext-mismatch case base **raises** / new **succeeds**; total-failure case raises the same `MadGraph5Error` on both; KeyboardInterrupt base **swallowed** / new **propagates**.

## The same pattern elsewhere — surveyed, not touched

- The other three bare `except:` in `export_v4.py` are unrelated (file open, `list.remove`).
- No loop exporter `make()` uses a bare except.
- `ProcessExporterFortranMW.make` hardcodes `.a` for eight libraries with **no** try/except — the same latent libext assumption but no masking. Left alone; MadWeight could not be validated here.
- `reweight_interface.py:2149` is the same *shape* (bare except around `misc.compile` + retry) but retries the **identical** target with `nb_core=1`, so it can only mask a parallelism problem, not a makefile bug. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make standalone Source build fallback failures visible while retaining compatible recovery paths for alternate library configurations.

Bug Fixes:
- Preserve and surface standalone Source build failures instead of silently masking them with a broad exception handler.
- Support fallback builds when configured library extensions differ from the default static `.a` targets.

Enhancements:
- Add warnings with the affected directory and original build output before attempting fallback builds.
- Allow fallback failures to re-raise the underlying error while continuing to propagate interrupts and process-exit signals.