### PR TITLE
MadSpin: bound the mass stage per production event, for any 2 -> N

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -8292,7 +8292,15 @@ class MadSpinInterface(extended_cmd.Cmd):
     # What is NOT bounded here, and falls back to the global probe bound:
     #  * the offshell spinmodes (madspin/full), whose w_mass carries the extra
     #    Tr(rho_off)/|M_prod|^2_on -- a matrix-element ratio with no cheap
-    #    maximum. Only PA/onshell is covered;
+    #    maximum. Only PA/onshell is covered. That ratio is not why: measured on
+    #    3.9e6 free mass sets it is 1.0000 +- 0.012. What kills the construction
+    #    offshell is Zhat, whose window spans a factor 3.2 there against 1.16
+    #    under PA, so max_m Zhat sits 2.9x above the typical weight and the
+    #    corner bound comes out LOOSER than the probe's global one (eps_m 5.00
+    #    against 3.06). Even the partial bound J_corner . max_sample(rest) is
+    #    worth 2%, and is a loss once the run-level factor is measured as a
+    #    maximum rather than extrapolated. Section 15 of
+    #    doc/madspin_sequential_plan.md has the numbers;
     #  * a production event carrying an onshell propagator (status 2), where
     #    reshuffle_production multiplies in a reshuffle_decay jacobian per
     #    sub-decay that is not part of this factorisation;
@@ -8333,8 +8341,10 @@ class MadSpinInterface(extended_cmd.Cmd):
             if getattr(self, '_mass_bound_fallback_announced', False):
                 return
             self._mass_bound_fallback_announced = True
-            reason = ('the spinmode is not PA/onshell, so the mass weight '
-                      'carries an offshell production matrix element'
+            reason = ('the spinmode is offshell (madspin/full), where the '
+                      'per-event construction was MEASURED to be looser than '
+                      'this bound, not merely unavailable -- see section 15 of '
+                      'doc/madspin_sequential_plan.md'
                       if offshell else self._MASS_BOUND_UNSUPPORTED)
             logger.info(
                 "MadSpin sequential: the mass stage keeps the probe's global "
@@ -8857,10 +8867,17 @@ class MadSpinInterface(extended_cmd.Cmd):
         # cancels out of it. Changing C therefore changes the trial sequence and
         # the cost, and nothing about the sample.
         mass_bound = None
-        if probe is None and maxwgts and draw_mass and not offshell:
+        if probe is None and maxwgts and upfront and draw_mass and not offshell:
             mass_bound = self._mass_stage_bound(production, order, particles,
                                                 slot_to_index, zkeys, keep_jac)
-        if maxwgts and draw_mass:
+        # Which events *have* a mass stage to bound: the up-front schemes, and
+        # there whichever family draws a virtuality up front. ``_upfront_production``
+        # fills slot_mass under `offshell or draw_mass`, and `draw_mass` alone is
+        # the PA half of that -- so gating on it left the offshell spinmodes
+        # counted in neither column and never announced, and let
+        # sequential_with_mass (which is not an up-front scheme at all, and whose
+        # mass_bound is dead) announce a bound it does not use.
+        if maxwgts and upfront and (offshell or draw_mass):
             # one per chain call, i.e. one per production event reaching the
             # mass stage -- a rejected mass set loops *inside* the chain, so
             # these count events and not draws

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4666,6 +4666,15 @@ class MadSpinInterface(extended_cmd.Cmd):
                         drawn, rejects,
                         ', %d dropped by a rejected decay' % exact_restarts
                         if exact_restarts else '')
+        per_event = merged.get('nb_mass_bound_event', 0)
+        global_bound = merged.get('nb_mass_bound_global', 0)
+        if per_event or global_bound:
+            logger.info(
+                "MadSpin sequential mass stage: %d/%d production events used "
+                "the per-event bound%s", per_event, per_event + global_bound,
+                '' if not global_bound else
+                ' (%d fell back to the probe\'s global maximum weight)'
+                % global_bound)
         positions = sorted(int(k.rsplit('_', 1)[1]) for k in merged
                            if k.startswith('nb_try_'))
         for position in positions:
@@ -7960,11 +7969,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                                 ncomb=len(hel), dimension=len(hel),
                                 frame_boost=frame_boost, frame_rest_leg=rest_leg)
 
-    def _draw_mass_value(self, pdg, budget):
-        """Sample one resonance virtuality from its Breit-Wigner, capped at the
-        remaining ``budget`` (what is left of sqrt(shat)). Returns
-        ``(mass, reshuffle_info, jac_bw)`` where jac_bw is the Breit-Wigner
-        sampling jacobian (gap/pi)."""
+    def _mass_window(self, pdg, budget):
+        """The Breit-Wigner sampling window of one resonance and its sampling
+        jacobian: ``(pole, width, min_mass, max_mass, jac_bw)``.
+
+        Note ``jac_bw`` is a function of the *window*, not of the mass drawn in
+        it: the sampler is uniform in R = atan((m^2-pole^2)/(pole.Gamma)) and
+        gap/pi is exactly that window's width in R over pi. That is what makes
+        the mass-stage bound of ``_mass_stage_bound`` a maximum over the window
+        corners rather than a scan in m.
+        """
         pole = self.banner.get('param', 'mass', abs(pdg)).value
         width = self.banner.get('param', 'decay', abs(pdg)).value
         if self.options['BW_cut'] < 0:
@@ -7973,11 +7987,19 @@ class MadSpinInterface(extended_cmd.Cmd):
             bw_cut = self.options['BW_cut']
         min_mass = pole - bw_cut * width
         max_mass = min(pole + bw_cut * width, budget)
-        mass = lhe_parser.Event.generate_random_mass(pole, width, min_mass, max_mass)
-        info = (pole, width, min_mass, max_mass)
         gap = math.atan((pole**2-min_mass**2)/pole/width)
         gap += math.atan((max_mass**2-pole**2)/pole/width)
-        return mass, info, gap/math.pi
+        return pole, width, min_mass, max_mass, gap/math.pi
+
+    def _draw_mass_value(self, pdg, budget):
+        """Sample one resonance virtuality from its Breit-Wigner, capped at the
+        remaining ``budget`` (what is left of sqrt(shat)). Returns
+        ``(mass, reshuffle_info, jac_bw)`` where jac_bw is the Breit-Wigner
+        sampling jacobian (gap/pi)."""
+        pole, width, min_mass, max_mass, jac_bw = self._mass_window(pdg, budget)
+        mass = lhe_parser.Event.generate_random_mass(pole, width, min_mass, max_mass)
+        info = (pole, width, min_mass, max_mass)
+        return mass, info, jac_bw
 
     def _draw_offshell_mass(self, pdg, dec, budget):
         """Sample one resonance virtuality and store it on the decay event that
@@ -8187,6 +8209,224 @@ class MadSpinInterface(extended_cmd.Cmd):
         u = math.log(min(max(mass, lo), hi) / table['pole'])
         c = table['coeff']
         return math.exp(c[0] + u * (c[1] + u * c[2]))
+
+    def _zhat_max(self, key):
+        """max_m Zhat(key, m), exactly. ``_zhat`` is exp of a quadratic in
+        u = ln(m/pole) *clamped* to the probed range, so the reachable set of u
+        is the closed interval [ln(lo/pole), ln(hi/pole)] and the maximum of a
+        quadratic over a closed interval is at an endpoint or at its vertex.
+        No scan, no sample mean, no safety margin: this is the supremum.
+
+        Doing it this way rather than as ``margin * <jac_bw . Zhat>`` is the
+        point -- a sample mean is not a bound, and Zhat is allowed to have
+        structure (a decay threshold opening inside the window shows up as
+        ``zero_below`` plus a steep rise just above it, a narrow daughter
+        resonance as curvature). The quadratic fit is what ``_build_z_tables``
+        ships, so its exact maximum is what dominates every value ``_zhat`` can
+        return.
+        """
+        table = (getattr(self, '_z_tables', None) or {}).get(key)
+        if not table:
+            return 1.0
+        lo, hi = table['range']
+        pole = table['pole']
+        c = table['coeff']
+        u_lo, u_hi = math.log(lo / pole), math.log(hi / pole)
+        candidates = [u_lo, u_hi]
+        # c[2] >= 0 opens upwards, so the interior stationary point is a
+        # minimum and the endpoints already win; only a downward parabola can
+        # peak inside
+        if c[2] < 0:
+            vertex = -c[1] / (2 * c[2])
+            if u_lo < vertex < u_hi:
+                candidates.append(vertex)
+        return max(math.exp(c[0] + u * (c[1] + u * c[2])) for u in candidates)
+
+    # ------------------------------------------------------------------
+    # The per-event bound of the mass stage
+    # ------------------------------------------------------------------
+    # The mass-stage weight under PA/onshell is
+    #
+    #     w_mass = J(m) . prod_s jac_bw_s(m) . prod_s Zhat_s(m_s)
+    #
+    # with every factor non-negative, so any product of per-factor maxima
+    # dominates it. All three maxima are exact and cheap per production event:
+    #
+    #  * J is the RAMBO reshuffling jacobian, and it is monotone DECREASING in
+    #    every m_s at fixed sqrt(shat) and fixed production configuration --
+    #    proved below -- so max J over the window is J at the low corner, for
+    #    any n, with no scan;
+    #  * jac_bw_s is the width in R of slot s's Breit-Wigner window, a function
+    #    of the *budget* sqrt(shat) - sum of the masses drawn before it, not of
+    #    m_s. It is increasing in that budget, which is largest when every
+    #    earlier slot sits at its own window minimum -- the same low corner;
+    #  * Zhat_s is a 1-D function of m_s alone, maximised by ``_zhat_max``.
+    #
+    # The low corner therefore maximises J and every jac_bw simultaneously, and
+    # Zhat factorises, so the product of the three maxima is a true bound. The
+    # window is not a box -- sum(m) <= sqrt(shat) couples the slots -- but the
+    # coupled region is a SUBSET of the box that contains the low corner
+    # whenever it contains anything at all, so a monotone function's maximum
+    # over it is still at that corner and a scan cannot do better.
+    #
+    # Proof that J is monotone decreasing. Write a_i = |p_i|^2 in the
+    # reshuffling CM frame, mu_i = m_i'^2, E_i' = sqrt(mu_i + chi^2 a_i),
+    # beta_i = |p_i'|/E_i' and n the number of final-state particles. Eq. (4.9)
+    # is J = const . chi^(3n-5) / (G . prod_i E_i') with G = sum_i a_i/E_i'.
+    # Differentiating the constraint sum_i E_i' = sqrt(shat) gives
+    # d(chi)/d(mu_k) = -1/(2 E_k' chi G) < 0, and then
+    #
+    #   2 E_k' G chi^2 . dlnJ/dmu_k
+    #       = -(3n-5) + beta_k^2 + sum_i beta_i^2
+    #         - (sum_i E_i' beta_i^4)/(sum_i E_i' beta_i^2)
+    #         - (sum_i E_i' beta_i^2)/E_k'      ==  D_k .
+    #
+    # The third term is >= 0 and the fourth is >= beta_k^2 (its k-th summand
+    # alone), so D_k <= -(3n-5) + sum_i beta_i^2 <= -(3n-5) + n = 5 - 2n, which
+    # is <= -1 for every n >= 3. For n = 2 the closed form settles it directly:
+    # J = chi = lambda^(1/2)(s,m_1'^2,m_2'^2)/lambda^(1/2)(s,m_1^2,m_2^2), and
+    # lambda^(1/2) decreases in each mass. Checked numerically as well: 1.6e6
+    # directional probes over n = 2..10, |p| and m each spanning eight decades,
+    # zero violations.
+    #
+    # What is NOT bounded here, and falls back to the global probe bound:
+    #  * the offshell spinmodes (madspin/full), whose w_mass carries the extra
+    #    Tr(rho_off)/|M_prod|^2_on -- a matrix-element ratio with no cheap
+    #    maximum. Only PA/onshell is covered;
+    #  * a production event carrying an onshell propagator (status 2), where
+    #    reshuffle_production multiplies in a reshuffle_decay jacobian per
+    #    sub-decay that is not part of this factorisation;
+    #  * a window whose low corner is already over threshold
+    #    (sum of the window minima > sqrt(shat)), or one that inverts
+    #    (max_mass <= min_mass, i.e. a budget below the window's own floor);
+    #  * a jacobian the kernel reports as infeasible or non-finite at the
+    #    corner.
+
+    _MASS_BOUND_UNSUPPORTED = None      # last fallback reason, for the log
+
+    def _announce_mass_bound(self, mass_bound, offshell, probe):
+        """Say once, per worker, which bound the mass stage is using.
+
+        Loud on purpose. When the per-event bound is in force, ``nb_sigma`` and
+        ``Nevents_for_max_weight`` no longer reach the mass stage -- they still
+        set every angle-stage bound -- and that is a user-visible change in what
+        those knobs do. It is also what finally makes the mass stage's cost
+        reproducible: the probe-based bound was measured to scatter +-40% run to
+        run without converging, because it extrapolates a tail from the first
+        ``Nevents_for_max_weight`` events of the file.
+        """
+        if probe is not None:
+            return
+        if mass_bound is not None:
+            if getattr(self, '_mass_bound_announced', False):
+                return
+            self._mass_bound_announced = True
+            logger.info(
+                "MadSpin sequential: the mass stage now bounds each production "
+                "event separately -- max(J) at the low corner of the "
+                "Breit-Wigner windows, times the exact maximum of "
+                "jac_BW.Zhat per resonance. It is an upper bound by "
+                "construction, so no mass-set weight can overflow it. Note "
+                "nb_sigma and Nevents_for_max_weight no longer set the MASS "
+                "stage's bound (they still set every angle stage's).")
+        else:
+            if getattr(self, '_mass_bound_fallback_announced', False):
+                return
+            self._mass_bound_fallback_announced = True
+            reason = ('the spinmode is not PA/onshell, so the mass weight '
+                      'carries an offshell production matrix element'
+                      if offshell else self._MASS_BOUND_UNSUPPORTED)
+            logger.info(
+                "MadSpin sequential: the mass stage keeps the probe's global "
+                "maximum weight -- %s.", reason or 'unsupported event')
+
+    def _mass_stage_bound(self, production, order, particles, slot_to_index,
+                          zkeys, keep_jac):
+        """C_e for one production event, or None when the event is one of the
+        unsupported cases listed above (the caller then uses the global bound).
+
+        Cached on the production event: the chain re-enters on every rejected
+        mass set and the bound does not depend on the draw.
+        """
+        cached = getattr(production, '_ms_mass_bound', False)
+        if cached is not False:
+            return cached
+        bound = self._mass_stage_bound_compute(production, order, particles,
+                                               slot_to_index, zkeys, keep_jac)
+        production._ms_mass_bound = bound
+        return bound
+
+    def _mass_stage_bound_compute(self, production, order, particles,
+                                  slot_to_index, zkeys, keep_jac):
+        if any(int(p.status) not in (-1, 1) for p in production):
+            self._MASS_BOUND_UNSUPPORTED = (
+                'the production event carries an onshell propagator, whose '
+                'sub-decay reshuffling jacobian is not part of the bound')
+            return None
+        sqrts = production.sqrts
+        if not sqrts or not (sqrts > 0):
+            self._MASS_BOUND_UNSUPPORTED = 'sqrt(shat) is not usable'
+            return None
+
+        # the low corner of the window, slot by slot, in the order the draw
+        # spends the budget in -- which is what makes each jac_bw maximal
+        budget = sqrts
+        corner = {}
+        bw_max = 1.0
+        for slot in order:
+            pdg = particles[slot_to_index[slot]].pid
+            pole, width, min_mass, max_mass, jac_bw = self._mass_window(pdg, budget)
+            if not (max_mass > min_mass) or not (min_mass > 0):
+                self._MASS_BOUND_UNSUPPORTED = (
+                    'the Breit-Wigner window of pdg %s is empty at this '
+                    'sqrt(shat)' % pdg)
+                return None
+            corner[slot] = min_mass
+            bw_max *= jac_bw
+            budget -= min_mass
+            if budget <= 0:
+                self._MASS_BOUND_UNSUPPORTED = (
+                    'the window minima alone exceed sqrt(shat)')
+                return None
+
+        jac_max = 1.0
+        if keep_jac:
+            frame = getattr(production, '_ms_shuffle_frame', None)
+            if frame is None:
+                # from the *round-tripped* event, because that is what
+                # _production_jacobian_for reshuffles: str() truncates every
+                # momentum to %.10e, and the bound has to dominate the weight
+                # the accept/reject actually computes, not an idealised one.
+                probe = lhe_parser.Event(str(production))
+                finals = [p for p in probe if int(p.status) == 1]
+                frame = lhe_parser.Event.mass_shuffle_frame(
+                    [lhe_parser.FourMomentum(p) for p in finals], probe.sqrts)
+                production._ms_shuffle_frame = frame
+                production._ms_shuffle_sqrts = probe.sqrts
+                # the undrawn slots keep their nominal mass, and it is the
+                # round-tripped one reshuffle_production reads
+                production._ms_shuffle_masses = [p.mass for p in finals]
+            masses = list(production._ms_shuffle_masses)
+            for slot, mass in corner.items():
+                masses[slot_to_index[slot]] = mass
+            jac_max = lhe_parser.Event.mass_shuffle_jacobian(
+                frame, masses, production._ms_shuffle_sqrts)
+            if jac_max in (0, -1) or not math.isfinite(jac_max) \
+                    or not jac_max > 0:
+                self._MASS_BOUND_UNSUPPORTED = (
+                    'the reshuffling jacobian has no value at the window low '
+                    'corner (that mass set is already infeasible)')
+                return None
+
+        z_max = 1.0
+        for slot in order:
+            z_max *= self._zhat_max(zkeys[slot])
+
+        bound = jac_max * bw_max * z_max
+        if not math.isfinite(bound) or not bound > 0:
+            self._MASS_BOUND_UNSUPPORTED = 'the bound is not a positive number'
+            return None
+        return bound
 
     @staticmethod
     def _weighted_polyfit2(xs, ys, ws):
@@ -8605,6 +8845,30 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         if stats is None:
             stats = collections.defaultdict(int)
+
+        # The mass stage's bound. Per production event where that is possible
+        # (see _mass_stage_bound), the probe's global maxwgts[0] otherwise. The
+        # per-event one is a proven upper bound rather than an extrapolation of
+        # the probe's tail, so nothing it tests can overflow -- which is what
+        # the overweight counters at the end of the run report.
+        #
+        # The accepted mass distribution is q_e(m) . min(1, w/C) followed by a
+        # redraw, i.e. proportional to q_e(m) w(m) for ANY C >= max w: the bound
+        # cancels out of it. Changing C therefore changes the trial sequence and
+        # the cost, and nothing about the sample.
+        mass_bound = None
+        if probe is None and maxwgts and draw_mass and not offshell:
+            mass_bound = self._mass_stage_bound(production, order, particles,
+                                                slot_to_index, zkeys, keep_jac)
+        if maxwgts and draw_mass:
+            # one per chain call, i.e. one per production event reaching the
+            # mass stage -- a rejected mass set loops *inside* the chain, so
+            # these count events and not draws
+            if mass_bound is None:
+                stats['nb_mass_bound_global'] += 1
+            else:
+                stats['nb_mass_bound_event'] += 1
+            self._announce_mass_bound(mass_bound, offshell, probe)
         if probe is not None and probe_extra is None:
             probe_extra = {}
 
@@ -8726,15 +8990,16 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # no virtuality to unweight means w_mass is the constant 1
                     # (onshell, and 2 -> 1 production under PA): testing it
                     # against its bound would only throw chains away
-                    if w_mass > maxwgts[0]:
+                    cmass = maxwgts[0] if mass_bound is None else mass_bound
+                    if w_mass > cmass:
                         stats['nb_overflow_mass'] += 1
                         # accepted with probability 1 instead of w/C: carry the
                         # excess. Set after the test would be equivalent (an
                         # overflowing weight cannot be rejected, since
                         # random.random() < 1), but it is set here so the
                         # counter and the factor stay one statement apart.
-                        carry_mass = w_mass / maxwgts[0]
-                    if random.random() * maxwgts[0] >= w_mass:
+                        carry_mass = w_mass / cmass
+                    if random.random() * cmass >= w_mass:
                         stats['nb_mass_reject'] += 1
                         continue            # redraw the whole mass set
 

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -2894,3 +2894,153 @@ sits `+2.9` and `+3.4` sigma away. In the `sqrt(shat) < 360 GeV` threshold slice
 the carried result is `-0.1` / `+0.0` sigma from the two references and the
 clipped one `+3.0` / `+2.6`. A factor 30 in the bound leaves the carried
 physics where it was, which is the whole content of `min(1,x) max(1,x) = x`.
+
+## 15. The mass stage's per-event bound
+
+Section 14 made an under-estimated bound harmless. This makes it impossible, at
+the mass stage, and cheaper at the same time.
+
+### What the bound is
+
+Under `PA`/`onshell` the mass-set weight is
+
+    w_mass = J(m) . prod_s jac_BW_s(m) . prod_s Zhat_s(m_s)
+
+with `J` the RAMBO production reshuffling jacobian, `jac_BW_s = gap/pi` the
+width in `R = atan((m^2-pole^2)/(pole.Gamma))` of slot `s`'s Breit-Wigner
+window, and `Zhat_s` the tabulated rate factor. Every factor is non-negative, so
+a product of per-factor maxima dominates it. All three maxima are exact and cost
+O(n) per production event:
+
+* **`max J` is at the low corner of the windows.** `J` is monotone *decreasing*
+  in every new mass at fixed `sqrt(shat)` and fixed configuration -- proved in
+  the comment above `_mass_stage_bound`, `d ln J/d mu_k <= (5-2n)/(2 E_k' G
+  chi^2) < 0` for `n >= 3`, and the `lambda^(1/2)` ratio for `n = 2`. Checked on
+  1.6e6 directional probes over `n = 2..10` with `|p|` and `m` each spanning
+  eight decades: zero violations.
+* **`jac_BW_s` does not depend on `m_s` at all** -- it is the *window's* width,
+  a function of the budget `sqrt(shat) - sum of the masses drawn before it`. It
+  is increasing in that budget, which is largest at the same low corner. (The
+  earlier design note treated `jac_BW` as a function of the drawn mass and
+  proposed maximising `jac_BW . Zhat` jointly; there is nothing to maximise
+  jointly.)
+* **`max Zhat_s` is a 1-D maximum of `exp` of a quadratic in `ln(m/pole)` over
+  the clamped range** -- endpoint or vertex, `_zhat_max`. Deliberately *not*
+  `1.1 . <jac_BW . Zhat>`: a sample mean is not a bound, and `Zhat` is allowed
+  to have structure.
+
+The window is not a box (`sum m <= sqrt(shat)` couples the slots), but the
+coupled region is a subset of the box that contains the low corner whenever it
+contains anything, so a monotone function's maximum over it is at that corner
+and a scan over the coupled region cannot beat it for `J`.
+
+### Not restricted to `2 -> 2`
+
+`Event.mass_shuffle_jacobian` evaluates RAMBO eqs. (4.3)/(4.9) from the
+per-event data `Event.mass_shuffle_frame` returns -- `(E_i, m_i^2, |p_i|^2)` in
+the reshuffling CM frame, computed once per event -- so a candidate mass set is
+one scalar Newton solve plus O(n) arithmetic, for any `n`. The `2 -> 2` closed
+form `lambda^(1/2)/lambda^(1/2)` is the case where the solve is explicit; it is
+not the only case that is cheap. Against `_production_jacobian_for` (which
+re-parses the event from a string, splits it, boosts it and rebuilds the
+momenta) the kernel agrees to **8.9e-16** at `n = 2` and **6.6e-16 / 6.7e-16 /
+8.8e-16** at `n = 3, 4, 5` on identical inputs, reproduces the `0` and `-1`
+verdicts exactly (7683 such cases), and is 6-7x faster (5.3 vs 33 us at `n = 2`,
+7.8 vs 55 us at `n = 5`). Fed the *untruncated* event it differs from the
+shipped path by up to 4.4e-5, which is the `%.10e` truncation `str(Event)`
+applies -- so the bound builds its frame from the round-tripped event, and sees
+exactly what the accept/reject computes.
+
+### What it is worth
+
+`p p > t t~` at 6.5+6.5 TeV, 20 000 events, `spinmode = PA`,
+`unweighting = sequential`, `BW_cut = 15`, both tops to `e nu b`. Offline probe,
+2500 production events, ~1e6 free mass sets, same slicing as
+`doc/madspin_pa_mass_stage/bound_design.md` section 4B:
+
+| `sqrt(shat)` [GeV] | % of sample | `eps_m` global `C` | `eps_m` per-event `C_e` | overflows global | overflows per-event |
+|---|---|---|---|---|---|
+| 346-350 | 0.40 | 1.96 | 5.50 | 3841 | 0 |
+| 350-355 | 1.20 | 1.89 | 3.26 | 1127 | 0 |
+| 355-360 | 1.64 | 1.86 | 2.46 | 3 | 0 |
+| 360-370 | 3.64 | 1.83 | 2.04 | 0 | 0 |
+| 370-380 | 4.64 | 1.82 | 1.75 | 0 | 0 |
+| 380-400 | 8.68 | 1.82 | 1.56 | 0 | 0 |
+| 400-450 | 19.96 | 1.81 | 1.38 | 0 | 0 |
+| 450-500 | 16.24 | 1.81 | 1.27 | 0 | 0 |
+| 500-600 | 21.32 | 1.81 | 1.22 | 0 | 0 |
+| 600-800 | 15.56 | 1.81 | 1.17 | 0 | 0 |
+| > 800 | 6.72 | 1.81 | 1.14 | 0 | 0 |
+| **all** | 100 | **1.82** | **1.39** | **4971** | **0** |
+
+Same shape as the earlier study: worse than the global bound in the first few
+GeV above threshold, where `J` at the corner is large and the Breit-Wigner
+essentially never goes there, and better everywhere else. The largest
+`max(w)/C_e` seen anywhere in that scan is **0.9635** -- tight, and never
+exceeded.
+
+End to end, against the same sample, the same seed and the *same* `ms_dir`
+cache (so the `Zhat` tables and the global bound are identical):
+
+| run | `eps_m` before | `eps_m` after | overweight events before | after |
+|---|---|---|---|---|
+| `p p > t t~` (2 -> 2) | 1.80 | **1.39** | 20 / 20 000 | **0** |
+| `p p > t t~ j` (2 -> 3) | 2.76 | **1.50** | 0 / 8 000 | **0** |
+| `p p > t t~`, `BW_cut = 70` | 1.74 | **1.68** | 23 / 20 000 | **0** |
+
+The third row is the case where `Zhat` is *not* smooth: with a 70-width window
+the top's `b W` threshold at 85 GeV falls inside it, and the fitted table runs
+`Z(70.3) = 0.002`, `Z(173) = 1`, `Z(275.5) = 0.263` -- a factor 500 across the
+window, with a 35 % bin-to-fit deviation. There the exact `max Zhat` is far
+above the typical `Zhat`, so the bound is barely tighter than the global one.
+It is still a *bound*, which the global one was not: 23 overflows became 0.
+
+### The safety case: the bound cancels
+
+The mass stage redraws until it accepts, so the accepted density is
+proportional to `q_e(m) . min(1, w/C)`, i.e. to `q_e(m) w(m)` for **any**
+`C >= max w`. Changing `C` changes the trial sequence and the cost and nothing
+else. Measured, not asserted -- same production sample, same seed, base bound
+against per-event bound, accepted virtualities of both parents:
+
+| run | pdg | two-sample chi2 / d.o.f. | KS p |
+|---|---|---|---|
+| `t t~` | 6 | 19.3 / 24 | 0.22 |
+| `t t~` | -6 | 14.0 / 24 | 0.71 |
+| `t t~ j` | 6 | 30.1 / 24 | 0.94 |
+| `t t~ j` | -6 | 17.1 / 24 | 0.56 |
+| `t t~`, `BW_cut = 70` | 6 | 23.5 / 22 | 0.32 |
+| `t t~`, `BW_cut = 70` | -6 | 22.3 / 22 | 0.99 |
+
+(The base runs carry a handful of non-unit weights from section 14, worth
+0.03 % of the normalisation; the histograms above ignore weights, which is
+three orders of magnitude below their resolution.)
+
+### Would a scan do better?
+
+Only through `Zhat`. `J` and every `jac_BW` peak at the same corner, so the
+only slack is `prod_s max Zhat_s` against `Zhat` where `w` actually peaks. A
+120x120 grid over the true coupled region measures `C_corner/C_scan` at median
+**1.26** (min 1.10, max 1.35 for `BW_cut = 15`; max 1.40 for `BW_cut = 70`), so
+a scan would buy about 25 % of acceptance for ~14 000 kernel evaluations per
+production event against ~2 -- and a grid maximum is not a bound, so it would
+need a margin back. Not taken.
+
+### Behaviour change, and the fallbacks
+
+`nb_sigma` and `Nevents_for_max_weight` no longer set the **mass** stage's
+bound; they still set every angle stage's. This is logged once per run, not
+silent, and it is what makes the mass stage's cost reproducible -- the
+probe-based bound was measured scattering +-40 % run to run without converging.
+The probe still measures `maxwgts[0]`, and it is still what the mass stage uses
+when the per-event bound does not apply:
+
+* the offshell spinmodes (`madspin`/`full`), whose `w_mass` carries
+  `Tr(rho_off)/|M_prod|^2_on`;
+* a production event with an onshell propagator (status 2), where
+  `reshuffle_production` folds in a `reshuffle_decay` jacobian per sub-decay;
+* a window that does not fit (`sum` of the minima above `sqrt(shat)`, or a
+  budget below a window's own floor);
+* a jacobian that is infeasible or not finite at the corner.
+
+The end-of-run report says how many production events took each path.

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -3036,11 +3036,96 @@ The probe still measures `maxwgts[0]`, and it is still what the mass stage uses
 when the per-event bound does not apply:
 
 * the offshell spinmodes (`madspin`/`full`), whose `w_mass` carries
-  `Tr(rho_off)/|M_prod|^2_on`;
+  `Tr(rho_off)/|M_prod|^2_on` -- see the next subsection, which is why it is
+  not a gap waiting to be filled;
 * a production event with an onshell propagator (status 2), where
   `reshuffle_production` folds in a `reshuffle_decay` jacobian per sub-decay;
 * a window that does not fit (`sum` of the minima above `sqrt(shat)`, or a
   budget below a window's own floor);
 * a jacobian that is infeasible or not finite at the corner.
 
-The end-of-run report says how many production events took each path.
+The end-of-run report says how many production events took each path -- for
+every up-front-mass run, offshell included. (Until this was fixed the counters
+and the announcement were gated on `draw_mass`, which is the *PA* half of "this
+event has a mass stage": the offshell spinmodes appeared in neither column and
+said nothing, while `sequential_with_mass` -- not an up-front scheme at all, and
+whose `mass_bound` is dead code -- announced a bound it does not use.)
+
+### The offshell spinmodes: measured, and left alone
+
+`Tr(rho_off)/|M_prod|^2_on` has no cheap maximum, so the exact construction
+above does not extend. The obvious partial bound does:
+
+    C_e  =  J(low corner of the windows)_e  x  max_sample[ everything else ]
+
+per-event and provable in the first factor, run-level in the rest; still a
+bound, since it is a product of maxima over non-negative factors; and tighter
+than today's global bound on every event whose `J_corner` is below the
+sample-wide worst. **It is worth 2 %, and the measurement says so before any of
+it is built.**
+
+`p p > t t~` at 6.5+6.5 TeV, 10 000 production events, both tops to `e nu b`,
+`BW_cut = 15`, `spinmode = madspin`, `unweighting = sequential`. Offline probe
+on the *run's own* production events -- 200-400 **free** mass sets each through
+`_upfront_production`, 3.90e6 in total, the run's own `ms_dir` cache, with the
+weight
+
+    w_mass = R . J . prod_s jac_BW_s . prod_s Zhat_s ,   R = Tr(rho_off)/|M_prod|^2_on
+
+kept factorised. `eps_m = mean_e(C_e/A_e)`, with `A_e` the event's mean weight
+over its free draws (infeasible sets counted as zero, as redraw-until-accept
+does). The estimator reproduces the runs' own log line: it predicts **3.06**
+for the shipped offshell bound and the run reports **3.06**, and **1.400** for
+the shipped PA per-event bound against a reported **1.41**.
+
+| the mass stage's bound | `eps_m` | events whose free draws exceed it |
+|---|---|---|
+| global `maxwgts[0]` -- shipped | **3.06** | 10 / 10 000, worst `w/C` = 1.98 |
+| `J_corner . combine(max R.jac_BW.Zhat)` | **3.00** | 0 |
+| `J_corner . max_sample(R.jac_BW.Zhat)` | 3.26 | 0 |
+| `J_corner . jac_BW_corner . max Zhat . combine(max R)` | 5.00 | 0 |
+| the per-event supremum of `w` (not reachable) | 1.42 | 0 |
+
+The second row is the proposal, with its run-level factor built exactly the way
+`maxwgts[0]` is (`_combine_maxwgt` over the first 75 probe events). The third is
+the same construction with that factor measured honestly, as the sample-wide
+maximum instead of a `mean + 4.5 sd` extrapolation of 75 events -- and it is
+*worse* than the bound it replaces. A 2 % gain that turns negative when the
+estimate it rests on is replaced by the quantity it estimates is not a gain.
+
+**Why, exactly.** Not the offshell ratio. Over 3.90e6 mass sets `R` is
+`1.00000 +- 0.0119`, range `[0.733, 1.314]` -- the factor the fallback is
+*named* after is the flattest thing in the weight. Two other things do the work:
+
+* **`Zhat` is steep offshell and flat under PA.** Same process, same sample,
+  same windows: the fitted table runs `Z(150.6) = 0.522, Z(173) = 1,
+  Z(195.3) = 1.699` offshell against `0.912 / 1 / 1.059` under PA. So the
+  event-independent `jac_BW_corner . max Zhat` over the two resonances is
+  **2.775** offshell and **1.074** under PA. The corner construction multiplies
+  `max jac_BW` (at the *low* end of the window) by `max Zhat` (at the *high*
+  end); under PA that costs 7 %, offshell it costs 190 %, which is the whole
+  difference between `eps_m = 1.40` and `eps_m = 5.00`.
+* **`J` and the rest are anti-correlated across events**, `corr = -0.49`: both
+  are driven by `sqrt(shat)`, `J_corner` blowing up at threshold (median 1.13,
+  mean 1.25, p99 2.9, max 13.2) exactly where the coupled window `sum m <=
+  sqrt(shat)` squeezes `jac_BW . Zhat` down. A maximum *of the product* -- which
+  is what the probe measures -- sees that; a product of maxima throws it away.
+  Over this sample `max_e max_draw(w) / [max_e J_corner . max_e (R.jac_BW.Zhat)]`
+  is **0.176**, i.e. fully factorising costs a factor 5.7.
+
+Under PA the same probe, on the same 10 000 events, gives `eps_m` 2.29 for the
+global bound (with 49 events over it, worst `w/C` = 3.94) against 1.40 for the
+shipped per-event one. That is the shape the offshell case does *not* have.
+
+**And a run-level table for `R`?** Tabulating `max_configurations R` against the
+virtualities the way `Zhat` is tabulated, conservative but free at
+accept/reject time, is the fuller option. It is not worth building either: `R`
+is 1.00 to a percent, a 7x7 table of its maximum in `(ln m_1, ln m_2)` runs
+1.02-1.31 against a single global 1.31, so the whole table is worth at most 25 %
+*of a factor that is already 1* -- and it would cost the probe an extra record
+per free mass set plus a `_UPFRONT_CACHE_FORMAT` bump. The slack offshell is in
+`max Zhat`, and `Zhat` is already tabulated and already exact.
+
+So the offshell spinmodes keep `maxwgts[0]`, section 14 keeps carrying the
+handful of overflows it leaves (1-2 events in 10 000, largest factor 1.38), and
+the fallback is now announced and counted rather than silent.

--- a/madgraph/various/lhe_parser.py
+++ b/madgraph/various/lhe_parser.py
@@ -2940,9 +2940,85 @@ class Event(list):
         return tag, order
     
     @staticmethod
+    def mass_shuffle_frame(momenta, sqrts):
+        """The per-event half of ``mass_shuffle``: everything the RAMBO
+        reshuffling jacobian needs that does *not* depend on the new masses.
+
+        ``mass_shuffle`` boosts the momenta to the frame where their sum is at
+        rest with energy ``sqrts`` and from there on only ever uses, per
+        particle, the three numbers returned here:
+
+            E     the energy in that frame              (eq. 4.2/4.3)
+            m2    ``p.mass_sqr`` **before** the boost   (eq. 4.3's ``oldm``)
+            p2    ``p.norm_sq`` in that frame           (eq. 4.9)
+
+        so a bound that has to evaluate the jacobian for many candidate mass
+        sets of one event pays the boost once, here, and then only arithmetic
+        (``mass_shuffle_jacobian``). Returns ``(E, m2, p2)``, three lists.
+
+        ``m2`` is taken before the boost and ``p2`` after it, exactly as
+        ``mass_shuffle`` does; the two differ from each other by rounding only,
+        but reproducing the shipped path to the last digit is the point.
+        """
+        oldm = [p.mass_sqr for p in momenta]
+        tot_mom = sum(momenta, FourMomentum())
+        lor = tot_mom.get_lorentz_map(FourMomentum(sqrts, 0, 0, 0))
+        boosted = [p.apply_lorentzmap(lor) for p in momenta]
+        return ([p.E for p in boosted], oldm, [p.norm_sq for p in boosted])
+
+    @staticmethod
+    def mass_shuffle_jacobian(frame, new_mass, new_sqrts):
+        """The RAMBO reshuffling jacobian of ``new_mass``, from the per-event
+        data ``mass_shuffle_frame`` returned -- no Event, no FourMomentum, no
+        boost. Same value, and the same 0/-1 verdicts, as
+        ``reshuffle_production`` would give for that mass set.
+
+        RAMBO eqs. (4.3), (4.2) and (4.9), in that order:
+
+            chi solves  new_sqrts = sum_i sqrt(m_i'^2 + chi^2 (E_i^2 - m_i^2))
+            E_i'      = sqrt(m_i'^2 + chi^2 (E_i^2 - m_i^2))
+            jac       = chi^(3n-3) prod_i (E_i/E_i')
+                        . [sum_i |p_i|^2/E_i] / [sum_i |p_i'|^2/E_i']
+
+        Every dependence on the production event is through ``frame``, i.e.
+        through n numbers per particle, so the whole thing is one scalar Newton
+        solve plus O(n) arithmetic per candidate mass set. The 2 -> 2 closed
+        form lambda^(1/2)/lambda^(1/2) is the case where that solve happens to
+        be explicit; nothing here is restricted to n = 2.
+
+        Returns -1 when ``sum(new_mass) > new_sqrts`` (what
+        ``reshuffle_production`` reports for a mass set above threshold) and 0
+        when the Newton solve does not converge -- the two failures the callers
+        test for with ``jac in (0, -1)``.
+        """
+        Es, oldm, normsq = frame
+        if sum(new_mass, 0) > new_sqrts:
+            return -1
+        newm = [m ** 2 for m in new_mass]
+        # a_i = E_i^2 - m_i^2, the only combination eq. 4.3 uses
+        avail = [E ** 2 - m for E, m in zip(Es, oldm)]
+
+        f = lambda chi: new_sqrts - sum(math.sqrt(max(0, M + chi ** 2 * a))
+                                        for M, a in zip(newm, avail))
+        df = lambda chi: -1 * sum(chi * a / math.sqrt(max(0, a * chi ** 2 + M))
+                                  for M, a in zip(newm, avail))
+        try:
+            chi = misc.newtonmethod(f, df, 1.0, error=1e-7, maxiter=1000)
+        except Exception:
+            return 0
+
+        newE = [math.sqrt(M + chi ** 2 * a) for M, a in zip(newm, avail)]
+        jac = chi ** (3 * len(Es) - 3)
+        for E, Ep in zip(Es, newE):
+            jac *= E / Ep
+        jac *= sum(p2 / E for p2, E in zip(normsq, Es))
+        jac /= sum(chi ** 2 * p2 / Ep for p2, Ep in zip(normsq, newE))
+        return jac
+
+    @staticmethod
     def mass_shuffle(momenta, sqrts, new_mass, new_sqrts=None):
         """use the RAMBO method to shuffle the PS. initial sqrts is preserved."""
-        
+
         if not new_sqrts:
             new_sqrts = sqrts
         

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -4757,7 +4757,7 @@ class TestPAUpFrontMass(unittest.TestCase):
             return self.head
 
     def _stub(self, rho, pools, z_table=True, keep_jac=True,
-              unweighting='sequential'):
+              unweighting='sequential', spinmode='PA'):
         interface = interface_madspin.MadSpinInterface
         outer = self
         hels = self.HELS
@@ -4796,11 +4796,12 @@ class TestPAUpFrontMass(unittest.TestCase):
             _pure_interference = staticmethod(lambda: {})
 
             def __init__(self):
+                self.mass_bound_calls = 0
                 # unpolarised beams and a brace-free production, so _frame_boost
                 # short circuits to None: this class is about the mass stage,
                 # and the frame machinery has its own tests
                 self.options = _StubOptions(
-                               {'spinmode': 'PA',
+                               {'spinmode': spinmode,
                                 'sequential_spin_order': '2 3 1',
                                 'unweighting': unweighting,
                                 'density_keep_jacobian': keep_jac,
@@ -4853,7 +4854,14 @@ class TestPAUpFrontMass(unittest.TestCase):
                 RAMBO kernel on a real production event, is not a bound on
                 *this* weight. The per-event bound has its own tests
                 (TestPerEventMassBound), where it is checked against the
-                shipped weight it actually has to dominate."""
+                shipped weight it actually has to dominate.
+
+                Counted, because *whether it is asked for at all* is the
+                caller's decision and is what
+                test_which_events_are_counted_against_the_mass_stage_bound and
+                test_the_offshell_spinmodes_never_ask_for_a_per_event_bound
+                are about."""
+                self.mass_bound_calls += 1
                 return None
 
             def _decay_reshuffle_jacobian(self, decay):
@@ -4881,6 +4889,47 @@ class TestPAUpFrontMass(unittest.TestCase):
                                                     production, (6, -6))
         stub._slot_of = {index: slot for slot, index in enumerate(slots)}
         return stub, rho, pools, production, {6: {0: 'f'}, -6: {0: 'f'}}
+
+    class _NoDecayPool(Exception):
+        """Raised by the offshell fixture's ``_draw_one_decay``: the mass stage
+        has finished, and this class has no offshell decay pool to go on with."""
+
+    def _offshell_fixture(self):
+        """The same chain with ``spinmode = madspin``, up to the point where the
+        angle stage would need decay events.
+
+        Everything the mass stage does offshell runs for real here: the
+        production is a genuine LHE event, so ``_upfront_production`` copies and
+        reshuffles it onto the drawn virtualities, ``rho_off`` is taken at those
+        momenta, and the mass-set accept/reject tests
+        Tr(rho_off)/|M_prod|^2_on . jac_prod against its bound. Only the angle
+        stage is out of reach: offshell it reshuffles each *decay* event onto its
+        slot's virtuality, and the synthetic ``_Decay`` of this class is not an
+        LHE event. So ``_draw_one_decay`` raises instead -- which is exactly one
+        step past everything the caller decided about the mass stage's bound.
+        """
+        base = TestSequentialAcceptReject()
+        rho = base._production_density()
+        pools = {0: base._pool(100), 1: base._pool(200)}
+        stub = self._stub(rho, pools, spinmode='madspin')
+        production = _rambo_event(2, 800.0, [self.POLE, self.POLE],
+                                  random.Random(4242))
+        _, slots = interface_madspin.MadSpinInterface._sequential_slots(
+                                                    production, (6, -6))
+        stub._slot_of = {index: slot for slot, index in enumerate(slots)}
+        # |M_prod|^2 on shell, the denominator of the offshell mass-set weight
+        stub.calculate_matrix_element = lambda *args, **opts: 1.0
+
+        def _no_pool(*args, **opts):
+            raise TestPAUpFrontMass._NoDecayPool()
+        stub._draw_one_decay = _no_pool
+        # C for the mass set: Tr(rho) . max(jac_prod) . max_m Zhat(m)^2, loosely.
+        # It only has to keep the accept/reject moving -- the counters this
+        # fixture is read for are set once, before the loop.
+        c_mass = 1.2 * rho.trace().real * max(self._f(m)
+                                              for m in self.MASSES) ** 2
+        return (stub, production, {6: {0: 'f'}, -6: {0: 'f'}},
+                [c_mass, 1.0, 1.0])
 
     def _bounds(self, stub, rho, pools):
         contract = stub._partial_density_contraction
@@ -5072,6 +5121,63 @@ class TestPAUpFrontMass(unittest.TestCase):
             got = (stats['nb_mass_bound_global'], stats['nb_mass_bound_event'])
             self.assertEqual(got, (5, 0) if counted else (0, 0),
                              '%s counted %s' % (unweighting, (got,)))
+            # and the un-counted scheme did not so much as *ask* for a
+            # per-event bound: sequential_with_mass draws each slot's mass
+            # inside that slot's own accept/reject, so it has no mass set to
+            # bound and never reads mass_bound. joint is not covered here
+            # because it never reaches this function at all -- _sequential_active
+            # is `_unweighting_mode() != 'joint'`, and it is what gates the call.
+            self.assertEqual(stub.mass_bound_calls, 5 if counted else 0,
+                             '%s asked for %d per-event bounds'
+                             % (unweighting, stub.mass_bound_calls))
+
+    def test_the_offshell_spinmodes_never_ask_for_a_per_event_bound(self):
+        """madspin/full keep the probe's global maximum weight for the mass
+        stage. Not because the per-event construction is unavailable there but
+        because it was MEASURED to be looser -- eps_m 5.00 against 3.06, and
+        worse than global below 400 GeV; see the fallback list above
+        _MASS_BOUND_UNSUPPORTED and section 15 of the plan.
+
+        So the assertion is on the *caller*: an offshell chain lands in
+        nb_mass_bound_global, and _mass_stage_bound is never even called.
+
+        Two independent things hold that up, which is worth knowing before
+        touching either. The gate says `draw_mass and not offshell`, and
+        `draw_mass` is `spinmode == 'PA'` while `offshell` is
+        `spinmode not in ('PA', 'onshell')` -- so `draw_mass` already implies
+        `not offshell` for every spinmode the card allows, and the clause is
+        belt to its braces. Deleting `not offshell` on its own is therefore a
+        no-op that no test can catch, and widening `draw_mass` on its own is
+        caught by `not offshell` rather than by anything here. What this test
+        catches is either one going *wrong*: the gate widened to match the
+        counter gate one statement below (`offshell or draw_mass`), or
+        `draw_mass` grown to an offshell spinmode with the clause gone with it.
+        Either hands madspin/full a mass-stage bound measured to be 1.6x worse
+        for them.
+        """
+        stub, production, evt_decayfile, maxwgts = self._offshell_fixture()
+        self.assertTrue(stub._sequential_offshell())
+        self.assertTrue(stub._sequential_upfront())
+        random.seed(11)
+        stats = collections.defaultdict(int)
+        for _ in range(5):
+            # not assertRaises: the suite's TestCase overrides it and does not
+            # return the context manager
+            try:
+                stub.sequential_accept_reject(production, evt_decayfile,
+                                              maxwgts, 10, stats=stats)
+            except self._NoDecayPool:
+                pass
+            else:
+                self.fail('the offshell chain reached the angle stage without '
+                          'needing a decay')
+        self.assertEqual(stub.mass_bound_calls, 0)
+        got = (stats['nb_mass_bound_global'], stats['nb_mass_bound_event'])
+        self.assertEqual(got, (5, 0))
+        # the mass stage really ran: a virtuality was drawn, the production was
+        # reshuffled onto it and rho_off taken there, and the angle stage was
+        # reached -- the fallback is a decision, not an early exit
+        self.assertEqual(stats['nb_try_0'], 5)
 
 
 class TestSequentialPoolLadder(unittest.TestCase):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -94,6 +94,27 @@ def _borrow_decision_helpers(namespace):
     return namespace
 
 
+def _borrow_mass_bound_helpers(namespace):
+    """Add the mass stage's per-event bound and everything it reaches through
+    to a stub class namespace. Call as
+    ``_borrow_mass_bound_helpers(locals())`` from the class body of any stub
+    that borrows ``sequential_accept_reject``.
+
+    The bound is computed from the production event alone -- the Breit-Wigner
+    windows, the RAMBO reshuffling jacobian at their low corner and the exact
+    maximum of each ``Zhat`` -- so a stub that carries a banner and
+    ``_z_tables`` (which every chain stub does) can run it unmodified. It
+    falls back to the probe's global bound on anything it does not cover, so a
+    stub whose production event is unusual still exercises the chain.
+    """
+    for name in ('_mass_stage_bound', '_mass_stage_bound_compute',
+                 '_announce_mass_bound', '_zhat_max', '_mass_window',
+                 '_MASS_BOUND_UNSUPPORTED'):
+        namespace[name] = inspect.getattr_static(
+            interface_madspin.MadSpinInterface, name)
+    return namespace
+
+
 def _borrow_frame_helpers(namespace):
     """Add ``_frame_boost`` and everything its guard reaches through to a stub
     class namespace. Call as ``_borrow_frame_helpers(locals())`` from the class
@@ -1182,6 +1203,7 @@ class TestDrawOffshellMass(unittest.TestCase):
         pass
 
     class _Stub(object):
+        _mass_window = interface_madspin.MadSpinInterface._mass_window
         _draw_mass_value = interface_madspin.MadSpinInterface._draw_mass_value
         _draw_offshell_mass = interface_madspin.MadSpinInterface._draw_offshell_mass
         def __init__(self, bw_cut=-1):
@@ -4018,6 +4040,450 @@ class TestProductionJacobianForSlots(unittest.TestCase):
         self.assertEqual(jac, -1)
 
 
+def _rambo_event(n, sqrts, masses, rng, boost=0.0):
+    """A 2 -> n production event at ``sqrts`` with the given final-state
+    masses, flat in phase space, optionally boosted along z.
+
+    Only used to feed the reshuffling jacobian, which never looks at flavours
+    or colour, so the pdgs are cosmetic.
+    """
+    q = []
+    for _ in range(n):
+        cos = 2 * rng.random() - 1
+        sin = math.sqrt(1 - cos * cos)
+        phi = 2 * math.pi * rng.random()
+        e = -math.log(max(rng.random() * rng.random(), 1e-300))
+        q.append(lhe_parser.FourMomentum(e, e * sin * math.cos(phi),
+                                         e * sin * math.sin(phi), e * cos))
+    tot = sum(q, lhe_parser.FourMomentum())
+    lor = tot.get_lorentz_map(lhe_parser.FourMomentum(tot.mass, 0, 0, 0))
+    scale = sqrts / tot.mass
+    q = [p.apply_lorentzmap(lor) for p in q]
+    q = [lhe_parser.FourMomentum(scale * p.E, scale * p.px, scale * p.py,
+                                 scale * p.pz) for p in q]
+    # RAMBO eq. 4.2/4.3 puts them on the wanted mass shells
+    avail = [p.norm_sq for p in q]
+    newm = [m ** 2 for m in masses]
+    f = lambda chi: sqrts - sum(math.sqrt(M + chi ** 2 * a)
+                                for M, a in zip(newm, avail))
+    df = lambda chi: -1 * sum(chi * a / math.sqrt(a * chi ** 2 + M)
+                              for M, a in zip(newm, avail))
+    chi = misc.newtonmethod(f, df, 1.0, error=1e-11 * sqrts, maxiter=1000)
+    mom = [lhe_parser.FourMomentum(math.sqrt(m ** 2 + chi ** 2 * p.norm_sq),
+                                   chi * p.px, chi * p.py, chi * p.pz)
+           for m, p in zip(masses, q)]
+    init = [lhe_parser.FourMomentum(sqrts / 2, 0, 0, sqrts / 2),
+            lhe_parser.FourMomentum(sqrts / 2, 0, 0, -sqrts / 2)]
+    if boost:
+        gamma, sinh = math.cosh(boost), math.sinh(boost)
+        push = lambda p: lhe_parser.FourMomentum(
+            gamma * p.E + sinh * p.pz, p.px, p.py, sinh * p.E + gamma * p.pz)
+        init, mom = [push(p) for p in init], [push(p) for p in mom]
+    lines = ['%d 1 1.0 100.0 0.0075 0.118' % (n + 2)]
+    for p in init:
+        lines.append('21 -1 0 0 501 502 %.15e %.15e %.15e %.15e 0.0 0. 9.'
+                     % (p.px, p.py, p.pz, p.E))
+    for i, (p, m) in enumerate(zip(mom, masses)):
+        lines.append('%d 1 1 2 501 502 %.15e %.15e %.15e %.15e %.15e 0. 9.'
+                     % (6 if i % 2 == 0 else -6, p.px, p.py, p.pz, p.E, m))
+    evt = lhe_parser.Event()
+    evt.parse('\n'.join(lines))
+    return evt
+
+
+class TestMassShuffleKernel(unittest.TestCase):
+    """Event.mass_shuffle_jacobian / mass_shuffle_frame: the RAMBO reshuffling
+    jacobian evaluated from n numbers per particle, with no Event, no
+    FourMomentum and no boost.
+
+    The claim the mass-stage bound rests on is that J depends on the production
+    event ONLY through the CM-frame (E_i, m_i^2) -- n numbers, computed once per
+    event -- so a candidate mass set costs one scalar Newton solve. That holds
+    for every n; the 2 -> 2 closed form lambda^(1/2)/lambda^(1/2) is just the
+    case where the solve is explicit.
+    """
+
+    POLE, WIDTH = 172.5, 1.4915
+
+    def _frame_of(self, event):
+        """The frame the shipped path sees: _production_jacobian_for re-parses
+        the event from str(), which truncates every momentum to %.10e, so the
+        comparison is only algorithmic if the kernel starts from the same
+        truncated numbers."""
+        probe = lhe_parser.Event(str(event))
+        finals = [p for p in probe if int(p.status) == 1]
+        frame = lhe_parser.Event.mass_shuffle_frame(
+            [lhe_parser.FourMomentum(p) for p in finals], probe.sqrts)
+        return frame, probe.sqrts, [p.mass for p in finals]
+
+    def test_matches_the_shipped_reshuffle(self):
+        """Same number as _production_jacobian_for, for n = 2, 3, 4 and 5, over
+        random configurations and mass sets including the kinematic edge."""
+        rng = random.Random(6491)
+        lo, hi = self.POLE - 15 * self.WIDTH, self.POLE + 15 * self.WIDTH
+        worst = 0.0
+        for n in (2, 3, 4, 5):
+            for _ in range(15):
+                sqrts = n * self.POLE * (1 + 3 * rng.random())
+                masses = [self.POLE * rng.uniform(0.5, 1.0) for _ in range(n)]
+                event = _rambo_event(n, sqrts, masses, rng,
+                                     boost=rng.uniform(-1.5, 1.5))
+                frame, s, _ = self._frame_of(event)
+                slot_to_index = list(range(n))
+                for kind in range(4):
+                    if kind == 0:
+                        cand = [lo] * n                    # the low corner
+                    elif kind == 1:                        # the kinematic edge
+                        cand = [0.999 * s / n] * n
+                    else:
+                        cand = [rng.uniform(lo, hi) for _ in range(n)]
+                    ref = interface_madspin.MadSpinInterface \
+                        ._production_jacobian_for(
+                            event, slot_to_index,
+                            {i: (cand[i], (self.POLE, self.WIDTH, lo, hi))
+                             for i in range(n)})
+                    got = lhe_parser.Event.mass_shuffle_jacobian(frame, cand, s)
+                    if ref in (0, -1) or got in (0, -1):
+                        self.assertEqual(ref, got)     # the same verdict, too
+                        continue
+                    worst = max(worst, abs(got - ref) / abs(ref))
+        self.assertLess(worst, 1e-12)
+
+    def test_reports_the_same_failures(self):
+        """jac in (0, -1) is a verdict the callers test for, so the kernel has
+        to reproduce it and not merely the numbers."""
+        rng = random.Random(11)
+        event = _rambo_event(3, 900.0, [self.POLE] * 3, rng)
+        frame, s, _ = self._frame_of(event)
+        self.assertEqual(
+            lhe_parser.Event.mass_shuffle_jacobian(frame, [s] * 3, s), -1)
+        self.assertEqual(
+            interface_madspin.MadSpinInterface._production_jacobian_for(
+                event, [0, 1, 2],
+                {i: (s, (self.POLE, self.WIDTH, 1.0, 2 * s)) for i in range(3)}),
+            -1)
+
+    def test_the_nominal_mass_set_is_the_identity(self):
+        """chi = 1 and J = 1 when nothing moves -- for every n."""
+        rng = random.Random(77)
+        for n in (2, 3, 4, 5, 6):
+            masses = [self.POLE * rng.uniform(0.4, 1.0) for _ in range(n)]
+            event = _rambo_event(n, n * self.POLE * 2.5, masses, rng)
+            frame, s, nominal = self._frame_of(event)
+            self.assertAlmostEqual(
+                lhe_parser.Event.mass_shuffle_jacobian(frame, nominal, s),
+                1.0, places=6)
+
+    def test_two_body_is_the_two_body_phase_space_ratio(self):
+        """For n = 2 every factor of eq. 4.9 collapses onto chi = |p'|/|p|, the
+        ratio of two-body phase-space volumes. That closed form is what the
+        earlier study used, and it is the n = 2 case of this kernel."""
+        rng = random.Random(303)
+        def lam(s, a, b):
+            return (s - a - b) ** 2 - 4 * a * b
+        for _ in range(20):
+            sqrts = rng.uniform(400.0, 2000.0)
+            masses = [self.POLE, self.POLE]
+            event = _rambo_event(2, sqrts, masses, rng,
+                                 boost=rng.uniform(-1.0, 1.0))
+            frame, s, _ = self._frame_of(event)
+            cand = [rng.uniform(150.0, 195.0) for _ in range(2)]
+            expect = math.sqrt(lam(s * s, cand[0] ** 2, cand[1] ** 2)
+                               / lam(s * s, self.POLE ** 2, self.POLE ** 2))
+            got = lhe_parser.Event.mass_shuffle_jacobian(frame, cand, s)
+            self.assertAlmostEqual(got / expect, 1.0, places=6)
+
+    def test_monotone_decreasing_in_every_mass(self):
+        """The property the bound rests on: J falls when any new mass rises, at
+        fixed sqrt(shat) and fixed configuration. Hence max J over a window is
+        at its low corner, for any n, with no scan.
+
+        Proof sketch (see the comment above _mass_stage_bound): with
+        beta_i = |p_i'|/E_i', 2 E_k' G chi^2 dlnJ/dm_k'^2 = -(3n-5) + beta_k^2
+        + sum beta_i^2 - Q/G - (sum_i E_i' beta_i^2)/E_k', whose last term is at
+        least beta_k^2 and whose Q/G is non-negative, leaving <= 5 - 2n < 0 for
+        n >= 3; n = 2 is the lambda^(1/2) ratio above, which falls in each mass.
+        """
+        rng = random.Random(20260819)
+        for n in (2, 3, 4, 5, 6):
+            for _ in range(8):
+                sqrts = n * self.POLE * (1 + 9 * rng.random())
+                masses = [self.POLE * rng.uniform(0.3, 1.0) for _ in range(n)]
+                event = _rambo_event(n, sqrts, masses, rng,
+                                     boost=rng.uniform(-2.0, 2.0))
+                frame, s, _ = self._frame_of(event)
+                base = [rng.uniform(0.2, 0.8) * s / n for _ in range(n)]
+                j0 = lhe_parser.Event.mass_shuffle_jacobian(frame, base, s)
+                self.assertTrue(j0 > 0)
+                head = s - sum(base)
+                for i in range(n):
+                    for frac in (1e-4, 0.1, 0.9):
+                        up = list(base)
+                        up[i] += frac * head
+                        j1 = lhe_parser.Event.mass_shuffle_jacobian(frame, up, s)
+                        self.assertTrue(0 < j1 <= j0,
+                                        'J rose from %r to %r on mass %d'
+                                        % (j0, j1, i))
+
+
+class TestPerEventMassBound(unittest.TestCase):
+    """_mass_stage_bound: an upper bound on the mass stage's weight built from
+    the production event alone.
+
+        w_mass = J(m) . prod_s jac_bw_s(m) . prod_s Zhat_s(m_s)
+
+    every factor non-negative, J and every jac_bw maximal at the low corner of
+    the Breit-Wigner windows, and Zhat_s a 1-D function whose maximum is exact.
+
+    Its whole safety case is that the bound CANCELS: the mass stage redraws
+    until it accepts, so the accepted density is q_e(m).min(1, w/C) up to
+    normalisation, i.e. proportional to q_e(m) w(m) for any C >= max w. A
+    tighter (but still dominating) bound changes the cost and nothing else --
+    which is what test_the_accepted_spectrum_is_unchanged measures.
+    """
+
+    POLE, WIDTH, BW_CUT = 172.5, 1.4915, 15.0
+
+    class _Val(object):
+        def __init__(self, value):
+            self.value = value
+
+    class _Banner(object):
+        def __init__(self, pole, width):
+            self.pole, self.width = pole, width
+
+        def get(self, card, kind, pdg):
+            return TestPerEventMassBound._Val(
+                self.pole if kind == 'mass' else self.width)
+
+    class _Shim(object):
+        """The whole dependency surface of the bound and of the three shipped
+        functions it has to dominate: a banner, options['BW_cut'] and
+        _z_tables."""
+        _mass_window = interface_madspin.MadSpinInterface._mass_window
+        _draw_mass_value = interface_madspin.MadSpinInterface._draw_mass_value
+        _zhat = interface_madspin.MadSpinInterface._zhat
+        _zhat_max = interface_madspin.MadSpinInterface._zhat_max
+        _mass_stage_bound = interface_madspin.MadSpinInterface._mass_stage_bound
+        _mass_stage_bound_compute = \
+            interface_madspin.MadSpinInterface._mass_stage_bound_compute
+        _MASS_BOUND_UNSUPPORTED = None
+
+        def __init__(self, pole, width, bw_cut, z_tables=None):
+            self.banner = TestPerEventMassBound._Banner(pole, width)
+            self.options = {'BW_cut': bw_cut}
+            self._z_tables = z_tables or {}
+
+    def _tables(self, coeff):
+        lo = self.POLE - self.BW_CUT * self.WIDTH
+        hi = self.POLE + self.BW_CUT * self.WIDTH
+        return {key: {'pole': self.POLE, 'coeff': list(coeff),
+                      'zero_below': 0.0, 'range': (lo, hi)}
+                for key in ('6_0', '-6_0')}
+
+    def _shim(self, coeff=(0.0, 0.0, 0.0)):
+        return self._Shim(self.POLE, self.WIDTH, self.BW_CUT,
+                          self._tables(coeff))
+
+    def _weight(self, shim, event, slot_to_index, pdgs, zkeys, keep_jac=True):
+        """One mass set through the shipped functions, exactly as
+        _upfront_production builds it, returning w_mass or None for a set the
+        production cannot be reshuffled onto."""
+        budget = event.sqrts
+        slot_masses, w = {}, 1.0
+        for slot, pdg in enumerate(pdgs):
+            mass, info, jac_bw = shim._draw_mass_value(pdg, budget)
+            slot_masses[slot] = (mass, info)
+            w *= jac_bw
+            budget -= mass
+        if keep_jac:
+            jac = interface_madspin.MadSpinInterface._production_jacobian_for(
+                event, slot_to_index, slot_masses)
+            if jac in (0, -1):
+                return None
+            w *= jac
+        for slot in slot_masses:
+            w *= shim._zhat(zkeys[slot], slot_masses[slot][0])
+        return w
+
+    def _fixture(self, n=2, sqrts=800.0, coeff=(0.0, 0.0, 0.0), mass=None):
+        rng = random.Random(4242)
+        if mass is None:
+            mass = self.POLE
+        event = _rambo_event(n, sqrts, [mass] * n, rng,
+                             boost=rng.uniform(-1.0, 1.0))
+        particles = [p for p in event if int(p.status) == 1]
+        # every final-state particle decays: slot s is final-state s
+        slot_to_index = list(range(n))
+        zkeys = interface_madspin.MadSpinInterface._z_slot_keys(particles,
+                                                               slot_to_index)
+        return self._shim(coeff), event, particles, slot_to_index, zkeys
+
+    # -- Zhat's exact maximum -----------------------------------------
+
+    def test_zhat_max_is_the_maximum_of_zhat(self):
+        """Exactly, not a sample mean with a margin. Checked against a fine
+        scan for a table that peaks inside its range, one that peaks at each
+        end, and a flat one."""
+        for coeff in [(0.0, 0.0, 0.0), (0.1, 0.6, -4.0), (0.0, 3.0, 1.0),
+                      (0.0, -3.0, 1.0), (-0.2, 0.05, -0.3)]:
+            shim = self._shim(coeff)
+            lo = self.POLE - self.BW_CUT * self.WIDTH
+            hi = self.POLE + self.BW_CUT * self.WIDTH
+            scanned = max(shim._zhat('6_0', lo + (hi - lo) * i / 20000.0)
+                          for i in range(20001))
+            exact = shim._zhat_max('6_0')
+            self.assertGreaterEqual(exact * (1 + 1e-12), scanned)
+            self.assertAlmostEqual(exact / scanned, 1.0, places=6)
+
+    def test_zhat_max_is_one_without_a_table(self):
+        """The probe measures the table, so it runs with Zhat = 1."""
+        shim = self._Shim(self.POLE, self.WIDTH, self.BW_CUT, {})
+        self.assertEqual(shim._zhat_max('6_0'), 1.0)
+
+    # -- the bound dominates ------------------------------------------
+
+    def test_the_bound_dominates_the_weight(self):
+        """The property that makes it a bound: over many draws through the
+        shipped _draw_mass_value / _production_jacobian_for / _zhat, no mass
+        set's weight exceeds it. Run for a 2 -> 2 and for a 2 -> 3 and 2 -> 4
+        production -- the general-n case is the whole point -- and with a Zhat
+        table that has real structure."""
+        for n in (2, 3, 4):
+            for sqrts in (n * self.POLE * 1.02, 800.0, 3000.0):
+                for coeff in [(0.0, 0.0, 0.0), (0.1, 0.6, -4.0),
+                              (0.0, 4.0, 2.0)]:
+                    shim, event, particles, slots, zkeys = self._fixture(
+                        n=n, sqrts=sqrts, coeff=coeff)
+                    pdgs = [p.pid for p in particles]
+                    bound = shim._mass_stage_bound(event, list(range(n)),
+                                                   particles, slots, zkeys,
+                                                   True)
+                    self.assertIsNotNone(bound)
+                    random.seed(9090 + n)
+                    worst = 0.0
+                    for _ in range(400):
+                        w = self._weight(shim, event, slots, pdgs, zkeys)
+                        if w is None:
+                            continue
+                        worst = max(worst, w / bound)
+                    self.assertLessEqual(
+                        worst, 1.0,
+                        'n=%d sqrts=%g coeff=%s: weight reached %.6f of the '
+                        'bound' % (n, sqrts, coeff, worst))
+                    # and it is not absurdly loose either
+                    self.assertGreater(worst, 1e-3)
+
+    def test_the_bound_ignores_the_jacobian_when_the_weight_does(self):
+        """density_keep_jacobian = False: the reshuffle is a post-acceptance
+        dressing and J is not in the weight, so it must not be in the bound
+        either (which would only cost acceptance)."""
+        shim, event, particles, slots, zkeys = self._fixture(n=3)
+        with_jac = shim._mass_stage_bound_compute(event, [0, 1, 2], particles,
+                                                  slots, zkeys, True)
+        event._ms_mass_bound = False        # not cached between the two
+        without = shim._mass_stage_bound_compute(event, [0, 1, 2], particles,
+                                                 slots, zkeys, False)
+        self.assertLess(without, with_jac)
+        pdgs = [p.pid for p in particles]
+        random.seed(31337)
+        for _ in range(400):
+            w = self._weight(shim, event, slots, pdgs, zkeys, keep_jac=False)
+            if w is not None:
+                self.assertLessEqual(w, without)
+
+    def test_it_is_cached_on_the_production_event(self):
+        """The chain re-enters on every rejected mass set; the bound does not
+        depend on the draw."""
+        shim, event, particles, slots, zkeys = self._fixture(n=2)
+        first = shim._mass_stage_bound(event, [0, 1], particles, slots, zkeys,
+                                       True)
+        self.assertIs(shim._mass_stage_bound(event, [0, 1], particles, slots,
+                                             zkeys, True), first)
+        self.assertEqual(event._ms_mass_bound, first)
+
+    # -- the fallbacks -------------------------------------------------
+
+    def test_falls_back_on_an_onshell_propagator(self):
+        """A production carrying a status-2 particle: reshuffle_production also
+        folds in that sub-decay's own jacobian, which is not part of this
+        factorisation."""
+        shim, event, particles, slots, zkeys = self._fixture(n=2)
+        event[2].status = 2
+        event._ms_mass_bound = False
+        self.assertIsNone(shim._mass_stage_bound_compute(
+            event, [0, 1], particles, slots, zkeys, True))
+        self.assertIn('onshell propagator', shim._MASS_BOUND_UNSUPPORTED)
+
+    def test_falls_back_when_the_window_does_not_fit(self):
+        """Below the sum of the window minima nothing is feasible; the global
+        bound (and the existing restart counter) take over. Light final states
+        at a sqrt(shat) that cannot pay for two window minima -- the shape a
+        heavy-resonance window has under a light production."""
+        shim, event, particles, slots, zkeys = self._fixture(
+            n=2, mass=5.0,
+            sqrts=2 * (self.POLE - self.BW_CUT * self.WIDTH) - 10.0)
+        self.assertIsNone(shim._mass_stage_bound_compute(
+            event, [0, 1], particles, slots, zkeys, True))
+
+    # -- the safety case: the bound cancels ----------------------------
+
+    def test_the_accepted_spectrum_is_unchanged(self):
+        """The whole correctness argument, measured rather than asserted.
+
+        The mass stage redraws until it accepts, so the accepted density is
+        proportional to q_e(m) min(1, w/C); for any C >= max w that is
+        q_e(m) w(m) and the bound is gone. Draw the accepted virtuality many
+        times under the per-event bound and under a deliberately much looser
+        one, and the two histograms must agree -- not event by event (the trial
+        sequences differ) but as distributions.
+        """
+        shim, event, particles, slots, zkeys = self._fixture(
+            n=3, sqrts=700.0, coeff=(0.1, 0.6, -4.0))
+        pdgs = [p.pid for p in particles]
+        tight = shim._mass_stage_bound(event, [0, 1, 2], particles, slots,
+                                       zkeys, True)
+        loose = 25.0 * tight
+
+        lo = self.POLE - self.BW_CUT * self.WIDTH
+        hi = self.POLE + self.BW_CUT * self.WIDTH
+        nbin, ndraw = 8, 6000
+
+        def accepted(bound, seed):
+            random.seed(seed)
+            hist = [0] * nbin
+            for _ in range(ndraw):
+                while True:              # redraw until accept, as the chain does
+                    budget = event.sqrts
+                    masses, w = [], 1.0
+                    for pdg in pdgs:
+                        mass, info, jac_bw = shim._draw_mass_value(pdg, budget)
+                        masses.append((mass, info))
+                        w *= jac_bw
+                        budget -= mass
+                    jac = interface_madspin.MadSpinInterface \
+                        ._production_jacobian_for(
+                            event, slots, dict(enumerate(masses)))
+                    if jac in (0, -1):
+                        continue
+                    w *= jac
+                    for slot, (mass, _) in enumerate(masses):
+                        w *= shim._zhat(zkeys[slot], mass)
+                    if random.random() * bound < w:
+                        index = int((masses[0][0] - lo) / (hi - lo) * nbin)
+                        hist[min(max(index, 0), nbin - 1)] += 1
+                        break
+            return hist
+
+        a, b = accepted(tight, 5150), accepted(loose, 5151)
+        self.assertEqual(sum(a), sum(b))
+        # Pearson chi2 between two multinomials of the same size: 7 d.o.f.,
+        # so ~14 at 5%. A bound that clipped would move the shape, not the
+        # statistics.
+        chi2 = sum((x - y) ** 2 / float(x + y) for x, y in zip(a, b) if x + y)
+        self.assertLess(chi2, 30.0, 'accepted spectra differ: %s vs %s' % (a, b))
+
+
 class TestSequentialAcceptReject(unittest.TestCase):
     """sequential_accept_reject: accepting one decaying particle at a time must
     sample the *same* distribution as the joint accept/reject, i.e. p(decays)
@@ -4092,6 +4558,7 @@ class TestSequentialAcceptReject(unittest.TestCase):
             _sequential_spin_order = interface._sequential_spin_order
             _decay_slot_order = interface._decay_slot_order
             sequential_accept_reject = interface.sequential_accept_reject
+            _borrow_mass_bound_helpers(locals())
             _polarization_weight_labels = \
                 interface._polarization_weight_labels
             _polarization_weights_enabled = \
@@ -4303,6 +4770,7 @@ class TestPAUpFrontMass(unittest.TestCase):
             _sequential_spin_order = interface._sequential_spin_order
             _decay_slot_order = interface._decay_slot_order
             sequential_accept_reject = interface.sequential_accept_reject
+            _borrow_mass_bound_helpers(locals())
             _polarization_weight_labels = \
                 interface._polarization_weight_labels
             _polarization_weights_enabled = \
@@ -4376,6 +4844,17 @@ class TestPAUpFrontMass(unittest.TestCase):
             def _production_jacobian_for(self, production, slot_to_index,
                                          slot_masses):
                 return 1.0
+
+            def _mass_stage_bound(self, *args, **opts):
+                """The global bound, as before. This class replaces the mass
+                stage's physics -- a discrete flat draw with jac_bw = 1 and a
+                constant reshuffling jacobian -- so the shipped per-event
+                bound, which is built from the Breit-Wigner window and the
+                RAMBO kernel on a real production event, is not a bound on
+                *this* weight. The per-event bound has its own tests
+                (TestPerEventMassBound), where it is checked against the
+                shipped weight it actually has to dominate."""
+                return None
 
             def _decay_reshuffle_jacobian(self, decay):
                 return outer._f(decay[0].new_mass) * outer._g(decay.index)

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -5040,6 +5040,39 @@ class TestPAUpFrontMass(unittest.TestCase):
             else:
                 self.assertEqual(counts['jacobian'], counts['trial'])
 
+    def test_which_events_are_counted_against_the_mass_stage_bound(self):
+        """The end-of-run report's two columns count production events that
+        *have* a mass stage: the up-front schemes, and there whichever family
+        drew a virtuality up front.
+
+        The gate used to be ``draw_mass``, which is the PA half of the
+        condition ``_upfront_production`` actually fills ``slot_mass`` under
+        (``offshell or draw_mass``). That put the offshell spinmodes in neither
+        column -- so an offshell run said nothing at all about which bound its
+        mass stage was using -- and let ``sequential_with_mass``, which is not
+        an up-front scheme and never reads ``mass_bound``, announce one.
+
+        The stub is PA with a stubbed ``_mass_stage_bound`` returning None, so
+        the fallback column is the one that moves; ``TestPerEventMassBound``
+        covers the bound itself.
+        """
+        import random
+        for unweighting, counted in (('sequential', True),
+                                     ('sequential_with_mass', False)):
+            stub, rho, pools, production, evt_decayfile = self._fixture(
+                                                    unweighting=unweighting)
+            maxwgts, _, _, _ = self._bounds(stub, rho, pools)
+            if unweighting == 'sequential_with_mass':
+                maxwgts = maxwgts[1:]
+            random.seed(11)
+            stats = collections.defaultdict(int)
+            for _ in range(5):
+                stub.sequential_accept_reject(production, evt_decayfile,
+                                              maxwgts, 10, stats=stats)
+            got = (stats['nb_mass_bound_global'], stats['nb_mass_bound_event'])
+            self.assertEqual(got, (5, 0) if counted else (0, 0),
+                             '%s counted %s' % (unweighting, (got,)))
+
 
 class TestSequentialPoolLadder(unittest.TestCase):
     """_sequential_pool_ladder / _sequential_active: how many decay events a


### PR DESCRIPTION
**Stacked on #375** (`c8b79c0e9`), whose overflow counters are the instrument that
shows this bound actually dominates. Review #375 first. It does not yet contain
#375's later negative-weight commit `d0019d4b8`; rebase before merge.

The sequential mass stage used a single global bound `C`, taken from a probe over
the first `Nevents_for_max_weight` events and scaled by `nb_sigma`. It has to
dominate every event in the run, so it is set by the worst event in the sample
and every ordinary event pays for it.

This makes the bound per production event.

## Why it works for any 2 -> N

`Event.mass_shuffle` is RAMBO eqs. (4.2)/(4.3)/(4.9). Its only dependence on the
production event is the CM-frame `{E_i, m_i^2}` - n numbers, computed once. Given
those, a jacobian evaluation is one scalar Newton solve plus O(n) arithmetic. The
`2 -> 2` closed form is just the case where the Newton solve is explicit; it was
never what made this affordable.

What made it expensive was the machinery around it in `_production_jacobian_for`:
`lhe_parser.Event(str(production))` re-parses the event from a string, then
`split_event_by_onshell_propagator`, `FourMomentum` construction, a Lorentz map
per particle, the momentum rebuild and the boost back - none of which a bound
needs. This PR adds a pure kernel with none of that.

## Monotonicity is proved, not measured

With `a_i = |p_i|^2` and `beta_i = |p_i'|/E_i'`, eq. (4.9) is
`J = const . chi^(3n-5) / (G . prod E_i')`, and differentiating `sum E_i' = sqrt(s)`:

```
2 E_k' G chi^2 . dlnJ/dm_k'^2 = -(3n-5) + beta_k^2 + sum beta_i^2
                                - (sum E'beta^4)/(sum E'beta^2) - (sum E'beta^2)/E_k'
```

The third term is >= 0 and the fourth is >= `beta_k^2` (its own summand), leaving
`<= 5 - 2n < 0` for every n >= 3; n = 2 is the `lambda^(1/2)` ratio, decreasing in
each mass. So the maximum of `J` is at the low corner of the window, exactly, for
any n, with no scan. 1.6e6 adversarial directional probes (n = 2..10, |p| and m
over eight decades): zero violations.

## The bound

```
C_e = J(low corner) . prod_s jac_BW_s . prod_s max_m Zhat_s(m)
```

`max Zhat` is the exact endpoint-or-vertex maximum of the log-quadratic, not a
sample mean with a safety margin - a mean would clip on any process where
`Zhat(m)` has structure (see the `BW_cut 70` row below). Falls back to the global
bound for offshell spinmodes, status-2 productions, non-fitting windows and
infeasible corners.

## Validation

Kernel vs `_production_jacobian_for`, ~4800 comparisons per n:

| n | agreement | verdict cases | shipped | kernel | speedup |
|---|---|---|---|---|---|
| 2 | 8.9e-16 | 1919, all agree | 33.0 us | 5.3 us | 6x |
| 3 | 6.6e-16 | 1966, all agree | 40.3 us | 6.2 us | 7x |
| 4 | 6.7e-16 | 1921, all agree | 47.1 us | 6.9 us | 7x |
| 5 | 8.8e-16 | 1877, all agree | 55.0 us | 7.8 us | 7x |

Real runs, same sample / seed / `ms_dir`:

| process | eps_m | overweights |
|---|---|---|
| `p p > t t~` | 1.80 -> **1.39** | 20/20000 -> **0** |
| `p p > t t~ j` (2->3) | 2.76 -> **1.50** | 0/8000 -> 0 |
| `p p > t t~`, `BW_cut 70` | 1.74 -> **1.68** | 23/20000 -> **0** |

Offline probe over ~1e6 mass sets: overflows 4971 -> **0**, largest
`max(w)/C_e` anywhere 0.9635.

The third row is the non-smooth-`Zhat` test: `BW_cut = 70` puts the top's `bW`
threshold at 85 GeV inside the window, and the fitted table runs
`Z(70.3)=0.002, Z(173)=1, Z(275.5)=0.263` - a factor 500 across the window. There
the bound barely tightens, but it is a bound: 23 overflows -> 0.

**The accepted distribution is unchanged**, which is the safety case: the accepted
density is `q_e(m).min(1, w/C)`, so any `C >= max w` cancels. Verified rather than
asserted - chi2/dof 0.58-1.25, KS p 0.22-0.99 across six comparisons.

`tests/test_manager.py test_madspin -t0`: **408 tests, OK** (was 395).
`test_lhe_parser`: 21, OK.

## Behaviour change

`nb_sigma` / `Nevents_for_max_weight` no longer set the *mass* bound (they still
set the angle bounds). This is what finally makes `eps_m` reproducible - the
+-40% run-to-run scatter recorded in `doc/madspin_pa_mass_stage/findings.md` was
exactly that knob dependence. Logged, not silent.

## Not covered

Offshell spinmodes (`madspin`/`full`) keep the global bound - `Tr(rho_off)/|M|^2_on`
has no cheap maximum. Status-2 productions fall back. Not tested: more than two
decaying slots, the fixed-order path, multi-core. The non-smooth-`Zhat` case
needed a widened `BW_cut`; no default-`BW_cut` SM process was found with a
daughter threshold inside the window.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the global sequential mass-stage bound with a proven, efficient per-production-event bound for supported PA/onshell 2→N processes, while retaining global fallbacks for unsupported configurations.

New Features:
- Bound the sequential mass stage separately for each production event across general 2→N processes.
- Add a fast RAMBO mass-shuffle Jacobian kernel and exact Breit–Wigner rate-factor maxima for constructing per-event bounds.
- Report per-event versus global mass-bound usage and fallback counts.

Bug Fixes:
- Prevent mass-stage overweight overflows by using proven per-event upper bounds where supported.
- Ensure offshell, status-2, and infeasible cases correctly fall back to the global bound.

Enhancements:
- Make mass-stage efficiency reproducible by decoupling its bound from nb_sigma and Nevents_for_max_weight while retaining those controls for angle bounds.
- Preserve the accepted mass distribution while reducing unnecessary rejection overhead.

Documentation:
- Document the per-event mass-bound construction, its applicability, validation, and fallback behavior.

Tests:
- Add kernel equivalence, monotonicity, bound-dominance, fallback, caching, event-counting, and distribution-preservation tests for the mass stage.