### PR TITLE
MadSpin: the 2 -> 3 joint overweights are the production's own resonance, not the jacobian

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -5041,10 +5041,7 @@ class MadSpinInterface(extended_cmd.Cmd):
             # breakdown.
             near, res, far = self._nwa_threshold_split(stats_list)
             msg = ("MadSpin sequential: %d weights exceeded their stage "
-                   "maximum (mass set / angles / per particle). The excess is "
-                   "CARRIED on the weight of the affected events rather than "
-                   "dropped (see the overweight line below for how much it is "
-                   "worth). " % total_overflow)
+                   "maximum (mass set / angles / per particle). " % total_overflow)
             if (near or res) and not far:
                 msg += ("Every event that carried one sits within %s of the "
                         "sum-of-poles threshold, or on a resonance of the "
@@ -5296,28 +5293,12 @@ class MadSpinInterface(extended_cmd.Cmd):
         note = ''
         if near:
             note += ("%d of them are production events within %s of "
-                     "the sum-of-poles threshold, where the narrow-width "
-                     "approximation MadSpin factorises with is invalid by "
-                     "construction -- the windows there are cut off by the "
-                     "energy budget rather than by BW_cut, and the production "
-                     "reshuffling jacobian diverges because there is no recoil "
-                     "left. An overweight there is expected and is carried "
-                     "exactly, not clipped. "
+                     "the sum-of-poles threshold, "
                      % (near, self._nwa_threshold_margin()))
         if res:
             note += ("%d of them have a resonance and another production-level "
                      "final state whose invariant mass is within %g widths of "
-                     "that resonance's own pole: there the PRODUCTION matrix "
-                     "element has the same resonance on an internal line -- a "
-                     "region that only exists once the production process has "
-                     "a jet in it, and that a virtuality below the pole is "
-                     "what makes reachable at all. The weight there is a "
-                     "Breit-Wigner peak of the production process itself, it "
-                     "is correct, and it is carried exactly. Lowering BW_cut "
-                     "closes that region (measured on p p > t t~ j: reachable "
-                     "for 3.5%% of the production events at BW_cut = 15, 0.9%% "
-                     "at 10, 0.03%% at 5). "
-                     % (res, self._PRODUCTION_RESONANCE_WIDTHS))
+                     "that resonance's own pole." % (res, self._PRODUCTION_RESONANCE_WIDTHS))
         both = 'either region' if (near and res) else 'that region'
         it = 'those' if (near and res) else 'it'
         if far:
@@ -5385,16 +5366,11 @@ class MadSpinInterface(extended_cmd.Cmd):
         # string: the head already contains literal per-cent signs.
         msg = ("MadSpin overweight safety net: %d/%d written events (%.3g%%) "
                "carried a non-unit weight because a trial weight exceeded its "
-               "accept/reject bound (largest factor %.4f%s). "
-               % (nb, n_written, 100.0 * nb / n_written, biggest,
-                  ', %d of them from the joint accept/reject' % joint
-                  if joint else ''))
+               "accept/reject bound (largest factor %.4f). "
+               % (nb, n_written, 100.0 * nb / n_written, biggest))
         if z >= self._OVERWEIGHT_MIN_Z:
-            msg += ("Carrying it added %+.6g to the summed event weight, i.e. "
-                    "%+.3g%% of the sample's cross-section (IDWTUP = -4: sigma "
-                    "is the mean weight and the event count does not change, "
-                    "so this is the relative shift). "
-                    % (d_w, 100.0 * d_w / sum_w))
+            msg += ("Carrying it added %+.3g%% of the sample's cross-section. "
+                    % (100.0 * d_w / sum_w))
         else:
             # pure_interference, or any sample whose weights cancel: the
             # cross-section is consistent with zero, so it is not a denominator
@@ -5406,14 +5382,17 @@ class MadSpinInterface(extended_cmd.Cmd):
                     "shift is quoted against sum|w| = %.4g instead: %+.3g%%. "
                     % (d_w, d_abs, sum_w, delta, z, sum_abs,
                        100.0 * d_abs / sum_abs if sum_abs else float('nan')))
-        msg += ("Clipping it -- what MadSpin did before -- would have discarded "
-                "that silently. ")
         near, res, far = self._nwa_threshold_split(stats_list)
+        #no need dedicated note when very small
+        if 100.0 * d_w / sum_w < 0.5:
+            logger.info(msg)
+            return 
+            
         msg = (msg + self._nwa_threshold_note(near, res, far)).rstrip()
         # Calmer only when EVERY one of them is in one of the two explained
         # regions: the count in the head of the line is the total either way,
         # so this changes the volume and not the arithmetic.
-        if (near or res) and not far:
+        if ((near or res) and not far):
             logger.info(msg)
         else:
             logger.warning(msg)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4530,6 +4530,10 @@ class MadSpinInterface(extended_cmd.Cmd):
         nb_overweight_nwa = 0    # ... of which sat in the region where the
                                  # narrow-width approximation is invalid by
                                  # construction (_near_nwa_threshold)
+        nb_overweight_res = 0    # ... and of which sat on the production
+                                 # matrix element's own resonance
+                                 # (_near_production_resonance). Exclusive with
+                                 # the line above, threshold winning.
         max_overweight = 1.0     # the largest single factor carried
         sum_overweight_dw = 0.0     # sum of (factor - 1) * w_nominal: the signed
                                     # weight the clipping used to throw away
@@ -4649,6 +4653,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                     nb_overweight += 1
                     if self._near_nwa_threshold(production, evt_decayfile):
                         nb_overweight_nwa += 1
+                    elif self._near_production_resonance(full_evt, production,
+                                                         evt_decayfile):
+                        nb_overweight_res += 1
                     if carry > max_overweight:
                         max_overweight = carry
                 full_evt.wgt *= br
@@ -4865,6 +4872,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                 nb_overweight += 1
                 if self._near_nwa_threshold(production, evt_decayfile):
                     nb_overweight_nwa += 1
+                elif self._near_production_resonance(full_evt, production,
+                                                     evt_decayfile):
+                    nb_overweight_res += 1
                 if carry > max_overweight:
                     max_overweight = carry
             if self.options['fixed_order']:
@@ -4914,6 +4924,7 @@ class MadSpinInterface(extended_cmd.Cmd):
                     nb_overflow_joint=nb_overflow_joint,
                     nb_overweight=nb_overweight,
                     nb_overweight_nwa=nb_overweight_nwa,
+                    nb_overweight_res=nb_overweight_res,
                     sum_overweight_dw=float(sum_overweight_dw),
                     sum_overweight_dabs=float(sum_overweight_dabs),
                     sum_nom=float(sum_nom),
@@ -5028,18 +5039,19 @@ class MadSpinInterface(extended_cmd.Cmd):
             # line counts written EVENTS -- so the note is only allowed to
             # decide the volume of this line, never to be read as its
             # breakdown.
-            near, far = self._nwa_threshold_split(stats_list)
+            near, res, far = self._nwa_threshold_split(stats_list)
             msg = ("MadSpin sequential: %d weights exceeded their stage "
                    "maximum (mass set / angles / per particle). The excess is "
                    "CARRIED on the weight of the affected events rather than "
                    "dropped (see the overweight line below for how much it is "
                    "worth). " % total_overflow)
-            if near and not far:
+            if (near or res) and not far:
                 msg += ("Every event that carried one sits within %s of the "
-                        "sum-of-poles threshold, where the narrow-width "
-                        "approximation is invalid by construction and no "
-                        "accept/reject bound built on it can dominate; see the "
-                        "overweight line below."
+                        "sum-of-poles threshold, or on a resonance of the "
+                        "production matrix element itself -- regions where the "
+                        "narrow-width approximation is invalid by "
+                        "construction and no accept/reject bound built on it "
+                        "can dominate; see the overweight line below."
                         % self._nwa_threshold_margin())
                 logger.info(msg)
             else:
@@ -5141,39 +5153,160 @@ class MadSpinInterface(extended_cmd.Cmd):
         production._ms_near_nwa_threshold = answer
         return answer
 
+    # ------------------------------------------------------------------
+    # The second region an overweight can come from: the production matrix
+    # element's OWN resonance
+    # ------------------------------------------------------------------
+    # This one has nothing to do with threshold and does not exist at all in
+    # ``2 -> 2``. Once the production process has a final-state particle
+    # besides the resonances -- a jet -- its matrix element contains a
+    # propagator of the resonance itself, on the line the jet is radiated
+    # from, with virtuality
+    #
+    #     (p_r + p_j)^2  =  m_r^2 + 2 p_r.p_j .
+    #
+    # With ``m_r`` ON its pole that is ``>= M_r^2`` for any real jet, so the
+    # propagator can never go on shell: the singularity sits exactly on the
+    # boundary of phase space and is unreachable. Sampling ``m_r`` BELOW the
+    # pole -- which is what ``BW_cut`` is for -- opens it: the equation
+    # ``2 p_r.p_j = M_r^2 - m_r^2`` now has solutions, and on them the
+    # production matrix element is a Breit-Wigner peak regulated only by
+    # ``M_r Gamma_r``. The weight there is correct; it is simply enormous, and
+    # a single run-level bound cannot dominate it.
+    #
+    # In ``2 -> 2`` the only internal resonance line is t-channel,
+    # ``(p_in - p_r)^2 = m_r^2 - 2 p_in.p_r < m_r^2 <= M_r^2``, so it is
+    # spacelike and this region does not exist. That asymmetry is the whole
+    # reason a ``2 -> 3`` production overweights 26x more often than the same
+    # ``2 -> 2`` one.
+    #
+    # Measured, ``p p > t t~ j`` at 6.5+6.5 TeV, ``spinmode madspin``,
+    # ``unweighting joint``, ``BW_cut = 15``, 300 000 events: **all 265** of
+    # the run's carried overweights have one resonance within 5.2 M_r Gamma_r
+    # of this pole (51 % within one, the largest -- factor 48.9 -- at 0.12),
+    # against 3.30 for the trials that merely came close to the bound. Their
+    # production reshuffling jacobian is 1.07 (max 2.47), i.e. the threshold
+    # mechanism above is not involved. The region is reachable inside
+    # ``BW_cut = 15`` for 3.5 % of the production events and essentially never
+    # below ``BW_cut = 8`` -- see doc/madspin_sequential_plan.md section 17.
+    #
+    # The margin is 10 and not the 5.2 that population happens to fill: twice
+    # the measured envelope, so the tag is not fitted to one sample, and still
+    # specific -- the fraction of joint TRIALS that land inside it is 9.2e-4
+    # (against 2.9e-4 at 5 and 5.3e-5 at 1), i.e. a thousand times rarer than
+    # the tag firing would need to be to silence an overweight by coincidence.
+    _PRODUCTION_RESONANCE_WIDTHS = 10.0
+
+    def _near_production_resonance(self, full_evt, production, evt_decayfile):
+        """Does this accepted event sit on the production process's own
+        resonance, i.e. is there a decayed resonance ``r`` and another
+        production-level final state ``k`` with
+
+            |m^2(r + k) - M_r^2|  <=  _PRODUCTION_RESONANCE_WIDTHS . M_r Gamma_r
+
+        evaluated at the virtuality the event actually carries?
+
+        The first ``len(production)`` entries of ``full_evt`` are the
+        production event's own particles (``add_decay_to_particle`` appends the
+        decay products after them and flips the parent to status 2), so this is
+        a pairwise invariant mass over the production final state, on the
+        reshuffled momenta -- O(n^2) four-vector arithmetic on an event that is
+        already built, and only ever on an event that overflowed.
+
+        False -- never an exception -- when anything it needs is missing: like
+        ``_near_nwa_threshold`` this decides how loudly a diagnostic prints and
+        must not be able to stop a run.
+        """
+        try:
+            # fixed_order hands in the event GROUP (born + counter-events);
+            # they share the draw, so the born one answers for all of them.
+            # Tested on the element and not with isinstance(list): Event is
+            # itself a list of Particle, so that test is always true.
+            if full_evt and isinstance(full_evt[0], lhe_parser.Event):
+                full_evt = full_evt[0]
+            parts = list(full_evt)[:len(production)]
+            finals = [q for q in parts if int(q.status) in (1, 2)]
+            if len(finals) < 3:
+                # 2 -> 2: no jet to radiate the resonance off, so the internal
+                # propagator is t-channel and cannot go on shell
+                return False
+            for r in finals:
+                if int(r.status) != 2:
+                    continue
+                pdg = r.pdg
+                if pdg not in evt_decayfile or not len(evt_decayfile[pdg]):
+                    continue
+                pole = self.banner.get('param', 'mass', abs(pdg)).value
+                width = self.banner.get('param', 'decay', abs(pdg)).value
+                if not pole or not width:
+                    continue
+                qr = lhe_parser.FourMomentum(r)
+                for k in finals:
+                    if k is r:
+                        continue
+                    s2 = (qr + lhe_parser.FourMomentum(k)).mass_sqr
+                    if abs(s2 - pole * pole) <= (
+                            self._PRODUCTION_RESONANCE_WIDTHS * pole * width):
+                        return True
+        except (AttributeError, KeyError, TypeError, ValueError, IndexError):
+            return False
+        return False
+
     def _nwa_threshold_margin(self):
         """``_NWA_THRESHOLD_WIDTHS`` as it is said out loud."""
         return ('one summed width' if self._NWA_THRESHOLD_WIDTHS == 1
                 else '%g summed widths' % self._NWA_THRESHOLD_WIDTHS)
 
     def _nwa_threshold_split(self, stats_list):
-        """(in the region, outside it) over the carried overweights of a run."""
+        """(at threshold, on a production resonance, neither) over the carried
+        overweights of a run. Exclusive, in that order: an event that is both
+        counts as threshold, which is the stronger statement."""
         nb = sum(s.get('nb_overweight', 0) for s in stats_list)
         near = sum(s.get('nb_overweight_nwa', 0) for s in stats_list)
-        return near, nb - near
+        res = sum(s.get('nb_overweight_res', 0) for s in stats_list)
+        return near, res, nb - near - res
 
-    def _nwa_threshold_note(self, near, far):
+    def _nwa_threshold_note(self, near, res, far):
         """The sentence both end-of-run lines append when the split is
-        non-trivial. Always quotes both halves, so the total the head of the
+        non-trivial. Always quotes every part, so the total the head of the
         line gives stays recoverable from it."""
-        if not near:
+        if not near and not res:
             return ''
-        note = ("%d of them are production events within %s of "
-                "the sum-of-poles threshold, where the narrow-width "
-                "approximation MadSpin factorises with is invalid by "
-                "construction -- the windows there are cut off by the energy "
-                "budget rather than by BW_cut, and the production reshuffling "
-                "jacobian diverges because there is no recoil left. An "
-                "overweight there is expected and is carried exactly, not "
-                "clipped. "
-                % (near, self._nwa_threshold_margin()))
+        note = ''
+        if near:
+            note += ("%d of them are production events within %s of "
+                     "the sum-of-poles threshold, where the narrow-width "
+                     "approximation MadSpin factorises with is invalid by "
+                     "construction -- the windows there are cut off by the "
+                     "energy budget rather than by BW_cut, and the production "
+                     "reshuffling jacobian diverges because there is no recoil "
+                     "left. An overweight there is expected and is carried "
+                     "exactly, not clipped. "
+                     % (near, self._nwa_threshold_margin()))
+        if res:
+            note += ("%d of them have a resonance and another production-level "
+                     "final state whose invariant mass is within %g widths of "
+                     "that resonance's own pole: there the PRODUCTION matrix "
+                     "element has the same resonance on an internal line -- a "
+                     "region that only exists once the production process has "
+                     "a jet in it, and that a virtuality below the pole is "
+                     "what makes reachable at all. The weight there is a "
+                     "Breit-Wigner peak of the production process itself, it "
+                     "is correct, and it is carried exactly. Lowering BW_cut "
+                     "closes that region (measured on p p > t t~ j: reachable "
+                     "for 3.5%% of the production events at BW_cut = 15, 0.9%% "
+                     "at 10, 0.03%% at 5). "
+                     % (res, self._PRODUCTION_RESONANCE_WIDTHS))
+        both = 'either region' if (near and res) else 'that region'
+        it = 'those' if (near and res) else 'it'
         if far:
-            note += ("The other %d are NOT in that region, and those do say "
+            note += ("The other %d are NOT in %s, and those do say "
                      "the bound is under-estimated: raise nb_sigma or "
-                     "Nevents_for_max_weight. " % far)
+                     "Nevents_for_max_weight. " % (far, both))
         else:
-            note += ("None of them is outside it, so nothing here says the "
-                     "bound is under-estimated away from threshold. ")
+            note += ("None of them is outside %s, so nothing here says the "
+                     "bound is under-estimated for an unexplained reason. "
+                     % it)
         return note
 
     def _report_overweight(self, stats_list, n_written):
@@ -5254,12 +5387,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                        100.0 * d_abs / sum_abs if sum_abs else float('nan')))
         msg += ("Clipping it -- what MadSpin did before -- would have discarded "
                 "that silently. ")
-        near, far = self._nwa_threshold_split(stats_list)
-        msg = (msg + self._nwa_threshold_note(near, far)).rstrip()
-        # Calmer only when EVERY one of them is in the region: the count in the
-        # head of the line is the total either way, so this changes the volume
-        # and not the arithmetic.
-        if near and not far:
+        near, res, far = self._nwa_threshold_split(stats_list)
+        msg = (msg + self._nwa_threshold_note(near, res, far)).rstrip()
+        # Calmer only when EVERY one of them is in one of the two explained
+        # regions: the count in the head of the line is the total either way,
+        # so this changes the volume and not the arithmetic.
+        if (near or res) and not far:
             logger.info(msg)
         else:
             logger.warning(msg)

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -5067,6 +5067,14 @@ class MadSpinInterface(extended_cmd.Cmd):
     # z = O(1) and always does.
     _OVERWEIGHT_MIN_Z = 5.0
 
+    # How much the carried excess has to be worth, in per-cent of whatever
+    # denominator the overweight line was allowed to quote, before the region
+    # breakdown is printed at all. Below it the head of the line has already
+    # said how many events carried one and what it was worth, and a paragraph
+    # about WHY only buries that; above it the three-way split still decides
+    # both the wording and the volume.
+    _OVERWEIGHT_QUIET_PERCENT = 0.5
+
     # ------------------------------------------------------------------
     # The region where the narrow-width approximation is invalid by
     # construction
@@ -5298,7 +5306,8 @@ class MadSpinInterface(extended_cmd.Cmd):
         if res:
             note += ("%d of them have a resonance and another production-level "
                      "final state whose invariant mass is within %g widths of "
-                     "that resonance's own pole." % (res, self._PRODUCTION_RESONANCE_WIDTHS))
+                     "that resonance's own pole. "
+                     % (res, self._PRODUCTION_RESONANCE_WIDTHS))
         both = 'either region' if (near and res) else 'that region'
         it = 'those' if (near and res) else 'it'
         if far:
@@ -5342,6 +5351,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         of its own Monte Carlo errors away from zero. When it is not, the shift
         is quoted against ``sum |w|`` -- which cannot cancel -- and the line says
         which convention it used, so the two are never confused.
+
+        The line has two volumes. Whatever the regions say, an excess worth
+        less than ``_OVERWEIGHT_QUIET_PERCENT`` of that denominator gets the
+        head of the line and nothing else, at info: the number is already
+        printed and nobody needs a paragraph explaining a per-mille. At or
+        above it the three-way region split decides the wording and the volume
+        as before. Only the volume moves -- the counts and the shift in the
+        head of the line are identical on both sides of the threshold.
         """
         nb = sum(s.get('nb_overweight', 0) for s in stats_list)
         if not n_written or not nb:
@@ -5355,7 +5372,6 @@ class MadSpinInterface(extended_cmd.Cmd):
         d_w = sum(s.get('sum_overweight_dw', 0.0) for s in stats_list)
         d_abs = sum(s.get('sum_overweight_dabs', 0.0) for s in stats_list)
         biggest = max([s.get('max_overweight', 1.0) for s in stats_list] or [1.0])
-        joint = sum(s.get('nb_overflow_joint', 0) for s in stats_list)
         # the file as clipping would have written it
         sum_w = sum(s.get('sum_nom', 0.0) for s in stats_list)
         sum_abs = sum(s.get('sum_abs_nom', 0.0) for s in stats_list)
@@ -5369,25 +5385,36 @@ class MadSpinInterface(extended_cmd.Cmd):
                "accept/reject bound (largest factor %.4f). "
                % (nb, n_written, 100.0 * nb / n_written, biggest))
         if z >= self._OVERWEIGHT_MIN_Z:
+            shift = 100.0 * d_w / sum_w
             msg += ("Carrying it added %+.3g%% of the sample's cross-section. "
-                    % (100.0 * d_w / sum_w))
+                    % shift)
         else:
             # pure_interference, or any sample whose weights cancel: the
             # cross-section is consistent with zero, so it is not a denominator
+            shift = 100.0 * d_abs / sum_abs if sum_abs else float('nan')
             msg += ("Carrying it added %+.6g to the summed event weight and "
                     "%+.6g to the summed |weight|. The summed weight is %+.4g "
                     "against a Monte Carlo error of %.4g (z = %.2f), i.e. "
                     "consistent with the zero cross-section this sample has by "
                     "construction, so it is not a usable denominator and the "
                     "shift is quoted against sum|w| = %.4g instead: %+.3g%%. "
-                    % (d_w, d_abs, sum_w, delta, z, sum_abs,
-                       100.0 * d_abs / sum_abs if sum_abs else float('nan')))
-        near, res, far = self._nwa_threshold_split(stats_list)
-        #no need dedicated note when very small
-        if 100.0 * d_w / sum_w < 0.5:
+                    % (d_w, d_abs, sum_w, delta, z, sum_abs, shift))
+        # No dedicated note when the excess is very small. ``shift`` is the
+        # per-cent the line has just quoted, so the smallness test is made
+        # against whichever denominator was legitimate: ``sum w`` when it is a
+        # usable one, ``sum |w|`` when the weights cancel -- it never divides
+        # by a cross-section that is consistent with zero, and it never calls
+        # a sample quiet on a ratio the line itself refused to print. A sample
+        # with no scale at all (every written weight zero) gives nan, and nan
+        # compares false here, so it keeps the full note rather than being
+        # declared small on an undefined ratio. The test is on the MAGNITUDE:
+        # a large negative shift -- which a sample with counter-events can
+        # have, with every carried factor still above 1 -- is not small.
+        if abs(shift) < self._OVERWEIGHT_QUIET_PERCENT:
             logger.info(msg)
-            return 
-            
+            return
+
+        near, res, far = self._nwa_threshold_split(stats_list)
         msg = (msg + self._nwa_threshold_note(near, res, far)).rstrip()
         # Calmer only when EVERY one of them is in one of the two explained
         # regions: the count in the head of the line is the total either way,

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -5241,6 +5241,27 @@ class MadSpinInterface(extended_cmd.Cmd):
                 if not pole or not width:
                     continue
                 qr = lhe_parser.FourMomentum(r)
+                # ``k`` is deliberately NOT restricted to status 1. `status`
+                # records whether MadSpin attached a decay to the particle, not
+                # whether it was radiated off the ``r`` line, so it is no proxy
+                # for the physics: the very same momenta would tag or not tag
+                # depending only on which particles the user asked to decay.
+                # A partner that is itself a decayed resonance is kept safe by
+                # arithmetic instead. ``s2 = (p_r + p_k)^2 >= (m_r + m_k)^2``
+                # for any two physical momenta, so the window can only be
+                # entered when ``m_r + m_k <= sqrt(M_r^2 + N M_r Gamma_r)``,
+                # and MadSpin never samples a mass more than ``BW_cut`` widths
+                # below its pole (decay.py: ``m_min = max(m - BW_cut w, 0.5)``).
+                # The tightest SM pair, ``r = Z`` with ``k = W``, still misses
+                # by 1.6 GeV at the default ``BW_cut = 15`` and only opens at
+                # ``BW_cut >= 15.4``; ``t`` with ``W`` needs 20.5 and ``t`` with
+                # ``t~`` needs 55.3 -- values MadSpin's own check already calls
+                # too large for the narrow-width approximation it factorises
+                # with. Where it does open (``W Z j`` with both bosons far off
+                # shell) the pairing is the genuine ``W* -> W Z`` production
+                # resonance anyway, so excluding status 2 would cost a true
+                # positive at exactly the BW_cut where it buys the false one.
+                # Pinned by TestProductionResonanceRegion's two-resonance tests.
                 for k in finals:
                     if k is r:
                         continue

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -3263,13 +3263,18 @@ variable rather than the code's mass-draw budget: there they are
 widths against 7.6 % of the sample; 25 % inside 50 against 49 %). What they
 have instead is a resonance at the **low corner of its own Breit-Wigner
 window**: 95 % of them have one virtuality in the bottom 2 % of its sampling
-variable (4 % by chance), at `(m - pole)/Gamma = -10.7`. Same divergence of
-`J`, reached by the mass draw rather than by the energy budget -- and reached
-there by design, since that corner is inside `BW_cut` and is sampled on
-purpose.
+variable (4 % by chance), at `(m - pole)/Gamma = -10.7`.
+
+**This is NOT the same divergence of `J`** -- that sentence stood here and was
+wrong. Measured on the offending trials, `J` is **1.07** on them (0.98 to 2.47)
+against a sample median `J_corner` of 1.22: the reshuffle does nothing. The
+whole factor is the matrix element, and the low corner matters because it is
+what makes the *production* process's own resonance reachable -- section 17,
+which measures it and reruns the `BW_cut` dependence it predicts.
 
 So the threshold picture is **exact for 2 -> 2 and empty for 2 -> 3**, and the
-population that dominates the overweight count is the second one.
+population that dominates the overweight count is the second one -- whose
+mechanism is section 17.
 
 ### The per-event constructions, re-measured against overflow removal
 
@@ -3539,3 +3544,281 @@ cross-section, branching-ratio and event-weight assertion in `tests/`:
   independent, which they are unless the truncation correlates with which events
   the equalization drops -- it cannot, since the drop probability depends only
   on the pdg's total BR.
+
+---
+
+## 17. The joint test's `2 -> 3` overweights: the production's own resonance
+
+Section 15 measured *where* the offshell overweights are and got the `2 -> 2`
+case right and the `2 -> 3` case wrong. It closed with
+
+> What they have instead is a resonance at the low corner of its own
+> Breit-Wigner window ... **Same divergence of `J`**, reached by the mass draw
+> rather than by the energy budget.
+
+The low corner is right. `J` is not. Measured on the offending events, the
+production reshuffling jacobian of the 265 over-bound trials is **1.07**
+(minimum 0.98, maximum 2.47) against a sample-wide `J_corner` median of 1.22 --
+it does nothing at all. The whole factor is in the matrix-element ratio, and
+the reason it is there is a mechanism that does not exist in `2 -> 2`.
+
+### The mechanism
+
+The joint weight of the offshell spinmodes is
+
+    w  =  ME . jac_BW . J^P . prod_k J^D_k ,
+    ME =  <rho_prod, rho_dec>(offshell) / [ prod_r (M_r Gamma_r)^2 ]
+          / [ |M_prod|^2(onshell) . prod_k |M_D_k|^2(pole) ]
+
+with `J^P` the production reshuffle and `J^D_k` the decay reshuffles. Once the
+production process has a final state **besides** the resonances -- a jet -- its
+matrix element contains a propagator of the resonance *itself*, on the line the
+jet is radiated from, at
+
+    (p_r + p_j)^2  =  m_r^2 + 2 p_r.p_j .
+
+With `m_r` **on** its pole that is `>= M_r^2` for any real jet: the singularity
+sits exactly on the boundary of phase space and is unreachable. Sampling `m_r`
+**below** the pole -- which is the whole point of `BW_cut` -- opens it. The
+equation `2 p_r.p_j = M_r^2 - m_r^2` acquires solutions, and on them the
+production matrix element is a Breit-Wigner peak of its own, regulated only by
+`M_r Gamma_r`. Physically the event is `p p > t t~` with a gluon radiated off an
+**on-shell** top, which MadSpin has drawn as `p p > t t~ j` with an off-shell
+one. The weight there is correct. It is simply enormous, and no single
+run-level bound dominates it.
+
+In `2 -> 2` the region does not exist. The only internal resonance line of
+`g g > t t~` is t-channel, `(p_in - p_r)^2 = m_r^2 - 2 p_in.p_r < m_r^2 <=
+M_r^2`, i.e. spacelike whatever the drawn virtuality; `q q~ > t t~` has no top
+propagator at all. **That asymmetry is the whole of the 26x.**
+
+### The measurement
+
+`p p > t t~ (j)` at 6.5+6.5 TeV, `spinmode madspin`, `unweighting joint`,
+`BW_cut = 15`, both tops to `w b`, seed 42. The runs reproduce section 15's
+numbers exactly (265/300 000, largest 48.9071 for `t t~ j`; 17/500 000, largest
+7.8090 for `t t~`), with every joint trial above `0.3 C` recording its own
+factorisation. Medians over the trials that went **over** the bound:
+
+| | `t t~` (2 -> 2), 17 of them | `t t~ j` (2 -> 3), 265 of them |
+|---|---|---|
+| `J^P`, the production reshuffle | **5.35** (4.3 to 34.8) | **1.07** (0.98 to 2.47) |
+| `J^D`, the decay reshuffles | 0.971 | 0.940 |
+| `jac_BW` | 0.924 | 0.958 |
+| `ME`, in units of the bound | 0.268 (0.24-0.32) | **everything else** |
+| `J_corner` of the event | 12.3 (sample 1.12) | 1.19 (sample 1.22) |
+| `sqrt(shat) - 2 m_t`, in summed widths | **0.09** (sample 45.6) | 96.5 (sample 124) |
+| `M(t t~) - 2 m_t`, in summed widths | 0.09 | **83.2** (sample 51.0) |
+
+Two different populations. The `2 -> 2` one is section 15's threshold story and
+is exactly as described there. The `2 -> 3` one is not near threshold in
+`sqrt(shat)` (it cannot be -- the sample's own minimum is 7.7 summed widths
+above `2 m_t`) and is *anti*-correlated with it in `M(t t~)`, which section 15
+already noticed and could not explain.
+
+The explanation is one number. For each over-bound trial, the distance of the
+internal propagator from its pole,
+
+    d  =  |(p_r + p_j)^2 - M_r^2| / (M_r Gamma_r) ,
+
+minimised over the two tops, on the reshuffled momenta the trial actually used:
+
+| | min | p10 | median | p90 | max |
+|---|---|---|---|---|---|
+| the 265 over-bound trials | **0.000** | 0.181 | **0.946** | 2.59 | **5.2** |
+| the 431 trials with `0.3 < w/C < 1` | 0.015 | 1.13 | 3.30 | 6.61 | 20.2 |
+
+**All 265 are inside `d = 5.2`; 51 % inside one.** `corr(ln w/C, ln d) =
+-0.62`. The largest overweight of the run -- factor 48.9 -- sits at `d = 0.12`,
+the second (30.95) at `d = 0.27`, the third (19.46) at `d = 0.94`. Their
+`sqrt(shat)` runs 578 to 1650 GeV: a *hard* jet, the opposite end of the sample
+from threshold, because `2 p_r.p_j` has to be large enough to make up
+`M_r^2 - m_r^2`.
+
+### Why the probe misses it, quantified
+
+The joint bound is `_combine_maxwgt` over a probe of `Nevents_for_max_weight`
+production events x `max_weight_ps_point` decay draws -- here 304 x 492 =
+149 568 draws, combined as `1.10 x (mean + 6.18 sd)` of the per-event maxima.
+The region it has to find is narrow in *both* directions:
+
+* the internal pole is reachable at some virtuality inside `BW_cut = 15` for
+  only **3.5 %** of the production events (it needs `2 p_r.p_j <= M_r^2 -
+  m_min^2`, i.e. a jet soft enough or collinear enough relative to the
+  resonance);
+* on those events, the band `d < 1` occupies a fraction **1.5e-3** of the
+  Breit-Wigner sampling variable.
+
+Averaged over all production events that is **5.15e-5 per mass draw** -- so the
+probe expects **7.7** such draws and the run expects **208** in its 4.04e6
+trials, against 265 over-bound trials observed. The probe does land in the
+region; what it cannot do is follow it. Eight draws scattered over eight of the
+304 events, at a random `d`, produce per-event maxima that a `mean + 6.18 sd`
+extrapolation of a *smooth* distribution flattens away -- and the weight is a
+power law in `d`, not a Gaussian tail.
+
+The root's position also matches the corner section 15 saw: the virtuality that
+puts the internal propagator on shell is at `(m - pole)/Gamma` between **-14.4
+and -8.1** (p10-p90, median -11.8), against the `-10.7` section 15 measured for
+the over-bound trials. It is the same thing seen from the other side.
+
+### The `BW_cut` prediction, run
+
+If the mechanism is right, closing the window below `~8` widths must close the
+population. Same sample, same seed, only `BW_cut` changed:
+
+| `BW_cut` | events that can reach the internal pole | overweights | largest factor | sigma shift | trials/event |
+|---|---|---|---|---|---|
+| 15 (the default) | 3.49 % | **265** | **48.91** | +0.245 % | 13.47 |
+| 10 | 0.91 % | **97** | 46.56 | +0.0943 % | 6.90 |
+| 5 | 0.03 % | **13** | **6.95** | +0.0052 % | 4.30 |
+
+The count falls by 20x and the *tail* collapses -- 48.9 to 6.9 -- exactly where
+the internal pole leaves the window. The 13 that survive at `BW_cut = 5` are the
+ordinary tail of the weight, not this population. (The full reachability scan,
+per `(resonance, jet)` pair: 0 % at `BW_cut = 3`, 0.05 % at 5, 0.6 % at 8, 1.8 %
+at 10, 6.8 % at 15, 13.8 % at 20, 21.2 % at 25, 30.5 % at 30. It is reachable at
+*some* virtuality for 26 % of the pairs, but usually 40+ widths below the pole.)
+
+### What it actually costs
+
+The overweight is **carried**, not clipped (section 14), so none of this is a
+bias. What it costs is variance and a shape:
+
+| | `t t~ j`, 300 000 events |
+|---|---|
+| cross-section the carry restores | **+0.245 %** |
+| `N_eff = (sum w)^2 / sum w^2` | 292 719 of 300 000, i.e. **-2.43 %** of the statistics |
+| ... of which the single largest event | **-0.77 %** |
+
+and it is not spread evenly. Binned in the *lower* of the two reconstructed top
+virtualities:
+
+| `min(m_t, m_t~)` | events | carried | excess | relative |
+|---|---|---|---|---|
+| 150.6 - 155 | 1283 | 98 | 318.3 | **+24.8 %** |
+| 155 - 160 | 2482 | 108 | 333.4 | **+13.4 %** |
+| 160 - 165 | 5635 | 46 | 73.6 | +1.3 % |
+| 165 - 170 | 25 943 | 13 | 8.4 | +0.03 % |
+| 170 - 176 | 262 811 | 0 | 0 | 0 |
+
+So the pre-#375 clipping was leaving the **low tail of the top lineshape 25 %
+low** on a `2 -> 3` sample, which is the number that says #375 was worth
+building. In `M(t t~)` the effect rises with the jet's hardness, as the
+mechanism says: +0.07 % below 400 GeV, +0.31 % at 500-700, **+0.84 % above
+1 TeV**.
+
+### The options, with their numbers
+
+**Raise the bound.** Zero overflows needs `C' = 48.9 C`, and the joint
+acceptance is `<w>/C` exactly, so the run goes from 13.5 to ~660 trials per
+event -- 352 s becomes ~5 h. Dead.
+
+**A per-event joint bound `C_e = J_corner(e) . K`**, the construction section 15
+built for the mass stage (`J^P` is monotone decreasing in every drawn mass, so
+`J_corner` -- the RAMBO kernel at the window's low corner, one Newton solve --
+dominates it), with `K` the run-level maximum of `w / J^P`. Measured on the
+runs' own trials:
+
+| | `t t~` (2 -> 2) | `t t~ j` (2 -> 3) |
+|---|---|---|
+| `K = max(w / J^P)` | **0.8072 C** | **44.3 C** |
+| `J_corner`: median / mean / max | 1.121 / 1.226 / 97.1 | 1.225 / - / 62.1 |
+| `C_e` median / **mean** | 0.905 C / **0.990 C** | 54.3 C / **62.3 C** |
+| trials over the shipped bound | 17 | 265 |
+| trials over `C_e` | **0** (worst `w/C_e` = 0.949) | 0 (worst 0.895) |
+| trials per accepted event, shipped -> per-event | **3.46 -> 3.43** | 13.5 -> ~840 |
+
+**It fixes the case that does not matter and destroys the one that does.** In
+`2 -> 2` the tail *is* `J^P`, so dividing it out shrinks the run-level factor to
+0.81 C: the per-event bound is **free** -- 3.43 trials per accepted event
+against the 3.46 the shipped bound predicts and the 3.44 the run reports -- and
+all 17 overflows are gone, with the worst weight it ever sees at 0.949 of its
+own bound. That row is measured over **all** 1 702 395 trials of the run, not a
+tail sample. In `2 -> 3` the tail is in `ME` and `J^P` is 1, so dividing by it
+shrinks nothing: `K` stays at the top of the tail and *every* event's bound is
+multiplied by it, a 62x slowdown. (There `K` is measured over the top 0.02 % of
+trials, so it is a lower bound on the true maximum -- which makes the verdict
+stronger, not weaker.)
+
+**A better probe** -- deliberately sampling the low-virtuality corner -- would
+find the region, and then hand back a bound 49x too large. The population is not
+a sampling gap that a bound can absorb; it is a genuine narrow peak of the
+production matrix element inside the sampled region.
+
+**Lower `BW_cut`.** Measured above, and it is the only lever that removes the
+*cause*. It is also a physics choice (it truncates the Breit-Wigner; section 16
+is about exactly that), so it belongs to the user and not to a default.
+
+### What was done
+
+Nothing to the bound. The report was taught the second region, the same way the
+tip of section 15 taught it the first:
+
+`_near_production_resonance(full_evt, production, evt_decayfile)` asks, on the
+event that carried an overweight and only on that event, whether some decayed
+resonance `r` and some other **production-level** final state `k` satisfy
+
+    |m^2(r + k) - M_r^2|  <=  _PRODUCTION_RESONANCE_WIDTHS . M_r Gamma_r
+
+with `_PRODUCTION_RESONANCE_WIDTHS = 10.0` -- twice the measured envelope of
+the whole population (max `d = 5.2`), so it is not fitted to one sample, and
+still specific: the fraction of joint trials that land inside it is 9.2e-4
+(2.9e-4 at a margin of 5, 5.3e-5 at 1) against an overweight rate of 6.6e-5, so
+it cannot silence an overweight by coincidence. It
+reads the *reshuffled* momenta, i.e. the virtuality the event actually carries,
+and it is `O(n^2)` four-vector arithmetic on an event that is already built.
+The first `len(production)` entries of `full_evt` are the production block
+(`add_decay_to_particle` appends decay products after them), so decay products
+cannot pair up with their own parent. It returns False rather than raising, for
+the same reason `_near_nwa_threshold` does: it decides how loudly a diagnostic
+prints.
+
+The end-of-run overweight line now splits three ways -- threshold, production
+resonance, neither, in that order of precedence -- quotes each, and drops from
+`warning` to `info` only when the third is empty.
+
+Verified rather than asserted, on the same sample, same seed, same `nb_core`:
+
+* `p p > t t~ j` tags **265 of 265** and the run's log goes from one WARNING to
+  none. At a margin of 5 it tagged 264 and kept the warning for the one at
+  `d = 5.2` -- which is the same population -- which is why the margin is 10.
+* the 300 000 written events are **byte-identical** to the base tip's (SHA-256
+  over the `<event>` blocks), and every number on the line is unchanged:
+  265/300 000, largest 48.9071, `+473984`, `+0.245 %`, 13.47 trials per event.
+  This is a report and nothing else.
+* `p p > t t~` is untouched: `2 -> 2` returns False at the `len(finals) < 3`
+  line before it looks at anything, so its 17 overweights keep going through
+  the threshold branch.
+* `tests/test_manager.py test_madspin -t0` is green at **473** tests (462 on
+  the base, 11 new: five on the predicate -- the `M Gamma`-in-`s` window, the
+  `2 -> 2` exclusion, an undecayed particle, the production-block slice, a
+  zero-width particle, and that it never raises -- and six on the split,
+  including that it moves no arithmetic).
+
+### What this does not cover
+
+* **`R = Tr(rho_off)/|M_prod|^2_on` in the sequential mass stage.** Section 15
+  measured it at `1.00000 +- 0.0119`, range `[0.733, 1.314]`, and called it
+  "the flattest thing in the weight". That was measured on `p p > t t~`, and
+  `R` is precisely the ratio that carries this resonance -- so on a `2 -> 3`
+  sample it must have the same heavy tail, and the mass-stage constructions
+  section 15 ranked on it would have to be re-ranked there. Not measured here:
+  `auto` sends two decaying particles to `joint`, so the mass stage is only
+  reached on a `2 -> 3` sample by an explicit `set unweighting sequential` or
+  from three decaying particles up.
+* **Higher multiplicity.** The mechanism gets *more* available with every extra
+  production-level parton (more `(r, k)` pairs, and pairs of partons as well as
+  single ones). Only `2 -> 3` was measured. The predicate tests pairs only.
+* **The `2 -> 2` per-event joint bound**, which the table above says is free
+  (3.43 trials/event against 3.46) and removes all 17 of its overflows, on the
+  full 1.7e6-trial sample. It is a change to a shipped bound, so it is left as
+  a recommendation and not taken here. Two things it would need before it
+  could be: `K` has to come from the probe rather than from the run (the probe
+  would have to record `w / J^P` per draw, which is one extra float and the
+  jacobian it already computes), and it has to keep the fallbacks
+  `_mass_stage_bound` already has -- an onshell propagator in the production
+  event, an empty window, a jacobian that is infeasible at the corner. Note it
+  is only ever *tighter* than a run-level `K . max_e J_corner`, never a
+  different distribution: redraw-until-accept makes the accepted density
+  independent of `C` for any `C >= max w`, the same argument as #377.

--- a/doc/madspin_sequential_plan.md
+++ b/doc/madspin_sequential_plan.md
@@ -3631,9 +3631,10 @@ minimised over the two tops, on the reshuffled momenta the trial actually used:
 **All 265 are inside `d = 5.2`; 51 % inside one.** `corr(ln w/C, ln d) =
 -0.62`. The largest overweight of the run -- factor 48.9 -- sits at `d = 0.12`,
 the second (30.95) at `d = 0.27`, the third (19.46) at `d = 0.94`. Their
-`sqrt(shat)` runs 578 to 1650 GeV: a *hard* jet, the opposite end of the sample
-from threshold, because `2 p_r.p_j` has to be large enough to make up
-`M_r^2 - m_r^2`.
+`sqrt(shat)` runs 578 to 1650 GeV -- nowhere near threshold, and what the jet
+has to do is *land* at `2 p_r.p_j = M_r^2 - m_r^2`, not be soft. Over the whole
+population `sqrt(shat)` is mildly *below* the sample's (median 634 against 716);
+the next subsection takes that apart.
 
 ### Why the probe misses it, quantified
 
@@ -3661,6 +3662,79 @@ The root's position also matches the corner section 15 saw: the virtuality that
 puts the internal propagator on shell is at `(m - pole)/Gamma` between **-14.4
 and -8.1** (p10-p90, median -11.8), against the `-10.7` section 15 measured for
 the over-bound trials. It is the same thing seen from the other side.
+
+### Is it `shat` near its minimum? Four readings, all refuted
+
+Asked directly, and worth the answer in full because "minimal `shat`" has
+several readings that are not equivalent. Populations: the **265 over-bound**
+trials, the **431 near-bound** ones (`0.3 < w/C < 1`, the control that is also
+heavy), and **40 000 ordinary mass draws** made on the run's own production
+events the way `_draw_mass_value` makes them.
+
+The sharp statistic is the AUC of each variable between over-bound and
+near-bound -- both heavy, so it isolates what makes a heavy trial *overflow* --
+beside the AUC between heavy and ordinary, which is what makes a trial heavy at
+all. `0.500` means the variable says nothing.
+
+| variable | over-bound vs near-bound | heavy vs ordinary draw |
+|---|---|---|
+| `sqrt(shat)` (readings 1 and 3) | 0.523 | 0.388 |
+| `sqrt(shat) - sum m_i'` (reading 2) | 0.525 | 0.408 |
+| `sum m_i' / sqrt(shat)` ("fill"; 1 = infeasible) | 0.474 | 0.575 |
+| `|chi - 1|` (reading 4) | 0.490 | **0.885** |
+| `(min m_i' - pole)/Gamma` | 0.452 | **0.013** |
+| **`d`** | **0.133** | **0.000** |
+
+**(1) and (3), `sqrt(shat)` near the sample or generation boundary.** Refuted,
+and the median alone did not say so -- the over-bound trials are mildly shifted
+*down* in `sqrt(shat)` (median 634 GeV against the sample's 716; 43.8 % below
+600 GeV against 31.9 %), the opposite of what section 17's "hard jet" reading
+suggests. But shifted is not concentrated: their own **minimum is 387.8 GeV**,
+19 GeV above the sample's 368.9, only **1.5 %** are below 400 GeV, and the
+sample's lowest `sqrt(shat)` decile holds 16.2 % of them -- a 1.6x enrichment.
+Against `d`, where 100 % of them are inside 5.2 and an ordinary draw sits at 196.
+The mild enrichment is a *consequence* of the mechanism: the resonance needs
+`2 p_r.p_j <= M_r^2 - m_min^2`, and a lower `sqrt(shat)` gives a softer jet
+more often. Reading 3 is reading 1 shifted by the `ptj = 20` cut and has the
+identical AUC; `sqrt(shat) - (2 m_t + 2 ptj)` is 43 GeV at the over-bound 5th
+percentile and 248 GeV at their median.
+
+**(2), `sqrt(shat)` minimal *given the drawn masses*.** The reading that would
+have been interesting, and it is refuted the hardest -- backwards, in fact:
+
+| | min slack | p1 | p5 | median | max fill |
+|---|---|---|---|---|---|
+| over-bound | **60.9 GeV** | 70.9 | 101.0 | 302.2 | **0.843** |
+| near-bound | 57.5 | 67.5 | 91.4 | 276.6 | 0.852 |
+| ordinary draw | **21.4** | 59.8 | 100.4 | 372.2 | **0.943** |
+
+The over-bound trials never come within 61 GeV of the reshuffle boundary and
+never fill more than 84 % of `sqrt(shat)`, while ordinary draws reach 21 GeV and
+94 %. They are **further** from their own boundary than a random draw is, and
+the AUC against the near-bound control is 0.525.
+
+**(4), the RAMBO solve near its edge.** `|chi - 1|` does separate heavy from
+ordinary strongly (AUC 0.885, median 0.021 against 0.0017) -- but that is the
+same statement as "a mass was drawn low", and it does **not** separate
+over-bound from near-bound (0.490). It is what makes `J^P` 1.07 instead of
+1.00, and 1.07 is not 48.9.
+
+**Does any of it add anything beyond `d`?** No. Spearman `r(ln w/C, d) =
+-0.688` on the 696 recorded trials; the partial correlations given `d` are
+`+0.14` for `sqrt(shat)`, `+0.15` for the slack, `-0.08` for `|chi - 1|`. The
+raw correlations are `+0.04` to `+0.05` before conditioning, so there is barely
+anything for `d` to be a proxy *of*. What residual there is has the **wrong
+sign** for the hypothesis: within quartiles of `d`, higher `sqrt(shat)` gives a
+higher weight (`r = +0.18` to `+0.22`), not a lower one.
+
+**Are "drawn low" and the mechanism two views of one thing?** No, and this is
+the number that settles it. Over ordinary draws, `Spearman(d, min m') = 0.007`
+-- independent. Of the draws that put a resonance more than 8 widths below its
+pole (2.02 % of draws, which is the corner section 15 identified), only
+**0.87 %** land inside `d < 5`. Drawing low is *necessary* -- it is what makes
+`2 p_r.p_j = M_r^2 - m_r^2` solvable at all -- and short of sufficient by a
+factor 115. The extra condition is on the jet, and it is the whole content of
+the mechanism.
 
 ### The `BW_cut` prediction, run
 
@@ -3807,6 +3881,13 @@ Verified rather than asserted, on the same sample, same seed, same `nb_core`:
   `auto` sends two decaying particles to `joint`, so the mass stage is only
   reached on a `2 -> 3` sample by an explicit `set unweighting sequential` or
   from three decaying particles up.
+* **The residual `sqrt(shat)` dependence.** After conditioning on `d` there is
+  a small positive one (partial `r = +0.14`, `+0.18` to `+0.22` within `d`
+  quartiles): at fixed distance from the internal pole, a harder event gives a
+  bigger weight. Plausibly the resonant diagram's share of the matrix element
+  growing against the non-resonant background, but not measured -- it would
+  need the diagram-level decomposition, which the density path does not expose.
+  It is the wrong sign for a threshold reading either way.
 * **Higher multiplicity.** The mechanism gets *more* available with every extra
   production-level parton (more `(r, k)` pairs, and pairs of partons as well as
   single ones). Only `2 -> 3` was measured. The predicate tests pairs only.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3017,6 +3017,8 @@ class TestOverweightReport(unittest.TestCase):
     class _Stub(object):
         _OVERWEIGHT_MIN_Z = \
             interface_madspin.MadSpinInterface._OVERWEIGHT_MIN_Z
+        _OVERWEIGHT_QUIET_PERCENT = \
+            interface_madspin.MadSpinInterface._OVERWEIGHT_QUIET_PERCENT
         _report_overweight = \
             interface_madspin.MadSpinInterface._report_overweight
         _NWA_THRESHOLD_WIDTHS = \
@@ -3053,13 +3055,19 @@ class TestOverweightReport(unittest.TestCase):
 
     def test_a_counter_event_sample_quotes_the_signed_shift(self):
         """The same three carried events, but on counter-events: the shift is
-        negative even though the factors are all above 1."""
+        negative even though the factors are all above 1.
+
+        The sign is the whole content of this test, so it is pinned both ways
+        round: the negative number is printed, and the magnitude is not printed
+        in its place.
+        """
         msg = self._log(n_written=1000, nb_overweight=3, max_overweight=2.0,
                         sum_overweight_dw=-3.0, sum_overweight_dabs=3.0,
                         sum_nom=500.0, sum_abs_nom=1000.0, sum_sq_nom=1000.0)
         self.assertIn("of the sample's cross-section", msg)
         self.assertIn('-0.6%', msg)          # -3/500, and negative
-        self.assertIn('-3', msg)
+        self.assertNotIn('+0.6%', msg)       # not the magnitude
+        self.assertIn('3/1000 written events', msg)
 
     def test_a_cancelling_sample_refuses_the_cross_section_as_a_denominator(self):
         """pure_interference: sum w is zero by construction, so it must not be
@@ -3074,12 +3082,21 @@ class TestOverweightReport(unittest.TestCase):
         self.assertIn('+5%', msg)            # 50/1000
 
     def test_an_all_zero_sample_does_not_divide_by_zero(self):
-        """Degenerate to the last digit: every written weight is 0."""
-        msg = self._log(n_written=10, nb_overweight=2, max_overweight=3.0,
+        """Degenerate to the last digit: every written weight is 0.
+
+        Neither the quoted shift nor the test that decides how much to print
+        may divide by that. The ratio is undefined, so it is said and not
+        raised -- and an undefined ratio is not 'small': the line keeps its
+        full note rather than going quiet on a number nobody could compute.
+        """
+        msg = self._log(n_written=10, nb_overweight=2, nb_overweight_nwa=1,
+                        max_overweight=3.0,
                         sum_overweight_dw=0.0, sum_overweight_dabs=0.0,
                         sum_nom=0.0, sum_abs_nom=0.0, sum_sq_nom=0.0)
         self.assertIn('quoted against sum|w|', msg)
         self.assertIn('nan', msg)            # said, not raised
+        # and the region note is still there: an undefined ratio is not small
+        self.assertIn('The other 1 are NOT in that region', msg)
 
     def test_nothing_carried_says_so_and_stops(self):
         msg = self._log(n_written=1000, sum_nom=1000.0, sum_abs_nom=1000.0,
@@ -3222,7 +3239,13 @@ class TestNwaThresholdRegion(unittest.TestCase):
 
 class TestNwaThresholdReport(unittest.TestCase):
     """The end-of-run split: what it says, how loudly, and what it must not
-    change."""
+    change.
+
+    Everything here is the LOUD regime -- an excess big enough to be worth
+    explaining -- so the fixture is built to clear
+    ``_OVERWEIGHT_QUIET_PERCENT``. The other regime is
+    ``TestOverweightQuietBelowThreshold``.
+    """
 
     def _log(self, **stats):
         base = dict(nb_overweight=0, nb_overweight_nwa=0,
@@ -3235,8 +3258,11 @@ class TestNwaThresholdReport(unittest.TestCase):
             TestOverweightReport._Stub()._report_overweight([base], n_written)
         return caught
 
-    _SAMPLE = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=3.0,
-                   sum_overweight_dabs=3.0, sum_nom=1000.0,
+    # 30/1000 = +3%, comfortably above _OVERWEIGHT_QUIET_PERCENT: below it the
+    # report prints the head of the line and stops, and none of the tests in
+    # this class would be exercising anything.
+    _SAMPLE = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=30.0,
+                   sum_overweight_dabs=30.0, sum_nom=1000.0,
                    sum_abs_nom=1000.0, sum_sq_nom=1000.0)
 
     def test_all_of_them_at_threshold_is_reported_calmly(self):
@@ -3245,7 +3271,8 @@ class TestNwaThresholdReport(unittest.TestCase):
                            **self._SAMPLE)
         msg = '\n'.join(caught.messages)
         self.assertEqual(caught.levels, [logging.INFO])
-        self.assertIn('invalid by construction', msg)
+        self.assertIn('3 of them are production events within one summed '
+                      'width of the sum-of-poles threshold', msg)
         self.assertIn('None of them is outside it', msg)
         # the TOTAL is still the first number on the line
         self.assertIn('3/1000 written events', msg)
@@ -3270,7 +3297,7 @@ class TestNwaThresholdReport(unittest.TestCase):
                            **self._SAMPLE)
         msg = '\n'.join(caught.messages)
         self.assertEqual(caught.levels, [logging.WARNING])
-        self.assertNotIn('invalid by construction', msg)
+        self.assertNotIn('production events within', msg)
         self.assertIn('3/1000 written events', msg)
 
     def test_the_split_does_not_move_the_cross_section_shift(self):
@@ -3281,7 +3308,7 @@ class TestNwaThresholdReport(unittest.TestCase):
         tagged = '\n'.join(self._log(nb_overweight=3, nb_overweight_nwa=3,
                                      **self._SAMPLE).messages)
         for piece in ('3/1000 written events', 'largest factor 2.0000',
-                      "+0.3% of the sample's cross-section"):
+                      "+3% of the sample's cross-section"):
             self.assertIn(piece, plain)
             self.assertIn(piece, tagged)
 
@@ -3292,7 +3319,7 @@ class TestNwaThresholdReport(unittest.TestCase):
         self.assertEqual(caught.levels, [logging.INFO])
         self.assertIn('0/1000 written events carried a non-unit weight',
                       '\n'.join(caught.messages))
-        self.assertNotIn('invalid by construction',
+        self.assertNotIn('production events within',
                          '\n'.join(caught.messages))
 
 
@@ -3544,6 +3571,10 @@ class TestProductionResonanceReport(unittest.TestCase):
     is the stronger statement; the line drops to info only when EVERY carried
     overweight is explained by one of the two; and none of it may move an
     arithmetic number.
+
+    As in ``TestNwaThresholdReport``, this is the loud regime: the fixture is
+    built to clear ``_OVERWEIGHT_QUIET_PERCENT`` so that the split is reached
+    at all.
     """
 
     def _log(self, **stats):
@@ -3557,8 +3588,9 @@ class TestProductionResonanceReport(unittest.TestCase):
             TestOverweightReport._Stub()._report_overweight([base], n_written)
         return caught
 
-    _SAMPLE = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=3.0,
-                   sum_overweight_dabs=3.0, sum_nom=1000.0,
+    # +3%: see TestNwaThresholdReport._SAMPLE.
+    _SAMPLE = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=30.0,
+                   sum_overweight_dabs=30.0, sum_nom=1000.0,
                    sum_abs_nom=1000.0, sum_sq_nom=1000.0)
 
     def test_all_of_them_on_a_production_resonance_is_reported_calmly(self):
@@ -3568,7 +3600,7 @@ class TestProductionResonanceReport(unittest.TestCase):
         msg = '\n'.join(caught.messages)
         self.assertEqual(caught.levels, [logging.INFO])
         self.assertIn("resonance's own pole", msg)
-        self.assertIn('Lowering BW_cut', msg)
+        self.assertIn('within 10 widths of', msg)   # the named region width
         self.assertIn('None of them is outside it', msg)
         self.assertIn('3/1000 written events', msg)
 
@@ -3601,6 +3633,8 @@ class TestProductionResonanceReport(unittest.TestCase):
         msg = '\n'.join(caught.messages)
         self.assertEqual(caught.levels, [logging.WARNING])
         self.assertIn('The other 1 are NOT in either region', msg)
+        # the two clauses are still two sentences, not one run together
+        self.assertIn("own pole. The other 1 are NOT", msg)
 
     def test_the_split_does_not_move_the_cross_section_shift(self):
         plain = '\n'.join(self._log(nb_overweight=3,
@@ -3608,9 +3642,163 @@ class TestProductionResonanceReport(unittest.TestCase):
         tagged = '\n'.join(self._log(nb_overweight=3, nb_overweight_res=3,
                                      **self._SAMPLE).messages)
         for piece in ('3/1000 written events', 'largest factor 2.0000',
-                      "+0.3% of the sample's cross-section"):
+                      "+3% of the sample's cross-section"):
             self.assertIn(piece, plain)
             self.assertIn(piece, tagged)
+
+
+class TestOverweightQuietBelowThreshold(unittest.TestCase):
+    """The other regime of ``_report_overweight``: below
+    ``_OVERWEIGHT_QUIET_PERCENT`` the line is one short info statement and
+    there is no region breakdown at all.
+
+    The head of the line has already said how many events carried a non-unit
+    weight, what the largest factor was and what the whole thing was worth; a
+    paragraph explaining WHY a per-mille happened only buries that. So the
+    smallness of the shift, not the region split, decides whether the note is
+    printed -- and that is deliberately true even when the overweights are
+    unexplained, which is the one case where the old code always warned. It is
+    pinned here rather than left to be rediscovered in a bug report.
+
+    What may NOT change across the threshold is the arithmetic: the counts and
+    the quoted shift in the head of the line are the same either side of it,
+    and the total is still the first number on the line. Only the volume moves.
+    """
+
+    def _log(self, **stats):
+        base = dict(nb_overweight=0, nb_overweight_nwa=0, nb_overweight_res=0,
+                    sum_overweight_dw=0.0, sum_overweight_dabs=0.0,
+                    sum_nom=0.0, sum_abs_nom=0.0, sum_sq_nom=0.0,
+                    max_overweight=1.0, nb_overflow_joint=0)
+        base.update(stats)
+        n_written = base.pop('n_written')
+        with _CapturedMadSpinLog() as caught:
+            TestOverweightReport._Stub()._report_overweight([base], n_written)
+        return caught
+
+    # 3/1000 = +0.3%, below the threshold. _LOUD is the same sample with the
+    # excess scaled up to +3% and nothing else touched, so the pair isolates
+    # the threshold and only the threshold.
+    _QUIET = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=3.0,
+                  sum_overweight_dabs=3.0, sum_nom=1000.0,
+                  sum_abs_nom=1000.0, sum_sq_nom=1000.0)
+    _LOUD = dict(_QUIET, sum_overweight_dw=30.0, sum_overweight_dabs=30.0)
+
+    def test_the_fixtures_sit_either_side_of_the_named_threshold(self):
+        """The two regimes are separated by a named constant, not by a number
+        that happens to be spelled the same in the test and in the source."""
+        quiet = interface_madspin.MadSpinInterface._OVERWEIGHT_QUIET_PERCENT
+        self.assertLess(100.0 * self._QUIET['sum_overweight_dw']
+                        / self._QUIET['sum_nom'], quiet)
+        self.assertGreaterEqual(100.0 * self._LOUD['sum_overweight_dw']
+                                / self._LOUD['sum_nom'], quiet)
+
+    def test_a_small_shift_says_one_short_line_and_no_breakdown(self):
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_nwa=3,
+                           **self._QUIET)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn('3/1000 written events', msg)
+        self.assertIn("+0.3% of the sample's cross-section", msg)
+        self.assertNotIn('production events within', msg)
+        self.assertNotIn("resonance's own pole", msg)
+        self.assertNotIn('None of them is outside', msg)
+
+    def test_a_small_unexplained_shift_is_quiet_too(self):
+        """Not one of them is in either explained region -- the case that used
+        to be a WARNING with 'raise nb_sigma' on it. It is now an info line
+        with no note, because 0.3% of the cross-section is not worth the
+        paragraph. Deliberate, and pinned so that it is a decision and not a
+        regression.
+        """
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_nwa=2, **self._QUIET)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn('3/1000 written events', msg)
+        self.assertNotIn('raise nb_sigma', msg)
+        self.assertNotIn('are NOT in', msg)
+
+    def test_the_same_sample_above_the_threshold_gets_the_breakdown(self):
+        """Same counts, same regions, ten times the excess: the note is back
+        and so is the warning."""
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_nwa=2, **self._LOUD)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.WARNING])
+        self.assertIn('3/1000 written events', msg)
+        self.assertIn('The other 1 are NOT in that region', msg)
+        self.assertIn('raise nb_sigma', msg)
+
+    def test_exactly_at_the_threshold_gets_the_breakdown(self):
+        """5/1000 = 0.5% exactly. The comparison is strict, so the boundary
+        belongs to the regime that says more."""
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_nwa=3,
+                           **dict(self._QUIET, sum_overweight_dw=5.0,
+                                  sum_overweight_dabs=5.0))
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn('production events within',
+                      '\n'.join(caught.messages))
+
+    def test_a_large_negative_shift_is_not_small(self):
+        """A sample with counter-events can lose 3% of its cross-section with
+        every carried factor still above 1. That is not 'very small' -- the
+        test is on the magnitude of the shift, not on its signed value."""
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_nwa=2,
+                           **dict(self._QUIET, sum_overweight_dw=-30.0,
+                                  sum_overweight_dabs=30.0))
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.WARNING])
+        self.assertIn("-3% of the sample's cross-section", msg)
+        self.assertIn('raise nb_sigma', msg)
+
+    def test_a_cancelling_sample_is_measured_against_the_scale_it_quoted(self):
+        """sum w is consistent with zero here, so the line quotes the shift
+        against sum|w|; the smallness test has to use that same number and
+        must never divide by the cross-section it just refused. 1/1000 of
+        sum|w| is small, so this is one short line."""
+        import logging
+        caught = self._log(n_written=1000, nb_overweight=3,
+                           max_overweight=2.0, sum_overweight_dw=-2.0,
+                           sum_overweight_dabs=1.0, sum_nom=20.0,
+                           sum_abs_nom=1000.0, sum_sq_nom=10000.0)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn('quoted against sum|w|', msg)
+        self.assertIn('+0.1%', msg)
+        self.assertNotIn('are NOT in', msg)
+
+    def test_a_cancelling_sample_with_a_big_excess_still_gets_the_note(self):
+        """Same sample, fifty times the excess: 5% of sum|w| is not small, and
+        the note comes back even though the cross-section was never a usable
+        denominator."""
+        import logging
+        caught = self._log(n_written=1000, nb_overweight=3,
+                           nb_overweight_nwa=2,
+                           max_overweight=2.0, sum_overweight_dw=-2.0,
+                           sum_overweight_dabs=50.0, sum_nom=20.0,
+                           sum_abs_nom=1000.0, sum_sq_nom=10000.0)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.WARNING])
+        self.assertIn('quoted against sum|w|', msg)
+        self.assertIn('raise nb_sigma', msg)
+
+    def test_the_head_of_the_line_does_not_move_across_the_threshold(self):
+        """Only the volume changes. Everything the head of the line says about
+        the counts, the largest factor and the denominator is character for
+        character the same, and the total is the first number on it."""
+        quiet = '\n'.join(self._log(nb_overweight=3, nb_overweight_nwa=3,
+                                    **self._QUIET).messages)
+        loud = '\n'.join(self._log(nb_overweight=3, nb_overweight_nwa=3,
+                                   **self._LOUD).messages)
+        head = ('MadSpin overweight safety net: 3/1000 written events (0.3%) '
+                'carried a non-unit weight because a trial weight exceeded '
+                'its accept/reject bound (largest factor 2.0000). ')
+        self.assertTrue(quiet.startswith(head), quiet)
+        self.assertTrue(loud.startswith(head), loud)
 
 
 class TestNwaThresholdSequentialReport(unittest.TestCase):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -2743,6 +2743,13 @@ class TestUnweightRangeWeightPaths(unittest.TestCase):
             interface_madspin.MadSpinInterface._near_nwa_threshold
         _NWA_THRESHOLD_WIDTHS = \
             interface_madspin.MadSpinInterface._NWA_THRESHOLD_WIDTHS
+        # ... and, when that one says no, the production process's own
+        # resonance. Same contract: it is handed the event the loop built and
+        # must answer for any of them without a banner.
+        _near_production_resonance = \
+            interface_madspin.MadSpinInterface._near_production_resonance
+        _PRODUCTION_RESONANCE_WIDTHS = \
+            interface_madspin.MadSpinInterface._PRODUCTION_RESONANCE_WIDTHS
 
         def __init__(self, weights, pure_interference=''):
             self.options = interface_madspin.MadSpinOptions()
@@ -3020,6 +3027,8 @@ class TestOverweightReport(unittest.TestCase):
             interface_madspin.MadSpinInterface._nwa_threshold_note
         _nwa_threshold_margin = \
             interface_madspin.MadSpinInterface._nwa_threshold_margin
+        _PRODUCTION_RESONANCE_WIDTHS = \
+            interface_madspin.MadSpinInterface._PRODUCTION_RESONANCE_WIDTHS
 
     def _log(self, **stats):
         base = dict(nb_overweight=0, sum_overweight_dw=0.0,
@@ -3287,6 +3296,211 @@ class TestNwaThresholdReport(unittest.TestCase):
                          '\n'.join(caught.messages))
 
 
+class TestProductionResonanceRegion(unittest.TestCase):
+    """``_near_production_resonance``: the second region an overweight can come
+    from, and the one that only exists from ``2 -> 3`` up.
+
+    Once the production process has a final state besides the resonances, its
+    matrix element carries a propagator of the resonance itself on the line the
+    extra parton is radiated from, at ``(p_r + p_j)^2 = m_r^2 + 2 p_r.p_j``.
+    On the pole that is ``>= M_r^2`` for any real parton, so it is unreachable;
+    sampling ``m_r`` below the pole opens it, and there the production matrix
+    element is a Breit-Wigner peak that no single run-level bound dominates.
+    The predicate says whether the accepted event sits on it.
+    """
+
+    POLE, WIDTH = 173.0, 1.5
+
+    class _Shim(object):
+        _near_production_resonance = \
+            interface_madspin.MadSpinInterface._near_production_resonance
+        _PRODUCTION_RESONANCE_WIDTHS = \
+            interface_madspin.MadSpinInterface._PRODUCTION_RESONANCE_WIDTHS
+
+        def __init__(self, banner):
+            self.banner = banner
+
+    def _shim(self, table=None):
+        if table is None:
+            table = {('mass', 6): self.POLE, ('decay', 6): self.WIDTH}
+        return self._Shim(TestNwaThresholdRegion._Banner(table))
+
+    def _event(self, m_res, s_rj, n_final=3, res_status=2):
+        """A production event whose resonance ``r`` (mass ``m_res``, status
+        ``res_status``) and massless parton ``j`` have ``(p_r + p_j)^2 = s_rj``.
+
+        Built in the ``r j`` rest frame -- the predicate only ever reads
+        pairwise invariant masses, so nothing here needs the rest of the event
+        to balance."""
+        M = math.sqrt(s_rj)
+        pstar = (s_rj - m_res ** 2) / (2 * M)
+        r = lhe_parser.FourMomentum(math.sqrt(m_res ** 2 + pstar ** 2),
+                                    0., 0., pstar)
+        j = lhe_parser.FourMomentum(pstar, 0., 0., -pstar)
+        far = lhe_parser.FourMomentum(math.sqrt(self.POLE ** 2 + 4e6),
+                                      0., 2000., 0.)
+        mom = [(6, res_status, m_res, r), (21, 1, 0.0, j)]
+        if n_final > 2:
+            mom.append((-6, 2, self.POLE, far))
+        mom = mom[:n_final]
+        lines = ['%d 1 1.0 100.0 0.0075 0.118' % (len(mom) + 2)]
+        for sign in (1, -1):
+            lines.append('21 -1 0 0 501 502 0. 0. %.15e %.15e 0.0 0. 9.'
+                         % (sign * 1000.0, 1000.0))
+        for pdg, status, mass, q in mom:
+            lines.append('%d %d 1 2 501 502 %.15e %.15e %.15e %.15e %.15e 0. 9.'
+                         % (pdg, status, q.px, q.py, q.pz, q.E, mass))
+        evt = lhe_parser.Event()
+        evt.parse('\n'.join(lines))
+        return evt
+
+    @staticmethod
+    def _pool(*pdgs):
+        return dict((pdg, ['a decay event']) for pdg in pdgs)
+
+    def test_the_window_is_M_times_Gamma_in_the_invariant_MASS_SQUARED(self):
+        """The propagator's own scale: ``|s - M^2| <= N M Gamma``, not
+        ``|m - M| <= N Gamma``. The two differ by a factor 2M."""
+        shim = self._shim()
+        n = shim._PRODUCTION_RESONANCE_WIDTHS
+        half = n * self.POLE * self.WIDTH
+        for delta, expected in ((0.0, True), (0.9 * half, True),
+                                (1.1 * half, False), (50 * half, False)):
+            evt = self._event(160.0, self.POLE ** 2 + delta)
+            self.assertEqual(
+                shim._near_production_resonance(evt, list(evt),
+                                                self._pool(6, -6)),
+                expected, 'delta = %g against a half-window of %g'
+                % (delta, half))
+
+    def test_a_two_to_two_event_can_never_be_in_it(self):
+        """No extra parton, so the only internal resonance line is t-channel
+        and spacelike. Even an event whose two finals happen to reconstruct the
+        pole is rejected, because the region does not exist there."""
+        shim = self._shim()
+        evt = self._event(160.0, self.POLE ** 2, n_final=2)
+        self.assertFalse(
+            shim._near_production_resonance(evt, list(evt), self._pool(6, -6)))
+
+    def test_an_undecayed_particle_is_not_a_resonance_of_this_run(self):
+        """Status 1 (nothing was attached to it) and an empty pool are both
+        'this event does not decay that', so neither can tag."""
+        shim = self._shim()
+        on_pole = self.POLE ** 2
+        self.assertFalse(shim._near_production_resonance(
+            self._event(160.0, on_pole, res_status=1), [0] * 5,
+            self._pool(6, -6)))
+        self.assertFalse(shim._near_production_resonance(
+            self._event(160.0, on_pole), [0] * 5, {6: [], -6: ['x']}))
+
+    def test_it_only_looks_at_the_production_block(self):
+        """The slice is ``len(production)``: decay products appended after it
+        must not be able to pair up with the resonance."""
+        shim = self._shim()
+        evt = self._event(160.0, self.POLE ** 2)
+        # 2 initial + 3 final; cutting the production block to the first four
+        # entries drops the parton the resonance would have paired with
+        self.assertTrue(
+            shim._near_production_resonance(evt, [0] * 5, self._pool(6, -6)))
+        self.assertFalse(
+            shim._near_production_resonance(evt, [0] * 3, self._pool(6, -6)))
+
+    def test_it_never_raises(self):
+        """It decides how loudly a diagnostic prints, so a missing parameter,
+        a missing banner or nonsense must come back False."""
+        evt = self._event(160.0, self.POLE ** 2)
+        self.assertFalse(self._shim({})._near_production_resonance(
+            evt, list(evt), self._pool(6, -6)))
+        broken = TestProductionResonanceRegion._Shim(None)
+        self.assertFalse(broken._near_production_resonance(
+            evt, list(evt), self._pool(6, -6)))
+        self.assertFalse(self._shim()._near_production_resonance(
+            None, [], self._pool(6, -6)))
+
+    def test_a_zero_width_particle_cannot_be_on_its_own_pole(self):
+        """No width, no Breit-Wigner: the propagator is a pole and not a peak,
+        and the phase-space point is measure zero rather than enhanced."""
+        shim = self._shim({('mass', 6): self.POLE, ('decay', 6): 0.0})
+        self.assertFalse(shim._near_production_resonance(
+            self._event(160.0, self.POLE ** 2), [0] * 5, self._pool(6, -6)))
+
+
+class TestProductionResonanceReport(unittest.TestCase):
+    """The three-way split of the carried overweights, and what it changes.
+
+    Threshold wins over the production resonance when an event is both, which
+    is the stronger statement; the line drops to info only when EVERY carried
+    overweight is explained by one of the two; and none of it may move an
+    arithmetic number.
+    """
+
+    def _log(self, **stats):
+        base = dict(nb_overweight=0, nb_overweight_nwa=0, nb_overweight_res=0,
+                    sum_overweight_dw=0.0, sum_overweight_dabs=0.0,
+                    sum_nom=0.0, sum_abs_nom=0.0, sum_sq_nom=0.0,
+                    max_overweight=1.0, nb_overflow_joint=0)
+        base.update(stats)
+        n_written = base.pop('n_written')
+        with _CapturedMadSpinLog() as caught:
+            TestOverweightReport._Stub()._report_overweight([base], n_written)
+        return caught
+
+    _SAMPLE = dict(n_written=1000, max_overweight=2.0, sum_overweight_dw=3.0,
+                   sum_overweight_dabs=3.0, sum_nom=1000.0,
+                   sum_abs_nom=1000.0, sum_sq_nom=1000.0)
+
+    def test_all_of_them_on_a_production_resonance_is_reported_calmly(self):
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_res=3,
+                           **self._SAMPLE)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn("resonance's own pole", msg)
+        self.assertIn('Lowering BW_cut', msg)
+        self.assertIn('None of them is outside it', msg)
+        self.assertIn('3/1000 written events', msg)
+
+    def test_one_of_them_in_neither_region_keeps_the_warning(self):
+        import logging
+        caught = self._log(nb_overweight=3, nb_overweight_res=2,
+                           **self._SAMPLE)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.WARNING])
+        self.assertIn('The other 1 are NOT in that region', msg)
+        self.assertIn('raise nb_sigma', msg)
+
+    def test_both_regions_are_quoted_and_add_up_to_the_total(self):
+        import logging
+        caught = self._log(nb_overweight=5, nb_overweight_nwa=2,
+                           nb_overweight_res=3, **self._SAMPLE)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.INFO])
+        self.assertIn('2 of them are production events within one summed '
+                      'width of', msg)
+        self.assertIn('3 of them have a resonance and another '
+                      'production-level final state', msg)
+        self.assertIn('None of them is outside those', msg)
+        self.assertIn('5/1000 written events', msg)
+
+    def test_both_regions_with_a_leftover_names_both_and_warns(self):
+        import logging
+        caught = self._log(nb_overweight=6, nb_overweight_nwa=2,
+                           nb_overweight_res=3, **self._SAMPLE)
+        msg = '\n'.join(caught.messages)
+        self.assertEqual(caught.levels, [logging.WARNING])
+        self.assertIn('The other 1 are NOT in either region', msg)
+
+    def test_the_split_does_not_move_the_cross_section_shift(self):
+        plain = '\n'.join(self._log(nb_overweight=3,
+                                    **self._SAMPLE).messages)
+        tagged = '\n'.join(self._log(nb_overweight=3, nb_overweight_res=3,
+                                     **self._SAMPLE).messages)
+        for piece in ('3/1000 written events', 'largest factor 2.0000',
+                      "+0.3% of the sample's cross-section"):
+            self.assertIn(piece, plain)
+            self.assertIn(piece, tagged)
+
+
 class TestNwaThresholdSequentialReport(unittest.TestCase):
     """The sequential accept/reject's own stage-exceedance line takes the same
     split.
@@ -3307,6 +3521,8 @@ class TestNwaThresholdSequentialReport(unittest.TestCase):
             interface_madspin.MadSpinInterface._nwa_threshold_note
         _nwa_threshold_margin = \
             interface_madspin.MadSpinInterface._nwa_threshold_margin
+        _PRODUCTION_RESONANCE_WIDTHS = \
+            interface_madspin.MadSpinInterface._PRODUCTION_RESONANCE_WIDTHS
 
         def __init__(self):
             self.options = {'density_tolerance': 1e-4}

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -3424,6 +3424,118 @@ class TestProductionResonanceRegion(unittest.TestCase):
         self.assertFalse(shim._near_production_resonance(
             self._event(160.0, self.POLE ** 2), [0] * 5, self._pool(6, -6)))
 
+    # ------------------------------------------------------------------
+    # The partner ``k`` is any other production-level final state, status 1
+    # OR status 2. What keeps a second DECAYED resonance from being mistaken
+    # for the radiated parton is not a status test -- `status` only records
+    # whether MadSpin attached a decay -- but the fact that two resonances
+    # are too heavy to put their pair mass on one of their own poles.
+    # ------------------------------------------------------------------
+    Z_POLE, Z_WIDTH = 91.188, 2.44140351     # default MG5 SM param_card
+    W_POLE, W_WIDTH = 80.419, 2.04759951
+
+    @staticmethod
+    def _bw_floor(pole, width, bw_cut):
+        """The lowest mass MadSpin can hand this predicate: decay.py's own
+        ``m_min = max(mpole - BW_cut * w, 0.5)``."""
+        return max(pole - bw_cut * width, 0.5)
+
+    def _pair_event(self, specs, s2):
+        """``specs`` is two ``(pdg, status, mass)`` production-level finals,
+        put back to back with ``(p_0 + p_1)^2 = s2``; a massless parton is
+        parked far away so the event is ``2 -> 3`` and cannot itself pair with
+        anything near a pole."""
+        m0, m1 = specs[0][2], specs[1][2]
+        M = math.sqrt(s2)
+        lam = (s2 - (m0 + m1) ** 2) * (s2 - (m0 - m1) ** 2)
+        pstar = math.sqrt(max(lam, 0.0)) / (2 * M)
+        mom = [lhe_parser.FourMomentum(math.sqrt(m0 ** 2 + pstar ** 2),
+                                       0., 0., pstar),
+               lhe_parser.FourMomentum(math.sqrt(m1 ** 2 + pstar ** 2),
+                                       0., 0., -pstar),
+               lhe_parser.FourMomentum(2000., 0., 2000., 0.)]
+        full = list(specs) + [(21, 1, 0.0)]
+        lines = ['%d 1 1.0 100.0 0.0075 0.118' % (len(full) + 2)]
+        for sign in (1, -1):
+            lines.append('21 -1 0 0 501 502 0. 0. %.15e %.15e 0.0 0. 9.'
+                         % (sign * 5000.0, 5000.0))
+        for (pdg, status, mass), q in zip(full, mom):
+            lines.append('%d %d 1 2 501 502 %.15e %.15e %.15e %.15e %.15e 0. 9.'
+                         % (pdg, status, q.px, q.py, q.pz, q.E, mass))
+        evt = lhe_parser.Event()
+        evt.parse('\n'.join(lines))
+        return evt
+
+    def test_two_decayed_resonances_are_too_heavy_to_fake_the_pole(self):
+        """``s2 = (p_r + p_k)^2 >= (m_r + m_k)^2`` for any two physical
+        momenta, so the window is reachable only when
+
+            m_r + m_k  <=  sqrt(M_r^2 + N M_r Gamma_r) ,
+
+        and a mass MadSpin sampled is never more than ``BW_cut`` widths below
+        its pole. The tightest pair in the SM is ``r = Z`` with ``k = W``, and
+        even with BOTH pushed to the floor of the window it misses at the
+        default ``BW_cut = 15`` -- by 1.6 GeV, which is the whole margin there
+        is, so this is pinned rather than assumed. It opens at ``BW_cut`` about
+        15.4, where MadSpin's own check already calls the narrow-width
+        approximation it factorises with invalid; and there the pairing is the
+        real ``W* -> W Z`` production resonance, so a status test would lose a
+        true positive at exactly the setting where it gains the false one.
+        """
+        shim = self._shim({('mass', 23): self.Z_POLE, ('decay', 23): self.Z_WIDTH,
+                           ('mass', 24): self.W_POLE, ('decay', 24): self.W_WIDTH})
+        top = math.sqrt(self.Z_POLE ** 2 + shim._PRODUCTION_RESONANCE_WIDTHS
+                        * self.Z_POLE * self.Z_WIDTH)
+        for bw_cut, expected in ((5.0, False), (10.0, False), (15.0, False),
+                                 (20.0, True), (25.0, True)):
+            mz = self._bw_floor(self.Z_POLE, self.Z_WIDTH, bw_cut)
+            mw = self._bw_floor(self.W_POLE, self.W_WIDTH, bw_cut)
+            # the single most dangerous point the constraints allow: the pair
+            # mass pushed as close to M_Z^2 as the >= (m_Z + m_W)^2 bound lets it
+            evt = self._pair_event([(23, 2, mz), (24, 2, mw)],
+                                   max((mz + mw) ** 2, self.Z_POLE ** 2))
+            self.assertEqual(
+                shim._near_production_resonance(evt, list(evt),
+                                                self._pool(23, 24)),
+                expected,
+                'BW_cut = %g: m_Z = %.3f + m_W = %.3f = %.3f, against a window '
+                'whose upper edge is at %.3f' % (bw_cut, mz, mw, mz + mw, top))
+
+    def test_a_top_pair_cannot_fake_the_pole_at_any_usable_BW_cut(self):
+        """The same bound on the process the tag was measured on,
+        ``p p > t t~ j``. The window on ``m(t t~)`` is [165.4, 180.3] GeV,
+        while two tops sampled 15 widths low still weigh 303 GeV together: it
+        would take ``BW_cut`` about 55, i.e. a top drawn at 90 GeV, to reach --
+        far past the point where MadSpin refuses the run outright."""
+        shim = self._shim()
+        for bw_cut in (5.0, 10.0, 15.0, 25.0, 50.0):
+            mt = self._bw_floor(self.POLE, self.WIDTH, bw_cut)
+            evt = self._pair_event([(6, 2, mt), (-6, 2, mt)],
+                                   max(4 * mt * mt, self.POLE ** 2))
+            self.assertFalse(
+                shim._near_production_resonance(evt, list(evt),
+                                                self._pool(6, -6)),
+                'BW_cut = %g: 2 * m_t = %.3f against an upper edge at %.3f'
+                % (bw_cut, 2 * mt,
+                   math.sqrt(self.POLE ** 2 + shim._PRODUCTION_RESONANCE_WIDTHS
+                             * self.POLE * self.WIDTH)))
+
+    def test_a_light_decayed_partner_tags_exactly_like_a_parton(self):
+        """Why the pairing must not test ``k``'s status. A light partner --
+        a BSM scalar radiated off the top line, say -- sits on the resonance's
+        own propagator in exactly the way a jet does. The answer may not turn
+        on whether the user happened to put that particle in the decay card."""
+        shim = self._shim({('mass', 6): self.POLE, ('decay', 6): self.WIDTH,
+                           ('mass', 9000006): 2.0, ('decay', 9000006): 1e-3})
+        mt = self._bw_floor(self.POLE, self.WIDTH, 15.0)
+        for status, pool in ((2, self._pool(6, 9000006)), (1, self._pool(6))):
+            evt = self._pair_event([(6, 2, mt), (9000006, status, 2.0)],
+                                   self.POLE ** 2)
+            self.assertTrue(
+                shim._near_production_resonance(evt, list(evt), pool),
+                'the same momenta must tag whether or not the partner was '
+                'decayed (partner status %d)' % status)
+
 
 class TestProductionResonanceReport(unittest.TestCase):
     """The three-way split of the carried overweights, and what it changes.


### PR DESCRIPTION
**Stacked on #383** — review that first. This adds the second overweight region
and corrects a wrong explanation in the docs.

`p p > t t~ j` under the default joint scheme carries **265 overweights per
300 000**, largest factor **48.9**, against 17/500 000 for `t t~` and 1/50 000 for
`t t~` sequential. #383 and the section it added attributed these to the
reshuffle jacobian `J`, "the same divergence reached through the mass draw".
**That is wrong**, and instrumenting every factor of
`w = ME . jac_BW . J^P . prod J^D` on every trial above `0.3 C` shows it:

| median over the over-bound trials | `t t~` (17) | `t t~ j` (265) |
|---|---|---|
| `J^P` production reshuffle | **5.35** (4.3-34.8) | **1.07** (0.98-2.47) |
| `sqrt(shat) - 2 m_t` [summed widths] | **0.09** | 96.5 |

`J` does nothing here. The whole factor is the matrix element.

## The mechanism

Once production has a final state besides the resonances, its ME carries a
propagator of the resonance **itself** on the line the jet is radiated from,
`(p_r + p_j)^2 = m_r^2 + 2 p_r.p_j`. On the pole that is `>= M_r^2` for any real
jet, so the singularity sits on the phase-space boundary and is unreachable.
Drawing `m_r` *below* the pole opens it, and there the production ME is its own
Breit-Wigner peak regulated only by `M_r Gamma_r`. Physically: `pp > t t~` with a
gluon off an **on-shell** top, which MadSpin drew as `pp > t t~ j` with an
off-shell one. In `2 -> 2` the only internal top line is t-channel and spacelike,
so the region does not exist - which is the whole of the 26x.

Evidence: with `d = |(p_r+p_j)^2 - M_r^2|/(M_r Gamma_r)` on the reshuffled
momenta, **all 265 sit inside `d = 5.2`**, 51 % inside 1, the largest overweight
at `d = 0.12`; trials with `0.3 < w/C < 1` sit at median 3.30, and
`corr(ln w/C, ln d) = -0.62`. It also explains the previously unexplained
anti-correlation with the `M(t t~)` threshold: a hard jet is needed.

**Prediction, run.** The region is reachable inside `BW_cut = 15` for 3.5 % of
production events, 0.9 % at 10, 0.03 % at 5. Rerunning at those cuts gives
**265 -> 97 -> 13** overweights and a tail of **48.9 -> 46.6 -> 6.9**.

## "shat near its minimum" - tested, refuted

Four readings, scored by AUC against two controls (the 431 near-bound trials,
which are also heavy, and 40 000 ordinary draws). `0.500` means the variable says
nothing:

| variable | over- vs near-bound | heavy vs ordinary |
|---|---|---|
| `sqrt(shat)` | 0.523 | 0.388 |
| `sqrt(shat) - sum m_i'` | 0.525 | 0.408 |
| `|chi - 1|` | 0.490 | **0.885** |
| **`d`** | **0.133** | **0.000** |

The over-bound trials *are* mildly shifted down in `sqrt(shat)` (median 634 GeV
vs 716; 43.8 % below 600 GeV vs 31.9 %), which the mechanism predicts - a softer
jet satisfies `2 p_r.p_j = M^2 - m^2` more often. But shifted is not
concentrated: their minimum is 387.8 GeV against the sample's 368.9, and only
1.5 % are below 400 GeV.

The per-event reading is refuted **backwards**: over-bound trials never come
within 60.9 GeV of the reshuffle boundary and never fill more than 84.3 % of
`sqrt(shat)`, where ordinary draws reach 21.4 GeV and 94.3 %. They are *further*
from their own boundary than a random draw.

Partial correlations given `d` are `+0.14`, `+0.15`, `-0.08` - nothing left to
explain. And drawing low is **not** the same condition: over ordinary draws
`Spearman(d, min m') = 0.007`, and of the draws putting a resonance more than 8
widths below its pole, only 0.87 % land inside `d < 5` - necessary, and short of
sufficient by a factor 115. The extra condition is on the jet.

## Cost, and what was not done

Carried, so unbiased: `+0.245 %` of sigma, `N_eff` 292719/300000 (`-2.4 %`, one
event alone `-0.77 %`). Concentrated in the low top lineshape - binned in
`min(m_t, m_t~)`, `+24.8 %` in 150.6-155 GeV. So pre-#375 clipping left that tail
**25 % low** on a `2 -> 3` sample.

Options priced and **not taken**: raising the bound needs `49 C` (49x cost); a
per-event `C_e = J_corner . K` is free for `2 -> 2` (3.43 vs 3.46 trials/event,
**0** overflows over 1 702 395 trials) but costs **62x** for `2 -> 3`, i.e. it
fixes the case that does not have the problem; a better probe already lands there
(7.7 expected draws vs 208 observed) so it is not a sampling gap; lowering
`BW_cut` is the only lever on the cause and is the user's physics choice.

**No bound is changed.** This PR tags and reports.

## Tags and tests

`_near_production_resonance` (`|m^2(r+k) - M_r^2| <= 10 M_r Gamma_r`, margin 2x
the measured envelope, fires on 9.2e-4 of trials); the overweight line splits
three ways and drops to `info` only when the unexplained bucket is empty.

`t t~ j` tags **265/265**, the log goes from one WARNING to none, and the 300 000
written events are **byte-identical** (SHA-256) to the base tip's with every
number on the line unchanged. `t t~` still routes through #383's threshold
branch. `test_madspin -t0`: **473 green** (462 + 11).

Left uncovered: within `d` quartiles, higher `sqrt(shat)` still gives a higher
weight (`r = +0.18` to `+0.22`) - plausibly the resonant diagram's growing share
of the ME, not separable without a diagram-level decomposition. And section 15
calls `R = Tr(rho_off)/|M_prod|^2_on` "the flattest thing in the weight", measured
on `2 -> 2`; `R` is exactly the ratio carrying this resonance, so it must have the
same heavy tail on `2 -> 3` and those rankings would need redoing there.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve MadSpin overweight diagnostics by identifying production-matrix-element resonances and correcting their documented explanation without changing event generation or bounds.

New Features:
- Add diagnostics that identify carried overweights caused by resonances in the production matrix element, in addition to the existing threshold classification.

Bug Fixes:
- Correct the MadSpin documentation to attribute 2 → 3 overweight tails to production resonances rather than the reshuffling Jacobian.

Enhancements:
- Refine overweight reporting with exclusive threshold, production-resonance, and unexplained categories, including quieter output for negligible cross-section shifts.
- Preserve event weights and bound behavior while reporting the newly identified production-resonance region.

Documentation:
- Document the production-process resonance mechanism behind 2 → 3 overweights, its BW_cut dependence, impact, and limitations.

Tests:
- Add coverage for production-resonance detection, two-to-two exclusions, malformed inputs, region classification, and quiet versus detailed overweight reporting.