### PR TITLE
MadSpin: one decay_output option with auto, and drop three deprecated spellings

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -53,7 +53,7 @@ logger_stderr = logging.getLogger('decay.stderr') # ->stderr
 cmd_logger = logging.getLogger('cmdprint2') # -> print
 
 # ---------------------------------------------------------------------------
-# Polarisation labels accepted by keep_weight_for_polarization
+# Polarisation labels accepted by keep_weight_for_polarization_*
 # ---------------------------------------------------------------------------
 # Same spelling and same meaning as MG5's polarisation braces:
 #   {L} -> [-1], {R}/{+} -> [1], {T} -> [-1,1], {0} -> [0]
@@ -70,8 +70,9 @@ POLARIZATION_ALIASES = {
 
 
 def parse_polarization_label(label):
-    """(canonical label, helicity values) for one keep_weight_for_polarization
-    entry, or None if it is not one of 0/+/-/T (L and R aliasing - and +)."""
+    """(canonical label, helicity values) for one
+    keep_weight_for_polarization_vector/_fermion entry, or None if it is not
+    one of 0/+/-/T (L and R aliasing - and +)."""
     key = str(label).strip().lower()
     if key.startswith('{') and key.endswith('}'):
         key = key[1:-1].strip()
@@ -323,14 +324,6 @@ class MadSpinOptions(banner.ConfigFile):
                        "offered to each decaying SPIN-1/2 particle. '0' is unphysical "
                        "for a fermion and is dropped from its choices; 'T' is its full "
                        "helicity basis, i.e. that particle summed over.")
-        self.add_param('keep_weight_for_polarization', [], typelist=str,
-                       comment="DEPRECATED spelling of the two options above: it sets "
-                       "both keep_weight_for_polarization_vector and "
-                       "keep_weight_for_polarization_fermion to the same list. Note "
-                       "that the meaning changed: the entries are no longer applied to "
-                       "every decaying particle at once, they are combined, so the "
-                       "number of extra weights is now the product over the decaying "
-                       "particles instead of the length of the list.")
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -347,9 +340,6 @@ class MadSpinOptions(banner.ConfigFile):
                        "sequential_with_mass: one test per decaying particle with that particle's virtuality drawn *inside* its own accept/reject, so nothing is ever frozen and no stage has a conditional normalisation to divide out. Needs a per-particle mass draw, i.e. the PA spinmode; elsewhere it falls back to sequential. "
                        "sequential and sequential_global_retry unweight the set of virtualities first; the former then needs a tabulated running-width factor, measured during the max-weight scan to ~0.5%, which is far inside the pole approximation these modes already assume; sequential_global_retry does without it at 2-3x the cost, and is meant as a cross-check rather than a default. "
                        "auto: sequential under PA/onshell, where it was the fastest scheme at every decay multiplicity measured; offshell joint up to two decaying particles and sequential from three, since offshell every mass set costs a production reshuffle and a production density and below three decays there are not enough of them to save to pay for it; but sequential at every multiplicity when the production process carries a polarisation brace, since restricting the convolution to a polarisation subspace peaks the joint weight far below the single bound the joint test has -- measured on `p p > t t~` with both tops decayed, 112 trials per accepted event under joint for `t{+}t~{+}` and 162 for `t{+}t~{-}` against 9.1 and 8.4 under sequential, where unpolarised joint takes 3.3 (and at 50000 events, where the max-weight bound is looser still, the polarised joint columns were 204-213 and 5800-6300). An explicit 'set unweighting joint' is still honoured.")
-        self.add_param('sequential_decay', 'auto',
-                       comment='DEPRECATED, use unweighting: True maps to sequential, False to joint.')
-        self.auto_set.add('sequential_decay')
         self.add_param('sequential_spin_order', '2 3 1', comment='spin order (MG5 2S+1 convention) deciding which particle is accept/rejected first in the sequential unweighting modes: default fermions, then vectors, then scalars (which can never be rejected).')
         self.add_param('sequential_debug', False, comment='the up-front-mass unweighting schemes (sequential, sequential_global_retry): on every accepted chain, recompute the joint weight for the same production event, virtualities and decays and check that the product of the stage weights reproduces it (times the number of helicity states). Deterministic check of the decomposition itself -- the tabulated factor cancels out of it -- at roughly the cost of a joint trial per event. Debugging only.')
 
@@ -446,28 +436,6 @@ class MadSpinOptions(banner.ConfigFile):
         if canonical != list(value):
             dict.__setitem__(self, name, canonical)
 
-    def post_set_keep_weight_for_polarization(self, value, change_userdefine,
-                                              raiseerror, *opts):
-        """Deprecated alias for the two per-species options. The list is handed
-        to both of them; the entries a species has no use for are dropped when
-        the combinations are built ('0' on a fermion), so the old spelling keeps
-        meaning something -- but it now produces the *product* over the decaying
-        particles rather than one weight per entry, which is a different (and
-        much larger) set of weights, so the warning is worth its noise."""
-        if not value:
-            return
-        canonical = self._canonical_polarization_list(
-            'keep_weight_for_polarization', value)
-        logger.warning(
-            "MadSpin: 'keep_weight_for_polarization' is deprecated; use "
-            "'set keep_weight_for_polarization_vector %s' and "
-            "'set keep_weight_for_polarization_fermion %s'. Note that the "
-            "weights are now one per COMBINATION of the per-particle "
-            "polarisations, not one per entry.", canonical, canonical)
-        dict.__setitem__(self, 'keep_weight_for_polarization', canonical)
-        self['keep_weight_for_polarization_vector'] = list(canonical)
-        self['keep_weight_for_polarization_fermion'] = list(canonical)
-
     def beampol_me(self):
         """The beam polarisations in the convention the matrix elements use.
 
@@ -487,20 +455,6 @@ class MadSpinOptions(banner.ConfigFile):
             out.append(1. if not value
                        else math.copysign(1 + abs(value) / 100., value))
         return tuple(out)
-
-    def post_set_sequential_decay(self, value, change_userdefine, raiseerror, *opts):
-        """Deprecated alias for 'unweighting'. True/False were the only values
-        it ever had beyond 'auto', so they map onto the two modes that existed
-        then."""
-        if value in ('auto', None):
-            mode = 'auto'
-        elif value in (True, 'True', 'true', 1, '1'):
-            mode = 'sequential'
-        else:
-            mode = 'joint'
-        logger.warning("MadSpin: 'sequential_decay' is deprecated; "
-                       "use 'set unweighting %s'", mode)
-        self['unweighting'] = mode
 
     ############################################################################        
     def post_set_run_card(self, value, change_userdefine, raiseerror, *opts):
@@ -7366,9 +7320,10 @@ class MadSpinInterface(extended_cmd.Cmd):
     #    ('0' alone on a fermion).
     #
     # A label that is unphysical for a slot is dropped from that slot's choices
-    # rather than silently left unrestricted, so the deprecated
-    # 'keep_weight_for_polarization = [0, T, +, -]' does not emit a '0' and a 'T'
-    # copy of the same fermion weight.
+    # rather than silently left unrestricted, so a card that gives both species
+    # the same list -- 'keep_weight_for_polarization_vector = [0, T, +, -]' and
+    # the same for _fermion -- does not emit a '0' and a 'T' copy of the same
+    # fermion weight.
     #
     # Production braces (PR #349, #353)
     # ---------------------------------

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -238,10 +238,14 @@ class MadSpinOptions(banner.ConfigFile):
         self.add_param('global_order_coupling', '')
         self.add_param('identical_particle_in_prod_and_decay', 'average')
         self.add_param('beampol', [0., 0.], comment='beam polarisation of each beam in percent, -100 .. 100, exactly as the run_card polbeam1/polbeam2 (0 is unpolarised). Taken from the run_card of the production when it has one.')
-        self.add_param('decay_output', 'unweighted',
-                       allowed=['unweighted', 'weighted'],
-                       comment="whether MadSpin unweights its decays at all. 'unweighted' "
-                       "(default, and what MadSpin has always done): draw decay "
+        self.add_param('decay_output', 'auto',
+                       allowed=['auto', 'unweighted', 'weighted'],
+                       comment="whether MadSpin unweights its decays at all. 'auto' "
+                       "(default): 'weighted' when pure_interference is set, "
+                       "'unweighted' otherwise -- i.e. each mode's own historical "
+                       "default. The resolved value is announced in the log. "
+                       "'unweighted' (what MadSpin has always done outside "
+                       "pure_interference): draw decay "
                        "configurations until one is accepted, so every production event "
                        "yields exactly one output event and every event of a given "
                        "production process carries the same weight. 'weighted': NO "
@@ -264,10 +268,13 @@ class MadSpinOptions(banner.ConfigFile):
                        "constant weight -- unit-weight event counting, simple histogram "
                        "entry counts -- is wrong on it. Density spin modes only "
                        "(madspin/full, PA, onshell): the v1 modes and spinmode = none "
-                       "build no density matrix and have no W. Ignored under "
-                       "pure_interference, which is always weighted and has its own "
-                       "pure_interference_output. See doc/madspin_sequential_plan.md "
-                       "section 13.18.")
+                       "build no density matrix and have no W. Under "
+                       "pure_interference this option governs that mode's (always "
+                       "signed) output too: 'weighted' keeps every trial with "
+                       "w = sigma_ref*BR*W/c, 'unweighted' unweights on |W| with ONE "
+                       "draw per production event and writes w = +- sigma_ref*BR*<|W|>/c "
+                       "-- exactly two weight magnitudes, i.e. unweighted up to a sign. "
+                       "See doc/madspin_sequential_plan.md sections 13.17 and 13.18.")
         self.add_param('pure_interference', '',
                        comment="pure-interference mode: keep ONLY the interference between two "
                        "polarisations of a decaying particle in the production/decay density "
@@ -283,27 +290,8 @@ class MadSpinOptions(banner.ConfigFile):
                        "UNPOLARISED on the legs given an I block (the interference between two "
                        "polarisations does not exist in a sample generated with a brace on that "
                        "leg). The sample then has zero total cross-section by construction, and "
-                       "its event weights are SIGNED; see pure_interference_output for their "
+                       "its event weights are SIGNED; see decay_output for their "
                        "value and doc/madspin_sequential_plan.md section 13.")
-        self.add_param('pure_interference_output', 'weighted',
-                       allowed=['weighted', 'unweighted'],
-                       comment="how the pure-interference mode writes its (always signed) event "
-                       "weights. Ignored unless pure_interference is set. 'weighted' (default): "
-                       "no accept/reject at all, every trial is kept and carries the fully "
-                       "weighted w = sigma_ref*BR*W/c, with W the signed convolution of that "
-                       "trial and c = <W> the unrestricted decay-side constant. 'unweighted': "
-                       "unweight on |W| against the probed maximum, ONE draw per production "
-                       "event and nothing written on rejection, and give each accepted event "
-                       "w = +- sigma_ref*BR*<|W|>/c -- i.e. exactly two weight magnitudes, so "
-                       "the sample is unweighted up to a sign. Both give mean(w) = 0 and "
-                       "sum_bin(w)/N_file = the interference contribution to that bin in pb "
-                       "(N_file = the number of events IN THE FILE, which is N_read only for "
-                       "'weighted'), and in neither does the accept/reject bound enter the "
-                       "normalisation. 'weighted' is the default because it uses every "
-                       "production event instead of the few percent an accept/reject keeps: "
-                       "measured ~6x less variance per production event on <C_nn>, "
-                       "<cos phi_ll> and <Delta phi> (section 13.17). Choose 'unweighted' only "
-                       "when a downstream tool needs near-constant |w|.")
         self.add_param('keep_weight_for_polarization_vector', [], typelist=str,
                        comment="density spin modes only. Polarisations (0, +, -, T; "
                        "L/R accepted as aliases of -/+) offered to each decaying "
@@ -1906,14 +1894,20 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         logger.info("Running MadSpin in spinmode %s" % spinmode)
         self._check_fixed_order_spinmode(spinmode)
-        # decay_output is refused outside the density modes too, so it is
-        # checked before the branch rather than inside it
+        # Both of these are refused outside the density modes, so they are
+        # checked before the branch rather than inside it. pure_interference
+        # goes first: it is the more fundamental request of the two -- when it
+        # is on, decay_output only chooses the shape of ITS output -- so a card
+        # that gets both wrong should be told about pure_interference rather
+        # than about the option that follows it. (_validate_pure_interference
+        # returns immediately when the mode is off, and everything it touches
+        # beyond the spinmode check is behind that guard.)
+        self._validate_pure_interference()
         self._validate_weighted_decay()
         if self._density_spinmode():
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
             self._production_polarization()
-            self._validate_pure_interference()
             self._polarization_weights_enabled()
         elif (self.options['keep_weight_for_polarization_vector']
               or self.options['keep_weight_for_polarization_fermion']):
@@ -4250,7 +4244,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         # entirely, and every production event is used instead of the 3-9% an
         # accept/reject kept. See doc/madspin_sequential_plan.md section 13.13.
         #
-        # ``pure_interference_output = unweighted`` selects the other
+        # ``decay_output = unweighted`` selects the other
         # representation of the same estimator (section 13.17): keep the
         # accept/reject, but on |W| and with ONE draw -- nothing is written on
         # rejection, so the keep rate carries <|W|> -- and give each accepted
@@ -4291,15 +4285,15 @@ class MadSpinInterface(extended_cmd.Cmd):
             absw = ctx.get('pure_interference_absw')
             if not absw:
                 raise self.InvalidCmd(
-                    "MadSpin: pure_interference_output = unweighted needs "
-                    "<|W|>, the decay-phase-space mean of the absolute "
+                    "MadSpin: pure_interference + decay_output = unweighted "
+                    "needs <|W|>, the decay-phase-space mean of the absolute "
                     "convolution, and the maximum-weight scan produced none. "
                     "This is an internal error -- the scan measures it beside "
                     "c.")
             if not maxwgt:
                 raise self.InvalidCmd(
-                    "MadSpin: pure_interference_output = unweighted needs a "
-                    "positive maximum weight to unweight |W| against, and the "
+                    "MadSpin: pure_interference + decay_output = unweighted "
+                    "needs a positive maximum weight to unweight |W| against, and the "
                     "scan produced %r." % (maxwgt,))
             pi_w0_factor = absw / pure_interference_c
         nb_pi_dead = 0     # trials whose convolution was not a finite number:
@@ -4760,7 +4754,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         if unweighted:
             logger.info(
                 "MadSpin pure_interference: wrote %d/%d production events "
-                "(%.4f). pure_interference_output = unweighted: one decay "
+                "(%.4f). decay_output = unweighted: one decay "
                 "draw per production event, accepted with probability "
                 "|W|/max|W|, so the keep rate -- not the weight magnitude -- "
                 "carries the local size of the interference.",
@@ -5796,8 +5790,8 @@ class MadSpinInterface(extended_cmd.Cmd):
             self._pi_absw_err = 0.0
             if self._pure_interference_unweighted():
                 raise self.InvalidCmd(
-                    "MadSpin: pure_interference_output = unweighted needs "
-                    "<|W|>, the decay-phase-space mean of |W|, and the "
+                    "MadSpin: pure_interference + decay_output = unweighted "
+                    "needs <|W|>, the decay-phase-space mean of |W|, and the "
                     "maximum-weight scan measured %s over %d trials. Raise "
                     "Nevents_for_max_weight / max_weight_ps_point, or report "
                     "this case." % ('zero' if n else 'nothing', n))
@@ -7034,41 +7028,74 @@ class MadSpinInterface(extended_cmd.Cmd):
         self._pure_interference_cache = out
         return out
 
+    def _decay_output(self):
+        """``decay_output`` with ``auto`` resolved: 'weighted' or 'unweighted'.
+
+        ``auto`` (the default) is 'weighted' under ``pure_interference`` and
+        'unweighted' otherwise -- each mode's own historical default, so a card
+        that does not mention the option behaves exactly as it always has. The
+        two are opposite for a reason rather than by accident: the ordinary run
+        writes one event per production event either way and the accept/reject
+        is the exact sampler, so unweighting is the safe default there; the
+        interference mode has no exact sampler to fall back on (its weights are
+        signed and its cross-section is zero), and unweighting on ``|W|`` there
+        throws away all but a few percent of the production events for ~6x the
+        variance on the observables that mode exists to measure -- section
+        13.17. Announced by ``_announce_decay_output``.
+        """
+        try:
+            asked = self.options['decay_output']
+        except (KeyError, TypeError):
+            # option sets built by hand (unit-test stubs): the same fallback
+            # _pure_interference makes, and the same reason
+            return 'unweighted'
+        if asked != 'auto':
+            return asked
+        return 'weighted' if self._pure_interference() else 'unweighted'
+
+    def _announce_decay_output(self):
+        """Say once what ``decay_output`` resolved to, and why. Same convention
+        as ``_announce_mode``: ``auto`` decides on the run, so the card no
+        longer answers the question on its own."""
+        try:
+            asked = self.options['decay_output']
+        except (KeyError, TypeError):
+            return
+        if asked == 'auto':
+            why = ('auto, pure_interference is set' if self._pure_interference()
+                   else 'auto, ordinary run')
+        else:
+            why = 'set explicitly'
+        self._log_once('decay_output', "MadSpin: decay_output = %s (%s)",
+                       self._decay_output(), why)
+
     def _weighted_decay(self):
         """True when the ordinary (non-interference) decay output is to be
         written WEIGHTED -- no accept/reject, one draw per production event,
         ``w = w_prod * BR * W / c``.
 
-        False in the pure-interference mode: that mode is always weighted (or
-        unweighted up to a sign) on its own terms and answers to
-        ``pure_interference_output`` instead, so the two options never both
-        apply. Also false outside the density spin modes, where there is no
-        ``W`` -- ``_validate_weighted_decay`` refuses that combination at
-        launch rather than silently ignoring it, so this is belt and braces.
+        False in the pure-interference mode: that mode reaches the same
+        'keep every trial' path by its own route (``pure_interference`` in the
+        worker context), with a signed ``W`` and a zeroed ``<init>``, so it is
+        ``_pure_interference_unweighted`` that reads ``decay_output`` there.
+        Also false outside the density spin modes, where there is no ``W`` --
+        ``_validate_weighted_decay`` refuses that combination at launch rather
+        than silently ignoring it, so this is belt and braces.
         """
-        try:
-            asked = self.options['decay_output']
-        except (KeyError, TypeError):
-            # option sets built by hand (unit-test stubs, older cards): the
-            # same fallback _pure_interference makes, and the same reason
-            return False
-        return (asked == 'weighted'
+        return (self._decay_output() == 'weighted'
                 and not self._pure_interference()
                 and self._density_spinmode())
 
     def _validate_weighted_decay(self):
-        """Card-level checks for ``decay_output = weighted``, run once at
-        launch. Refuses rather than ignores: an option that silently does
-        nothing is how a user ends up quoting statistics they never got."""
-        if self.options['decay_output'] != 'weighted':
+        """Card-level checks for ``decay_output``, run once at launch. Refuses
+        rather than ignores: an option that silently does nothing is how a user
+        ends up quoting statistics they never got."""
+        self._announce_decay_output()
+        if self._decay_output() != 'weighted':
             return
         if self._pure_interference():
-            logger.warning(
-                "MadSpin: decay_output = weighted has no effect under "
-                "pure_interference, which writes a signed sample on its own "
-                "terms. Use pure_interference_output (currently '%s') to "
-                "choose that mode's output shape.",
-                self.options['pure_interference_output'])
+            # the mode announces its own output shape, spinmode requirement
+            # included, in _validate_pure_interference -- which runs first
             return
         if not self._density_spinmode():
             raise self.InvalidCmd(
@@ -7089,26 +7116,19 @@ class MadSpinInterface(extended_cmd.Cmd):
 
     def _pure_interference_unweighted(self):
         """True when the pure-interference mode must write the 'unweighted'
-        (up to a sign) output instead of the fully weighted default.
+        (up to a sign) output instead of its fully weighted default.
 
-        Only meaningful when the mode is on -- ``pure_interference_output`` is
-        ignored otherwise, which ``_validate_pure_interference`` says out loud.
+        Only meaningful when the mode is on: outside it ``decay_output =
+        unweighted`` is the ordinary accept/reject, not this.
         """
         return (bool(self._pure_interference())
-                and self.options['pure_interference_output'] == 'unweighted')
+                and self._decay_output() == 'unweighted')
 
     def _validate_pure_interference(self):
         """Card-level checks for the pure-interference mode, run once at launch
         rather than on the first event inside a worker process."""
         pure = self._pure_interference()
         if not pure:
-            if self.options['pure_interference_output'] != 'weighted':
-                logger.warning(
-                    "MadSpin: pure_interference_output = %s has no effect "
-                    "because pure_interference is not set. It only chooses "
-                    "how the pure-interference mode writes its signed "
-                    "weights; ordinary runs are unweighted as always.",
-                    self.options['pure_interference_output'])
             return
         if not self._density_spinmode():
             raise self.InvalidCmd(
@@ -7222,7 +7242,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             "sample keeps ONLY the interference between the polarisations "
             "named, so its total cross-section is zero by construction and its "
             "events carry a SIGNED weight. Output shape "
-            "(pure_interference_output = %s) -- %s. Under MG5's IDWTUP = -4 "
+            "(decay_output = %s) -- %s. Under MG5's IDWTUP = -4 "
             "convention (cross-section = mean of the weights) the file is "
             "self-normalising either way: mean(w) = 0 and sum_bin(w)/N_file is "
             "the interference contribution to that bin in pb, with N_file the "
@@ -7232,7 +7252,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             "the <MGPureInterference> banner block for the reference "
             "cross-section, c, <|W|>, and the zero-cross-section check.",
             ', '.join(str(p) for p in sorted(pure)),
-            self.options['pure_interference_output'], shape)
+            self._decay_output(), shape)
 
     def _apply_pure_interference(self, decaying_pdg, helicities, restriction):
         """Overlay the pure-interference cross restriction on the (symmetric)

--- a/doc/madspin_decay_groups.md
+++ b/doc/madspin_decay_groups.md
@@ -433,6 +433,13 @@ has no assignment factor in it, agreeing to 9e-4.
 
 ### 7.3 PA, and `sequential_decay`
 
+> **Names, since this was written.** `sequential_decay` was replaced by
+> `unweighting` and then removed outright (see `madspin_sequential_plan.md`
+> 11 and 13.19). Read `sequential_decay True` below as `unweighting
+> sequential` and `sequential_decay False` as `unweighting joint`; the log
+> line now ends `(unweighting ignored)`. The runs recorded here were made with
+> the old spelling and are left as they were.
+
 Grouping forces the joint accept/reject (section 4.1), so both need checking:
 that the fallback happens, and that it costs nothing but efficiency.
 

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2504,12 +2504,19 @@ Caveats:
   exactly where the derivation says it should hold. It has **not** been checked
   offshell, where the derivation says it should *not* hold.
 
-### 13.17 The unweighted-up-to-a-sign output -- `pure_interference_output`
+### 13.17 The unweighted-up-to-a-sign output -- `decay_output = unweighted`
 
 **Status: implemented and validated end to end.** The fully weighted output of
-13.13 stays the **default**; `set pure_interference_output = unweighted`
-selects the other representation of the same estimator, in which the sample
-carries exactly two weight magnitudes.
+13.13 stays the **default**; `set decay_output = unweighted` selects the other
+representation of the same estimator, in which the sample carries exactly two
+weight magnitudes.
+
+> **Option name.** This was originally a separate option,
+> `pure_interference_output`, with its own `weighted`/`unweighted` pair. It has
+> been folded into `decay_output` (13.18, 13.19): one option now answers "does
+> MadSpin unweight?" in both modes, and `decay_output = auto` -- the default --
+> resolves to `weighted` here and to `unweighted` for an ordinary run, which is
+> each mode's own historical default.
 
 **The derivation.** Unweight on `|W|` against any bound `M >= max|W|`, ONE
 decay draw per production event, nothing written on rejection, and give each
@@ -2703,9 +2710,11 @@ collected on the same draws and is unused here.)
 **Scope: the density spin modes only.** `madspin`/`full`, `PA`, `onshell`.
 `madspin_v1`, `onshell_v1` and `spinmode = none` build no density matrix and
 have no `W`; the option raises `InvalidCmd` there rather than being ignored.
-Under `pure_interference` it warns and steps aside -- that mode is always
-weighted on its own terms and answers to `pure_interference_output`, so the
-two never both apply.
+Under `pure_interference` it does **not** step aside -- it chooses that mode's
+output shape instead (13.17, 13.19). The two constraints compose without
+conflict, because `pure_interference` needs a density spinmode as well;
+`_validate_pure_interference` runs first so the message names the more
+fundamental of the two.
 
 **It forces the joint path**, for the plain reason that there is no
 accept/reject left to stage: the sequential and two-stage schemes exist to
@@ -2774,7 +2783,8 @@ CPU. Which of the two matters depends on whether MadSpin or the parent
 generation is the bottleneck. That is why the default stays `unweighted`.
 
 **Byte-identical with the option off.** The same card without
-`decay_output`, run against the base branch and against this one, produces
+`decay_output` (i.e. at the default), run against the base branch and against
+this one, produces
 the same 90 368 979-byte file, SHA-256
 `767da240c5221ecc0d7193a3031044b3304a457f909212158728c2ab7f242855`.
 
@@ -2815,3 +2825,86 @@ Caveats, stated rather than glossed:
   interference mode's `<|W|>`, `c` really is a decay-side constant, so the
   probe's few production events are enough for it -- and `mean(w)` against
   `sigma*BR` is the direct measurement of whether that held.
+
+### 13.19 One option: `decay_output`, with `auto`
+
+**Status: implemented; behaviour-preserving by construction, checked against
+the base branch.** 13.17 and 13.18 arrived as two options with the same value
+space and the same question behind them -- *does MadSpin unweight?* --
+answered separately for the interference mode (`pure_interference_output`) and
+for an ordinary run (`decay_output`). They are now one.
+
+* `pure_interference_output` is **removed**. Nothing maps onto it and no
+  deprecated spelling survives: none of this has been in a release, so there
+  are no cards in the wild to protect.
+* `decay_output` gains **`auto`**, and `auto` is the default.
+* `auto` resolves to `weighted` when `pure_interference` is set and to
+  `unweighted` otherwise (`_decay_output`).
+
+**Why those two directions, and why this preserves behaviour exactly.** The
+old defaults were `decay_output = unweighted` and
+`pure_interference_output = weighted`, and each mode saw only its own option
+(`decay_output` warned and stepped aside under `pure_interference`). So the
+pair (ordinary run, interference run) had exactly the resolved defaults
+(`unweighted`, `weighted`) -- which is what `auto` now computes. A card that
+does not mention either option therefore lands on the same path as before, in
+both modes.
+
+They point opposite ways for a reason rather than by accident. The ordinary
+run writes one event per production event either way and its accept/reject is
+the *exact* sampler, so unweighting is the safe default and the weighted path
+buys CPU at the cost of a weighted file. The interference mode has no exact
+sampler to fall back on -- its weights are signed and its cross-section is
+zero by construction -- and unweighting on `|W|` there keeps only a few
+percent of the production events, for ~6x the variance on exactly the
+observables the mode exists to measure (13.17).
+
+**The step-aside is gone.** `_validate_weighted_decay` used to warn and return
+under `pure_interference`, on the grounds that the other option governed
+there. There is no other option now, so it governs. What the step-aside was
+avoiding was a *contradiction* between two live options, not a code hazard:
+the two flags reach the worker separately (`weighted_decay` and
+`pure_interference_unweighted` in the run context) and `_weighted_decay` still
+returns False under `pure_interference`, because the interference mode reaches
+the same "keep every trial" branch by its own route, with a signed `W` and a
+zeroed `<init>`. Only the *source* of the interference mode's choice changed.
+
+**The two spinmode restrictions compose.** `decay_output = weighted` needs a
+density spinmode (there is no `W` otherwise) and so does `pure_interference`,
+so the constraints never disagree -- but a card that violates both would get
+two refusals in a row, the less useful one first. `_validate_pure_interference`
+is therefore now called *before* `_validate_weighted_decay`, and both are
+called before the `if self._density_spinmode():` branch. `decay_output` is
+then silent under `pure_interference`: the mode announces its own output shape,
+spinmode requirement included.
+
+That reordering fixes a **pre-existing gap** found on the way:
+`_validate_pure_interference` was called only *inside* the density branch, so
+`set spinmode none` together with `set pure_interference ...` reached no
+validation at all and the mode was silently inert while the card asked for it.
+It now raises, which is the error that was always intended (the raise existed;
+it was unreachable).
+
+**`auto` announces itself** through `_announce_decay_output`, on the same
+`_log_once` convention as `_announce_mode`:
+
+    MadSpin: decay_output = unweighted (auto, ordinary run)
+    MadSpin: decay_output = weighted (auto, pure_interference is set)
+    MadSpin: decay_output = weighted (set explicitly)
+
+**Removed alongside it**, for the same "not in a release" reason, two other
+deprecated spellings that were pure load-time translations with no run-time
+reader: `sequential_decay` (mapped onto `unweighting`: `True` ->
+`sequential`, `False` -> `joint`) and `keep_weight_for_polarization` (the
+singular alias that set both `keep_weight_for_polarization_vector` and
+`_fermion`). The per-species options and the refusal of
+`keep_weight_for_polarization_*` under `pure_interference` are untouched.
+
+**The one behaviour change, stated rather than glossed.** A card that combined
+`set pure_interference ...` with an *explicit* `set decay_output unweighted`
+used to get the fully weighted interference output (the explicit
+`decay_output` was warned about and ignored, and `pure_interference_output`
+kept its `weighted` default); it now gets the unweighted-up-to-a-sign output.
+That is the intended meaning of the unification -- the option no longer steps
+aside -- and it is the only combination whose resolved behaviour differs. A
+card that does not set `decay_output` is unaffected in either mode.

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -1089,10 +1089,13 @@ longer spanned a clean 2x2:
     sequential               yes          per particle            that particle
     sequential_global_retry  yes          per particle            the virtualities too
 
-`sequential_decay` survives as a deprecated alias (`True` -> sequential,
-`False` -> joint, warning once), so cards written against the earlier revisions
-of this branch keep working. `sequential_spin_order` and `sequential_debug` keep
-their names: an ordering and a check, not modes.
+`sequential_decay` survived for a while as a deprecated alias (`True` ->
+sequential, `False` -> joint, warning once), so cards written against the
+earlier revisions of this branch kept working. **It has since been removed
+outright** -- see 13.19; nothing on this branch has been in a release, so there
+are no cards in the wild to protect, and it was a load-time translation with no
+run-time reader. Use `unweighting` directly. `sequential_spin_order` and
+`sequential_debug` keep their names: an ordering and a check, not modes.
 
 **`sequential_exact` was renamed, not kept.** "Exact" advertised a distinction of
 ~0.001 GeV on the top lineshape -- the tabulated factor is good to ~0.5%, and the

--- a/tests/parallel_tests/test_madspin_factory.py
+++ b/tests/parallel_tests/test_madspin_factory.py
@@ -94,13 +94,13 @@ MULTICORE_NB = int(os.environ.get('MADSPIN_TEST_NB_CORE', '8'))
 # (400) alone unless explicitly overridden -- the CI tests want trustworthy
 # unweighting.
 _MAX_WEIGHT_PS_POINT = os.environ.get('MADSPIN_MAX_WEIGHT_PS_POINT', '')
-EXTRA_MADSPIN_SETTINGS = {'sequential_decay': False}
+EXTRA_MADSPIN_SETTINGS = {'unweighting': 'joint'}
 if _MAX_WEIGHT_PS_POINT:
     EXTRA_MADSPIN_SETTINGS['max_weight_ps_point'] = _MAX_WEIGHT_PS_POINT
 
 # The unweighting tests below drive ``unweighting`` directly, so they must not
-# inherit the deprecated ``sequential_decay`` alias above -- it resolves to a
-# mode of its own and would fight the per-run setting.
+# inherit the ``unweighting = joint`` above -- it would fight the per-run
+# setting.
 UNWEIGHTING_BASE_SETTINGS = {'nb_core': 1}
 if _MAX_WEIGHT_PS_POINT:
     UNWEIGHTING_BASE_SETTINGS['max_weight_ps_point'] = _MAX_WEIGHT_PS_POINT

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2301,9 +2301,9 @@ class TestPureInterferenceNormalisation(unittest.TestCase):
 
 
 class TestPureInterferenceUnweightedOutput(unittest.TestCase):
-    """``pure_interference_output = unweighted``: ``<|W|>``, its plumbing, and
-    the estimator identity that says the accept/reject bound cancels out of
-    the weight (section 13.17)."""
+    """``pure_interference`` + ``decay_output = unweighted``: ``<|W|>``, its
+    plumbing, and the estimator identity that says the accept/reject bound
+    cancels out of the weight (section 13.17)."""
 
     class _Stub(object):
         InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -74,8 +74,10 @@ def _borrow_decision_helpers(namespace):
                  '_density_spinmode', '_production_polarization',
                  # _unweighting_mode consults these first: the interference
                  # mode and decay_output = weighted both force joint, so a stub
-                 # that borrows the resolver needs them
-                 '_pure_interference', '_weighted_decay'):
+                 # that borrows the resolver needs them -- and _weighted_decay
+                 # is built on the decay_output resolver
+                 '_pure_interference', '_weighted_decay', '_decay_output',
+                 '_announce_decay_output'):
         namespace[name] = inspect.getattr_static(
             interface_madspin.MadSpinInterface, name)
 
@@ -1915,10 +1917,10 @@ class TestPureInterferenceMode(unittest.TestCase):
 
         def __init__(self, spec='', spinmode='madspin', pol_map=None,
                      branches=('w+', 'w-'), unweighting='sequential',
-                     pol_weights=False, output='weighted'):
+                     pol_weights=False, output='auto'):
             self.options = interface_madspin.MadSpinOptions()
             self.options['pure_interference'] = spec
-            self.options['pure_interference_output'] = output
+            self.options['decay_output'] = output
             self.options['spinmode'] = spinmode
             self.options['unweighting'] = unweighting
             self.options['fixed_order'] = False
@@ -2099,14 +2101,23 @@ class TestPureInterferenceMode(unittest.TestCase):
         # ... and without the mode the two are unrelated
         self._Stub('w+ = 0 T', pol_weights=False)._validate_pure_interference()
 
-    # -- pure_interference_output ------------------------------------------
+    # -- decay_output, which governs this mode's output shape ---------------
 
-    def test_the_output_option_defaults_to_the_fully_weighted_mode(self):
-        """The fully weighted output stays the default: it uses every
-        production event and measures ~6x less variance per production event
-        (section 13.17)."""
+    def test_auto_gives_the_fully_weighted_output(self):
+        """``decay_output = auto`` (the default) resolves to the fully
+        weighted output here: it uses every production event and measures ~6x
+        less variance per production event (section 13.17). That is what the
+        mode has always done."""
         stub = self._Stub('w+ = 0 T')
-        self.assertEqual(stub.options['pure_interference_output'], 'weighted')
+        self.assertEqual(stub.options['decay_output'], 'auto')
+        self.assertEqual(stub._decay_output(), 'weighted')
+        self.assertFalse(stub._pure_interference_unweighted())
+
+    def test_auto_resolves_the_other_way_without_the_mode(self):
+        """The same 'auto' is the ordinary accept/reject outside the mode --
+        that is the whole point of it being one option."""
+        stub = self._Stub('')
+        self.assertEqual(stub._decay_output(), 'unweighted')
         self.assertFalse(stub._pure_interference_unweighted())
 
     def test_the_output_option_selects_the_unweighted_variant(self):
@@ -2114,22 +2125,33 @@ class TestPureInterferenceMode(unittest.TestCase):
         self.assertTrue(stub._pure_interference_unweighted())
         stub._validate_pure_interference()
 
-    def test_the_output_option_is_inert_without_the_mode(self):
-        """It only chooses how the interference mode writes its signed
-        weights, so an ordinary run must not be touched by it."""
+    def test_an_explicit_weighted_matches_what_auto_resolves_to(self):
+        stub = self._Stub('w+ = 0 T', output='weighted')
+        self.assertFalse(stub._pure_interference_unweighted())
+        stub._validate_pure_interference()
+
+    def test_the_unweighted_variant_is_inert_without_the_mode(self):
+        """Outside the mode 'unweighted' is the ordinary accept/reject, not
+        the unweighted-up-to-a-sign interference output."""
         stub = self._Stub('', output='unweighted')
         self.assertFalse(stub._pure_interference_unweighted())
-        # and validation is a no-op (it only warns)
+        # and validation is a no-op
         stub._validate_pure_interference()
+
+    def test_the_replaced_option_no_longer_exists(self):
+        """``pure_interference_output`` was folded into ``decay_output``; the
+        old spelling is gone rather than silently accepted."""
+        options = interface_madspin.MadSpinOptions()
+        self.assertNotIn('pure_interference_output', options)
 
     def test_the_output_option_rejects_an_unknown_value(self):
         """ConfigFile keeps the previous value and warns rather than raising,
         so the check is that an unknown spelling does not silently become the
         active one."""
         options = interface_madspin.MadSpinOptions()
-        options['pure_interference_output'] = 'unweighted'
-        options['pure_interference_output'] = 'signed'
-        self.assertEqual(options['pure_interference_output'], 'unweighted')
+        options['decay_output'] = 'unweighted'
+        options['decay_output'] = 'signed'
+        self.assertEqual(options['decay_output'], 'unweighted')
 
 
 class TestPureInterferenceCardSyntax(unittest.TestCase):
@@ -2484,6 +2506,8 @@ class TestWeightedDecayOutput(unittest.TestCase):
     class _Stub(object):
         InvalidCmd = interface_madspin.MadSpinInterface.InvalidCmd
         _weighted_decay = interface_madspin.MadSpinInterface._weighted_decay
+        _pure_interference_unweighted = \
+            interface_madspin.MadSpinInterface._pure_interference_unweighted
         _validate_weighted_decay = \
             interface_madspin.MadSpinInterface._validate_weighted_decay
         _weighted_decay_note = \
@@ -2497,7 +2521,7 @@ class TestWeightedDecayOutput(unittest.TestCase):
         _parse_pol_side = interface_madspin.MadSpinInterface._parse_pol_side
         _borrow_decision_helpers(locals())
 
-        def __init__(self, output='unweighted', spinmode='onshell',
+        def __init__(self, output='auto', spinmode='onshell',
                      pure_interference='', unweighting='auto'):
             self.options = interface_madspin.MadSpinOptions()
             self.options['decay_output'] = output
@@ -2511,8 +2535,15 @@ class TestWeightedDecayOutput(unittest.TestCase):
     # -- the predicate ------------------------------------------------------
 
     def test_off_by_default(self):
+        """The shipped default is 'auto', which is 'unweighted' for an
+        ordinary run -- what MadSpin has always done."""
         stub = self._Stub()
-        self.assertEqual(stub.options['decay_output'], 'unweighted')
+        self.assertEqual(stub.options['decay_output'], 'auto')
+        self.assertEqual(stub._decay_output(), 'unweighted')
+        self.assertFalse(stub._weighted_decay())
+
+    def test_an_explicit_unweighted_is_the_same_as_the_default(self):
+        stub = self._Stub(output='unweighted')
         self.assertFalse(stub._weighted_decay())
 
     def test_on_when_asked_for_in_a_density_mode(self):
@@ -2520,13 +2551,37 @@ class TestWeightedDecayOutput(unittest.TestCase):
             stub = self._Stub(output='weighted', spinmode=spinmode)
             self.assertTrue(stub._weighted_decay(), spinmode)
 
-    def test_the_two_output_options_do_not_both_apply(self):
-        """pure_interference is always weighted (or unweighted up to a sign)
-        on its own terms, so decay_output steps aside there rather than
-        contradicting pure_interference_output."""
+    def test_it_governs_the_interference_output_instead(self):
+        """Under pure_interference the option does not step aside: it chooses
+        that mode's output shape. The ordinary weighted path stays off -- the
+        interference mode reaches the same 'keep every trial' code by its own
+        route, with a signed W and a zeroed <init>."""
         stub = self._Stub(output='weighted', pure_interference='t = + -')
+        self.assertEqual(stub._decay_output(), 'weighted')
         self.assertFalse(stub._weighted_decay())
-        stub._validate_weighted_decay()          # warns, does not raise
+        self.assertFalse(stub._pure_interference_unweighted())
+        stub._validate_weighted_decay()          # no refusal, no step-aside
+
+        stub = self._Stub(output='unweighted', pure_interference='t = + -')
+        self.assertFalse(stub._weighted_decay())
+        self.assertTrue(stub._pure_interference_unweighted())
+        stub._validate_weighted_decay()
+
+    def test_auto_follows_the_mode(self):
+        """'auto' is 'weighted' under pure_interference and 'unweighted'
+        otherwise, which is each mode's own historical default."""
+        self.assertEqual(self._Stub()._decay_output(), 'unweighted')
+        self.assertEqual(
+            self._Stub(pure_interference='t = + -')._decay_output(),
+            'weighted')
+
+    def test_auto_never_raises_outside_the_density_modes(self):
+        """'weighted' is refused there, so the default must not resolve to it
+        -- an ordinary spinmode=none card has to keep working."""
+        for spinmode in ('madspin_v1', 'onshell_v1', 'none'):
+            stub = self._Stub(spinmode=spinmode)
+            self.assertEqual(stub._decay_output(), 'unweighted')
+            stub._validate_weighted_decay()
 
     def test_refused_outside_the_density_modes(self):
         for spinmode in ('madspin_v1', 'onshell_v1', 'none'):
@@ -2543,6 +2598,12 @@ class TestWeightedDecayOutput(unittest.TestCase):
         options['decay_output'] = 'weighted'
         options['decay_output'] = 'signed'
         self.assertEqual(options['decay_output'], 'weighted')
+
+    def test_the_option_accepts_its_three_spellings(self):
+        options = interface_madspin.MadSpinOptions()
+        for value in ('auto', 'unweighted', 'weighted'):
+            options['decay_output'] = value
+            self.assertEqual(options['decay_output'], value)
 
     # -- it forces the joint path ------------------------------------------
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3315,7 +3315,6 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         options = interface_madspin.MadSpinOptions()
         self.assertEqual(options['keep_weight_for_polarization_vector'], [])
         self.assertEqual(options['keep_weight_for_polarization_fermion'], [])
-        self.assertEqual(options['keep_weight_for_polarization'], [])
 
         stub = self._Stub()
         self.assertFalse(stub._polarization_weights_enabled())
@@ -3358,8 +3357,6 @@ class TestKeepWeightForPolarization(unittest.TestCase):
                           'keep_weight_for_polarization_vector', '[0, A]')
         self.assertRaises(banner.InvalidCmd, options.__setitem__,
                           'keep_weight_for_polarization_fermion', '[+, A]')
-        self.assertRaises(banner.InvalidCmd, options.__setitem__,
-                          'keep_weight_for_polarization', '[0, A]')
 
     def test_needs_frame_axis_covers_the_three_projections(self):
         """A helicity *projection* does not commute with a boost, so it only
@@ -3408,18 +3405,18 @@ class TestKeepWeightForPolarization(unittest.TestCase):
         self.assertEqual(options['keep_weight_for_polarization_vector'],
                          ['0', 'T'])
 
-    def test_deprecated_option_sets_both_lists(self):
-        """The old spelling is accepted, canonicalised and mapped onto both
-        species -- the name has been in a released PR, and silently ignoring it
-        would change the output of an existing card without saying so."""
+    def test_the_same_list_on_both_species_drops_the_unphysical_entry(self):
+        """A card that gives both species the same list is legal and each side
+        is canonicalised on its own; the '0' is then unphysical for a fermion
+        slot and is dropped when the combinations are built, so it does not emit
+        a duplicate column."""
         options = interface_madspin.MadSpinOptions()
-        options['keep_weight_for_polarization'] = '[0, R, -]'
+        options['keep_weight_for_polarization_vector'] = '[0, R, -]'
+        options['keep_weight_for_polarization_fermion'] = '[0, R, -]'
         self.assertEqual(options['keep_weight_for_polarization_vector'],
                          ['0', '+', '-'])
         self.assertEqual(options['keep_weight_for_polarization_fermion'],
                          ['0', '+', '-'])
-        # ... and the '0' it puts on the fermions is dropped when the
-        # combinations are built, so the alias does not emit a duplicate column
         stub = self._Stub(vector=['0', '+', '-'], fermion=['0', '+', '-'])
         self.assertEqual(
             [wid for wid, _ in stub._polarization_combinations(
@@ -4854,16 +4851,13 @@ class TestSequentialPoolLadder(unittest.TestCase):
             options['unweighting'] = value
             self.assertEqual(options['unweighting'], value)
 
-    def test_deprecated_sequential_decay_alias(self):
-        """sequential_decay is gone as a knob but still understood: the two
-        values it ever had map onto the two modes that existed then."""
+    def test_the_replaced_spellings_no_longer_exist(self):
+        """``sequential_decay`` and the singular
+        ``keep_weight_for_polarization`` were deprecated aliases that only ever
+        translated at load time; they are gone rather than silently accepted."""
         options = interface_madspin.MadSpinOptions()
-        options['sequential_decay'] = 'True'
-        self.assertEqual(options['unweighting'], 'sequential')
-        options['sequential_decay'] = 'False'
-        self.assertEqual(options['unweighting'], 'joint')
-        options['sequential_decay'] = 'auto'
-        self.assertEqual(options['unweighting'], 'auto')
+        self.assertNotIn('sequential_decay', options)
+        self.assertNotIn('keep_weight_for_polarization', options)
 
 
 class TestScanMaxwgtDecomposition(unittest.TestCase):


### PR DESCRIPTION
Collapses the two options controlling whether MadSpin unweights into one, and removes three deprecated spellings outright. None of these are in an official release, so there is no card in the wild to protect and no deprecation path is provided — `check_set` raises `InvalidCmd: Unknown options X`, so an old card gets a loud error rather than a silent no-op.

## The unification

`decay_output` gains **`auto`**, which is now the default:

- `auto` -> `unweighted` for an ordinary run;
- `auto` -> `weighted` when `pure_interference` is set.

`pure_interference_output` is gone; the interference mode follows `decay_output`.

This was chosen to preserve today's behaviour exactly — a normal run defaulted to unweighted, and an interference run defaulted to weighted because `pure_interference_output` did. **Verified rather than assumed**, two ways.

**Exhaustive decision surface.** 70 base rows (7 spinmodes x pure on/off x 5 option settings) compared against the new tree under the card mapping, on `_weighted_decay`, `_pure_interference_unweighted`, the resolved unweighting scheme and whether validation refuses: **4 mismatches out of 70**, all the same corner — see below. Every other combination is bit-for-bit the same decision.

**Six real end-to-end MadSpin runs on each tree** (100 events, `seed 33`), decompressed and diffed:

| | config | result |
|---|---|---|
| A | ordinary, unset | identical but for the echoed `import <path>` line |
| B | ordinary, `decay_output = weighted` | identical |
| C | pure-interference, both unset | identical |
| D | base `pure_interference_output=unweighted` vs new `decay_output=unweighted` | identical but for the migrated card line |
| E | `spinmode madspin`, unset | identical |
| F | `spinmode none`, unset (`auto` must **not** resolve to `weighted`) | identical |

Every event record, weight, `<init>` block and banner block byte-identical. Weight structure preserved: A = 1 distinct weight; B/C = 100 distinct; **D = 14 events written of 100 read, exactly two signed values +/-76.401968, one magnitude**, element-wise equal to the base.

## The one intended behaviour change

`pure_interference` **plus an explicit `decay_output = unweighted`** (the 4 mismatching rows, one per density spinmode). On the base that combination was warned about and ignored, so the run silently got the *weighted* interference output. It now gets the unweighted-up-to-a-sign one — which is the whole point of the unification. Recorded in plan §13.19.

## A bug found on the way

`_validate_pure_interference` was called only *inside* the `if self._density_spinmode():` branch, so **its own spinmode refusal was unreachable**. Confirmed empirically: on the base, `set spinmode none` + `set pure_interference t = + -` runs to completion, writes a normal decayed file, and emits no warning and no `<MGPureInterference>` block — the mode was **silently inert while the card explicitly asked for it**. It now raises the error that was always intended.

## Points settled

- **The step-aside** was avoiding a contradiction between two live options, not a code hazard: the two flags reach the worker separately, and `_weighted_decay()` still returns False under `pure_interference` because that mode reaches the same "keep every trial" branch by its own route, with a signed `W` and a zeroed `<init>`. Only the *source* of the interference mode's choice moved. Runs C and D are the evidence.
- **The two spinmode restrictions compose.** `_validate_pure_interference` now runs *before* `_validate_weighted_decay`, so a card violating both is told about `pure_interference` — the more fundamental request — instead of getting a double refusal. `decay_output` stays silent under `pure_interference`; the mode announces its own shape.
- **`auto` is inspectable**, via `_announce_decay_output` on the same `_log_once` convention as `_announce_mode`: `decay_output = unweighted (auto, ordinary run)`, `decay_output = weighted (auto, pure_interference is set)`, `decay_output = weighted (set explicitly)`.

## The three removals

All verified to be pure **load-time translations with no run-time reader** before deletion — `_sequential_active` / `_unweighting_mode` read `unweighting` only, and the polarisation machinery builds `keep_weight_for_polarization_%s` per species:

1. `pure_interference_output`
2. `sequential_decay` (alias onto `unweighting`)
3. `keep_weight_for_polarization` (singular alias onto the `_vector` / `_fermion` pair)

The per-species `keep_weight_for_polarization_vector` / `_fermion` options are untouched, as is their refusal under `pure_interference` — that is a live guard, not deprecation machinery.

`TestUnweightingDecisionTable` never referenced `sequential_decay`, so its coverage is untouched. The `'0'`-on-a-fermion drop test was **migrated** to set both per-species options rather than deleted. Only tests pinning the aliases themselves were removed, replaced by two pinning that the spellings no longer exist.

Remaining textual references are deliberate: `doc/madspin_decay_groups.md` keeps a historical investigation intact under a translation note (*"read `sequential_decay True` below as `unweighting sequential`"*) rather than being rewritten, and `doc/madspin_sequential_plan.md` §13.19 documents the change.

## Verification

`tests/test_manager.py test_madspin -t0`: baseline re-measured **388 OK** -> **395 OK**.

## Not verified

- Only `spinmode onshell` was exercised end to end (plus `madspin` and `none` for the unset-option cases); `PA` and `fixed_order` were not run, matching the pre-existing caveats in plan §13.18.
- 100-event runs with a small max-weight probe — enough for byte-identity, not physics precision. Run B shows a 3.51-sigma `mean(w)` pull, but the base produces the identical number, so it is small-statistics noise rather than a regression.
- `tests/parallel_tests/test_madspin_factory.py` (now asking for `unweighting: joint` directly instead of `sequential_decay: False`) was edited but not run — it needs full process generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify MadSpin decay output configuration around `decay_output`, remove obsolete option aliases, and enforce pure-interference validation consistently.

New Features:
- Unify ordinary and pure-interference output selection under `decay_output`, with `auto` resolving to each mode’s historical default and reporting the resolved choice.

Bug Fixes:
- Validate pure-interference requests before entering density-spinmode processing, preventing unsupported spinmodes from silently ignoring the requested mode.

Enhancements:
- Remove the unused deprecated `pure_interference_output`, `sequential_decay`, and singular `keep_weight_for_polarization` option spellings while retaining the canonical per-species polarization settings.

Documentation:
- Update MadSpin planning and historical documentation to describe the unified output option and removed aliases.

Tests:
- Expand MadSpin option and decision-path coverage for `auto`, pure-interference output selection, removed spellings, and spinmode validation.

Chores:
- Update MadSpin factory test settings to use the canonical `unweighting` option directly.