### PR TITLE
MG5: make the custom_fcts lookup case-insensitive, and name the function in the error

### DIFF
--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -3479,17 +3479,24 @@ class RunCard(ConfigFile):
                     fsock = file_writers.FortranWriter(tmp,'w')
                     function_text = fsock.remove_routine(text, fct)
                     fsock.close()
-                    test = open(tmp,'r').read()                        
-                    if fct not in self.dummy_fct_file:
-                        if fct.startswith('user_'):
-                            self.dummy_fct_file[fct] = self.dummy_fct_file['user_']
+                    test = open(tmp,'r').read()
+                    # fortran is case insensitive (and upper case is idiomatic),
+                    # while dummy_fct_file --and the routines of the template
+                    # files-- are written in lower case. So normalise the name
+                    # extracted from the user file before any comparison.
+                    # (the removal above has to use the original case since it
+                    #  operates on the user file itself)
+                    lfct = fct.lower()
+                    if lfct not in self.dummy_fct_file:
+                        if lfct.startswith('user_'):
+                            self.dummy_fct_file[lfct] = self.dummy_fct_file['user_']
                         else:
-                            raise InvalidRunCard("function %s is not designed for overwritting")
-                    writein = self.dummy_fct_file[fct]
+                            raise InvalidRunCard("function %s is not designed for overwriting" % fct)
+                    writein = self.dummy_fct_file[lfct]
                     if writein not in to_mod:
-                        to_mod[writein]=[[fct], [function_text]]
+                        to_mod[writein]=[[lfct], [function_text]]
                     else:
-                        to_mod[writein][0].append(fct)
+                        to_mod[writein][0].append(lfct)
                         to_mod[writein][1].append(function_text)
 
         # step 2: write the new files

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -541,6 +541,7 @@ Beams:LHEF='events_ouaf.lhe.gz'
 
 
 
+import re
 import shutil
 class TestRunCard(unittest.TestCase):
     """ A class to test the TestConfig functionality """
@@ -1001,6 +1002,86 @@ c
         self.assertEqual(orig, new_text)
         self.assertNotIn('CHECK1', new_text)
         self.assertNotIn('CHECK2', new_text)
+
+
+    def test_custom_fcts_uppercase(self):
+        """fortran is case insensitive: a custom_fcts file written in upper case
+           (which is the idiomatic f77 style) has to be accepted, has to be
+           written in the correct file and has to replace --not duplicate--
+           the original routine."""
+
+        custom_contents = """
+      LOGICAL FUNCTION DUMMY_CUTS(P)
+      IMPLICIT NONE
+      INCLUDE 'nexternal.inc'
+      DOUBLE PRECISION P(0:3,NEXTERNAL)
+      DUMMY_CUTS = .TRUE.
+      CHECKUP
+      RETURN
+      END
+
+      SUBROUTINE USER_UPPER_FCT()
+      IMPLICIT NONE
+      CHECKUSER
+      RETURN
+      END
+        """
+
+        # prepare simplify setup
+        os.mkdir(pjoin(self.tmpdir,'SubProcesses'))
+        import madgraph.iolibs.files as files
+        files.cp(pjoin(MG5DIR,'Template','LO','SubProcesses','dummy_fct.f'), pjoin(self.tmpdir,'SubProcesses'))
+        open(pjoin(self.tmpdir, 'custom'),'w').write(custom_contents)
+
+        LO = bannermod.RunCardLO()
+        # this used to raise InvalidRunCard since the lookup was case sensitive
+        LO.edit_dummy_fct_from_file([pjoin(self.tmpdir, 'custom')], self.tmpdir)
+
+        # the correct file is the one which has been patched
+        self.assertTrue(os.path.exists(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f.orig')))
+        new_text = open(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f')).read()
+        self.assertIn('CHECKUP', new_text)
+        self.assertIn('CHECKUSER', new_text)
+
+        # the original dummy_cuts has to be removed, not duplicated
+        # (otherwise the fortran compiler complains about a duplicated symbol)
+        self.assertEqual(1, len(re.findall(r'FUNCTION\s+DUMMY_CUTS', new_text)))
+        # the routine we did not overwrite is still there
+        self.assertIn('GET_DUMMY_X1', new_text)
+
+        # and cleaning still works
+        LO.edit_dummy_fct_from_file([], self.tmpdir)
+        self.assertFalse(os.path.exists(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f.orig')))
+        new_text = open(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f')).read()
+        self.assertNotIn('CHECKUP', new_text)
+        self.assertNotIn('CHECKUSER', new_text)
+
+    def test_custom_fcts_unknown_fct(self):
+        """a function which is not allowed to be overwritten has to raise an
+           error which actually names that function"""
+
+        custom_contents = """
+      LOGICAL FUNCTION NOT_A_DUMMY_FCT(P)
+      IMPLICIT NONE
+      NOT_A_DUMMY_FCT = .TRUE.
+      RETURN
+      END
+        """
+
+        os.mkdir(pjoin(self.tmpdir,'SubProcesses'))
+        import madgraph.iolibs.files as files
+        files.cp(pjoin(MG5DIR,'Template','LO','SubProcesses','dummy_fct.f'), pjoin(self.tmpdir,'SubProcesses'))
+        open(pjoin(self.tmpdir, 'custom'),'w').write(custom_contents)
+
+        for card in [bannermod.RunCardLO(), bannermod.RunCardNLO()]:
+            try:
+                card.edit_dummy_fct_from_file([pjoin(self.tmpdir, 'custom')], self.tmpdir)
+            except bannermod.InvalidRunCard as error:
+                # the name of the offending function has to be in the message
+                self.assertIn('NOT_A_DUMMY_FCT', str(error))
+                self.assertNotIn('%s', str(error))
+            else:
+                self.fail('InvalidRunCard should have been raised')
 
 
     def test_pdlabel_block(self):

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -1045,7 +1045,7 @@ c
 
         # the original dummy_cuts has to be removed, not duplicated
         # (otherwise the fortran compiler complains about a duplicated symbol)
-        self.assertEqual(1, len(re.findall(r'FUNCTION\s+DUMMY_CUTS', new_text)))
+        self.assertEqual(1, len(re.findall(r'FUNCTION\s+DUMMY_CUTS', new_text, re.I)))
         # the routine we did not overwrite is still there
         self.assertIn('GET_DUMMY_X1', new_text)
 


### PR DESCRIPTION
Two defects in `RunCard.edit_dummy_fct_from_file`, both hit by anyone writing a
`custom_fcts` file in conventional uppercase Fortran.

**The error message never named the function.** `banner.py` raised
`InvalidRunCard("function %s is not designed for overwritting")` with the `%s`
unsubstituted, so the user saw that string verbatim. Now substituted (with the
original-case name, so they see what they typed), and `overwritting` ->
`overwriting`.

**The lookup was case-sensitive.** The regex that finds function names uses
`re.I`, so `fct` comes back in whatever case the user's file used, while both
`RunCardLO.dummy_fct_file` and `RunCardNLO.dummy_fct_file` are keyed entirely in
lower case. So `SUBROUTINE DUMMY_CUTS` missed the table and landed on exactly the
uninformative error above. The `user_` prefix branch had the same problem -
`fct.startswith('user_')` was tested against the raw name, so
`SUBROUTINE USER_MYFCT` fell through too.

## The normalisation is deliberately asymmetric

There are two `remove_routine` calls with different requirements, and normalising
both would have replaced a clear error with a silent one:

- step 1 operates on the **user's own file**, so the name must stay in the
  **user's original case** - `FileWriter.get_routine` matches with
  `fct[0] in fct_names`, a case-sensitive comparison despite its own `re.I`
  regex, so lowercasing here would break extraction from an uppercase file;
- step 2 operates on the pristine `.orig` template, whose routines are all lower
  case (`Template/{LO,NLO}/SubProcesses/dummy_fct.f`). Leaving `to_mod` carrying
  `DUMMY_CUTS` would mean the original routine is never stripped - a
  duplicate-symbol link failure instead of an error message.

So: original case for the user-file extraction; lower case for the dict lookup,
the `user_` test, and the `to_mod` list. The new uppercase test asserts exactly
one `FUNCTION DUMMY_CUTS` in the result, which is what pins that down.

## Tests

`test_banner -t0`: 30 tests, OK (28 before, +2 new). `test_madspin -t0`: 444, OK.
The pre-existing lowercase `test_custom_fcts` passes untouched.

Both new tests were confirmed to **fail on the pre-fix code**: the uppercase one
raised `function %s is not designed for overwritting`, and the unknown-function
one failed on `'NOT_A_DUMMY_FCT' not found in 'function %s ...'`.

```
BEFORE : function %s is not designed for overwritting
AFTER  : function NOT_A_DUMMY_FCT is not designed for overwriting
```

## Not covered

No `gfortran` link of a generated directory - the duplicate-symbol regression is
guarded by the "exactly one `FUNCTION DUMMY_CUTS`" assertion rather than by an
actual build. The acceptance tests exercise `custom_fcts` end to end but only on
the lowercase path, and were not run here.

One pre-existing, orthogonal issue left alone: step 1 passes `fct` as a bare
string to `remove_routine`, whose `fct_names` is documented as a list, so
`fct[0] in fct_names` degrades to a substring test - a file containing both
`user_foo` and `user_foobar` would pull one into the other. The one-character fix
touches behaviour that could not be validated here.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle custom Fortran routines case-insensitively and provide actionable errors for unsupported functions.

Bug Fixes:
- Make custom Fortran function lookup case-insensitive so uppercase routine names are handled correctly.
- Report the offending function name in unsupported-overwrite errors and correct the error wording.

Tests:
- Add coverage for uppercase custom routines, replacement without duplicate symbols, cleanup, and informative unknown-function errors.