### PR TITLE
MG5: refuse the propagator-only polarisation braces on final-state legs

### DIFF
--- a/madgraph/core/base_objects.py
+++ b/madgraph/core/base_objects.py
@@ -2085,6 +2085,20 @@ class ParamCardVariable(ModelVariable):
 #    Leg, Vertex, Diagram, Process
 #===============================================================================
 
+def polarization_to_string(polarization):
+    """Render a leg 'polarization' list as the brace content of a process
+    string. The propagator-only entries (4,5,6,7,9,99) are printed as the
+    letters the parser understands ('G','H','Q','W','S','A') rather than as
+    their raw integers, which the parser rejects ("polarization are between
+    -3 and 3"). This is what makes nice_string()/input_string() round-trip."""
+
+    # no separator: the process parser reads the brace character by character
+    # (and a ',' inside a brace additionally confuses the decay-chain split on
+    # ','), so '{0S}' round-trips where '{0,S}' does not.
+    return ''.join([Leg.propagator_only_polarizations.get(p, str(p))
+                    for p in polarization])
+
+
 #===============================================================================
 # Leg
 #===============================================================================
@@ -2096,6 +2110,18 @@ class Leg(PhysicsObject):
     # See [arXiv:1912.01725] for definitions (fermions,vectors) and
     # [arXiv:2512.10015] for extensions (vectors)
     list_of_allowed_polarizations = [-1, 1, 2,-2, 3,-3, 0, 4, 5, 6, 7, 9, 99]
+
+    # Polarizations that only exist as a piece of the *propagator* numerator
+    # of a massive vector (see aloha/create_aloha.py, the "1X" forms) and that
+    # therefore have no external-wavefunction counterpart. Values are the
+    # brace letters accepted by the process parser.
+    propagator_only_polarizations = {4: 'G',   # -metric
+                                     5: 'H',   # Theta
+                                     6: 'Q',   # q^mu q^nu / q^2
+                                     7: 'W',   # -metric + qq/(M^2-iM*W)
+                                     9: 'S',   # scalar = axial + width
+                                     99: 'A',  # axial/auxiliary
+                                     }
 
     def default_setup(self):
         """Default values for all properties"""
@@ -3194,7 +3220,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R}'
                 else:
-                    mystr = mystr + '{%s}' %','.join([str(p) for p in leg.get('polarization')]) 
+                    mystr = mystr + '{%s}' % polarization_to_string(leg.get('polarization')) 
 
             if leg.get('offshell'):
                 mystr = mystr + '*'
@@ -3332,7 +3358,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R}'
                 else:
-                    mystr = mystr + '{%s}' %','.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s}' % polarization_to_string(leg.get('polarization'))   
             if leg.get('offshell'):
                 mystr = mystr + '*'
             mystr = mystr + ' ' 
@@ -3427,7 +3453,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R}'
                 else:
-                    mystr = mystr + '{%s}' %','.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s}' % polarization_to_string(leg.get('polarization'))   
             if leg.get('offshell'):
                 mystr = mystr + '*'
             mystr = mystr + ' ' 
@@ -4047,7 +4073,7 @@ class ProcessDefinition(Process):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R}'
                 else:
-                    mystr = mystr + '{%s}' %''.join([str(p) for p in leg.get('polarization')])
+                    mystr = mystr + '{%s}' % polarization_to_string(leg.get('polarization'))
             if leg.get('offshell'):
                 mystr += '*'   
             else:

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -688,6 +688,24 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 if self['state'] == 'final' and self.get('pdg_code') in decay_ids:
                     self.set('decay', True)
                 else:
+                    # Braces that name a piece of the propagator numerator of a
+                    # massive vector have no external wavefunction: the integer
+                    # would end up in the NHEL table and VXXXXX would silently
+                    # return a meaningless vector. The command interface
+                    # already refuses them (check_propagator_polarization);
+                    # this catches the direct-API path as well.
+                    propagator_only = \
+                        base_objects.Leg.propagator_only_polarizations
+                    for value in leg.get('polarization'):
+                        # 99 ('{A}') has its own, softer rule just below
+                        if value == 99 or value not in propagator_only:
+                            continue
+                        raise InvalidCmd(
+                            "The polarization {%s} is a piece of a massive "
+                            "vector propagator, not a polarization vector: "
+                            "it is only valid on a particle that is decayed "
+                            "further (an internal line), not on an external "
+                            "leg of the process." % propagator_only[value])
                     if 99 in leg.get('polarization'):
                         # The axial/scalar polarization {A} of a massive vector
                         # is the k^mu piece of its *propagator*; it vanishes

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -766,6 +766,10 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info(" > Example: generate t{L} > w+{T} b{R}, w+ > ta+ vt",'$MG:color:GREEN')
         logger.info(" > Example: generate p p > z{T} z{A}, z > e+ e-",'$MG:color:GREEN')
         logger.info(" > Example: generate p p > z{0} z{T}, z > e+ e-, z > mu+ mu-",'$MG:color:GREEN')
+        logger.info(" > '{G}','{H}','{Q}','{W}','{S}' select a piece of the *propagator* of a massive vector")
+        logger.info("   and are only valid on a particle that is decayed further (an internal line).")
+        logger.info(" > '{A}' is the same on an internal line; on a final-state particle it also needs the")
+        logger.info("   off-shell '*' syntax and 'set consider_axial True'.")
         logger.info(" > Users need to set 'group_subprocesses False', 'nhel=1' (run_card), and 'me_frame' (run_card)")
         logger.info(" > For the proces 'p p > w+ z j j, w+ > l+ vl, z > l+ l-', the WZ rest frame is given by me_frame = [3,4,5,6]")
         logger.info(" > For further details, see appendices of [arXiv:1912.01725] and [arXiv:2512.10015],")
@@ -3334,9 +3338,10 @@ This implies that with decay chains:
                myprocdef.get_ninitial() and not standalone_only:
                 raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
 
-            # Check the axial/scalar polarization {A}: propagator-only unless
-            # 'consider_axial' is on AND the leg carries the off-shell '*'.
-            self.check_axial_polarization(myprocdef)
+            # Check the propagator-only polarization braces: {G},{H},{Q},{W}
+            # and {S} are internal-line only, and {A} needs 'consider_axial'
+            # plus the off-shell '*' unless the leg is decayed further.
+            self.check_propagator_polarization(myprocdef)
 
             #Check that we do not have situation like z{T} z
             if not myprocdef.check_polarization():
@@ -4871,13 +4876,31 @@ This implies that with decay chains:
     # The integer the '{A}' brace is parsed into (see extract_process).
     AXIAL_POLARIZATION = 99
 
-    def check_axial_polarization(self, procdef):
-        """Validate every '{A}' (axial/scalar, pol=99) brace of a
+    # The braces that name a piece of the *propagator* numerator of a massive
+    # vector and nothing else: they have no external-wavefunction counterpart
+    # (there is no VXXXXX helicity for them), so on a genuine external leg the
+    # integer would be written straight into the NHEL table and VXXXXX would
+    # quietly return a meaningless vector. See aloha/create_aloha.py for the
+    # numerators ("1G", "1H", ...) and [arXiv:2512.10015] for the definitions.
+    # '{A}' (99) is deliberately absent: it has its own, softer rule below.
+    PROPAGATOR_ONLY_POLARIZATIONS = {4: ('G', 'the metric piece -g^{mu nu}'),
+                                     5: ('H', 'the Theta projector'),
+                                     6: ('Q', 'the q^mu q^nu / q^2 tensor'),
+                                     7: ('W', 'the Ward-protected full '
+                                              'propagator'),
+                                     9: ('S', 'the scalar piece '
+                                              '(axial + finite width)'),
+                                     }
+
+    def check_propagator_polarization(self, procdef):
+        """Validate the propagator-only polarization braces of a
         ProcessDefinition and of its decay chains.
 
-        A massive spin-one particle has three physical polarisations; the
-        fourth, axial one is the k^mu piece its *propagator* carries off shell
-        (arXiv:1908.08454). Three cases:
+        Two families are checked, sharing one decay-chain-aware walk:
+
+        '{A}' (axial/scalar, pol=99). A massive spin-one particle has three
+        physical polarisations; the fourth, axial one is the k^mu piece its
+        *propagator* carries off shell (arXiv:1908.08454). Three cases:
 
         * '{A}' on a particle that is decayed further ('t > w+{A} b,
           w+ > ta+ vt') is the historical propagator use. Always allowed, and
@@ -4887,6 +4910,13 @@ This implies that with decay chains:
           identically for an on-shell particle. It additionally needs
           'set consider_axial True'.
         * '{A}' on an initial-state particle is never meaningful.
+
+        '{G}', '{H}', '{Q}', '{W}' and '{S}' (pol=4,5,6,7,9). Each of these
+        names a rank-two piece of the propagator numerator, complete with its
+        1/(q^2-M^2+iM*Gamma) pole; none of them is a polarisation vector. They
+        are therefore allowed on a decayed leg only -- on an external leg they
+        are refused outright, with no option to turn them on, because no
+        external wavefunction for them exists.
 
         Raises InvalidCmd; returns None.
         """
@@ -4902,7 +4932,24 @@ This implies that with decay chains:
                     decayed_ids.update(leg.get('ids'))
 
         for leg in procdef.get('legs'):
-            if axial not in leg.get('polarization'):
+            pol = leg.get('polarization')
+            # the strictly propagator-only braces: nothing rescues them on an
+            # external leg, so check them before the softer '{A}' rules.
+            if not decayed_ids.intersection(leg.get('ids')):
+                for value in pol:
+                    if value not in self.PROPAGATOR_ONLY_POLARIZATIONS:
+                        continue
+                    tag, what = self.PROPAGATOR_ONLY_POLARIZATIONS[value]
+                    raise self.InvalidCmd(
+                        'The polarization {%s} is %s of a massive vector '
+                        'propagator, not a polarization vector: it exists '
+                        'only for an internal line. It is allowed on a '
+                        'particle that is decayed further (write '
+                        '"t > w+{%s} b, w+ > ta+ vt"), and is not allowed on '
+                        'an %s-state particle of the process.'
+                        % (tag, what, tag,
+                           'final' if leg.get('state') else 'initial'))
+            if axial not in pol:
                 continue
             if not leg.get('state'):
                 raise self.InvalidCmd(
@@ -4925,7 +4972,7 @@ This implies that with decay chains:
                     'enable it.')
 
         for decay in procdef.get('decay_chains'):
-            self.check_axial_polarization(decay)
+            self.check_propagator_polarization(decay)
 
     def extract_process(self, line, proc_number = 0, overall_orders = {},
                         avoid_squared_orders=False):

--- a/madgraph/interface/master_interface.py
+++ b/madgraph/interface/master_interface.py
@@ -378,8 +378,8 @@ class Switcher(object):
     def check_load(self, *args, **opts):
         return self.cmd.check_load(self, *args, **opts)
         
-    def check_axial_polarization(self, *args, **opts):
-        return self.cmd.check_axial_polarization(self, *args, **opts)
+    def check_propagator_polarization(self, *args, **opts):
+        return self.cmd.check_propagator_polarization(self, *args, **opts)
 
     def check_open(self, *args, **opts):
         return self.cmd.check_open(self, *args, **opts)

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import unittest
 import madgraph
 import madgraph.interface.master_interface as cmd
+import madgraph.core.base_objects as base_objects
 import MadSpin.interface_madspin as ms_cmd
 import madgraph.interface.extended_cmd as ext_cmd
 import madgraph.various.misc as misc
@@ -392,6 +393,110 @@ class TestValidCmd(unittest.TestCase):
                 self.assertIn('not implemented', str(error).lower())
             else:
                 self.fail('axial final state built a matrix element')
+        finally:
+            cmd.options['consider_axial'] = original
+            cmd.exec_cmd('generate p p > t t~')
+
+    @test_aloha.set_global()
+    def test_generate_propagator_only_polarisation(self):
+        """{G},{H},{Q},{W},{S} name a piece of the propagator *numerator* of a
+        massive vector; there is no external wavefunction for them. They stay
+        valid on a leg that is decayed further and are refused everywhere
+        else."""
+        import madgraph.core.helas_objects as helas_objects
+
+        cmd = self.cmd
+        self.do('import model sm')
+        tags = ['G', 'H', 'Q', 'W', 'S']
+        try:
+            for tag in tags:
+                # --- refused on a genuine final state ------------------
+                for proc in ('generate p p > z{%s} h' % tag,
+                             # the off-shell '*' does not rescue them either
+                             'generate p p > z{%s}* h' % tag):
+                    self.assertRaises(madgraph.InvalidCmd, self.do, proc)
+                    try:
+                        self.do(proc)
+                    except madgraph.InvalidCmd as error:
+                        self.assertIn('{%s}' % tag, str(error))
+                        self.assertIn('propagator', str(error))
+                        self.assertIn('decayed further', str(error))
+                        self.assertIn('final-state particle', str(error))
+
+                # --- refused on an initial state ----------------------
+                self.assertRaises(madgraph.InvalidCmd,
+                                  self.do, 'generate z{%s} z > w+ w-' % tag)
+                try:
+                    self.do('generate z{%s} z > w+ w-' % tag)
+                except madgraph.InvalidCmd as error:
+                    self.assertIn('initial-state particle', str(error))
+
+                # --- still fine as a propagator -----------------------
+                self.do('generate t > w+{%s} b, w+ > ta+ vt' % tag)
+                self.assertTrue(cmd._curr_amps)
+
+            # the combined '{0S}' brace (pol=[0,9], propagator form P1LS) is
+            # covered by the same rule through its '9' entry
+            self.assertRaises(madgraph.InvalidCmd,
+                              self.do, 'generate p p > z{0S} h')
+            self.do('generate t > w+{0S} b, w+ > ta+ vt')
+            self.assertTrue(cmd._curr_amps)
+
+            # the walk recurses into the decay chains: here the '{G}' sits one
+            # level down, on a w+ that is itself never decayed
+            self.assertRaises(
+                madgraph.InvalidCmd, self.do,
+                'generate p p > t t~, t > w+{G} b, t~ > w- b~')
+
+            # the guard is duplicated one layer down, for the direct-API path
+            # that does not go through the command interface at all
+            legs = base_objects.LegList([
+                base_objects.Leg({'id': 2, 'state': False, 'number': 1}),
+                base_objects.Leg({'id': -2, 'state': False, 'number': 2}),
+                base_objects.Leg({'id': 23, 'state': True, 'number': 3,
+                                  'polarization': [4]}),
+                base_objects.Leg({'id': 25, 'state': True, 'number': 4}),
+                ])
+            try:
+                helas_objects.HelasWavefunction(legs[2], 0,
+                                                cmd._curr_model)
+            except madgraph.InvalidCmd as error:
+                self.assertIn('{G}', str(error))
+                self.assertIn('propagator', str(error))
+            else:
+                self.fail('HelasWavefunction accepted a {G} external leg')
+        finally:
+            cmd.exec_cmd('generate p p > t t~')
+
+    def test_propagator_polarisation_round_trip(self):
+        """nice_string()/input_string() used to print the raw integer ({4},
+        {99}, ...), which the parser rejects with "polarization are between -3
+        and 3". They must print the brace letter instead."""
+        cmd = self.cmd
+        self.do('import model sm')
+        original = cmd.options['consider_axial']
+        try:
+            cmd.options['consider_axial'] = True
+            self.do('generate p p > z{A}* h')
+            proc = cmd._curr_amps[0].get('process')
+            self.assertIn('z{A}*', proc.nice_string(prefix=False))
+            self.assertIn('z{A}*', proc.input_string())
+            self.assertIn('z{A}*', proc.base_string())
+            # and the printed string is accepted back by the parser
+            self.do('generate %s' % proc.input_string())
+            self.assertTrue(cmd._curr_amps)
+
+            # the propagator braces print their letter too, including the
+            # combined '{0S}' which must not grow a comma (a ',' inside the
+            # brace also breaks the decay-chain split)
+            for tag, expected in (('G', 'w+{G}'), ('H', 'w+{H}'),
+                                  ('Q', 'w+{Q}'), ('W', 'w+{W}'),
+                                  ('S', 'w+{S}'), ('0S', 'w+{0S}')):
+                self.do('generate t > w+{%s} b, w+ > ta+ vt' % tag)
+                proc = cmd._curr_amps[0].get('amplitudes')[0].get('process')
+                self.assertIn(expected, proc.nice_string(prefix=False))
+                self.assertIn(expected, proc.input_string())
+                self.assertNotIn(',', proc.input_string())
         finally:
             cmd.options['consider_axial'] = original
             cmd.exec_cmd('generate p p > t t~')


### PR DESCRIPTION
**Stacked on `claude/mg5-axial-polarization`** — review that first; this branch
reuses its decay-chain-aware walker and cannot merge before it.

`Leg.list_of_allowed_polarizations` (`base_objects.py:2098`) admits five
propagator-only braces beside `{A}`: `{G}`=4, `{H}`=5, `{Q}`=6, `{W}`=7,
`{S}`=9. Only `{A}` was ever guarded. The other five were accepted on a genuine
final-state leg - and on an initial-state one - and **silently produced a wrong
number**.

## What went wrong before the fix

`generate p p > z{G} h` generated fine and wrote the raw integer straight into
the helicity table:

```
DATA (NHEL(I,   1),I=1,4) / 1,-1, 4, 0/
CALL VXXXXX(P(0,3),MDL_MZ,NHEL(3),+1*IC(3),W(1,3))
```

`VXXXXX` then computes `hel = 4.0`, `hel0 = 1 - |hel| = -3`, `nsvahl = 4`, and
returns a vector that is neither normalised nor transverse. No crash, no warning.
Identical for `{H}`, `{Q}`, `{W}`, `{S}` and `{0S}`; the off-shell `*` made no
difference.

## What the five tags are

Parsed at `madgraph_interface.py:5245-5273` (letter -> int, spin-3 only),
consumed as ALOHA propagator tags at `helas_objects.py:1651-1668` and
`:1911-1919`, numerators at `create_aloha.py:481-493`:

| tag | int | ALOHA | numerator / denominator |
|---|---|---|---|
| `{G}` | 4 | `1G` | `-g^{mu nu}` / pole |
| `{H}` | 5 | `1H` | the Theta projector (`= -T - G`) |
| `{Q}` | 6 | `1Q` | `q^mu q^nu / q^2` / pole |
| `{W}` | 7 | `1W` | `-g^{mu nu} + qq/(M^2 - iMGamma)` |
| `{S}` | 9 | `1S` | `q^mu q^nu / (q^2 (M^2 - iMGamma))` |

All five are propagator-only, established four ways: every numerator is a
rank-two tensor carrying its own pole (and width, for `W`/`S`), none is an
`epsilon^mu`; there is no external wavefunction, `VXXXXX` handling only
`nhel in {-1,0,1}`; `create_aloha.py:922-925` auto-generates only the
external-capable `P1L`/`P1T`/`P1A`/`P1PS`; and MadSpin independently refuses
4-9 and 99. The only internal-line route for a brace is a decay chain -
`$` and `> >` s-channel specs reject braces outright in `extract_particle_ids`.

## The change

`check_axial_polarization` becomes `check_propagator_polarization`: the same
decay-chain-aware walk, now also refusing 4/5/6/7/9 on any leg not handed to a
decay chain, final or initial. No opt-in switch - unlike `{A}` there is nothing
to enable. The same guard sits beside the `{A}` one at `helas_objects.py:691`
for the direct-API path, sharing `Leg.propagator_only_polarizations`.

Propagator use verified intact: the exact command list from
`tests/acceptance_tests/test_cmd_madevent.py:1698` (`{0}`,`{A}`,`{S}`,`{0S}`,
`{S0}`,`{G}`,`{H}`,`{Q}`,`{W}`) still `output`s, producing
`FFV2P1A/G/H/Q/S/W_3.f`. Recursion checked both ways:
`p p > t t~, (t > w+{G} b, w+ > e+ ve), ...` passes, and the same without the
inner chain is refused.

## Round-trip, fixed in passing

`nice_string`/`input_string`/`base_string` printed `{4}`, `{5}`, `{99}`, `{0,9}`;
re-parsing gave *"polarization are between -3 and 3"*, and `{0,9}` failed even
earlier because a comma inside a brace collides with the decay-chain split. They
now go through a new `base_objects.polarization_to_string()`, emitting the brace
letter with no separator - `{G}`, `{A}`, `{0S}`, the syntax the acceptance tests
use. `shell_string`/`shell_string_v4` deliberately untouched so directory names
do not move; the `C Process:` comment in `matrix.f` improves as a side effect.

This is **not** a proc-card replay defect - `proc_card_mg5.dat` is written from
command history. The blast radius is `display`, generated-code comments, and any
tooling that re-parses a printed process line.

## Tests

`-p U test_cmd`: **20 OK** (18 on base + 2 new). `test_madspin -t0`: **485 OK**.
Full `-p U`: 1267 tests, only the pre-existing scipy
`test_DensityMatrixObservables22` error.

Mutation-checked three ways: disabling the interface veto, the helas guard, or
the letter mapping each fails exactly one of the new tests.

## Not covered

The acceptance tests were verified to `output`, not through a full `launch`
cross-section check. `input_string()` still drops decay chains entirely
(pre-existing, orthogonal). `{2,-2}`-style multi-value braces remain unusable
through `generate` because the comma breaks the decay-chain split - pre-existing,
untouched.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent propagator-only polarization braces from being treated as external wavefunctions while preserving valid internal-line use and process-string round trips.

Bug Fixes:
- Reject propagator-only polarization braces ({G}, {H}, {Q}, {W}, and {S}) on initial- and final-state legs where they could previously generate invalid external wavefunctions silently.

Enhancements:
- Apply consistent propagator-polarization validation across command-interface, decay-chain, and direct HELAS construction paths.
- Preserve process-string round trips by rendering propagator-only polarization values as parser-compatible brace letters, including combined forms such as {0S}.
- Clarify polarization help text and validation errors for external versus decay-chain usage.

Tests:
- Add coverage for rejecting invalid external and initial-state propagator polarizations, allowing valid decay-chain usage, direct API validation, and process-string round trips.