### PR TITLE
MadSpin: fix the "PA (default)" label on the post-acceptance reshuffle

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4459,12 +4459,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                     elif (density_needs_reshuffle
                             and density_pole_approximation
                             and not self.options['density_keep_jacobian']):
-                        # PA (default): reshuffle AFTER acceptance. The reshuffle is
-                        # a kinematic dressing of the accepted event; the Breit-Wigner
-                        # sampling jacobian is already folded into wgt, so the
-                        # reshuffling jacobian must not re-enter the accept/reject
-                        # test. For 2 -> 1 production no mass was sampled and
-                        # reshuffle_production short-circuits (NWA-style no-op).
+                        # PA with density_keep_jacobian = False (NOT the default;
+                        # the default is the branch above, which reshuffles before
+                        # the test so the jacobian enters the weight): reshuffle
+                        # AFTER acceptance, so the reshuffle is only a kinematic
+                        # dressing of the accepted event. The Breit-Wigner sampling
+                        # jacobian is already folded into wgt, and this mode
+                        # deliberately keeps the reshuffling jacobian out of the
+                        # accept/reject test. For 2 -> 1 production no mass was
+                        # sampled and reshuffle_production short-circuits
+                        # (NWA-style no-op).
                         full_evt = lhe_parser.Event(str(production))
                         full_evt = full_evt.add_decays(decays)
                         jac = full_evt.reshuffle_production()


### PR DESCRIPTION
Comment-only fix in the joint accept/reject loop of `MadSpin/interface_madspin.py`.

The branch guarded on `not self.options['density_keep_jacobian']` was commented as "PA (default)". It is the opposite: `density_keep_jacobian` is declared with default `True`, so the default PA path is the earlier `if` block, which reshuffles *before* the accept/reject so the reshuffling jacobian enters the weight. This branch is the `density_keep_jacobian = False` path, where the reshuffle runs after acceptance as a pure kinematic dressing.

The relabelled comment says so and points at the branch that is the default. No behaviour change.

I checked every other `density_keep_jacobian` mention in the file and the repo (`add_param` help at line 331, the two "PA with explicit jacobian tracking" blocks, the sequential-scheme comments around lines 8723-8820, and `doc/madspin_sequential_plan.md`): they all already had the polarity right. Only this one was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Correct the MadSpin post-acceptance reshuffle comment to accurately describe the non-default `density_keep_jacobian = False` path and identify the default branch.