### PR TITLE
MG5: accept {A} on an off-shell final-state leg, behind consider_axial (axial 1/4)

### DIFF
--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -689,7 +689,29 @@ class HelasWavefunction(base_objects.PhysicsObject):
                     self.set('decay', True)
                 else:
                     if 99 in leg.get('polarization'):
-                        raise Exception("polarization A only valid for propagator.")
+                        # The axial/scalar polarization {A} of a massive vector
+                        # is the k^mu piece of its *propagator*; it vanishes
+                        # identically for an on-shell particle. On an external
+                        # leg it is therefore only meaningful together with the
+                        # off-shell '*' syntax -- and even then the generated
+                        # code for it does not exist yet (see below).
+                        if not leg.get('offshell'):
+                            raise InvalidCmd(
+                                "polarization A only valid for propagator, or "
+                                "for an off-shell final-state particle written "
+                                "\"z{A}*\" (star after the brace).")
+                        raise InvalidCmd(
+                            "The axial polarization {A} of an off-shell "
+                            "final-state particle is accepted by the process "
+                            "syntax but is NOT implemented in the generated "
+                            "code yet: there is no external wavefunction for "
+                            "it (aloha/template_files/aloha_functions.f, "
+                            "VXXXXX), no helicity entry in the NHEL table and "
+                            "no fourth index in the MadSpin density matrix. "
+                            "Generating this process would silently produce a "
+                            "wrong number, so it is refused instead. Use {A} "
+                            "on a particle that is decayed further (the "
+                            "propagator case) until that support lands.")
                 # Set fermion flow state. Initial particle and final
                 # antiparticle are incoming, and vice versa for
                 # outgoing

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -900,6 +900,10 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("deactivates mixed expansion support at NLO, goes back to MG5aMCv2 behavior")
         logger.info("acknowledged_v3.1_syntax <value>",'$MG:color:GREEN') 
         logger.info("if set to True allows to use syntax which have change meaning between 3.0 and 3.1 version")
+        logger.info("consider_axial <value>",'$MG:color:GREEN')
+        logger.info(" > (default: False) allow the axial/scalar polarisation {A} on a FINAL-STATE")
+        logger.info(" > particle. Only meaningful together with the off-shell '*' syntax")
+        logger.info(" > ('generate p p > z{A}* z'), since {A} vanishes for an on-shell particle.")
           
 #===============================================================================
 # CheckValidForCmd
@@ -1588,6 +1592,7 @@ This will take effect only in a NEW terminal
                                           'loop_optimized_output',\
                                           'loop_color_flows',\
                                           'include_lepton_initiated_processes',\
+                                          'consider_axial',\
                                           'low_mem_multicore_nlo_generation']:
             args.append('True')
 
@@ -1637,7 +1642,7 @@ This will take effect only in a NEW terminal
             if not args[1].isdigit():
                 raise self.InvalidCmd('%s values should be a integer' % args[0])
             
-        if args[0] in ['loop_optimized_output', 'loop_color_flows', 'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
+        if args[0] in ['loop_optimized_output', 'loop_color_flows', 'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion', 'consider_axial']:
             try:
                 args[1] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
             except Exception:
@@ -2692,7 +2697,8 @@ class CompleteForCmd(cmd.CompleteCmd):
             if args[1] in ['complex_mass_scheme',\
                            'loop_optimized_output', 'loop_color_flows',\
                            'include_lepton_initiated_processes',\
-                           'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
+                           'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion',\
+                           'consider_axial']:
                 return self.list_completion(text, ['False', 'True', 'default'])
             elif args[1] in ['group_subprocesses']:
                 return self.list_completion(text, ['False', 'True', 'Auto', 'gpu', 'nlo'])
@@ -3036,7 +3042,8 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                     'max_t_for_channel',
                     'zerowidth_tchannel',
                     'default_unset_couplings',
-                    'nlo_mixed_expansion'
+                    'nlo_mixed_expansion',
+                    'consider_axial'
                     ]
     _valid_nlo_modes = ['all','real','virt','sqrvirt','tree','noborn','LOonly', 'only']
     _valid_sqso_types = ['==','<=','=','>']
@@ -3119,6 +3126,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                           'max_t_for_channel': 99, # means no restrictions
                           'zerowidth_tchannel': True,
                           'nlo_mixed_expansion':True,
+                          'consider_axial': False,
                         }
 
     options_madevent = {'automatic_html_opening':True,
@@ -3325,6 +3333,10 @@ This implies that with decay chains:
             if self._curr_amps and self._curr_amps[0].get_ninitial() != \
                myprocdef.get_ninitial() and not standalone_only:
                 raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
+
+            # Check the axial/scalar polarization {A}: propagator-only unless
+            # 'consider_axial' is on AND the leg carries the off-shell '*'.
+            self.check_axial_polarization(myprocdef)
 
             #Check that we do not have situation like z{T} z
             if not myprocdef.check_polarization():
@@ -4855,6 +4867,65 @@ This implies that with decay chains:
         args = self.split_arg(line)
         args.insert(0, 'process')
         self.do_add(" ".join(args))
+
+    # The integer the '{A}' brace is parsed into (see extract_process).
+    AXIAL_POLARIZATION = 99
+
+    def check_axial_polarization(self, procdef):
+        """Validate every '{A}' (axial/scalar, pol=99) brace of a
+        ProcessDefinition and of its decay chains.
+
+        A massive spin-one particle has three physical polarisations; the
+        fourth, axial one is the k^mu piece its *propagator* carries off shell
+        (arXiv:1908.08454). Three cases:
+
+        * '{A}' on a particle that is decayed further ('t > w+{A} b,
+          w+ > ta+ vt') is the historical propagator use. Always allowed, and
+          unaffected by 'consider_axial'.
+        * '{A}' on a genuinely final-state particle is only meaningful with the
+          off-shell '*' syntax, because the axial polarisation vanishes
+          identically for an on-shell particle. It additionally needs
+          'set consider_axial True'.
+        * '{A}' on an initial-state particle is never meaningful.
+
+        Raises InvalidCmd; returns None.
+        """
+        if procdef is None:
+            return
+        axial = self.AXIAL_POLARIZATION
+        # pdgs that this level hands over to a decay chain: those legs become
+        # internal propagators, which is the case '{A}' was written for.
+        decayed_ids = set()
+        for decay in procdef.get('decay_chains'):
+            for leg in decay.get('legs'):
+                if not leg.get('state'):
+                    decayed_ids.update(leg.get('ids'))
+
+        for leg in procdef.get('legs'):
+            if axial not in leg.get('polarization'):
+                continue
+            if not leg.get('state'):
+                raise self.InvalidCmd(
+                    'The axial polarization {A} is not supported for an '
+                    'initial-state particle.')
+            if decayed_ids.intersection(leg.get('ids')):
+                # propagator: the leg is replaced by the decay chain
+                continue
+            if not leg.get('offshell'):
+                raise self.InvalidCmd(
+                    'The axial polarization {A} of a final-state particle is '
+                    'identically zero on shell, so it requires the off-shell '
+                    '"*" syntax (write "z{A}*", the star after the brace). '
+                    'Without a star, {A} is only valid for a particle that is '
+                    'decayed further, i.e. for a propagator.')
+            if not self.options['consider_axial']:
+                raise self.InvalidCmd(
+                    'The axial polarization {A} of a final-state particle is '
+                    'disabled by default. Use "set consider_axial True" to '
+                    'enable it.')
+
+        for decay in procdef.get('decay_chains'):
+            self.check_axial_polarization(decay)
 
     def extract_process(self, line, proc_number = 0, overall_orders = {},
                         avoid_squared_orders=False):
@@ -8748,6 +8819,28 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         self.check_set(args)
         self.options[args[0]] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
         
+    def help_set2_consider_axial(self):
+        logger.info("consider_axial <value>",'$MG:color:GREEN')
+        logger.info(" > (default: False) allow the axial/scalar polarisation {A}")
+        logger.info("   of a massive spin-one particle to be requested on a")
+        logger.info("   FINAL-STATE particle, which is only meaningful together")
+        logger.info("   with the off-shell '*' syntax: 'generate p p > z{A}* z'.")
+        logger.info("   {A} is identically zero for an on-shell particle, so the")
+        logger.info("   star is mandatory. See arXiv:1908.08454.")
+        logger.info("   {A} on a particle that is decayed further (the propagator")
+        logger.info("   case, 'generate t > w+{A} b, w+ > ta+ vt') is always")
+        logger.info("   allowed and does not need this option.")
+
+    def set2_consider_axial(self, args, log=True):
+        """Set whether the axial/scalar polarisation {A} may be requested on a
+        final-state particle (which additionally requires the off-shell '*').
+        Default is False.
+        Example: set consider_axial True
+        """
+        args = ['consider_axial'] + args
+        self.check_set(args)
+        self.options[args[0]] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
+
     def help_set2_zerowidth_tchannel(self):
         logger.info("zerowidth_tchannel <value>",'$MG:color:GREEN')
         logger.info(" > (default: True) [Used ONLY for tree-level output with madevent]")

--- a/madgraph/interface/master_interface.py
+++ b/madgraph/interface/master_interface.py
@@ -378,6 +378,9 @@ class Switcher(object):
     def check_load(self, *args, **opts):
         return self.cmd.check_load(self, *args, **opts)
         
+    def check_axial_polarization(self, *args, **opts):
+        return self.cmd.check_axial_polarization(self, *args, **opts)
+
     def check_open(self, *args, **opts):
         return self.cmd.check_open(self, *args, **opts)
         
@@ -626,6 +629,9 @@ class Switcher(object):
 
     def help_set2_output_dependencies(self, *args, **opts):
         return self.cmd.help_set2_output_dependencies(self, *args, **opts)
+
+    def help_set2_consider_axial(self, *args, **opts):
+        return self.cmd.help_set2_consider_axial(self, *args, **opts)
 
     def help_set2_zerowidth_tchannel(self, *args, **opts):
         return self.cmd.help_set2_zerowidth_tchannel(self, *args, **opts)

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -328,6 +328,93 @@ class TestValidCmd(unittest.TestCase):
         self.do('generate v{0T} v{0} > w+ w-')
         self.assertEqual(len(cmd._curr_amps), 2)
 
+    def test_consider_axial_default(self):
+        """the axial option exists, is a MadGraph option, and is off."""
+        cmd = self.cmd
+        self.assertIn('consider_axial', cmd.options_madgraph)
+        self.assertEqual(cmd.options_madgraph['consider_axial'], False)
+        self.assertIn('consider_axial', cmd._set_options)
+        self.assertEqual(cmd.options['consider_axial'], False)
+
+    @test_aloha.set_global()
+    def test_generate_axial_polarisation(self):
+        """{A} on a FINAL-STATE particle: needs the off-shell '*' AND
+        'set consider_axial True'. On a particle that is decayed further it
+        stays the (unconditional) propagator syntax it always was."""
+        import madgraph.core.helas_objects as helas_objects
+
+        cmd = self.cmd
+        self.do('import model sm')
+        original = cmd.options['consider_axial']
+        try:
+            # --- option off (the default) -------------------------------
+            cmd.options['consider_axial'] = False
+
+            # no star: {A} is identically zero on shell
+            self.assertRaises(madgraph.InvalidCmd,
+                              self.do, 'generate p p > z{A} h')
+            try:
+                self.do('generate p p > z{A} h')
+            except madgraph.InvalidCmd as error:
+                self.assertIn('off-shell', str(error))
+
+            # star but option off
+            self.assertRaises(madgraph.InvalidCmd,
+                              self.do, 'generate p p > z{A}* h')
+            try:
+                self.do('generate p p > z{A}* h')
+            except madgraph.InvalidCmd as error:
+                self.assertIn('consider_axial', str(error))
+
+            # initial state is never meaningful
+            self.assertRaises(madgraph.InvalidCmd,
+                              self.do, 'generate z{A}* z > w+ w-')
+
+            # the propagator syntax does not go through the option at all
+            self.do('generate t > w+{A} b, w+ > ta+ vt')
+            self.assertTrue(cmd._curr_amps)
+
+            # --- option on ----------------------------------------------
+            cmd.options['consider_axial'] = True
+            self.do('generate p p > z{A}* h')
+            self.assertTrue(cmd._curr_amps)
+            legs = cmd._curr_amps[0].get('process').get('legs')
+            axial = [l for l in legs if l.get('polarization') == [99]]
+            self.assertEqual(len(axial), 1)
+            self.assertTrue(axial[0].get('state'))
+            self.assertTrue(axial[0].get('offshell'))
+
+            # ... but the generated code for it does not exist yet, so the
+            # matrix element refuses rather than producing a wrong number.
+            try:
+                helas_objects.HelasMultiProcess(cmd._curr_amps)
+            except madgraph.InvalidCmd as error:
+                self.assertIn('not implemented', str(error).lower())
+            else:
+                self.fail('axial final state built a matrix element')
+        finally:
+            cmd.options['consider_axial'] = original
+            cmd.exec_cmd('generate p p > t t~')
+
+    def test_set_consider_axial(self):
+        """'set consider_axial' parses like the other boolean MG5 options."""
+        cmd = self.cmd
+        original = cmd.options['consider_axial']
+        try:
+            cmd.exec_cmd('set consider_axial True')
+            self.assertEqual(cmd.options['consider_axial'], True)
+            cmd.exec_cmd('set consider_axial False')
+            self.assertEqual(cmd.options['consider_axial'], False)
+            # bare 'set consider_axial' means True, like complex_mass_scheme
+            cmd.exec_cmd('set consider_axial')
+            self.assertEqual(cmd.options['consider_axial'], True)
+            cmd.exec_cmd('set consider_axial default')
+            self.assertEqual(cmd.options['consider_axial'], False)
+            self.assertRaises(madgraph.InvalidCmd,
+                              cmd.exec_cmd, 'set consider_axial banana')
+        finally:
+            cmd.options['consider_axial'] = original
+
 
 class TestExtendedCmd(unittest.TestCase):
     """test the extension of cmd interface"""


### PR DESCRIPTION
**Milestone 1 of 4** for the axial (fourth) spin-1 polarisation. Bottom of a
stack: #386 sits on this, then the Fortran, the four-index convolution and the
`keep_weight` support.

A massive vector has three physical polarisations. Off shell its propagator
carries a **fourth**, the axial/scalar component along `k^mu`, which vanishes
identically on shell. MG5 already knows it as `{A}` — supported for
**propagators only**. This makes it usable on a final-state leg, where it is only
meaningful off shell.

## What this does

- New option `consider_axial`, default **False**.
- `{A}` on a genuine final-state leg is accepted **only** with the off-shell star
  (`z{A}*`) **and** `consider_axial` on. Refused on the initial state, refused
  without the star, refused with the option off.
- `check_propagator_polarization()` walks the `ProcessDefinition` **and its decay
  chains**, computing at each level which pdgs are handed to a chain. That is
  load-bearing: `t > w+{A} b, w+ > ta+ vt` and MadSpin's own rewrite
  `p p > z{A}*, z > e+ e-` both have `state=True` on the `{A}` leg, so the parser
  alone cannot tell a propagator from a final state.
- The propagator path is untouched and still works with the option off.

## How the not-yet-implemented path fails

`generate` succeeds (the leg carries `polarization=[99]`, `offshell=True`,
diagrams build) and the wall is at `HelasWavefunction` construction, which is the
file milestone 2 edits. It names every missing piece rather than returning a
number:

> …is accepted by the process syntax but is NOT implemented in the generated code
> yet: there is no external wavefunction for it, no helicity entry in the NHEL
> table and no fourth index in the MadSpin density matrix. Generating this process
> would silently produce a wrong number, so it is refused instead.

Deliberate: a silent zero is exactly what an unimplemented axial component looks
like.

## Tests

`-p U test_cmd` 18 OK (15 + 3 new); `test_madspin -t0` 485 OK. Full `-p U` 1265,
only the pre-existing environmental `test_DensityMatrixObservables22` (scipy).
The new tests were mutation-checked.

## Note

`consider_axial` currently lives in `options_madgraph`. Per the user it should be
a **MadSpin card option plus a standalone `--allow_axial`**, not a global MadGraph
one — that move lands in milestone 2 (`claude/mg5-axial-fortran`), together with
its answer for how MadSpin learns the setting.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate off-shell final-state axial polarization syntax behind a new `consider_axial` option while retaining propagator support and safely rejecting unsupported code generation.

New Features:
- Add the `consider_axial` option for controlling axial polarization requests on final-state particles.
- Accept off-shell `{A}` final-state syntax when enabled while preserving existing propagator support.

Enhancements:
- Validate axial polarization usage across process definitions and decay chains, rejecting initial-state and unsupported on-shell requests with clear errors.
- Prevent generation from producing incorrect results by explicitly refusing the not-yet-implemented off-shell final-state axial matrix-element path.

Documentation:
- Document the `consider_axial` option and the requirements for off-shell final-state `{A}` syntax.

Tests:
- Add coverage for default option behavior, validation rules, propagator compatibility, option parsing, and the intentional generation failure for unimplemented axial final states.