### PR TITLE
MadSpin: decay every member of a fixed_order event group

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -476,6 +476,8 @@ class MadSpinOptions(banner.ConfigFile):
         if value:
             logger.warning('Fix order madspin fails to have the correct scale information. This can bias the results!')
             logger.warning('Not all functionalities of MadSpin handle this mode correctly (only onshell mode so far).')
+            logger.warning('spinmode=PA and spinmode=madspin/full reshuffle the production, which an event group\'s '
+                           'counter-events cannot follow; launch will refuse those combinations.')
 
     ############################################################################
     def post_identical_particle_in_prod_and_decay(self, value, change_userdefine, raiseerror):
@@ -1771,6 +1773,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             self.options['spinmode'] = spinmode
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
+        self._check_fixed_order_spinmode(spinmode)
         if self._density_spinmode():
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
@@ -3289,6 +3292,45 @@ class MadSpinInterface(extended_cmd.Cmd):
         return in_density_mode and (not self._density_pole_approximation()
                                     or self._density_do_reshuffle())
 
+    # the spinmodes ``fixed_order`` reshuffles the production in, and so cannot
+    # decay an event group in: PA samples a virtuality per resonance,
+    # madspin/full evaluates its density at the reshuffled (offshell) momenta.
+    FIXED_ORDER_RESHUFFLING_SPINMODES = ('PA', 'madspin')
+
+    def _check_fixed_order_spinmode(self, spinmode):
+        """Refuse ``fixed_order`` in a spinmode that reshuffles the production.
+
+        An event group is decayed *once*: the born event's decays are attached
+        to the born event and to every counter-event, unchanged (the 2017
+        design of the option, and the only one under which the subtraction
+        still cancels after the decay -- an independent draw per member would
+        decay the event and the term subtracting it differently).
+
+        That is fine as long as nothing else moves the production kinematics.
+        PA and madspin/full do: they reshuffle the production onto sampled
+        virtualities, and only the born member goes through that reshuffling,
+        so its resonance would sit at the sampled mass while the counter-events
+        subtracting it stay onshell. Reshuffling each member separately is not
+        the answer either -- the members are related by the fixed-order mapping,
+        the jacobians would differ per member, and the reshuffling can fail for
+        one member and succeed for the others.
+
+        Until that is designed, refuse: a group whose members disagree looks
+        like a decayed sample and is not one. ``onshell``/``onshell_v1`` keep
+        the production kinematics and are unaffected.
+        """
+        if not self.options['fixed_order']:
+            return
+        if spinmode not in self.FIXED_ORDER_RESHUFFLING_SPINMODES:
+            return
+        raise self.InvalidCmd(
+            "fixed_order is not available in spinmode=%s: that mode reshuffles "
+            "the production onto sampled virtualities, and how an event "
+            "group's counter-events follow the born event through that "
+            "reshuffling is not defined -- only the born event would be "
+            "reshuffled. Use spinmode=onshell (or onshell_v1), which keeps the "
+            "production kinematics, or turn fixed_order off." % spinmode)
+
     def _spinmode_has_density(self):
         """Whether the spinmode carries the density-matrix machinery the staged
         accept/reject schemes are built on. The v1 spinmodes, ``none`` and
@@ -4164,7 +4206,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                         # jacobian is in wgt); build the event to write out from the
                         # reshuffled copy, without reshuffling a second time. If
                         # get_onshell already built it (fixed_order / density_debug),
-                        # reuse that event -- decays were consumed there.
+                        # reuse that event rather than build the same one twice.
                         if full_evt is None:
                             full_evt = lhe_parser.Event(str(prod_trial))
                             full_evt = full_evt.add_decays(decays)
@@ -7531,7 +7573,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                     full_event = lhe_parser.Event(str(production))
                 else:
                     full_event = production          
-                # CAUTION: the next line removes everything from decays dictionary
+                # add_decays is non-destructive: ``decays`` survives this, which
+                # is what lets the caller rebuild the event (PA reshuffling) and
+                # what lets fixed_order attach the same draw to every member of
+                # the event group.
                 full_event = full_event.add_decays(decays)
             
                 #print(f"full event 2 = {full_event}")

--- a/madgraph/various/lhe_parser.py
+++ b/madgraph/various/lhe_parser.py
@@ -2430,9 +2430,22 @@ class Event(list):
                     particle.color2 = color_mapping[particle.color2]                
 
     def add_decays(self, pdg_to_decay):
-        """use auto-recursion"""
+        """use auto-recursion
 
-        pdg_to_decay = dict(pdg_to_decay)
+        Non-destructive: the caller's dictionary -- and the lists inside it --
+        come back untouched, so the same set of decays can be attached to
+        several production events. ``dict(pdg_to_decay)`` alone was not enough:
+        it copies the mapping but shares the lists, which the recursion below
+        then ``pop(0)``s, so the first event consumed the decays and every
+        later one silently got nothing to attach. MadSpin does exactly that in
+        two places -- fixed_order attaches one draw to the born event and to
+        each of its counter-events, and the pole approximation rebuilds the
+        event after ``get_onshell_evt_and_wgt`` has already built one from the
+        same dict.
+        """
+
+        pdg_to_decay = dict((pdg, list(decays))
+                            for pdg, decays in pdg_to_decay.items())
 
         for i,particle in enumerate(self):
             if particle.status != 1:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -6131,6 +6131,246 @@ class TestDensityContractionIsReal(unittest.TestCase):
         self.assertIn('math.isfinite(wgt)', source)
 
 
+class TestFixedOrderGroupDecays(unittest.TestCase):
+    """Every member of a ``fixed_order`` event group comes back decayed.
+
+    ``Event.add_decays`` used to copy the *mapping* it is given
+    (``dict(pdg_to_decay)``) but share the lists inside it, which the recursion
+    then ``pop(0)``s. It looks like a defensive copy and is not one: the first
+    production event it is applied to drained the caller's own lists, so every
+    later one silently attached nothing and came back with the bare production
+    particles.
+
+    MadSpin applies one draw to several events in exactly the place where that
+    matters -- ``_unweight_range`` attaches the born event's decays to the born
+    event and then to each of its counter-events
+    (``[full_evt] + [evt.add_decays(decays) for evt in counterevt]``, the 2017
+    design of the option). So no counter-event had ever been decayed, in any
+    spinmode; and under the pole approximation, where
+    ``get_onshell_evt_and_wgt`` builds the event first and the caller then
+    rebuilds it to fold in the reshuffling jacobian, not even the born event
+    was.
+    """
+
+    # ---------------- fixtures ----------------
+
+    PROD = """<event>
+ 4      1 +1.0000000e+00 1.00000000e+02 7.54677160e-03 1.02860750e-01
+       21 -1    0    0  501  502 +0.00000000000e+00 +0.00000000000e+00 +%(E).11e  %(E).11e  0.00000000000e+00 0. 9.
+       21 -1    0    0  503  501 +0.00000000000e+00 +0.00000000000e+00 -%(E).11e  %(E).11e  0.00000000000e+00 0. 9.
+        6  1    1    2  503    0 +%(px).11e +0.00000000000e+00 +0.00000000000e+00  %(E).11e  1.73000000000e+02 0. 9.
+       -6  1    1    2    0  502 -%(px).11e +0.00000000000e+00 +0.00000000000e+00  %(E).11e  1.73000000000e+02 0. 9.
+</event>
+"""
+
+    DECAY = """<event>
+ 3      1 +1.0000000e+00 1.00000000e+02 7.54677160e-03 1.02860750e-01
+     %(pdg)4d -1    0    0  %(c1)3d  %(c2)3d +0.00000000000e+00 +0.00000000000e+00 +0.00000000000e+00  1.73000000000e+02  1.73000000000e+02 0. 9.
+     %(d1)4d  1    1    1  %(c1)3d    0 +0.00000000000e+00 +0.00000000000e+00 +%(E).11e  %(E).11e  0.00000000000e+00 0. 9.
+     %(d2)4d  1    1    1    0  %(c2)3d +0.00000000000e+00 +0.00000000000e+00 -%(E).11e  %(E).11e  0.00000000000e+00 0. 9.
+</event>
+"""
+
+    # 4 production particles + 2 extra per decayed top
+    UNDECAYED = 4
+    DECAYED = 8
+
+    @classmethod
+    def _production(cls, px):
+        """g g > t t~, the tops back to back along x with the given |px|."""
+        E = math.sqrt(173.0 ** 2 + px ** 2)
+        return lhe_parser.Event(cls.PROD % dict(px=px, E=E))
+
+    @classmethod
+    def _decay(cls, pdg, d1, d2, c1, c2):
+        """t > d1 d2 in the top rest frame, the two daughters massless."""
+        return lhe_parser.Event(cls.DECAY % dict(pdg=pdg, d1=d1, d2=d2,
+                                                 c1=c1, c2=c2, E=173.0 / 2))
+
+    @classmethod
+    def _decays(cls):
+        return {6: [cls._decay(6, 5, 24, 601, 0)],
+                -6: [cls._decay(-6, -5, -24, 0, 602)]}
+
+    # ---------------- the contract, at the lhe_parser level ----------------
+
+    def test_the_same_decays_can_be_attached_to_several_events(self):
+        """The bug in one line: three production events, one decays dict."""
+        decays = self._decays()
+        for i in range(3):
+            event = self._production(100.0 + i).add_decays(decays)
+            self.assertEqual(len(event), self.DECAYED,
+                             'event %d came back undecayed -- add_decays '
+                             'drained the caller\'s lists' % i)
+
+    def test_add_decays_leaves_the_callers_dict_untouched(self):
+        decays = self._decays()
+        before = dict((pdg, list(value)) for pdg, value in decays.items())
+        self._production(100.0).add_decays(decays)
+        self.assertEqual(sorted(decays), sorted(before))
+        for pdg in before:
+            self.assertEqual(decays[pdg], before[pdg],
+                             'the %s list was consumed' % pdg)
+
+    def test_the_decay_events_themselves_are_reusable(self):
+        """Not just the lists: the decay *events* are attached by copy, so the
+        second production event gets the same rest-frame decay boosted into its
+        own frame rather than a mutated one."""
+        decays = self._decays()
+        text = str(decays[6][0])
+        self._production(100.0).add_decays(decays)
+        self._production(400.0).add_decays(decays)
+        self.assertEqual(str(decays[6][0]), text)
+
+    # ---------------- the same thing through _unweight_range ----------------
+
+    class _Pool(object):
+        """An inexhaustible decay pool for one channel."""
+        cross = 1.0
+
+        def __init__(self, maker):
+            self.maker = maker
+
+        def __next__(self):
+            return self.maker()
+        next = __next__
+
+    class _Generate(object):
+        def __init__(self, mode):
+            self.mode = mode
+            self.all_me = collections.defaultdict(dict)
+
+    class _Output(object):
+        def __init__(self):
+            self.written = []
+
+        def write_events(self, event):
+            self.written.append(event)
+
+    class _Options(dict):
+        """The knobs _unweight_range reads that this stub does not care about
+        are all falsy; spelling every one of them out would only hide which
+        ones the test actually sets."""
+        def __missing__(self, key):
+            return False
+
+    def _stub(self, spinmode, density_method):
+        stub = interface_madspin.MadSpinInterface.__new__(
+            interface_madspin.MadSpinInterface)
+        stub.options = self._Options({'fixed_order': True,
+                                      'spinmode': spinmode,
+                                      'density_tolerance': 1e-2})
+        stub.generate_all = self._Generate(
+            'density' if density_method else 'onshell')
+        stub.efficiency = 1.0
+        stub.branching_ratio = 1.0
+        stub._shard_tag = None
+        stub._decay_groups = None
+        # the matrix elements are not what is under test: a flat weight makes
+        # the joint accept/reject take the first trial
+        stub.calculate_matrix_element = lambda event, *a, **kw: 1.0
+        stub.calculate_matrix_element_from_density = \
+            lambda production, decays, decay_dict, cached=None: \
+            (1.0, {'cached': True}, 1.0, 1.0, 1.0)
+        return stub
+
+    def _run_group(self, spinmode, density_method, nb_member=3):
+        """Decay one event group of ``nb_member`` members and return the
+        particle count of each member as written out."""
+        stub = self._stub(spinmode, density_method)
+        evt_decayfile = {
+            6: {0: self._Pool(lambda: self._decay(6, 5, 24, 601, 0))},
+            -6: {0: self._Pool(lambda: self._decay(-6, -5, -24, 0, 602))},
+        }
+        group = [self._production(100.0 + 0.1 * k) for k in range(nb_member)]
+        output = self._Output()
+        ctx = {'maxwgt': 1e-9,          # accept the first trial
+               'maxwgts': [], 'sequential': False,
+               'decay_dict': {6: (173.0, 1.5), -6: (173.0, 1.5)},
+               'drop_prob_per_pdg': None, 'mixed_pdgs_set': set(),
+               'density_method': density_method,
+               'density_pole_approximation': stub._density_pole_approximation(),
+               'density_needs_reshuffle':
+                   stub._density_needs_reshuffle(density_method),
+               'shard_nb_event': 1}
+        stub._unweight_range(iter([group]), evt_decayfile, output, ctx)
+        self.assertEqual(len(output.written), 1)
+        return [len(event) for event in output.written[0]]
+
+    def test_every_group_member_is_decayed_in_onshell_v1(self):
+        """spinmode=onshell_v1: no density, no reshuffling."""
+        self.assertEqual(self._run_group('onshell_v1', density_method=False),
+                         [self.DECAYED] * 3)
+
+    def test_every_group_member_is_decayed_in_onshell(self):
+        """spinmode=onshell: density matrices, still no reshuffling -- the
+        combination ``fixed_order`` is documented to support."""
+        self.assertEqual(self._run_group('onshell', density_method=True),
+                         [self.DECAYED] * 3)
+
+    def test_a_lone_born_event_is_still_decayed(self):
+        """A group of one is the degenerate case and must not regress."""
+        self.assertEqual(
+            self._run_group('onshell', density_method=True, nb_member=1),
+            [self.DECAYED])
+
+
+class TestFixedOrderReshufflingSpinmodesRefused(unittest.TestCase):
+    """``fixed_order`` is refused in the spinmodes that reshuffle the
+    production.
+
+    An event group is decayed once and the born event's decays are attached to
+    every member unchanged. PA and madspin/full then reshuffle the production
+    onto the sampled virtualities -- but only the born member goes through that
+    reshuffling, so its resonance sits at the sampled mass while the
+    counter-events subtracting it stay onshell. That is a decayed-looking
+    sample whose members disagree, which is worse than the undecayed output it
+    replaced, so launch refuses instead.
+    """
+
+    def _stub(self, spinmode, fixed_order):
+        stub = interface_madspin.MadSpinInterface.__new__(
+            interface_madspin.MadSpinInterface)
+        stub.options = {'spinmode': spinmode, 'fixed_order': fixed_order}
+        return stub
+
+    def _refuses(self, spinmode):
+        stub = self._stub(spinmode, fixed_order=True)
+        try:
+            stub._check_fixed_order_spinmode(spinmode)
+        except interface_madspin.MadSpinInterface.InvalidCmd as error:
+            return str(error)
+        self.fail('fixed_order + spinmode=%s was accepted' % spinmode)
+
+    def test_pa_is_refused(self):
+        message = self._refuses('PA')
+        self.assertIn('fixed_order', message)
+        self.assertIn('spinmode=PA', message)
+        self.assertIn('onshell', message)   # names the way out
+
+    def test_madspin_is_refused(self):
+        self.assertIn('spinmode=madspin', self._refuses('madspin'))
+
+    def test_the_supported_spinmodes_are_not_refused(self):
+        for spinmode in ('onshell', 'onshell_v1', 'none', 'madspin_v1'):
+            stub = self._stub(spinmode, fixed_order=True)
+            stub._check_fixed_order_spinmode(spinmode)   # must not raise
+
+    def test_nothing_is_refused_when_fixed_order_is_off(self):
+        for spinmode in ('PA', 'madspin', 'onshell'):
+            stub = self._stub(spinmode, fixed_order=False)
+            stub._check_fixed_order_spinmode(spinmode)   # must not raise
+
+    def test_the_refused_set_is_exactly_the_reshuffling_ones(self):
+        """The list is hand-kept; tie it to what actually reshuffles so a new
+        reshuffling spinmode cannot be added without landing here."""
+        for spinmode in ('PA', 'madspin', 'onshell'):
+            stub = self._stub(spinmode, fixed_order=True)
+            reshuffles = stub._density_needs_reshuffle(True)
+            refused = spinmode in stub.FIXED_ORDER_RESHUFFLING_SPINMODES
+            self.assertEqual(refused, reshuffles, spinmode)
+
+
 class _CaptureCritical(object):
     """Collect the CRITICAL records ``ms_density_real`` emits, and reset its
     once-per-site memory so the tests do not shadow one another."""


### PR DESCRIPTION
Under `fixed_order`, MadSpin was writing **undecayed** members into every event group. With `pure_interference` off, i.e. ordinary `fixed_order` behaviour, in every spinmode.

Particle count per group member (`g g > t t~`, one 2-body decay per top, so 4 undecayed / 8 decayed):

| configuration | before | after |
|---|---|---|
| `onshell_v1` (no density) | `[8, 4, 4]` | `[8, 8, 8]` |
| `onshell` (density) | `[8, 4, 4]` | `[8, 8, 8]` |
| `PA`, `density_keep_jacobian=False` | `[4, 4, 4]` | `[8, 8, 8]` |
| `PA`, `density_keep_jacobian=True` | `[4, 4, 4]` | `[8, 8, 8]` |
| `madspin`/`full` (offshell density) | `[8, 4, 4]` | `[8, 8, 8]` |

Correction to the original report: the PA half hits **both** `density_keep_jacobian` settings, not only `True` — the default post-acceptance branch rebuilds from the drained dict too.

## Root cause

`Event.add_decays` copied the *mapping* (`dict(pdg_to_decay)`) but shared the lists inside it, which the recursion `pop(0)`s. It looks like a defensive copy and is not one, so the first production event it is applied to drains the caller's own lists.

**Provenance correction**: the counter-event half is **not** from `1bb7ee1de`. It has been there since `8a01e798c` (2017), the commit that introduced `fixed_order` — that commit already wrote `[full_evt] + [evt.add_decays(decays) for evt in counterevt]` against a `get_onshell_evt_and_wgt` that had already drained the dict, and `add_decays` popped destructively then too. The PA half comes from `2297db3de`. Both pre-date the open PR stack.

## Fix in `add_decays`, not the caller

All ten call sites were checked first. **None relies on the drain**, and four are actively *broken* by it (`interface_madspin.py:4195, 4225, 4235`, and the `get_onshell_evt_and_wgt` rebuild at `:7580`). One line repairs everything; the caller-side fix would have needed patching four sites and left the trap armed for the next caller. The stale `# CAUTION: the next line removes everything from decays dictionary` comment is updated to describe the new contract.

## The physics decision

The born event's decays are **reused unchanged for every member**, not redrawn per member. That is unambiguous from the code (`fixed_order` rides the counter-events along with the decays; `_unweighting_mode`'s "counter-events ride along"; the 2017 call site itself), and it is the only choice under which the subtraction still cancels after the decay. Since decays are drawn in the resonance rest frame, `add_decay_to_particle` boosts the same decay into each member's own frame — no mutation of the decay events, pinned by a test.

## What was deliberately *not* made to work

After the fix, `spinmode=PA` produced a group where the born member sat at the sampled virtuality (m(t) = 172.55) while the counter-events subtracting it stayed onshell at 173.0 — only the born member goes through `reshuffle_production`. `madspin`/`full` has the same shape (the born member is reshuffled inside `calculate_matrix_element_from_density`, and the counter-events inherit a `new_mass` tag nothing ever honours).

Reshuffling each member separately is not obviously correct: the members are related by the fixed-order mapping, the jacobians would differ per member, and it can fail for one member and not the others. So rather than produce plausible-but-wrong output, **`fixed_order` + `PA`/`madspin`/`full` now raises** (`_check_fixed_order_spinmode`, early in `do_launch`), verified end to end. `onshell`/`onshell_v1` keep the production kinematics and are now genuinely correct — which matches the existing `set fixed_order` warning ("only onshell mode so far"), extended here to name the refusal.

## Verification

**Non-`fixed_order` byte-identity, from real end-to-end MadSpin runs** — `p p > t t~`, 100 events, `decay t > w+ b, w+ > all all` and conjugate, seeded, reusing a warm `ms_dir` so both sides use identical matrix elements and `max_wgt`. md5 of the decayed LHE, before vs after:

- `PA` (auto -> sequential): identical
- `onshell_v1`: identical
- `madspin` (offshell density, joint): identical
- `onshell` + `set unweighting joint`: identical

Worth flagging: the first comparison *looked* like a diff, but that was a cold-`ms_dir` vs warm-`ms_dir` artefact rather than the change. A control (unfixed code run twice, warm) was identical, and an `add_decays` call trace showed the non-`fixed_order` run reaches it from exactly one site with a fresh dict each time — so the drain provably cannot matter there.

- `tests/test_manager.py test_madspin -t0`: baseline **294 OK** -> **305 OK**.
- Full unit suite: 1082 tests, 1 error — `test_DensityMatrixObservables22`, `ModuleNotFoundError: No module named 'scipy'`, pre-existing and confirmed by running it alone.
- **11 regression tests** (`TestFixedOrderGroupDecays`, `TestFixedOrderReshufflingSpinmodesRefused`), verified to fail against the unfixed code — 4 failures/errors including `Lists differ: [8, 4, 4] != [8, 8, 8]` — while all 294 pre-existing tests still passed, i.e. nothing covered this before.

## Not verified

No real `fixed_order` end-to-end run: there is no `<eventgroup>` NLO fixed-order LHE fixture in the repository, so that half rests on the `_unweight_range` harness (real method, stubbed matrix elements) plus the unit tests rather than on a full MG5 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix fixed-order event-group decays and refuse spinmode combinations whose production reshuffling cannot be applied consistently across counter-events.

Bug Fixes:
- Ensure every member of a fixed-order event group receives the shared decay result instead of later members being written undecayed.
- Preserve decay mappings and decay events so they can be reused when rebuilding or attaching decays to multiple events.

Enhancements:
- Reject fixed-order runs with PA or madspin/full spinmodes that cannot consistently reshuffle counter-events, while retaining support for non-reshuffling modes.
- Clarify fixed-order warnings and decay-reuse behavior.

Tests:
- Add regression coverage for repeated decay attachment, event reuse, fixed-order group member decay counts, and unsupported spinmode combinations.