### PR TITLE
MadSpin: carry the overweight instead of clipping it, in every accept/reject stage

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2451,8 +2451,20 @@ class decay_all_events(object):
                 logger.debug('Got a production event with %s failures for the phase-space generation generation ' % failed)
 
             # Treat the case that we ge too many overweight.
+            # ``carry``: the overweight safety net (section 14 of
+            # doc/madspin_sequential_plan.md). The Fortran
+            # accept/reject (MadSpin/src/driver.f, "weight.gt.x*maxweight")
+            # stops on a trial with probability min(1, weight/max_weight), so a
+            # weight above the bound is accepted with probability 1 and the
+            # excess used to be dropped. Writing that event with weight
+            # max(1, weight/max_weight) restores the sampled density exactly,
+            # since min(1,x)*max(1,x) = x. Left as the literal 1.0 when nothing
+            # overflowed, so the written weights are bit-identical to before.
+            carry = 1.0
             if weight > decay_me['max_weight']:
+                carry = weight / decay_me['max_weight']
                 report['over_weight'] += 1
+                report['over_weight_excess'] += carry - 1.0
                 report['%s_f' % (decay['decay_tag'],)] +=1
                 if __debug__:               
                     misc.sprint('''over_weight: %s %s, occurence: %s%%, occurence_channel: %s%%
@@ -2493,7 +2505,11 @@ class decay_all_events(object):
                     raise MadSpinError(error)
                     
              
-            decayed_event.change_wgt(factor= self.branching_ratio) 
+            # the carried overweight rides the branching ratio, so it reaches
+            # both the event weight and every <rwgt> entry through the single
+            # multiplication change_wgt already does
+            decayed_event.change_wgt(factor= self.branching_ratio if carry == 1.0
+                                     else self.branching_ratio * carry)
             #decayed_event.wgt = decayed_event.wgt * self.branching_ratio
                     
             self.outputfile.write(decayed_event.string_event())
@@ -2527,6 +2543,30 @@ class decay_all_events(object):
             +str(float(trial_nb_all_events)/float(event_nb)))
         logger.info('Branching ratio to allowed decays: %g' % self.branching_ratio)
         logger.info('Number of events with weights larger than max_weight: %s' % report['over_weight'])
+        # The overweight safety net's measurement, same line as the density
+        # path's _report_overweight: how many events carry a non-unit weight,
+        # what the carried excess sums to, and what fraction of the sample's
+        # normalisation that is (IDWTUP = -4: sigma is the MEAN of the weights,
+        # so the relative shift is the excess over the number of events).
+        if event_nb:
+            if report['over_weight']:
+                logger.warning(
+                    "MadSpin overweight safety net: %d/%d written events "
+                    "(%.3g%%) carried a non-unit weight because a trial weight "
+                    "exceeded max_weight; total carried excess %.6g, i.e. "
+                    "%.3g%% of the sample's normalisation. Clipping those to 1 "
+                    "-- what MadSpin did before -- would have silently biased "
+                    "the sample low by that amount.",
+                    report['over_weight'], event_nb,
+                    100.0 * report['over_weight'] / event_nb,
+                    report['over_weight_excess'],
+                    100.0 * report['over_weight_excess'] / event_nb)
+            else:
+                logger.info(
+                    "MadSpin overweight safety net: 0/%d written events "
+                    "carried a non-unit weight -- max_weight was never "
+                    "exceeded, so the sample is unweighted and unbiased by "
+                    "clipping.", event_nb)
         logger.info('Number of subprocesses '+str(len(self.calculator)))
         logger.info('Number of failures when restoring the Monte Carlo masses: %s ' % nb_fail_mc_mass)
         if fail_nb:

--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2460,11 +2460,21 @@ class decay_all_events(object):
             # max(1, weight/max_weight) restores the sampled density exactly,
             # since min(1,x)*max(1,x) = x. Left as the literal 1.0 when nothing
             # overflowed, so the written weights are bit-identical to before.
+            # ``weight`` is the matrix-element weight the Fortran tested, not
+            # the event's LHE weight, so ``carry`` is always > 1 and unsigned: a
+            # negative production weight (an MC@NLO counter-event) keeps its
+            # sign and only grows in magnitude.
             carry = 1.0
             if weight > decay_me['max_weight']:
                 carry = weight / decay_me['max_weight']
                 report['over_weight'] += 1
-                report['over_weight_excess'] += carry - 1.0
+                # the accounting is on the WEIGHT, not on a count: a
+                # counter-event whose trial overflowed makes the cross-section
+                # more negative, so its excess subtracts. w_nom is what this
+                # event would have been written with under clipping.
+                w_nom = decayed_event.wgt * self.branching_ratio
+                report['over_weight_dw'] += w_nom * (carry - 1.0)
+                report['over_weight_dabs'] += abs(w_nom) * (carry - 1.0)
                 report['%s_f' % (decay['decay_tag'],)] +=1
                 if __debug__:               
                     misc.sprint('''over_weight: %s %s, occurence: %s%%, occurence_channel: %s%%
@@ -2511,7 +2521,14 @@ class decay_all_events(object):
             decayed_event.change_wgt(factor= self.branching_ratio if carry == 1.0
                                      else self.branching_ratio * carry)
             #decayed_event.wgt = decayed_event.wgt * self.branching_ratio
-                    
+            # the file as clipping would have written it: needed as the
+            # denominator of the overweight report, and as the scale that says
+            # whether that denominator is distinguishable from zero at all
+            w_nom = decayed_event.wgt if carry == 1.0 else decayed_event.wgt / carry
+            report['sum_nom'] += w_nom
+            report['sum_abs_nom'] += abs(w_nom)
+            report['sum_sq_nom'] += w_nom * w_nom
+
             self.outputfile.write(decayed_event.string_event())
                 #print "number of trials: "+str(trial_nb)
             trial_nb_all_events+=trial_nb
@@ -2543,30 +2560,56 @@ class decay_all_events(object):
             +str(float(trial_nb_all_events)/float(event_nb)))
         logger.info('Branching ratio to allowed decays: %g' % self.branching_ratio)
         logger.info('Number of events with weights larger than max_weight: %s' % report['over_weight'])
-        # The overweight safety net's measurement, same line as the density
-        # path's _report_overweight: how many events carry a non-unit weight,
-        # what the carried excess sums to, and what fraction of the sample's
-        # normalisation that is (IDWTUP = -4: sigma is the MEAN of the weights,
-        # so the relative shift is the excess over the number of events).
+        # The overweight safety net's measurement, the same convention as the
+        # density path's _report_overweight: how many events carry a non-unit
+        # weight, and what the carried excess is worth as a fraction of the
+        # sample's cross-section (IDWTUP = -4: sigma is the MEAN of the
+        # weights, and carrying changes no event count, so d(sum w)/sum w is
+        # the relative shift). The excess is summed WEIGHTED, so a
+        # counter-event's overflow subtracts instead of adding; and sum w is
+        # only used as a denominator when it is not itself ~0.
         if event_nb:
             if report['over_weight']:
-                logger.warning(
-                    "MadSpin overweight safety net: %d/%d written events "
-                    "(%.3g%%) carried a non-unit weight because a trial weight "
-                    "exceeded max_weight; total carried excess %.6g, i.e. "
-                    "%.3g%% of the sample's normalisation. Clipping those to 1 "
-                    "-- what MadSpin did before -- would have silently biased "
-                    "the sample low by that amount.",
-                    report['over_weight'], event_nb,
-                    100.0 * report['over_weight'] / event_nb,
-                    report['over_weight_excess'],
-                    100.0 * report['over_weight_excess'] / event_nb)
+                d_w = report['over_weight_dw']
+                d_abs = report['over_weight_dabs']
+                sum_w = report['sum_nom']
+                sum_abs = report['sum_abs_nom']
+                delta = math.sqrt(report['sum_sq_nom'])
+                z = (abs(sum_w) / delta) if delta else 0.0
+                # built with % here, not handed to the logger as a format
+                # string: the head already contains literal per-cent signs
+                msg = ("MadSpin overweight safety net: %d/%d written events "
+                       "(%.3g%%) carried a non-unit weight because a trial "
+                       "weight exceeded max_weight. "
+                       % (report['over_weight'], event_nb,
+                          100.0 * report['over_weight'] / event_nb))
+                # sum w is only a denominator when it is distinguishable
+                # from zero -- 5 of its own Monte Carlo errors, the same test
+                # the density path uses (_OVERWEIGHT_MIN_Z)
+                if z >= 5.0:
+                    msg += ("Carrying it added %+.6g to the summed event "
+                            "weight, i.e. %+.3g%% of the sample's "
+                            "cross-section. " % (d_w, 100.0 * d_w / sum_w))
+                else:
+                    msg += ("Carrying it added %+.6g to the summed event "
+                            "weight and %+.6g to the summed |weight|; the "
+                            "summed weight is %+.4g against a Monte Carlo "
+                            "error of %.4g (z = %.2f), i.e. consistent with "
+                            "zero, so it is not a usable denominator and the "
+                            "shift is quoted against sum|w| = %.4g instead: "
+                            "%+.3g%%. "
+                            % (d_w, d_abs, sum_w, delta, z, sum_abs,
+                               100.0 * d_abs / sum_abs if sum_abs
+                               else float('nan')))
+                msg += ("Clipping it -- what MadSpin did before -- would have "
+                        "discarded that silently.")
+                logger.warning(msg)
             else:
                 logger.info(
                     "MadSpin overweight safety net: 0/%d written events "
                     "carried a non-unit weight -- max_weight was never "
-                    "exceeded, so the sample is unweighted and unbiased by "
-                    "clipping.", event_nb)
+                    "exceeded, so nothing was clipped and nothing is biased "
+                    "by it.", event_nb)
         logger.info('Number of subprocesses '+str(len(self.calculator)))
         logger.info('Number of failures when restoring the Monte Carlo masses: %s ' % nb_fail_mc_mass)
         if fail_nb:

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4260,6 +4260,24 @@ class MadSpinInterface(extended_cmd.Cmd):
                            # -- the acceptance probability clips at 1 -- so an
                            # under-estimated max_weight biases the sample and
                            # has to be counted and reported.
+        nb_overflow_joint = 0  # joint accept/reject trials above ``maxwgt``.
+                           # Same story as nb_pi_overflow, for the ordinary
+                           # (unsigned) joint test, which had no counter at all.
+        # ---- the overweight safety net (doc/madspin_sequential_plan.md,
+        # section 14) ----------------------------------------------------------
+        # Every accept/reject below stops on a trial with probability
+        # min(1, w/C); when w > C that probability clips at 1 and the excess is
+        # silently dropped. Writing such an event with weight max(1, w/C)
+        # restores the correct shape exactly, because min(1,x)*max(1,x) = x. The
+        # carried factor rides on the branching ratio (see ``br`` below), so it
+        # reaches ``full_evt.wgt`` and every ``parse_reweight()`` entry through
+        # the same multiplication -- and it is the *literal* 1.0, never a
+        # division, whenever nothing overflowed, so the written weights are
+        # bit-identical to the clipping ones on the overwhelmingly common path.
+        nb_overweight = 0        # written events carrying a non-unit factor
+        sum_overweight_excess = 0.0   # sum of (factor - 1): the normalisation
+                                      # that used to be thrown away
+        max_overweight = 1.0     # the largest single factor carried
         sum_w = 0.0        # signed weight sum, for the zero-cross-section check
         sum_w2 = 0.0       # its second moment: no cancellation, so the MC error
         nb_try = 0
@@ -4325,6 +4343,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # nothing to decay in this production event
                     output_lhe.write_events(production)
                     continue
+                # the accepted chain's carried overweight (mass stage x angle
+                # stages, composed multiplicatively inside the chain -- see
+                # sequential_accept_reject). Popped rather than merged: the
+                # remaining keys are additive counters.
+                carry = seq_stats.pop('overweight_factor', 1.0)
                 for key, value in seq_stats.items():
                     sequential_stats[key] += value
                 nb_try += sum(v for k, v in seq_stats.items()
@@ -4337,10 +4360,21 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # sequential_accept_reject has already checked is possible
                     full_evt.reshuffle_production()
                 self.efficiency = float(curr_event + 1) / nb_try if nb_try else 1.0
-                full_evt.wgt *= self.branching_ratio
+                br = self.branching_ratio
+                if carry != 1.0:
+                    # exactly one multiplication either way: br is the same
+                    # float object as self.branching_ratio when nothing
+                    # overflowed, so this branch is the only thing that can
+                    # move a written weight.
+                    br = br * carry
+                    nb_overweight += 1
+                    sum_overweight_excess += carry - 1.0
+                    if carry > max_overweight:
+                        max_overweight = carry
+                full_evt.wgt *= br
                 wgts = full_evt.parse_reweight()
                 for key in wgts:
-                    wgts[key] *= self.branching_ratio
+                    wgts[key] *= br
                 self._add_polarization_weights(
                     full_evt, getattr(self, '_pol_weight_ratios', None))
                 output_lhe.write_events(full_evt)
@@ -4350,6 +4384,11 @@ class MadSpinInterface(extended_cmd.Cmd):
             prod_density_cached = None
             pi_factor = 1.0   # W/c ('weighted') or +-<|W|>/c ('unweighted') in
                               # the pure-interference mode, 1 elsewhere
+            carry = 1.0       # overweight safety net: max(1, w/C) of the trial
+                              # this production event stops on. SET (never
+                              # accumulated) at the acceptance, because a
+                              # rejected trial is redrawn from scratch and
+                              # contributes nothing to the event that is written.
             pi_rejected = False  # 'unweighted': the single draw failed, so this
                                  # production event writes nothing at all
             # Consecutive trials whose matrix-element weight was not a finite
@@ -4437,6 +4476,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                         if random.random() * maxwgt >= abs(signed):
                             pi_rejected = True
                             break
+                        if abs(signed) > maxwgt:
+                            # the |W|/M test clipped at 1: carry the excess on
+                            # the magnitude instead of dropping it. The 'two
+                            # weight magnitudes' claim of the banner note
+                            # acquires an exception here, which the note says.
+                            # <|W|> = (N_file/N_drawn)*M is unaffected: N_file
+                            # is a COUNT, and the estimator only needs
+                            # E[min(1,x)*max(1,x)] = E[x] -- which is exactly
+                            # what carrying restores.
+                            carry = abs(signed) / maxwgt
                         pi_factor = math.copysign(pi_w0_factor, signed)
                 else:
                     # ``wgt`` alone, not ``wgt*jac``: a zero/-1 jacobian is an
@@ -4447,6 +4496,17 @@ class MadSpinInterface(extended_cmd.Cmd):
                                                    'the joint accept/reject')
 
                 if no_joint_test or random.random()*maxwgt < test:
+                    if not no_joint_test and maxwgt > 0 and test > maxwgt:
+                        # The joint test clipped at probability 1 (it always
+                        # does when test > maxwgt, since random.random() < 1).
+                        # Carry max(1, test/maxwgt) instead of dropping the
+                        # excess. This branch is the ONLY joint-path
+                        # overflow -- there was no counter here at all before.
+                        nb_overflow_joint += 1
+                        carry = test / maxwgt
+                        logger.debug('joint accept/reject: weight %s above its '
+                                     'max %s, carried on the event weight',
+                                     test, maxwgt)
                     if offshell_density:
                         # prod_trial has already been reshuffled internally (its
                         # jacobian is in wgt); build the event to write out from the
@@ -4503,6 +4563,17 @@ class MadSpinInterface(extended_cmd.Cmd):
             br = self.branching_ratio * pi_factor \
                 if (pure_interference or weighted_decay) \
                 else self.branching_ratio
+            if carry != 1.0:
+                # the overweight safety net rides the same hook, for the same
+                # reason: one multiplication that reaches both full_evt.wgt and
+                # every parse_reweight() entry. Guarded so that the no-overflow
+                # path -- which is essentially the whole sample -- performs the
+                # identical arithmetic it did before this existed.
+                br = br * carry
+                nb_overweight += 1
+                sum_overweight_excess += carry - 1.0
+                if carry > max_overweight:
+                    max_overweight = carry
             if self.options['fixed_order']:
                 for evt in full_evt:
                     # change the weight associated to the event
@@ -4545,6 +4616,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # one shard or many gives the identical zero-cross-section
                     # test (section 13.8)
                     nb_pi_dead=nb_pi_dead,
+                    # overweight safety net: additive over shards, so one shard
+                    # or many gives the identical end-of-run number
+                    nb_overflow_joint=nb_overflow_joint,
+                    nb_overweight=nb_overweight,
+                    sum_overweight_excess=float(sum_overweight_excess),
+                    max_overweight=float(max_overweight),
                     sum_w=float(sum_w),
                     sum_w2=float(sum_w2),
                     sequential_stats=dict(sequential_stats))
@@ -4637,11 +4714,57 @@ class MadSpinInterface(extended_cmd.Cmd):
         total_overflow = sum(v for k, v in merged.items()
                              if k.startswith('nb_overflow_'))
         if total_overflow:
-            logger.critical(
-                "MadSpin sequential: %d weights exceeded their per-particle "
-                "maximum. That bound is under-estimated and the sample is "
-                "biased: raise nb_sigma or Nevents_for_max_weight, or set "
-                "unweighting = joint.", total_overflow)
+            logger.warning(
+                "MadSpin sequential: %d weights exceeded their stage maximum "
+                "(mass set / angles / per particle). That bound is "
+                "under-estimated; the excess is now CARRIED on the weight of "
+                "the affected events rather than dropped (see the overweight "
+                "line below for how much it is worth). To go back to unit "
+                "weights everywhere, raise nb_sigma or "
+                "Nevents_for_max_weight, or set unweighting = joint.",
+                total_overflow)
+
+    def _report_overweight(self, stats_list, n_written):
+        """The overweight safety net's end-of-run measurement.
+
+        Section 14 of ``doc/madspin_sequential_plan.md``: every
+        accept/reject in MadSpin stops on a trial with probability
+        ``min(1, w/C)``, so a trial with ``w > C`` is accepted with probability
+        1 and the excess ``w/C - 1`` used to be thrown away silently. It is now
+        written onto the event weight, which is exact because
+        ``min(1,x) * max(1,x) = x``; this turns what was an unquantified bias
+        into a number, and this is that number.
+
+        The fraction quoted is ``sum(factor - 1) / n_written``: under MG5's
+        ``IDWTUP = -4`` convention the sample's normalisation is the MEAN of the
+        weights over the events in the file, so a nominal file has mean 1 (times
+        the branching ratio) and the excess is exactly the relative shift. It is
+        the same quantity ``EventFile.unweight`` reports as "truncation", except
+        that there it is discarded and here it is kept.
+        """
+        nb = sum(s.get('nb_overweight', 0) for s in stats_list)
+        excess = sum(s.get('sum_overweight_excess', 0.0) for s in stats_list)
+        biggest = max([s.get('max_overweight', 1.0) for s in stats_list] or [1.0])
+        joint = sum(s.get('nb_overflow_joint', 0) for s in stats_list)
+        if not n_written:
+            return
+        if not nb:
+            logger.info(
+                "MadSpin overweight safety net: 0/%d written events carried a "
+                "non-unit weight -- no accept/reject bound was exceeded, so "
+                "the sample is unweighted and unbiased by clipping.",
+                n_written)
+            return
+        logger.warning(
+            "MadSpin overweight safety net: %d/%d written events (%.3g%%) "
+            "carried a non-unit weight because a trial weight exceeded its "
+            "accept/reject bound; total carried excess %.6g, i.e. %.3g%% of "
+            "the sample's normalisation, largest single factor %.4f%s. "
+            "Clipping those to 1 -- what MadSpin did before -- would have "
+            "silently biased the sample low by that amount.",
+            nb, n_written, 100.0 * nb / n_written, excess,
+            100.0 * excess / n_written, biggest,
+            ' (%d of them from the joint accept/reject)' % joint if joint else '')
 
     def _report_pure_interference(self, base_out, stats_list, n_processed,
                                   n_written):
@@ -4817,9 +4940,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                     reference * absw_run / c_value if c_value else 0.0),
                 '#     ( = sigma_ref * <|W|> / c ; every event carries +- this)',
                 '#  Trials above max|W|          : %d' % nb_pi_overflow,
-                '#     (accepted with probability 1 instead of |W|/max|W|, which',
-                '#      biases the sample. Non-zero means max_weight is',
-                '#      under-estimated: raise nb_sigma or Nevents_for_max_weight)',
+                '#     (accepted with probability 1 instead of |W|/max|W|. Those',
+                '#      events -- and ONLY those -- are written with |w| scaled',
+                '#      by |W|/max|W| > 1 instead of being clipped, so the file',
+                '#      may hold more than two weight magnitudes when this is',
+                '#      non-zero. <|W|> = (N_file/N_drawn) x max|W| is unchanged',
+                '#      by that: N_file is a count, and min(1,x)*max(1,x) = x.',
+                '#      Non-zero still means max_weight is under-estimated:',
+                '#      raise nb_sigma or Nevents_for_max_weight)',
             ]
         else:
             note += [
@@ -5028,6 +5156,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             eff, n_written, nb_try, (1.0 / eff if eff else float("inf"))
         )
         self._report_sequential_stats(stats_list, n_written)
+        self._report_overweight(stats_list, n_written)
         if self._pure_interference():
             self._report_pure_interference(base_out, stats_list,
                                            n_processed, n_written)
@@ -8490,10 +8619,36 @@ class MadSpinInterface(extended_cmd.Cmd):
         # nb_infeasible).
         dead_trials = 0
 
+        # ---- the overweight safety net (section 14 of
+        # doc/madspin_sequential_plan.md) --------------------------------------
+        # Every stage below accepts with probability min(1, w/C) and therefore
+        # clips at 1 when w > C. The chain records max(1, w/C) per stage and the
+        # caller multiplies the product onto the event weight, which restores
+        # the sampled density exactly because min(1,x)*max(1,x) = x.
+        #
+        # Composition. The stages are nested, not sequential, so the two factors
+        # have different lifetimes and each is reset where the quantity it
+        # describes is redrawn:
+        #   carry_mass   -- reset at the top of THIS loop, i.e. whenever a new
+        #                   mass set is drawn (a mass-set rejection, an
+        #                   infeasible set, or an ``exact``/joint-angle restart
+        #                   all come back here);
+        #   carry_angles -- reset at the top of the angle loop, i.e. whenever
+        #                   the whole angle set is redrawn. Inside it the
+        #                   per-slot factors *multiply*, exactly like ``w_slots``
+        #                   multiplies the raw per-slot weights: each slot is
+        #                   accepted once per pass, and a rejected slot trial is
+        #                   simply redrawn and contributes nothing.
+        # Only the accepted chain's factors survive, because both resets happen
+        # on the redraw path. The product is taken once, at the return.
+        carry_mass = 1.0
+        carry_angles = 1.0
+
         while True:     # restart point: an impossible/rejected production mass set
             parents = init_part
             jac_prod = 1.0
             slot_mass = {}
+            carry_mass = 1.0    # a new mass set: the previous one's factor is gone
             if upfront:
                 # draw every virtuality, then settle whatever depends on the
                 # mass set alone: offshell that is the production reshuffle and
@@ -8573,6 +8728,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # against its bound would only throw chains away
                     if w_mass > maxwgts[0]:
                         stats['nb_overflow_mass'] += 1
+                        # accepted with probability 1 instead of w/C: carry the
+                        # excess. Set after the test would be equivalent (an
+                        # overflowing weight cannot be rejected, since
+                        # random.random() < 1), but it is set here so the
+                        # counter and the factor stay one statement apart.
+                        carry_mass = w_mass / maxwgts[0]
                     if random.random() * maxwgts[0] >= w_mass:
                         stats['nb_mass_reject'] += 1
                         continue            # redraw the whole mass set
@@ -8601,6 +8762,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                 w_angles = 1.0      # joint_angles: the product tested once, below
                 angle_dead = False  # a zero member: reject the set, stop drawing
                 w_slots = 1.0       # product of the raw per-slot weights
+                carry_angles = 1.0  # overweight safety net: the product of the
+                                    # per-slot (or, under two_stage, the single
+                                    # angle-set) max(1, w/C) factors. Reset with
+                                    # w_slots because it has the same lifetime:
+                                    # a new pass here means a whole new angle set.
 
                 for position, slot in enumerate(order):
                     index = slot_to_index[slot]
@@ -8748,6 +8914,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                             # condition on (onshell, 2 -> 1 production under PA)
                             zhat = self._zhat(zkeys[slot], mass[0]) \
                                    if mass is not None else 1.0
+                            slot_carry = 1.0   # overweight safety net, this trial
                             if probe is not None:
                                 probe.append(float(wgt))
                                 # E[rate | m] = E[w_k | m] = Z_k(m) -- the pool
@@ -8775,6 +8942,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                     wgt = wgt / zhat if zhat > 0 else 0.0
                                 if wgt > maxwgt:
                                     stats['nb_overflow_%d' % position] += 1
+                                    slot_carry = wgt / maxwgt
                                     logger.debug('sequential: slot %s weight %s above'
                                                  ' its max %s', position, wgt, maxwgt)
                                 accept = random.random() * maxwgt < wgt
@@ -8782,6 +8950,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 slot_decays[slot] = decay
                                 n_prev = n_k
                                 w_slots *= wgt_raw
+                                if slot_carry != 1.0:
+                                    # only the ACCEPTED trial of this slot
+                                    # contributes; the slots multiply, like
+                                    # w_slots does
+                                    carry_angles *= slot_carry
                                 break
                             slot_densities.pop(slot, None)
                             if exact:
@@ -8854,6 +9027,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 dead_trials, wgt,
                                 'slot %d of the sequential accept/reject'
                                 % position)
+                        slot_carry = 1.0   # overweight safety net, this trial
                         if probe is not None:
                             # python float: these are marshalled as JSON when the
                             # scan runs across forked workers
@@ -8861,15 +9035,19 @@ class MadSpinInterface(extended_cmd.Cmd):
                             accept = True
                         else:
                             if wgt > maxwgt:
-                                # the bound was under-estimated: this biases
-                                # silently, so it has to be visible
+                                # the bound was under-estimated: the excess used
+                                # to be dropped silently, and is now carried on
+                                # the event weight instead (section 14)
                                 stats['nb_overflow_%d' % position] += 1
+                                slot_carry = wgt / maxwgt
                                 logger.debug('sequential: slot %s weight %s above '
                                              'its max %s', position, wgt, maxwgt)
                             accept = random.random() * maxwgt < wgt
                         if accept:
                             slot_decays[slot] = decay
                             n_prev, j_prev, budget = n_k, j_k, new_budget
+                            if slot_carry != 1.0:
+                                carry_angles *= slot_carry
                             break
                         # rejected: this slot only, drop what it contributed
                         slot_densities.pop(slot, None)
@@ -8886,6 +9064,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                     c_angles = maxwgts[1] if len(maxwgts) > 1 else maxwgts[-1]
                     if w_angles > c_angles:
                         stats['nb_overflow_angles'] += 1
+                        # the whole angle set is one test here, so this is the
+                        # only angle-side factor under two_stage (the per-slot
+                        # tests are disabled -- maxwgt is None there)
+                        carry_angles = w_angles / c_angles
                         logger.debug('sequential: angle weight %s above its max %s',
                                      w_angles, c_angles)
                     if random.random() * c_angles >= w_angles:
@@ -8924,6 +9106,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         decays = collections.defaultdict(list)
         for slot in range(len(order)):
             decays[particles[slot_to_index[slot]].pid].append(slot_decays[slot])
+        if probe is None and (carry_mass != 1.0 or carry_angles != 1.0):
+            # The overweight safety net's composed factor for the chain that was
+            # actually accepted. Only set when it is not the identity, so the
+            # caller's ``stats.pop('overweight_factor', 1.0)`` returns the
+            # LITERAL 1.0 in the no-overflow case and the written weight is
+            # bit-identical to the clipping one. Assigned rather than
+            # accumulated: this is a per-event quantity, not a counter.
+            stats['overweight_factor'] = carry_mass * carry_angles
         if (upfront and probe is None and decay_dict
                 and self.options['sequential_debug']):
             self._check_weight_identity(production, decays, decay_dict,

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4274,10 +4274,38 @@ class MadSpinInterface(extended_cmd.Cmd):
         # the same multiplication -- and it is the *literal* 1.0, never a
         # division, whenever nothing overflowed, so the written weights are
         # bit-identical to the clipping ones on the overwhelmingly common path.
+        #
+        # The factor itself is always > 1 and unsigned: every accept/reject
+        # below tests a MATRIX-ELEMENT weight (a ratio of densities times
+        # jacobians, positive by construction, and in the pure-interference
+        # mode the modulus |W| the test itself uses), never the event's LHE
+        # weight. So a negative production weight -- an MC@NLO counter-event --
+        # keeps its sign and only grows in magnitude, which is the whole point:
+        # the carry says "this event should have counted more", not "this event
+        # is positive".
+        #
+        # The ACCOUNTING, though, cannot be a count. Under IDWTUP = -4 the
+        # cross-section is the mean of the weights, and carrying does not change
+        # the number of events, so the shift it restores is
+        #     d(sum w) / sum w      with sum w over the file as it would have
+        #                           been written WITH clipping ('nominal').
+        # For a unit-weight sample that is exactly sum(factor - 1)/n_written,
+        # the number this used to print; with counter-events in the sample it is
+        # not, because the excess of a negative event subtracts. And sum w can
+        # be zero by construction (pure_interference), so the denominator has to
+        # be tested against its OWN Monte Carlo error sqrt(sum w^2) -- the same
+        # z that _report_pure_interference uses for the zero-cross-section
+        # check -- before it can be normalised against; hence the second moment
+        # here, and sum|w| as the fallback scale that cannot cancel.
         nb_overweight = 0        # written events carrying a non-unit factor
-        sum_overweight_excess = 0.0   # sum of (factor - 1): the normalisation
-                                      # that used to be thrown away
         max_overweight = 1.0     # the largest single factor carried
+        sum_overweight_dw = 0.0     # sum of (factor - 1) * w_nominal: the signed
+                                    # weight the clipping used to throw away
+        sum_overweight_dabs = 0.0   # ... and the same with |w_nominal|, which
+                                    # does not cancel between counter-events
+        sum_nom = 0.0            # sum of the weights clipping WOULD have written
+        sum_abs_nom = 0.0        # ... their absolute values
+        sum_sq_nom = 0.0         # ... and their squares, for the MC error on sum
         sum_w = 0.0        # signed weight sum, for the zero-cross-section check
         sum_w2 = 0.0       # its second moment: no cancellation, so the MC error
         nb_try = 0
@@ -4340,7 +4368,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 nb_event - curr_event, stats=seq_stats,
                                 decay_dict=decay_dict)
                 if decays is None:
-                    # nothing to decay in this production event
+                    # nothing to decay in this production event. It still goes
+                    # into the file, so it belongs to the normalisation the
+                    # overweight report divides by.
+                    sum_nom += production.wgt
+                    sum_abs_nom += abs(production.wgt)
+                    sum_sq_nom += production.wgt * production.wgt
                     output_lhe.write_events(production)
                     continue
                 # the accepted chain's carried overweight (mass stage x angle
@@ -4361,14 +4394,27 @@ class MadSpinInterface(extended_cmd.Cmd):
                     full_evt.reshuffle_production()
                 self.efficiency = float(curr_event + 1) / nb_try if nb_try else 1.0
                 br = self.branching_ratio
+                # what this event would have been written with had the excess
+                # been clipped -- taken BEFORE br absorbs the carry, so it needs
+                # no division and keeps its sign. When carry is 1 this is the
+                # identical multiplication the line below performs, so the
+                # written weight is unaffected by its existence.
+                w_nom = full_evt.wgt * br
+                sum_nom += w_nom
+                sum_abs_nom += abs(w_nom)
+                sum_sq_nom += w_nom * w_nom
                 if carry != 1.0:
+                    # the signed difference is what the sample's cross-section
+                    # gains; the unsigned one is the same quantity with the
+                    # counter-events' cancellation taken out.
+                    sum_overweight_dw += w_nom * (carry - 1.0)
+                    sum_overweight_dabs += abs(w_nom) * (carry - 1.0)
                     # exactly one multiplication either way: br is the same
                     # float object as self.branching_ratio when nothing
                     # overflowed, so this branch is the only thing that can
                     # move a written weight.
                     br = br * carry
                     nb_overweight += 1
-                    sum_overweight_excess += carry - 1.0
                     if carry > max_overweight:
                         max_overweight = carry
                 full_evt.wgt *= br
@@ -4563,15 +4609,26 @@ class MadSpinInterface(extended_cmd.Cmd):
             br = self.branching_ratio * pi_factor \
                 if (pure_interference or weighted_decay) \
                 else self.branching_ratio
+            # ``carry`` is unsigned even in the pure-interference mode: the
+            # |W|/M test clips on the MODULUS, so the factor is built from
+            # abs(signed) and the sign is carried exactly once, by pi_factor,
+            # inside br. w_nom is therefore the signed weight this event would
+            # have been written with under clipping.
+            w_nom = (full_evt[0] if self.options['fixed_order']
+                     else full_evt).wgt * br
+            sum_nom += w_nom
+            sum_abs_nom += abs(w_nom)
+            sum_sq_nom += w_nom * w_nom
             if carry != 1.0:
                 # the overweight safety net rides the same hook, for the same
                 # reason: one multiplication that reaches both full_evt.wgt and
                 # every parse_reweight() entry. Guarded so that the no-overflow
                 # path -- which is essentially the whole sample -- performs the
                 # identical arithmetic it did before this existed.
+                sum_overweight_dw += w_nom * (carry - 1.0)
+                sum_overweight_dabs += abs(w_nom) * (carry - 1.0)
                 br = br * carry
                 nb_overweight += 1
-                sum_overweight_excess += carry - 1.0
                 if carry > max_overweight:
                     max_overweight = carry
             if self.options['fixed_order']:
@@ -4620,7 +4677,11 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # or many gives the identical end-of-run number
                     nb_overflow_joint=nb_overflow_joint,
                     nb_overweight=nb_overweight,
-                    sum_overweight_excess=float(sum_overweight_excess),
+                    sum_overweight_dw=float(sum_overweight_dw),
+                    sum_overweight_dabs=float(sum_overweight_dabs),
+                    sum_nom=float(sum_nom),
+                    sum_abs_nom=float(sum_abs_nom),
+                    sum_sq_nom=float(sum_sq_nom),
                     max_overweight=float(max_overweight),
                     sum_w=float(sum_w),
                     sum_w2=float(sum_w2),
@@ -4724,47 +4785,95 @@ class MadSpinInterface(extended_cmd.Cmd):
                 "Nevents_for_max_weight, or set unweighting = joint.",
                 total_overflow)
 
+    # How many Monte Carlo errors the summed weight has to be away from zero
+    # before it may be used as a denominator. sum w = 0 is not a pathology to be
+    # detected by a magnitude cut -- pure_interference produces it BY DESIGN, and
+    # an ordinary sample only ever approaches it by accident -- so the test is
+    # the same z = S / sqrt(sum w^2) that _report_pure_interference already uses
+    # for its zero-cross-section check. An unweighted sample of N events has
+    # z = sqrt(N), so this never fires on one; a pure-interference sample has
+    # z = O(1) and always does.
+    _OVERWEIGHT_MIN_Z = 5.0
+
     def _report_overweight(self, stats_list, n_written):
         """The overweight safety net's end-of-run measurement.
 
-        Section 14 of ``doc/madspin_sequential_plan.md``: every
-        accept/reject in MadSpin stops on a trial with probability
-        ``min(1, w/C)``, so a trial with ``w > C`` is accepted with probability
-        1 and the excess ``w/C - 1`` used to be thrown away silently. It is now
-        written onto the event weight, which is exact because
-        ``min(1,x) * max(1,x) = x``; this turns what was an unquantified bias
-        into a number, and this is that number.
+        Section 14 of ``doc/madspin_sequential_plan.md``: every accept/reject in
+        MadSpin stops on a trial with probability ``min(1, w/C)``, so a trial
+        with ``w > C`` is accepted with probability 1 and the excess
+        ``w/C - 1`` used to be thrown away silently. It is now written onto the
+        event weight, which is exact because ``min(1,x) * max(1,x) = x``; this
+        turns what was an unquantified bias into a number, and this is that
+        number.
 
-        The fraction quoted is ``sum(factor - 1) / n_written``: under MG5's
-        ``IDWTUP = -4`` convention the sample's normalisation is the MEAN of the
-        weights over the events in the file, so a nominal file has mean 1 (times
-        the branching ratio) and the excess is exactly the relative shift. It is
-        the same quantity ``EventFile.unweight`` reports as "truncation", except
-        that there it is discarded and here it is kept.
+        **The number is a weight, not a count.** Under MG5's ``IDWTUP = -4``
+        convention the cross-section is the MEAN of the event weights, and
+        carrying changes no event count, so what the clipping used to discard is
+
+            d(sum w) / sum w        both over the file as clipping would have
+                                    written it
+
+        with ``d(sum w) = sum_over (factor - 1) * w_nominal``. For a sample of
+        identical positive weights that reduces exactly to
+        ``sum(factor - 1) / n_written``, which is what an unweighted MadSpin run
+        prints. It does **not** reduce to that once the input carries
+        counter-events: a negative event whose trial overflowed makes the
+        cross-section *more* negative, so its excess subtracts, and quoting a
+        count would claim a shift that is not there.
+
+        ``sum w`` is also zero by construction under ``pure_interference``, so it
+        is only used as a denominator when it is at least ``_OVERWEIGHT_MIN_Z``
+        of its own Monte Carlo errors away from zero. When it is not, the shift
+        is quoted against ``sum |w|`` -- which cannot cancel -- and the line says
+        which convention it used, so the two are never confused.
         """
         nb = sum(s.get('nb_overweight', 0) for s in stats_list)
-        excess = sum(s.get('sum_overweight_excess', 0.0) for s in stats_list)
+        if not n_written or not nb:
+            if n_written:
+                logger.info(
+                    "MadSpin overweight safety net: 0/%d written events carried "
+                    "a non-unit weight -- no accept/reject bound was exceeded, "
+                    "so nothing was clipped and nothing is biased by it.",
+                    n_written)
+            return
+        d_w = sum(s.get('sum_overweight_dw', 0.0) for s in stats_list)
+        d_abs = sum(s.get('sum_overweight_dabs', 0.0) for s in stats_list)
         biggest = max([s.get('max_overweight', 1.0) for s in stats_list] or [1.0])
         joint = sum(s.get('nb_overflow_joint', 0) for s in stats_list)
-        if not n_written:
-            return
-        if not nb:
-            logger.info(
-                "MadSpin overweight safety net: 0/%d written events carried a "
-                "non-unit weight -- no accept/reject bound was exceeded, so "
-                "the sample is unweighted and unbiased by clipping.",
-                n_written)
-            return
-        logger.warning(
-            "MadSpin overweight safety net: %d/%d written events (%.3g%%) "
-            "carried a non-unit weight because a trial weight exceeded its "
-            "accept/reject bound; total carried excess %.6g, i.e. %.3g%% of "
-            "the sample's normalisation, largest single factor %.4f%s. "
-            "Clipping those to 1 -- what MadSpin did before -- would have "
-            "silently biased the sample low by that amount.",
-            nb, n_written, 100.0 * nb / n_written, excess,
-            100.0 * excess / n_written, biggest,
-            ' (%d of them from the joint accept/reject)' % joint if joint else '')
+        # the file as clipping would have written it
+        sum_w = sum(s.get('sum_nom', 0.0) for s in stats_list)
+        sum_abs = sum(s.get('sum_abs_nom', 0.0) for s in stats_list)
+        sum_sq = sum(s.get('sum_sq_nom', 0.0) for s in stats_list)
+        delta = math.sqrt(sum_sq)
+        z = (abs(sum_w) / delta) if delta else 0.0
+        # Built with % here rather than handed to the logger as a format
+        # string: the head already contains literal per-cent signs.
+        msg = ("MadSpin overweight safety net: %d/%d written events (%.3g%%) "
+               "carried a non-unit weight because a trial weight exceeded its "
+               "accept/reject bound (largest factor %.4f%s). "
+               % (nb, n_written, 100.0 * nb / n_written, biggest,
+                  ', %d of them from the joint accept/reject' % joint
+                  if joint else ''))
+        if z >= self._OVERWEIGHT_MIN_Z:
+            msg += ("Carrying it added %+.6g to the summed event weight, i.e. "
+                    "%+.3g%% of the sample's cross-section (IDWTUP = -4: sigma "
+                    "is the mean weight and the event count does not change, "
+                    "so this is the relative shift). "
+                    % (d_w, 100.0 * d_w / sum_w))
+        else:
+            # pure_interference, or any sample whose weights cancel: the
+            # cross-section is consistent with zero, so it is not a denominator
+            msg += ("Carrying it added %+.6g to the summed event weight and "
+                    "%+.6g to the summed |weight|. The summed weight is %+.4g "
+                    "against a Monte Carlo error of %.4g (z = %.2f), i.e. "
+                    "consistent with the zero cross-section this sample has by "
+                    "construction, so it is not a usable denominator and the "
+                    "shift is quoted against sum|w| = %.4g instead: %+.3g%%. "
+                    % (d_w, d_abs, sum_w, delta, z, sum_abs,
+                       100.0 * d_abs / sum_abs if sum_abs else float('nan')))
+        msg += ("Clipping it -- what MadSpin did before -- would have discarded "
+                "that silently.")
+        logger.warning(msg)
 
     def _report_pure_interference(self, base_out, stats_list, n_processed,
                                   n_written):

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2864,16 +2864,90 @@ removes it. So the counters still warn.
 the number that was missing:
 
     MadSpin overweight safety net: 3/10000 written events (0.03%) carried a
-    non-unit weight because a trial weight exceeded its accept/reject bound;
-    total carried excess 1.28509, i.e. 0.0129% of the sample's normalisation,
-    largest single factor 2.0389. Clipping those to 1 -- what MadSpin did
-    before -- would have silently biased the sample low by that amount.
+    non-unit weight because a trial weight exceeded its accept/reject bound
+    (largest factor 2.0389). Carrying it added +1.53474 to the summed event
+    weight, i.e. +0.0129% of the sample's cross-section (IDWTUP = -4: sigma is
+    the mean weight and the event count does not change, so this is the
+    relative shift). Clipping it -- what MadSpin did before -- would have
+    discarded that silently.
 
-and, when nothing overflowed, says so at INFO rather than staying silent. Under
-`IDWTUP = -4` the cross-section is the *mean* of the weights over the events in
-the file, so `sum(factor - 1) / n_written` is exactly the relative shift the
-sample used to lose. The joint accept/reject gained a counter of its own here
-(`nb_overflow_joint`); it had none before.
+and, when nothing overflowed, says so at INFO rather than staying silent. The
+joint accept/reject gained a counter of its own here (`nb_overflow_joint`); it
+had none before.
+
+**Why the number is a weight and not a count.** Under `IDWTUP = -4` the
+cross-section is the *mean* of the event weights, and carrying changes no event
+count, so what the clipping used to discard is
+
+    d(sum w) / sum w        both over the file as clipping would have written it
+
+with `d(sum w) = sum_over (factor - 1) * w_nominal`. For a sample of identical
+positive weights that is exactly `sum(factor - 1)/n_written`, so an ordinary
+unweighted MadSpin run prints the same number either way. It stops being the
+same as soon as the input carries **MC@NLO counter-events**: a negative event
+whose trial overflowed makes the cross-section *more* negative, so its excess
+subtracts, and a count would have claimed a shift of the wrong sign. Measured on
+a 10 000-event `p p > t t~` sample with 25 % of the weights flipped negative and
+the mass bound forced 30x low: `d(sum w) = +1.48865e6`, `+1252 %` of the clipped
+`sum w`, against `+1250 %` for the count-based number -- close here only because
+the sign and the overflow are uncorrelated in that construction, and not equal
+in general.
+
+**And why `sum w` needs a guard.** It is zero *by construction* under
+`pure_interference`, so it cannot simply be divided by. The test is not a
+magnitude cut but the same `z = S / sqrt(sum w^2)` the mode already uses for its
+zero-cross-section check: `sum w` is used as a denominator only when it is at
+least `_OVERWEIGHT_MIN_Z = 5` of its own Monte Carlo errors from zero. An
+unweighted sample of N events has `z = sqrt(N)` and never trips it; a
+pure-interference sample has `z = O(1)` and always does, and then the shift is
+quoted against `sum |w|` -- which cannot cancel -- with the line saying which
+convention it used:
+
+    MadSpin overweight safety net: 6740/8274 written events (81.5%) carried a
+    non-unit weight because a trial weight exceeded its accept/reject bound
+    (largest factor 29.3165). Carrying it added -389.844 to the summed event
+    weight and +52253.7 to the summed |weight|. The summed weight is -134
+    against a Monte Carlo error of 290.2 (z = 0.46), i.e. consistent with the
+    zero cross-section this sample has by construction, so it is not a usable
+    denominator and the shift is quoted against sum|w| = 2.64e+04 instead:
+    +198%. Clipping it -- what MadSpin did before -- would have discarded that
+    silently.
+
+**Negative weights, twice over.** Two unrelated things make a MadSpin weight
+negative, and the carry is blind to both because it is never built from a signed
+quantity:
+
+* an **MC@NLO counter-event** in the input. The accept/reject tests a
+  matrix-element weight -- a ratio of density contractions times jacobians,
+  positive by construction -- and the event's own LHE weight never enters it, so
+  the factor is unsigned and the event keeps its sign and only grows in
+  magnitude. Measured: over 10 000 events with 25 % counter-events and the mass
+  bound forced low, **0 sign flips**, 2496 of the 2500 counter-events carried a
+  factor, and **0** carried factors below 1;
+* `pure_interference`, where the written weight is signed but the accept/reject
+  tests `|W|/M`. The factor is therefore built from `abs(signed)` -- the same
+  modulus the test used -- and the sign is applied exactly once, by `pi_factor`,
+  inside `br`. Had it been built from the signed `W`, `w > C` would be false for
+  every negative trial and **half the sample would still be silently clipped**.
+  Measured on a forced-low run: of the 6740 carrying events, **3417 are
+  negative** and 3323 positive, matching the 50.3 % negative fraction of the
+  file; **0** factors below 1; and, pairing every output event back onto its
+  input, **0** `<rwgt>` entries whose ratio to the nominal or whose sign differs.
+
+The closure for the interference case is sharp, because the mean magnitude of
+the weight estimates `sigma_ref * BR * E[|W|] / c`, which
+`decay_output = weighted` computes exactly:
+
+| | value (pb) |
+|---|---|
+| forced-low bound, **carried** | 3.29775 +- 0.04628  (+0.2 sd) |
+| forced-low bound, **clipped** (the old behaviour) | 1.10689 +- 0.01217  (**-46 sd**) |
+| shipped bound, no overflow | 3.30300 +- 0.11514  (+0.2 sd) |
+| `decay_output = weighted` (exact reference) | 3.28440 +- 0.04565 |
+
+With the bound 30x too low, clipping under-estimates the size of the
+interference by a factor 3 and says so with a *small* error bar; carrying
+recovers the exact answer, and recovers the correct error bar with it.
 
 **Validation.** With the mass-stage bound forced 30x low so that 99.9 % of the
 10 000 events overflow (mean carried factor 13.5, largest 74.3), the mean of

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2783,3 +2783,114 @@ requirement included.
     MadSpin: decay_output = unweighted (auto, ordinary run)
     MadSpin: decay_output = weighted (auto, pure_interference is set)
     MadSpin: decay_output = weighted (set explicitly)
+
+## 14. The overweight safety net: carry the excess instead of clipping it
+
+Every accept/reject in MadSpin -- the joint one, the sequential mass stage,
+each angle stage, and the legacy `spinmode = madspin_v1` Fortran loop -- has
+the same shape:
+
+    accept the trial with probability  min(1, w / C)
+
+with `C` the bound the maximum-weight probe measured. When a trial comes back
+with `w > C` that probability *clips at 1*: the trial is accepted, and the
+factor `w/C - 1` by which it should have counted more than an ordinary
+accepted trial is thrown away. The counters (`nb_overflow_mass`,
+`nb_overflow_<k>`, `nb_overflow_angles`, `report['over_weight']`) have always
+seen this happen; what they could not say is *how much* it was worth, and the
+sample went out silently biased low in exactly the region where the bound is
+too tight -- which for `p p > t t~` under PA is the `t t~` threshold, where the
+reshuffling jacobian goes like `1/beta_t`.
+
+**The fix is one multiplication.** The loop stops on the trial it accepts with
+probability proportional to `min(1, w/C)`, so writing that event with the
+weight `max(1, w/C)` restores the sampled density exactly:
+
+    min(1, x) * max(1, x) = x     identically, for every x > 0
+
+-- the accepted-and-carried density is `q(m) w(m)`, which is the target, and it
+no longer depends on `C` at all. Nothing about the accept/reject changes: the
+same random numbers are drawn, the same trials are accepted, the same events
+are written. Only their weight moves, and only for the events that overflowed.
+
+**Where it is applied.** The factor rides the branching ratio, the hook the
+pure-interference mode already uses (`br = self.branching_ratio * pi_factor`),
+so one multiplication reaches `full_evt.wgt` *and* every `parse_reweight()`
+entry, and the LHEF v3 multiweights stay proportional to the nominal one.
+`decay_all_events.decaying_events` uses `change_wgt(factor=...)`, which does
+the same thing for the legacy path.
+
+**Composition.** A chain can clip in more than one place, and the factors
+*multiply*. `sequential_accept_reject` keeps two of them, each reset where the
+quantity it describes is redrawn:
+
+| | reset at | composed by |
+|---|---|---|
+| `carry_mass` | the top of the mass-set loop | assignment (one mass set per chain) |
+| `carry_angles` | the top of the angle loop, beside `w_slots` | `*=` on each accepted slot (or a single assignment under `two_stage`, whose one bound covers the whole angle set) |
+
+so a rejected trial -- which is redrawn -- contributes nothing, and only the
+accepted chain's factors survive. The product is handed to `_unweight_range`
+through `stats['overweight_factor']`, which is set **only when it is not 1**,
+so the caller's `pop(..., 1.0)` returns the literal `1.0` on the common path.
+
+**Exactness when nothing overflowed.** The factor is never built by a division
+that could return `0.9999999999`: it is the literal `1.0` unless the code took
+an `if w > C` branch, and the multiplication into `br` is skipped entirely in
+that case. Measured on `p p > t t~`, 10 000 events, `spinmode = PA`,
+`unweighting = sequential`, same seed and same cached bounds, against the
+pre-change code: the two decayed LHE files are **byte-identical except for the
+weight field of the three events the log reports as carrying**, whose weights
+are the old ones times `2.038877`, `1.235717` and `1.010500`. Every momentum,
+every other weight, and every `<rwgt>` entry is bit-for-bit the same.
+
+**What it costs, and what it does not fix.** The unit-weight guarantee, for the
+handful of events that overflow -- 3 in 10 000 at the shipped bound above,
+worth 0.013 % of the sample's normalisation. MadSpin prefers dropping events to
+weighting them elsewhere (the BR-equalization path), so this is a deliberate
+exception; `EventFile.unweight` has always done the same thing
+(`written_weight(max(wgt, max_wgt))`, reported as "truncation"), so a
+downstream tool that cannot survive a non-unit weight could not survive an
+ordinary MG5 unweighted sample either. It is **not** a substitute for a bound
+that is high enough: it makes the mass stage exact, but for the *angle* stages
+it only fixes the angular shape. Those stages redraw until they accept and so
+divide out their own conditional normalisation, which the tabulated `Z_hat`
+models as `E[w | m]` -- an identity that itself assumes the bound dominates.
+Carrying restores `p(theta) w` at fixed `m` exactly; the residual `m`-dependence
+of `E[min(1, w/C) | m]` against `Z_hat(m)` survives, and only a larger bound
+removes it. So the counters still warn.
+
+**The end-of-run measurement.** `_report_overweight` turns the counters into
+the number that was missing:
+
+    MadSpin overweight safety net: 3/10000 written events (0.03%) carried a
+    non-unit weight because a trial weight exceeded its accept/reject bound;
+    total carried excess 1.28509, i.e. 0.0129% of the sample's normalisation,
+    largest single factor 2.0389. Clipping those to 1 -- what MadSpin did
+    before -- would have silently biased the sample low by that amount.
+
+and, when nothing overflowed, says so at INFO rather than staying silent. Under
+`IDWTUP = -4` the cross-section is the *mean* of the weights over the events in
+the file, so `sum(factor - 1) / n_written` is exactly the relative shift the
+sample used to lose. The joint accept/reject gained a counter of its own here
+(`nb_overflow_joint`); it had none before.
+
+**Validation.** With the mass-stage bound forced 30x low so that 99.9 % of the
+10 000 events overflow (mean carried factor 13.5, largest 74.3), the mean of
+`m(t) + m(t~)` over the `sqrt(shat) < 400 GeV` slice, where the mass weight
+actually varies:
+
+| | mean `m(t)+m(t~)` [GeV] |
+|---|---|
+| forced-low bound, carried | 345.584 +- 0.095 |
+| forced-low bound, clipped (the old behaviour, same events) | 345.926 +- 0.094 |
+| shipped bound | 345.539 +- 0.094 |
+| `decay_output = weighted` (joint path, fully weighted) | 345.446 +- 0.105 |
+
+The paired carried-minus-clipped difference is `-0.342 +- 0.036` (9.5 sigma):
+clipping does move the spectrum. The carried result sits `+0.3` sigma from the
+shipped-bound run and `+1.0` sigma from the weighted reference; the clipped one
+sits `+2.9` and `+3.4` sigma away. In the `sqrt(shat) < 360 GeV` threshold slice
+the carried result is `-0.1` / `+0.0` sigma from the two references and the
+clipped one `+3.0` / `+2.6`. A factor 30 in the bound leaves the carried
+physics where it was, which is the whole content of `min(1,x) max(1,x) = x`.

--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -234,7 +234,13 @@ _RE_IDENTITY_FAIL = re.compile(
     r'.*?relative spread of the ratio ([0-9eE.+\-]+), mean ([0-9eE.+\-]+)'
 )
 _RE_OVERFLOW = re.compile(
-    r'MadSpin sequential: (\d+) weights exceeded their per-particle maximum'
+    # Both spellings: the overweight safety net re-worded this line from
+    # "per-particle maximum" to "stage maximum (mass set / angles / per
+    # particle)".  Matching only the old one makes MadSpinResult.overflows read
+    # 0 on every current log, which is indistinguishable from a run in which no
+    # bound was exceeded.
+    r'MadSpin sequential: (\d+) weights exceeded their '
+    r'(?:per-particle|stage) maximum'
 )
 
 

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2681,12 +2681,20 @@ class TestUnweightRangeWeightPaths(unittest.TestCase):
     """
 
     EVENT = """<event>
- 4  1 +%.7e 1.00000000e+02 7.54677100e-03 1.30800000e-01
+ 4  1 %+.7e 1.00000000e+02 7.54677100e-03 1.30800000e-01
        -1 -1    0    0  501    0 +0.0000000e+00 +0.0000000e+00 +5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
         1 -1    0    0    0  501 +0.0000000e+00 +0.0000000e+00 -5.0e+02 5.0e+02 0.0e+00 0.0e+00 1.0
        11  1    1    2    0    0 +1.0000000e+02 +0.0000000e+00 +0.0e+00 1.0e+02 0.0e+00 0.0e+00 1.0
       -11  1    1    2    0    0 -1.0000000e+02 +0.0000000e+00 +0.0e+00 9.0e+02 0.0e+00 0.0e+00 1.0
 </event>"""
+
+    # the same event with two multiweights, one of each sign, so that the
+    # carry's effect on the <rwgt> block can be read off
+    EVENT_RWGT = EVENT.replace('</event>', """<rwgt>
+<wgt id='r1'> +3.0000000e+00 </wgt>
+<wgt id='r2'> -5.0000000e+00 </wgt>
+</rwgt>
+</event>""")
 
     class _Sink(object):
         def __init__(self):
@@ -2740,8 +2748,10 @@ class TestUnweightRangeWeightPaths(unittest.TestCase):
         ctx.update(over)
         return ctx
 
-    def _run(self, stub, ctx, nb_events=4):
-        source = [lhe_parser.Event(self.EVENT % 1.0) for _ in range(nb_events)]
+    def _run(self, stub, ctx, nb_events=4, prod_wgts=None):
+        if prod_wgts is None:
+            prod_wgts = [1.0] * nb_events
+        source = [lhe_parser.Event(self.EVENT % w) for w in prod_wgts]
         sink = self._Sink()
         stats = stub._unweight_range(source, {}, sink, ctx)
         return [e.wgt for e in sink.events], stats
@@ -2814,6 +2824,215 @@ class TestUnweightRangeWeightPaths(unittest.TestCase):
         self.assertEqual(sorted(set(round(abs(w), 9) for w in wgts)), [1.0])
         self.assertTrue(any(w > 0 for w in wgts))
         self.assertTrue(any(w < 0 for w in wgts))
+
+    # ------------------------------------------------------------------
+    # The overweight safety net and the SIGN of the weight it rides on.
+    #
+    # Two independent ways a MadSpin weight can be negative, and the carry has
+    # to be blind to both: an MC@NLO counter-event in the INPUT (the event
+    # weight is negative, the accept/reject weight is not), and the
+    # pure-interference mode (the accept/reject tests |W| while the written
+    # weight is signed). In either case the factor must be built from the
+    # unsigned quantity the test itself used -- a factor built from a signed
+    # weight simply never fires on the negative half of the sample, silently.
+    # ------------------------------------------------------------------
+
+    def test_the_joint_carry_is_unsigned_and_keeps_a_counter_event_negative(self):
+        """MC@NLO input: the production weight is negative, the matrix-element
+        weight the accept/reject tests is not. A trial at 2x the bound must be
+        written with 2x the magnitude and the SAME sign."""
+        random.seed(3)
+        stub = self._Stub([2.0])                      # ME weight 2.0, bound 1.0
+        wgts, stats = self._run(stub, self._ctx(), nb_events=6,
+                                prod_wgts=[1.0, -1.0] * 3)
+        # w = w_prod * BR * carry = w_prod * 2.0 * 2.0
+        self.assertEqual([round(w, 9) for w in wgts], [4.0, -4.0] * 3)
+        self.assertEqual(stats['nb_overweight'], 6)
+        self.assertEqual(stats['nb_overflow_joint'], 6)
+        self.assertEqual(round(stats['max_overweight'], 9), 2.0)
+        # the accounting is a WEIGHT: w_nom = w_prod * BR = +-2, and the
+        # excess of each event is w_nom * (carry - 1) = +-2, so the three
+        # counter-events cancel the three ordinary ones exactly
+        self.assertEqual(round(stats['sum_overweight_dw'], 9), 0.0)
+        self.assertEqual(round(stats['sum_overweight_dabs'], 9), 12.0)
+        self.assertEqual(round(stats['sum_nom'], 9), 0.0)
+        self.assertEqual(round(stats['sum_abs_nom'], 9), 12.0)
+
+    def test_a_counter_event_only_sample_gets_a_negative_carried_excess(self):
+        """The excess is signed. If every overflow lands on a counter-event the
+        carry makes the cross-section MORE negative, and a count-based number
+        would have claimed the opposite."""
+        random.seed(3)
+        stub = self._Stub([2.0])
+        wgts, stats = self._run(stub, self._ctx(), nb_events=4,
+                                prod_wgts=[-1.0] * 4)
+        self.assertEqual([round(w, 9) for w in wgts], [-4.0] * 4)
+        self.assertLess(stats['sum_overweight_dw'], 0.0)
+        self.assertGreater(stats['sum_overweight_dabs'], 0.0)
+        self.assertEqual(round(stats['sum_overweight_dw'], 9), -8.0)
+        self.assertEqual(round(stats['sum_overweight_dabs'], 9), 8.0)
+
+    def test_no_overflow_leaves_the_written_weight_and_the_counters_alone(self):
+        """The exactness guarantee, on a negative production weight too: a
+        weight below the bound must go out as w_prod * BR exactly."""
+        random.seed(3)
+        stub = self._Stub([0.5])
+        wgts, stats = self._run(stub, self._ctx(), nb_events=4,
+                                prod_wgts=[1.0, -1.0, 1.0, -1.0])
+        self.assertEqual([round(w, 9) for w in wgts], [2.0, -2.0, 2.0, -2.0])
+        self.assertEqual(stats['nb_overweight'], 0)
+        self.assertEqual(stats['nb_overflow_joint'], 0)
+        self.assertEqual(stats['sum_overweight_dw'], 0.0)
+        self.assertEqual(stats['max_overweight'], 1.0)
+
+    def test_the_interference_carry_is_built_from_the_modulus(self):
+        """THE pure-interference regression. |W| = 2 x the bound with
+        alternating sign: the |W|/M test clips for BOTH signs, so both must
+        carry the factor 2. A carry built from the signed W would leave every
+        negative event at 1 -- half the sample silently still clipped."""
+        random.seed(5)
+        stub = self._Stub([2.0, -2.0], pure_interference='w+ = 0 T')
+        wgts, stats = self._run(
+            stub, self._ctx(pure_interference_unweighted=True), nb_events=20)
+        self.assertEqual(len(wgts), 20)
+        # |w| = w_prod * BR * <|W|>/c * carry = 1 * 2.0 * (0.25/0.5) * 2
+        self.assertEqual(sorted(set(round(w, 9) for w in wgts)), [-2.0, 2.0])
+        self.assertEqual(sum(1 for w in wgts if w > 0), 10)
+        self.assertEqual(sum(1 for w in wgts if w < 0), 10)
+        self.assertEqual(stats['nb_overweight'], 20)       # not 10
+        self.assertEqual(stats['nb_pi_overflow'], 20)
+        self.assertEqual(round(stats['max_overweight'], 9), 2.0)
+        # the interference sample sums to zero: the excess does too
+        self.assertEqual(round(stats['sum_overweight_dw'], 9), 0.0)
+        self.assertEqual(round(stats['sum_overweight_dabs'], 9), 20.0)
+
+    def test_the_interference_sign_is_applied_exactly_once(self):
+        """The sign rides on pi_factor and the carry is a positive scale, so
+        the multiweights come out with the nominal's sign and the nominal's
+        factor -- not the sign twice, and not on the nominal only."""
+        random.seed(5)
+        stub = self._Stub([2.0, -2.0], pure_interference='w+ = 0 T')
+        source = [lhe_parser.Event(self.EVENT_RWGT % 1.0) for _ in range(8)]
+        sink = self._Sink()
+        stub._unweight_range(source, {}, sink,
+                             self._ctx(pure_interference_unweighted=True))
+        self.assertEqual(len(sink.events), 8)
+        seen = set()
+        for evt in sink.events:
+            rw = evt.parse_reweight()
+            # every weight scaled by the SAME signed factor as the nominal
+            self.assertEqual(round(rw['r1'] / 3.0, 9), round(evt.wgt / 1.0, 9))
+            self.assertEqual(round(rw['r2'] / -5.0, 9), round(evt.wgt / 1.0, 9))
+            # ... which means r2 keeps the opposite sign to r1, always
+            self.assertEqual(rw['r1'] > 0, rw['r2'] < 0)
+            # |w| = 2.0: the carry fired, and it fired on both signs
+            self.assertEqual(round(abs(evt.wgt), 9), 2.0)
+            seen.add(evt.wgt > 0)
+        self.assertEqual(seen, {True, False})
+
+
+class _CapturedMadSpinLog(object):
+    """Collect everything MadSpin's logger emits, at any level, without letting
+    it reach the console."""
+
+    def __enter__(self):
+        import logging
+        self.messages = []
+        capture = self
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                capture.messages.append(record.getMessage())
+
+        self._handler = _Handler(level=logging.DEBUG)
+        self._logger = interface_madspin.logger
+        self._level = self._logger.level
+        self._propagate = self._logger.propagate
+        self._logger.addHandler(self._handler)
+        self._logger.setLevel(logging.DEBUG)
+        self._logger.propagate = False
+        return self
+
+    def __exit__(self, *args):
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._level)
+        self._logger.propagate = self._propagate
+        return False
+
+
+class TestOverweightReport(unittest.TestCase):
+    """``_report_overweight``: the end-of-run number, and the denominator it is
+    allowed to use.
+
+    Under IDWTUP = -4 the cross-section is the MEAN of the weights, so the
+    quantity carrying restores is d(sum w)/sum w. That denominator is fine for
+    an ordinary sample and meaningless for one whose weights cancel -- which is
+    exactly what pure_interference produces -- so the report tests it against
+    its own Monte Carlo error before using it.
+    """
+
+    class _Stub(object):
+        _OVERWEIGHT_MIN_Z = \
+            interface_madspin.MadSpinInterface._OVERWEIGHT_MIN_Z
+        _report_overweight = \
+            interface_madspin.MadSpinInterface._report_overweight
+
+    def _log(self, **stats):
+        base = dict(nb_overweight=0, sum_overweight_dw=0.0,
+                    sum_overweight_dabs=0.0, sum_nom=0.0, sum_abs_nom=0.0,
+                    sum_sq_nom=0.0, max_overweight=1.0, nb_overflow_joint=0)
+        base.update(stats)
+        n_written = base.pop('n_written')
+        with _CapturedMadSpinLog() as caught:
+            self._Stub()._report_overweight([base], n_written)
+        return '\n'.join(caught.messages)
+
+    def test_an_unweighted_sample_quotes_the_cross_section_shift(self):
+        """1000 events of weight 1, three of which carried a factor 2: the
+        cross-section moves by 3/1000 -- the number a count would also have
+        given, which is why this stayed right for unweighted samples."""
+        msg = self._log(n_written=1000, nb_overweight=3, max_overweight=2.0,
+                        sum_overweight_dw=3.0, sum_overweight_dabs=3.0,
+                        sum_nom=1000.0, sum_abs_nom=1000.0, sum_sq_nom=1000.0)
+        self.assertIn('3/1000 written events', msg)
+        self.assertIn("of the sample's cross-section", msg)
+        self.assertIn('+0.3%', msg)
+
+    def test_a_counter_event_sample_quotes_the_signed_shift(self):
+        """The same three carried events, but on counter-events: the shift is
+        negative even though the factors are all above 1."""
+        msg = self._log(n_written=1000, nb_overweight=3, max_overweight=2.0,
+                        sum_overweight_dw=-3.0, sum_overweight_dabs=3.0,
+                        sum_nom=500.0, sum_abs_nom=1000.0, sum_sq_nom=1000.0)
+        self.assertIn("of the sample's cross-section", msg)
+        self.assertIn('-0.6%', msg)          # -3/500, and negative
+        self.assertIn('-3', msg)
+
+    def test_a_cancelling_sample_refuses_the_cross_section_as_a_denominator(self):
+        """pure_interference: sum w is zero by construction, so it must not be
+        divided by. z = 20/sqrt(10000) = 0.2 -- consistent with zero."""
+        msg = self._log(n_written=1000, nb_overweight=300, max_overweight=9.0,
+                        sum_overweight_dw=-2.0, sum_overweight_dabs=50.0,
+                        sum_nom=20.0, sum_abs_nom=1000.0, sum_sq_nom=10000.0)
+        self.assertNotIn("of the sample's cross-section", msg)
+        self.assertIn('consistent with the zero cross-section', msg)
+        self.assertIn('z = 0.20', msg)
+        self.assertIn('quoted against sum|w|', msg)
+        self.assertIn('+5%', msg)            # 50/1000
+
+    def test_an_all_zero_sample_does_not_divide_by_zero(self):
+        """Degenerate to the last digit: every written weight is 0."""
+        msg = self._log(n_written=10, nb_overweight=2, max_overweight=3.0,
+                        sum_overweight_dw=0.0, sum_overweight_dabs=0.0,
+                        sum_nom=0.0, sum_abs_nom=0.0, sum_sq_nom=0.0)
+        self.assertIn('quoted against sum|w|', msg)
+        self.assertIn('nan', msg)            # said, not raised
+
+    def test_nothing_carried_says_so_and_stops(self):
+        msg = self._log(n_written=1000, sum_nom=1000.0, sum_abs_nom=1000.0,
+                        sum_sq_nom=1000.0)
+        self.assertIn('0/1000 written events carried a non-unit weight', msg)
+        self.assertNotIn('cross-section', msg)
 
 
 class TestBannerEventWeightRescale(unittest.TestCase):


### PR DESCRIPTION
When a trial weight `w` exceeds its accept/reject bound `C`, MadSpin accepted the
trial with probability 1 instead of `w/C` and dropped the excess. Writing the
event with weight `max(1, w/C)` restores the correct shape, because the loop
stops on a trial with probability proportional to `min(1, w/C)` and
`min(1,x) * max(1,x) = x` identically.

Applied to **all seven** clipping sites - joint, pure-interference unweighted,
sequential mass-set, per-slot angle (both the up-front and `sequential_with_mass`
variants), `two_stage`, and the legacy Fortran loop - across every spinmode.

Notable: the **joint** accept/reject, the historical default, had no overflow
accounting at all. It now has `nb_overflow_joint`.

## Behaviour

- When nothing overflows, output is bit-identical. A 10 000-event PA/sequential
  run at the shipped bound differs from the base in **exactly 3 event-weight
  lines**; every momentum, every other weight and every `<rwgt>` entry is
  unchanged. Total carried excess 1.285, i.e. 0.013 % of the normalisation.
- The factor reaches `wgt` and every `parse_reweight()` entry by the same
  multiplication; verified with injected `<rwgt>` entries, 10 000/10 000 events
  agreeing to 2e-7.
- New end-of-run line reports how many events carried a non-unit weight, the
  total excess, the fraction of the normalisation it represents, and the largest
  single factor.

## Validation

- `tests/test_manager.py test_madspin -t0`: 395 tests, OK.
- All clipping paths exercised end to end (joint, two_stage,
  sequential_with_mass, madspin, PA, madspin_v1, and the onshell zero-case).
- **Forced-low bound** (`maxwgts[0]`/30, 9994/10000 overflowing). In the
  `sqrt(shat) < 400 GeV` slice, paired carried-minus-clipped shift in
  `<m(t)+m(t~)>` is -0.342 +- 0.036 GeV (9.5 sigma). Carried sits +0.3 / +1.0
  sigma from the shipped-bound and `decay_output = weighted` references; clipped
  sits +2.9 / +3.4 sigma.

## Notes

No option switch: `lhe_parser.EventFile.unweight` already ships this treatment
(`written_weight(max(wgt, max_wgt))`), so MG5's own unweighted samples already
contain over-weight events and nothing downstream asserts unit weights.

Carrying is exact for the mass stage. For the angle stages it restores the
angular shape at fixed `m` exactly and leaves an `m`-dependent residual, because
`Z_hat(m)` approximates `E[w|m]` under the assumption that the bound dominates -
which is why the `nb_overflow_*` warnings are kept rather than removed.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Carry excess accept/reject weights through all MadSpin unweighting paths to remove the bias caused by clipping under-estimated bounds.

New Features:
- Carry accept/reject overweights into event and reweight entries across MadSpin’s joint, sequential, interference, two-stage, and legacy unweighting paths.
- Report the number, magnitude, and normalisation impact of carried overweight events at the end of each run.

Bug Fixes:
- Prevent under-estimated accept/reject bounds from silently biasing MadSpin event distributions by clipping overweight trials.

Enhancements:
- Preserve signed event weights while applying unsigned overweight factors and handle zero or cancelling cross-section samples with appropriate accounting.
- Track joint-path overflows and retain compatibility with parallel overflow reporting.

Documentation:
- Document the overweight-carrying behaviour, composition across stages, accounting conventions, limitations, and validation results.

Tests:
- Add coverage for joint, counter-event, pure-interference, multiweight propagation, no-overflow identity, and overweight reporting scenarios.