### PR TITLE
MadSpin: publish a refill generation only once its files exist

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -3050,6 +3050,7 @@ class MadSpinInterface(extended_cmd.Cmd):
 
             # 2) Generate every particle's decay events at the same time.
             gen_results = self._generate_decays(gen_jobs, mg5)
+            self._clear_refill_state()
 
             # 3) Fold the measured partial widths into the branching ratio.
             channel_widths = {}
@@ -3751,10 +3752,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             out = self.generate_events(pdg, needed, self.mg5cmd,
                                        [decay_file_nb], run_name=run_name)
         reader = out[decay_file_nb]
-        if not os.path.exists(reader.name):
+        missing = [p for p in self._reader_paths(reader)
+                   if not os.path.exists(p)]
+        if missing:
             raise Exception(
                 "MadSpin: decay-event refill for pdg %s produced no events "
-                "(expected %s)." % (pdg, reader.name))
+                "(expected %s)." % (pdg, ', '.join(missing)))
         return reader
 
     @staticmethod
@@ -3872,13 +3875,26 @@ class MadSpinInterface(extended_cmd.Cmd):
                              in data.get('channel_widths', {}).items()))
         return out
 
-    def _refill_pool_path(self, decay_dir, gen):
-        """This worker's own file of the refill pool ``gen``. The refill asks the
-        unweighting for one file per worker, so a worker never reads (nor even
-        parses) the events that belong to the others."""
-        base = pjoin(decay_dir, 'Events', 'ms_refill_%d' % gen,
+    @staticmethod
+    def _refill_pool_dir(decay_dir, gen):
+        """Directory holding refill pool ``gen`` of this channel."""
+        return pjoin(decay_dir, 'Events', 'ms_refill_%d' % gen)
+
+    def _refill_pool_paths(self, decay_dir, gen):
+        """Every per-worker slice of the refill pool ``gen``, in worker order.
+        This layout is the contract between the owner (which puts the files
+        there, see :meth:`_generate_refill_pool`) and the waiters (which open
+        their own one and nothing else)."""
+        base = pjoin(self._refill_pool_dir(decay_dir, gen),
                      'unweighted_events.lhe')
-        paths = lhe_parser.EventFile.unweight_output_paths(base, self._shard_nb_core)
+        return lhe_parser.EventFile.unweight_output_paths(
+            base, self._shard_nb_core)
+
+    def _refill_pool_path(self, decay_dir, gen):
+        """This worker's own file of the refill pool ``gen``. The refill hands
+        each worker one file, so a worker never reads (nor even parses) the
+        events that belong to the others."""
+        paths = self._refill_pool_paths(decay_dir, gen)
         path = paths[self._shard_tag] if len(paths) > 1 else paths[0]
         if not os.path.exists(path):
             raise Exception("MadSpin: refill pool %s is missing for worker %s"
@@ -3933,6 +3949,112 @@ class MadSpinInterface(extended_cmd.Cmd):
         return reader
 
     @staticmethod
+    def _split_pool_round_robin(sources, targets):
+        """Deal the events of the ``sources`` LHE file(s) round-robin into the
+        ``targets`` files, each of which gets the banner of the first source (a
+        decay pool is picked among the channels of a pdg by its cross-section,
+        which is read from that banner). Returns the number of events written.
+
+        Worker i therefore ends up with the events at positions i, i+N, ... of
+        the pool -- exactly the stripe it would otherwise pick out itself, minus
+        having to parse the other workers' events to get there."""
+        first = lhe_parser.EventFile(sources[0])
+        banner = first.banner
+        first.close()
+        outs = [lhe_parser.EventFile(p, 'w') for p in targets]
+        nb_event = 0
+        try:
+            for out in outs:
+                if banner:
+                    out.write(banner)
+            for src in sources:
+                fsock = lhe_parser.EventFile(src)
+                fsock.parsing = False   # raw lines: no need to build Event objects
+                try:
+                    for text in fsock:
+                        outs[nb_event % len(outs)].write(''.join(text))
+                        nb_event += 1
+                finally:
+                    fsock.close()
+        finally:
+            for out in outs:
+                out.write('</LesHouchesEvents>\n')
+                out.close()
+        return nb_event
+
+    def _materialise_refill_pool(self, sources, targets, decay_dir, gen):
+        """Put the events the generation produced at the per-worker paths the
+        waiters will open, when the backend did not write them there itself.
+
+        Built in a sibling temporary directory and renamed into place, so
+        ``Events/ms_refill_<gen>`` never exists half-written -- a waiter that
+        gets as far as looking at it (it should not: it waits for the generation
+        marker, published later still) finds either nothing or the whole pool."""
+        final = self._refill_pool_dir(decay_dir, gen)
+        tmp = final + '.part'
+        if os.path.exists(tmp):
+            _force_rmtree(tmp)
+        os.makedirs(tmp)
+        nb_event = self._split_pool_round_robin(
+            sources, [pjoin(tmp, os.path.basename(p)) for p in targets])
+        if os.path.exists(final):
+            _force_rmtree(final)
+        os.rename(tmp, final)
+        return nb_event
+
+    def _generate_refill_pool(self, pdg, decay_file_nb, needed, gen):
+        """Generate generation ``gen`` of this channel's decay pool and leave it
+        COMPLETE at the per-worker paths of :meth:`_refill_pool_paths`. Returns
+        those paths. Publishing ``gen`` is only allowed once this has returned.
+
+        Two generation backends land here and they do not agree on where they
+        write. The plain madevent one honours ``run_name`` and splits the
+        unweighting one file per worker, i.e. it writes the canonical layout
+        itself. The gridpack one (any ``ms_dir`` run) goes through run.sh, which
+        knows nothing of either: it always writes a single
+        ``<decay_dir>/events.lhe.gz`` -- straight on top of the pool the other
+        workers are still reading. So on that backend, move the pool aside for
+        the duration, split what run.sh produced into the per-worker files, and
+        put the pool back: a refill then only ever *adds* a generation. Renaming
+        is safe for the workers that already hold the pool open -- they keep
+        their inode -- and this whole routine runs under the channel's exclusive
+        refill lock."""
+        decay_dir = self._decay_dir(self.path_me, pdg, decay_file_nb)
+        targets = self._refill_pool_paths(decay_dir, gen)
+        pool = pjoin(decay_dir, 'events.lhe.gz')
+        stash = pool + '.mspool'
+        # mirrors ``use_gridpack`` in generate_events
+        protect = bool(self.options['ms_dir']) and os.path.exists(pool)
+        if protect:
+            if os.path.exists(stash):
+                os.remove(stash)
+            os.rename(pool, stash)
+        try:
+            reader = self._regenerate_events(pdg, decay_file_nb, needed,
+                                             'ms_refill_%d' % gen)
+            sources = self._reader_paths(reader)
+            try:
+                reader.close()
+            except Exception:
+                pass
+            if sources != targets:
+                self._materialise_refill_pool(sources, targets, decay_dir, gen)
+        finally:
+            if protect:
+                try:
+                    os.remove(pool)
+                except OSError:
+                    pass
+                os.rename(stash, pool)
+        missing = [p for p in targets if not os.path.exists(p)]
+        if missing:
+            raise Exception(
+                "MadSpin: the refill of pdg %s (decay file %s) did not produce "
+                "%s; the generation was not published, so no worker will try to "
+                "read it." % (pdg, decay_file_nb, ', '.join(missing)))
+        return targets
+
+    @staticmethod
     def _published_gen(decay_dir):
         """Highest refill generation published on disk for this channel (0 if
         none). The single source of truth both the owner and the waiters read."""
@@ -3943,6 +4065,24 @@ class MadSpinInterface(extended_cmd.Cmd):
             return int(open(gen_file).read().strip())
         except (ValueError, IOError):
             return 0
+
+    @staticmethod
+    def _publish_gen(decay_dir, gen):
+        """Make ``gen`` the published generation of this channel.
+
+        Written to a temporary file and renamed over the marker, so a waiter
+        polling :meth:`_published_gen` reads either the old generation or the
+        new one, never a half-written number. The marker becoming visible IS the
+        promise that every file of that generation is complete and readable, so
+        this must only ever be called once :meth:`_generate_refill_pool` has
+        returned."""
+        gen_file = pjoin(decay_dir, 'ms_refill.gen')
+        tmp = '%s.%s.tmp' % (gen_file, os.getpid())
+        with open(tmp, 'w') as fp:
+            fp.write('%d\n' % gen)
+            fp.flush()
+            os.fsync(fp.fileno())
+        os.replace(tmp, gen_file)
 
     def _owner_generate(self, pdg, decay_file_nb, target_gen, needed):
         """Generate this channel's pool up to ``target_gen`` under the channel
@@ -3958,7 +4098,6 @@ class MadSpinInterface(extended_cmd.Cmd):
         -- that (rare) refill is intentionally not guaranteed reproducible."""
         import fcntl
         decay_dir = self._decay_dir(self.path_me, pdg, decay_file_nb)
-        gen_file = pjoin(decay_dir, 'ms_refill.gen')
         with open(pjoin(decay_dir, 'ms_refill.lock'), 'w') as lock:
             fcntl.flock(lock, fcntl.LOCK_EX)
             try:
@@ -3993,14 +4132,17 @@ class MadSpinInterface(extended_cmd.Cmd):
                     self.me_int = {}
                     stag, self._shard_tag = self._shard_tag, None
                     try:
-                        self._regenerate_events(pdg, decay_file_nb, det_needed,
-                                                'ms_refill_%d' % new_gen)
+                        self._generate_refill_pool(pdg, decay_file_nb,
+                                                   det_needed, new_gen)
                     finally:
                         self._shard_tag = stag
                         random.setstate(rng_state)
-                    # publish only once every file is complete on disk
-                    with open(gen_file, 'w') as fp:
-                        fp.write('%d\n' % new_gen)
+                    # Publish only once every per-worker file of the generation
+                    # is complete on disk: the marker is the ONLY thing a waiter
+                    # looks at before opening its slice, so making it visible any
+                    # earlier is telling that worker to open a file that is not
+                    # there. _generate_refill_pool has checked that they all are.
+                    self._publish_gen(decay_dir, new_gen)
                     current = new_gen
             finally:
                 fcntl.flock(lock, fcntl.LOCK_UN)
@@ -4013,6 +4155,36 @@ class MadSpinInterface(extended_cmd.Cmd):
     # so a blocked owner can walk the wait-for chain and spot a cycle.
     def _status_path(self, worker_id):
         return pjoin(self.path_me, 'ms_wstatus_%d' % worker_id)
+
+    def _clear_refill_state(self):
+        """Drop the refill bookkeeping an earlier run left in the decay
+        directories. Called by the parent, once, after the pools are generated
+        and before any worker is forked.
+
+        A reused ``ms_dir`` still holds the previous run's ``ms_refill.gen`` and
+        ``Events/ms_refill_*``. Every worker of THIS run starts at generation 0,
+        so the first time one runs its pool out it would read that marker,
+        conclude generation 1 is already published, generate nothing and open the
+        *other* run's pool -- which was sized for that run's efficiency and split
+        for its ``nb_core``, so the slice this run's worker wants may not even
+        exist. A run's refills are that run's own."""
+        for decay_dir in misc.glob("decay_*_*", self.path_me):
+            try:
+                os.remove(pjoin(decay_dir, 'ms_refill.gen'))
+            except OSError:
+                pass
+            # a refill interrupted midway leaves the pool stashed aside
+            # (_generate_refill_pool); the run about to start regenerates the
+            # pool anyway, so only put it back when nothing else is there
+            pool = pjoin(decay_dir, 'events.lhe.gz')
+            stash = pool + '.mspool'
+            if os.path.exists(stash):
+                if os.path.exists(pool):
+                    os.remove(stash)
+                else:
+                    os.rename(stash, pool)
+            for stale in misc.glob("ms_refill_*", pjoin(decay_dir, 'Events')):
+                _force_rmtree(stale)
 
     def _clear_worker_status(self, nb_core):
         """Remove stale per-worker status files before forking a phase, so a

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -7744,3 +7744,332 @@ class _CaptureCritical(object):
         self._logger.propagate = self._propagate
         interface_madspin._MS_IMAG_REPORTED.clear()
         return False
+
+
+class TestRefillPoolIsCompleteBeforeItIsPublished(unittest.TestCase):
+    """A refill generation must not become observable before the files the
+    other workers will open are there to be opened.
+
+    Context: under the parallel unweighting a channel's decay pool is refilled
+    by one fixed OWNER worker; every other worker blocks until the channel's
+    ``ms_refill.gen`` marker says the generation it needs is published, then
+    opens *its* slice of ``Events/ms_refill_<gen>/``. So the marker is a promise
+    about a set of files, and the owner must only make it once they are all on
+    disk and readable.
+
+    The regression: two generation backends produce those files and they do not
+    agree on where they write. The plain madevent one honours the run name and
+    has the unweighting split its output one file per worker -- the canonical
+    layout. The gridpack one, which EVERY ``ms_dir`` run uses, goes through
+    run.sh: it knows about neither, and writes a single ``events.lhe.gz`` on top
+    of the pool that is still being read. The owner published the generation all
+    the same, and the first worker to act on that promise -- the owner itself,
+    or any waiter -- died on
+
+        MadSpin: refill pool .../ms_refill_1/unweighted_events_0.lhe is missing
+        for worker 0
+    """
+
+    NB_CORE = 4
+
+    _BANNER = (
+        '<LesHouchesEvents version="1.0">\n'
+        '<header>\n'
+        '</header>\n'
+        '<init>\n'
+        '2212 2212 6.500000e+03 6.500000e+03 0 0 247000 247000 -4 1\n'
+        ' 3.000000e+00 1.000000e-02 3.000000e+00 1\n'
+        '</init>\n'
+    )
+
+    @classmethod
+    def _event(cls, tag):
+        """One decay event carrying ``tag`` as its weight, so that an event can
+        be followed from the file it was generated in to the slice it ends up
+        in."""
+        return (
+            '<event>\n'
+            ' 2      1 +%.7e 1.7300000e+02 7.5467711e-03 1.0236800e-01\n'
+            '        5  1    0    0    0    0 '
+            '+0.0000000000e+00 +0.0000000000e+00 '
+            '+6.8000000000e+01 6.8000000000e+01 4.7000000000e+00 '
+            '0.0000e+00 1.0000e+00\n'
+            '       24  1    0    0    0    0 '
+            '+0.0000000000e+00 +0.0000000000e+00 '
+            '-6.8000000000e+01 1.0500000000e+02 8.0419002000e+01 '
+            '0.0000e+00 1.0000e+00\n'
+            '</event>\n' % tag)
+
+    @classmethod
+    def _lhe(cls, tags):
+        return cls._BANNER + ''.join(cls._event(t) for t in tags) \
+            + '</LesHouchesEvents>\n'
+
+    @staticmethod
+    def _tags_of(path):
+        """The weights of the events in ``path``, in file order."""
+        import gzip
+        opener = gzip.open if path.endswith('.gz') else open
+        with opener(path, 'rt') as fsock:
+            lines = fsock.readlines()
+        return [float(lines[i + 1].split()[2])
+                for i, line in enumerate(lines) if line.startswith('<event')]
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_refill_')
+        self.decay_dir = pjoin(self.tmpdir, 'decay_6_0')
+        os.makedirs(pjoin(self.decay_dir, 'Events'))
+        with open(pjoin(self.decay_dir, 'run.sh'), 'w') as fsock:
+            fsock.write('#!/bin/sh\n')
+        # the pool the workers of this run are reading right now
+        self.pool_tags = list(range(1, 21))
+        self._write_pool(self.pool_tags)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_pool(self, tags):
+        import gzip
+        with gzip.open(pjoin(self.decay_dir, 'events.lhe.gz'), 'wt') as fsock:
+            fsock.write(self._lhe(tags))
+
+    # ---------------------------------------------------------------- stubs
+
+    class _Particle(object):
+        def get_name(self):
+            return 't'
+
+    class _Model(object):
+        def get_particle(self, pdg):
+            return TestRefillPoolIsCompleteBeforeItIsPublished._Particle()
+
+    def _stub(self, shard_tag=0, gridpack_tags=None, run_gridpack=None):
+        """A worker of a 4-core parallel unweighting, on an ``ms_dir`` run, with
+        the real refill machinery and a stand-in for run.sh."""
+        test = self
+        interface = interface_madspin.MadSpinInterface
+        if gridpack_tags is None:
+            gridpack_tags = list(range(100, 100 + 4 * self.NB_CORE + 2))
+
+        class Stub(object):
+            # the machinery under test, verbatim
+            generate_events = interface.generate_events
+            _regenerate_events = interface._regenerate_events
+            _generate_refill_pool = interface._generate_refill_pool
+            _materialise_refill_pool = interface._materialise_refill_pool
+            _refill_pool_paths = interface._refill_pool_paths
+            _refill_pool_path = interface._refill_pool_path
+            _open_refill_slice = interface._open_refill_slice
+            _owner_generate = interface._owner_generate
+            _clear_refill_state = interface._clear_refill_state
+            _channel_owner = interface._channel_owner
+            _split_group_tag = interface._split_group_tag
+            _DECAY_GROUP_TAG = interface._DECAY_GROUP_TAG
+            # the static ones have to be re-wrapped: taken off the class they
+            # are plain functions, and a plain function in a class body would
+            # be handed a ``self`` they do not take
+            _refill_pool_dir = staticmethod(interface._refill_pool_dir)
+            _count_lhe_events = staticmethod(interface._count_lhe_events)
+            _published_gen = staticmethod(interface._published_gen)
+            _publish_gen = staticmethod(interface._publish_gen)
+            _decay_dir = staticmethod(interface._decay_dir)
+            _reader_paths = staticmethod(interface._reader_paths)
+            _reader_from_paths = staticmethod(interface._reader_from_paths)
+            _split_pool_round_robin = staticmethod(
+                interface._split_pool_round_robin)
+
+            def _resolve_nb_core(self):
+                return test.NB_CORE
+
+            def _run_gridpack(self, cmd, cwd):
+                """run.sh: writes what it generated to <decay_dir>/events.lhe.gz
+                and knows nothing about run names or per-worker splitting."""
+                if run_gridpack is not None:
+                    return run_gridpack(cwd)
+                test._write_pool(gridpack_tags)
+                return 0, ''
+
+        stub = Stub()
+        stub.path_me = self.tmpdir
+        stub.options = {'ms_dir': self.tmpdir, 'seed': 11, 'run_card': ''}
+        stub.seed = 11
+        stub.mg5cmd = None
+        stub.me_int = {}
+        stub.model = self._Model()
+        stub.list_branches = {'t': ['t > b w+, w+ > l+ vl']}
+        stub._shard_tag = shard_tag
+        stub._shard_nb_core = self.NB_CORE
+        stub._channel_keys = [(6, 0)]
+        stub._refill_seed_base = 42
+        stub._owner_undersize = 0.10
+        return stub
+
+    def _generate(self, stub, gen=1):
+        with _CaptureCritical():
+            stub._owner_generate(6, 0, gen, 1000)
+
+    # ------------------------------------------------------- the regression
+
+    def test_every_worker_finds_its_slice_of_a_gridpack_refill(self):
+        """The regression itself. The owner generates through the gridpack;
+        every worker -- the owner included -- must then find the slice it is
+        about to open, at the canonical path."""
+        self._generate(self._stub())
+        for tag in range(self.NB_CORE):
+            worker = self._stub(shard_tag=tag)
+            path = worker._refill_pool_path(self.decay_dir, 1)
+            self.assertTrue(os.path.exists(path), path)
+            self.assertEqual(os.path.dirname(path),
+                             pjoin(self.decay_dir, 'Events', 'ms_refill_1'))
+
+    def test_the_refilled_pool_holds_each_generated_event_exactly_once(self):
+        """The slices partition the generated events: no worker sees another's
+        event, and none of them is lost on the way."""
+        generated = list(range(100, 126))
+        self._generate(self._stub(gridpack_tags=generated))
+        seen = []
+        for tag in range(self.NB_CORE):
+            worker = self._stub(shard_tag=tag)
+            seen.extend(self._tags_of(worker._refill_pool_path(self.decay_dir, 1)))
+        self.assertEqual(sorted(seen), sorted(float(t) for t in generated))
+
+    def test_the_slices_are_dealt_round_robin(self):
+        """Worker i gets the events at positions i, i+N, ... -- the same stripe
+        it would pick out itself if it had to read the whole pool."""
+        generated = list(range(100, 112))
+        self._generate(self._stub(gridpack_tags=generated))
+        worker = self._stub(shard_tag=2)
+        self.assertEqual(
+            self._tags_of(worker._refill_pool_path(self.decay_dir, 1)),
+            [float(t) for t in generated[2::self.NB_CORE]])
+
+    def test_a_slice_carries_the_banner_so_the_pool_keeps_its_cross_section(self):
+        """Channels of one pdg are picked by cross-section, which is read off
+        the pool's banner -- a slice without one would silently weigh 0."""
+        self._generate(self._stub())
+        worker = self._stub(shard_tag=1)
+        reader = lhe_parser.EventFile(
+            worker._refill_pool_path(self.decay_dir, 1))
+        self.assertEqual(reader.cross, 3.0)
+
+    def test_the_pool_being_read_survives_the_refill(self):
+        """run.sh writes over ``events.lhe.gz`` -- the pool the other workers of
+        this run are still reading. The refill must only ever ADD a generation,
+        so that pool has to be there, unchanged, afterwards."""
+        self._generate(self._stub())
+        self.assertEqual(self._tags_of(pjoin(self.decay_dir, 'events.lhe.gz')),
+                         [float(t) for t in self.pool_tags])
+        self.assertFalse(os.path.exists(
+            pjoin(self.decay_dir, 'events.lhe.gz.mspool')))
+
+    # ------------------------------------------ publish only what is readable
+
+    def test_the_generation_is_published_only_once_the_files_are_readable(self):
+        """The invariant behind the whole failure: at the instant the marker
+        becomes visible, every file a waiter may open is already there."""
+        stub = self._stub()
+        witness = {}
+        publish = stub._publish_gen
+
+        def watched_publish(decay_dir, gen):
+            witness['ready'] = [
+                os.path.exists(p)
+                for p in stub._refill_pool_paths(decay_dir, gen)]
+            return publish(decay_dir, gen)
+
+        stub._publish_gen = watched_publish
+        self._generate(stub)
+        self.assertEqual(witness['ready'], [True] * self.NB_CORE)
+
+    def test_a_generation_that_produced_nothing_is_not_published(self):
+        """A refill that fails must leave the marker where it was: a waiter then
+        keeps waiting (and the deadlock fail-safe eventually generates the pool
+        itself) instead of being sent to open a file that does not exist."""
+        def failed_run(cwd):
+            os.remove(pjoin(cwd, 'events.lhe.gz'))
+            return 1, 'gridrun died'
+        stub = self._stub(run_gridpack=failed_run)
+        with _CaptureCritical():
+            self.assertRaises(Exception, stub._owner_generate, 6, 0, 1, 1000)
+        self.assertEqual(stub._published_gen(self.decay_dir), 0)
+
+    def test_the_marker_is_replaced_atomically_not_truncated_in_place(self):
+        """The marker is the only thing a waiter reads, and it reads it without
+        any lock. Written in place it would be observable empty (or half a
+        number) between the truncation and the write; written to a temporary
+        file and renamed over, a waiter sees either the old generation or the
+        new one. Checked where it is observable: an interrupted publication
+        leaves the previous generation intact."""
+        interface = interface_madspin.MadSpinInterface
+        interface._publish_gen(self.decay_dir, 3)
+        real_replace = os.replace
+
+        def broken_replace(src, dst):
+            os.remove(src)
+            raise OSError('interrupted')
+
+        os.replace = broken_replace
+        try:
+            self.assertRaises(OSError, interface._publish_gen, self.decay_dir, 4)
+        finally:
+            os.replace = real_replace
+        self.assertEqual(interface._published_gen(self.decay_dir), 3)
+
+    def test_publishing_leaves_no_temporary_file_behind(self):
+        interface = interface_madspin.MadSpinInterface
+        interface._publish_gen(self.decay_dir, 2)
+        self.assertEqual(interface._published_gen(self.decay_dir), 2)
+        self.assertEqual(misc.glob('ms_refill.gen.*', self.decay_dir), [])
+
+    # ---------------------------------- the canonical layout is left as it is
+
+    def test_a_pool_already_split_per_worker_is_published_untouched(self):
+        """The madevent backend writes the canonical layout itself. Nothing may
+        be copied, rewritten or moved in that case -- the files the unweighting
+        produced are the pool."""
+        stub = self._stub()
+        targets = stub._refill_pool_paths(self.decay_dir, 1)
+        os.makedirs(os.path.dirname(targets[0]))
+
+        def already_split(pdg, decay_file_nb, needed, run_name):
+            for i, path in enumerate(targets):
+                with open(path, 'w') as fsock:
+                    fsock.write(self._lhe([200 + i]))
+            return interface_madspin._ChainedEvents(targets)
+
+        stub._regenerate_events = already_split
+        self._generate(stub)
+        for i, path in enumerate(targets):
+            self.assertEqual(self._tags_of(path), [float(200 + i)])
+        self.assertEqual(stub._published_gen(self.decay_dir), 1)
+        self.assertEqual(misc.glob('ms_refill_*.part',
+                                   pjoin(self.decay_dir, 'Events')), [])
+
+    # ------------------------------------------ a run's refills are its own
+
+    def test_a_previous_runs_generation_is_not_taken_for_this_ones(self):
+        """``ms_dir`` is reused across runs, and its decay directories keep the
+        marker and the pools of the run that wrote them. This run's workers all
+        start at generation 0, so an inherited marker would send them straight
+        to another run's pool -- sized for its efficiency and split for its
+        nb_core, so the slice they want need not even be there."""
+        stub = self._stub()
+        self._generate(stub)
+        self.assertEqual(stub._published_gen(self.decay_dir), 1)
+        stub._clear_refill_state()
+        self.assertEqual(stub._published_gen(self.decay_dir), 0)
+        self.assertEqual(misc.glob('ms_refill_*',
+                                   pjoin(self.decay_dir, 'Events')), [])
+
+    def test_the_cleanup_puts_back_a_pool_a_crashed_refill_had_stashed(self):
+        """A refill killed between moving the pool aside and regenerating it
+        leaves the run's only copy in the stash; the next run must find its
+        pool, not an empty directory."""
+        pool = pjoin(self.decay_dir, 'events.lhe.gz')
+        os.rename(pool, pool + '.mspool')
+        self._stub()._clear_refill_state()
+        self.assertTrue(os.path.exists(pool))
+        self.assertEqual(self._tags_of(pool),
+                         [float(t) for t in self.pool_tags])
+        self.assertFalse(os.path.exists(pool + '.mspool'))


### PR DESCRIPTION
## The bug

An `ms_dir` run of the parallel unweighting dies, deterministically, the first time a decay pool needs refilling:

```
Exception: MadSpin: refill pool /.../ms_madspin/decay_x6_0/Events/ms_refill_1/unweighted_events_0.lhe is missing for worker 0
```

Reported as an intermittent race between the generation marker and the pool files. It is not a race — the marker was already written after `_regenerate_events` returned, under the channel lock. It fails on every `ms_dir` run that needs a refill; what varies from run to run is only whether a refill is needed at all.

The parallel unweighting refills a channel's pool through one fixed OWNER worker; every other worker blocks until `ms_refill.gen` names the generation it needs, then opens its own slice of `Events/ms_refill_<gen>/`. So the marker is a promise about a set of files.

Two generation backends make those files and they disagree on where they write:

- the **madevent** one honours `run_name` and has the unweighting split its output one file per worker — the layout the waiters expect;
- the **gridpack** one, which *every* `ms_dir` run takes (`use_gridpack` is just `bool(options['ms_dir'])`), goes through `run.sh`. It knows about neither, and writes a single `events.lhe.gz` — straight on top of the pool the other workers are still reading.

The owner published the generation all the same, and the first worker to act on that promise — itself, or any waiter — died on a file that was never going to be there.

## The fix

`_generate_refill_pool` leaves the pool complete at the canonical per-worker paths whatever produced it. On the gridpack backend it moves `events.lhe.gz` aside for the duration and puts it back — renaming is safe for the workers holding it open, they keep their inode — so a refill only ever *adds* a generation instead of overwriting the live pool, then deals what `run.sh` produced round-robin into the per-worker slices: exactly the stripe each worker would otherwise read out of the whole pool itself. Built in a sibling `.part` directory and renamed into place. The madevent backend already writes those exact files, so it is left untouched (verified: its own `ms_refill_1_tag_1_banner.txt` still sits next to the slices after a refill).

Publication is atomic too, as originally suspected it might not be: the marker goes to a temporary file and is renamed over, so a waiter polling it without a lock reads either the old generation or the new one.

While reproducing this, a second bug surfaced: a reused `ms_dir` keeps the previous run's `ms_refill.gen`, which this run's workers — all starting at generation 0 — read as "generation 1 is already published", sending them to a pool sized for another run's efficiency and split for its `nb_core`. `_clear_refill_state` now drops that bookkeeping in the parent, once, before any fork.

## Verification

Reproduced at small scale from `tests/input_files/ttbar.lhe` inflated to 2000 production events, `nb_core 4`, `decay_event_mult 0.05`, fresh `ms_dir` — the exception verbatim, from the owner branch. After the fix:

- same run completes, 2000/2000 events written, two refills taken;
- native (no `ms_dir`) parallel run completes, four refills across two generations — that path is unchanged;
- 12 new tests in `TestRefillPoolIsCompleteBeforeItIsPublished`, including one that pins the invariant itself (at the instant the marker becomes visible, every slice a waiter may open exists) and one that shows an interrupted publication leaves the previous generation intact;
- full madspin unit file: 407 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure MadSpin parallel refill generations are complete and isolated from previous runs before making them visible to workers.

Bug Fixes:
- Prevent MadSpin refill generations from being published until all per-worker pool files exist and are readable.
- Preserve the active decay pool during gridpack refills and materialize generated events into canonical per-worker slices.
- Reset stale refill markers and pools when reusing an ms_dir run.

Enhancements:
- Publish refill generation markers atomically so workers observe either the previous or the new generation.

Tests:
- Add regression coverage for gridpack refill slicing, pool preservation, publication ordering, atomic marker updates, failed generations, madevent compatibility, and stale-state cleanup.