### PR TITLE
MadSpin: the overweight escalation must use the bound it tested against

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2458,7 +2458,7 @@ class decay_all_events(object):
                     misc.sprint('''over_weight: %s %s, occurence: %s%%, occurence_channel: %s%%
                     production_tag:%s [%s], decay:%s [%s], BW_cut: %1g\n
                     ''' %\
-                    (weight/decay['max_weight'], decay['decay_tag'], 
+                    (weight/decay_me['max_weight'], decay['decay_tag'], 
                     100 * report['over_weight']/event_nb,
                     100 * report['%s_f' % (decay['decay_tag'],)] / report[decay['decay_tag']],
                     os.path.basename(self.all_ME[production_tag]['path']),
@@ -2467,12 +2467,12 @@ class decay_all_events(object):
                     decay['decay_tag'],BWvalue))
                         
                 
-                if weight > 10.0 * decay['max_weight']:
+                if weight > 10.0 * decay_me['max_weight']:
                     error = """Found a weight MUCH larger than the computed max_weight (ratio: %s). 
     This usually means that the Narrow width approximation reaches it's limit on part of the Phase-Space.
     Do not trust too much the tale of the distribution and/or relaunch the code with smaller BW_cut.
     This is for channel %s with current BW_value at : %g'""" \
-                    % (weight/decay['max_weight'], decay['decay_tag'], BWvalue)  
+                    % (weight/decay_me['max_weight'], decay['decay_tag'], BWvalue)  
                     logger.error(error)
                 elif report['over_weight'] > max(0.005*event_nb,3):
                     error = """Found too many weight larger than the computed max_weight (%s/%s = %s%%). 
@@ -2480,8 +2480,6 @@ class decay_all_events(object):
     computation of the maximum_weight.
                     """ % (report['over_weight'], event_nb, 100 * report['over_weight']/event_nb )  
                     raise MadSpinError(error)
-                        
-                    error = True
                 elif report['%s_f' % (decay['decay_tag'],)] > max(0.01*report[decay['decay_tag']],3):
                     error = """Found too many weight larger than the computed max_weight (%s/%s = %s%%),
     for channel %s. Please relaunch MS with more events/PS point by event in the


### PR DESCRIPTION
The legacy (`spinmode = madspin_v1`) overweight handler tested against one bound
and escalated against another:

```python
if weight > decay_me['max_weight']:          # the test
    ...
    if weight > 10.0 * decay['max_weight']:  # the escalation
```

`decay` is the channel `get_random_decay` drew; `decay_me` is the master channel
it maps onto through `inverted_decay_mapping`, and it is the master's ME and the
master's `max_weight` that the Fortran unweighting is handed. The two bounds are
related by `1.1 * ratio` (`get_max_weight_from_event`), so they genuinely differ.

Dates to `5dd30eb51` (2013-08-20), a one-line commit that fixed the `if` and left
the four uses below it stale.

## Evidence

Instrumented `madspin_v1` run, `t > w+ b, w+ > all all`, 100 events:

- `decay is decay_me` false in **81/100** events
- `decay['max_weight'] != decay_me['max_weight']` in **44/100**
- observed bound ratios 1.0 (56), 0.3667 (41), 0.1222 (3) - i.e. `1.1 x 1/3` and
  `1.1 x 1/9`, the colour factor between hadronic and leptonic W decays

Overweights are 0/100 at the shipped bound, so the before/after comparison forced
every `max_weight` down by 10x, same seed:

| | before | after |
|---|---|---|
| overweight events | 69 | 69 |
| arm 1 - `10.0 *` "MUCH larger" hard error | **7** (ratios 10.8 - 27.2) | **0** |
| arm 2 - `0.005*event_nb` raise | 59 | **66** |

All 7 were false alarms: the true `weight/decay_me['max_weight']` never exceeded
10, the printed ratio being inflated by exactly 2.73x or 8.18x. Because arm 1 is
first in the `if/elif` chain, each false positive also **swallowed** the correct
escalation - 59 instead of 66.

The accept/reject decision is untouched (69 overweights either way): this is
diagnostics and escalation only. The reverse direction - silence on a real
overweight - requires the master to be the smaller-ME channel; the arithmetic
permits it, this sample did not produce one.

## Also removed

A dead `error = True` after `raise MadSpinError(error)`, introduced dead in
`cfa26c02b` (Feb 2013). Checked and **not** shadowing anything: the per-channel
escalation below it is a sibling arm of the same chain, not nested in the raising
arm's body (verified by AST and by execution). It is reachable, but only for
`event_nb > 600`, which is why it never fires in short runs.

## Validation

- `tests/test_manager.py test_madspin -t0`: 395 tests, OK.
- Clean `spinmode = madspin_v1` run with the fix: 100/100 events written, 0
  overweights.

Only the tt~ tree-level sample was exercised; no NLO or loop-induced sample, and
arm 3 was never fired empirically.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct MadSpin’s legacy overweight handling to consistently apply the bound used for unweighting.

Bug Fixes:
- Use the master decay channel’s maximum weight consistently when reporting and escalating overweight events, preventing false hard-error diagnostics and preserving the intended escalation behavior.

Enhancements:
- Remove unreachable dead code following the overweight error raise.