### PR TITLE
Add debug printouts for plugin version compatibility

### DIFF
--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -2179,6 +2179,10 @@ It has been validated for the last time with version: %s""",
         else:
             logger.error("Plugin %s is not supported by this version of MG5aMC." % name)
             plugin_support[name] = False
+        logger.error("plugin is %s"%obj)
+        logger.error("min_ver = %s"%str(min_ver))
+        logger.error("mg5_ver = %s"%str(mg5_ver))
+        logger.error("max_ver = %s"%str(max_ver))
     return plugin_support[name]
     
 


### PR DESCRIPTION
Hi @oliviermattelaer another simple suggestion, add some debug info for plugin version copmpatibility.

I used this to understand why the ATLAS installation of 3.6.4 on cvmfs by SFT is broken (it points to a plugin that requires 3.7.1). See related issue https://its.cern.ch/jira/browse/SPI-3052.
```
MG5_aMC>generate g g > t t~; output madevent_simd PROC_ggtt
INFO: Checking for minimal orders which gives processes. 
INFO: Please specify coupling orders to bypass this step. 
INFO: Trying coupling order WEIGHTED<=2: WEIGTHED IS QCD+2*QED 
INFO: Trying process: g g > t t~ WEIGHTED<=2 @1  
INFO: Process has 3 diagrams 
1 processes with 3 diagrams generated in 0.006 s
Total: 1 processes with 3 diagrams
Plugin PLUGIN.CUDACPP_OUTPUT is not supported by this version of MG5aMC.
plugin is <module 'PLUGIN.CUDACPP_OUTPUT' from '/cvmfs/atlas.cern.ch/repo/sw/Generators/madgraph/models/latest/PLUGIN/CUDACPP_OUTPUT/__init__.py'>
min_ver = (3, 7, 1)
mg5_ver = ['3', '6', '4']
max_ver = (1000, 1000, 1000)
```

By the way that trick of adding a path in PLUGIN/__init__.py is nice! But as I suggested to SFT, it should point to a specific cudacpp version for each madgraph version, not to a generic latest. Were you aware of this?

Thanks Andrea

## Summary by Sourcery

Enhancements:
- Add detailed error logging for unsupported plugins, including the plugin object and minimum, current, and maximum compatible MG5aMC versions.