### PR TITLE
MG5: give {A} a real external wavefunction, standalone output and density matrix (axial 2/4)

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -2129,6 +2129,11 @@ class decay_all_events(object):
             self.generate_all_matrix_element()
             self.save_status_to_pickle(pickle_info)
         else:
+            # before anything else: the directory we are about to reuse has a
+            # spin basis baked into its generated code, and it has to be the
+            # one this run asks for. Deliberately outside the try/except
+            # below, which would quietly fall back to regenerating.
+            self.check_spin_basis_tag()
             try:
                 data = save_load_object.load_from_file(pjoin(self.path_me,"production_me", "all_ME.pkl"))
                 self.all_ME, self.all_decay,self.width_estimator = data.all_ME, data.all_decay, data.width_estimator
@@ -2280,6 +2285,57 @@ class decay_all_events(object):
         # set the environment variable GFORTRAN_UNBUFFERED_ALL 
         # to its original value
         #os.environ['GFORTRAN_UNBUFFERED_ALL']='n'
+
+    # Name of the file recording which spin basis the standalone directories
+    # under path_me were generated with. See check_spin_basis_tag().
+    SPIN_BASIS_TAG = 'spin_basis.txt'
+
+    def write_spin_basis_tag(self):
+        """Record the spin basis the matrix-element directories were just
+        generated with, so that a later run reusing them ('ms_dir',
+        'use_old_dir') can check that it is asking for the same one."""
+
+        try:
+            with open(pjoin(self.path_me, self.SPIN_BASIS_TAG), 'w') as fsock:
+                fsock.write('consider_axial = %s\n'
+                            % bool(self.options['consider_axial']))
+        except IOError:
+            pass
+
+    def check_spin_basis_tag(self, consider_axial=None):
+        """Refuse to reuse matrix-element directories that were generated
+        with a different spin basis.
+
+        'consider_axial' decides how many states each decaying particle has --
+        three physical polarisations, or those plus the axial '{A}' direction.
+        It is baked into the generated code (the NHEL table and the ALLOW_HEL
+        rows of GET_DENSITY) at output time, so a directory built with one
+        value and a convolution written for the other would be silently
+        inconsistent: a four-index density matrix contracted against a
+        three-state matrix element. Unlike the old global MG5 option, this one
+        is not recorded in the banner's proc_card, so the directory carries its
+        own record instead."""
+
+        if consider_axial is None:
+            consider_axial = self.options['consider_axial']
+        consider_axial = bool(consider_axial)
+        path = pjoin(self.path_me, self.SPIN_BASIS_TAG)
+        if os.path.exists(path):
+            previous = 'true' in open(path).read().split('=')[-1].strip().lower()
+        else:
+            # directories from before this record existed are three-state
+            previous = False
+        if previous != consider_axial:
+            raise Exception(
+                "The matrix-element directories in %s were generated with "
+                "'consider_axial = %s' but this run asks for "
+                "'consider_axial = %s'. That option changes the spin basis "
+                "baked into the generated code (the NHEL table and the "
+                "ALLOW_HEL rows of GET_DENSITY), so the two cannot be mixed. "
+                "Either set 'consider_axial %s' in the MadSpin card, or drop "
+                "'ms_dir'/'use_old_dir' so that the directories are "
+                "regenerated." % (self.path_me, previous, consider_axial,
+                                  previous))
 
     def save_status_to_pickle(self, path=None):
         import madgraph.iolibs.save_load_object as save_load_object
@@ -4599,8 +4655,19 @@ class decay_all_events_onshell(decay_all_events):
             mgcmd.exec_cmd(commandline, precmd=True)
             fill_all_me(self, "production")
         else:
+            # 'consider_axial' is a MadSpin card option, not a global MG5 one:
+            # the axial ('{A}') direction of a decaying vector's spin basis is
+            # something MadSpin decides, and the standalone directories it
+            # generates have to be told about it on the output line. Passing
+            # the flag from here -- rather than reading it back out of the
+            # banner's proc_card, which is where the old global option lived --
+            # is what guarantees that the production directory, the decay
+            # directory and the convolution all agree on the size of the basis:
+            # they are all built in this one call from this one option.
+            axial = ' --allow_axial' if self.options['consider_axial'] else ''
+
             commandline_production = commandline.replace('add process', 'generate',1)
-            commandline_production += 'output standalone %s --prefix=int --density=1' % pjoin(path_me, ms_me_subdir)
+            commandline_production += 'output standalone %s --prefix=int --density=1%s' % (pjoin(path_me, ms_me_subdir), axial)
 
             logger.info(commandline_production)
             mgcmd.exec_cmd(commandline_production, precmd=True)
@@ -4609,7 +4676,7 @@ class decay_all_events_onshell(decay_all_events):
             fill_all_me(self, "production")
 
             commandline_decay = self.get_decay_command()
-            commandline_decay += 'output standalone %s --prefix=int --density=1 -f' % pjoin(path_me, ms_me_decay_subdir) #we add -f, else it would ask us if we want to clean the folder madspin_decay and madspin_me
+            commandline_decay += 'output standalone %s --prefix=int --density=1%s -f' % (pjoin(path_me, ms_me_decay_subdir), axial) #we add -f, else it would ask us if we want to clean the folder madspin_decay and madspin_me
             commandline_decay = commandline_decay.replace('add process', 'generate',1)
 
             logger.info(commandline_decay)
@@ -4618,6 +4685,7 @@ class decay_all_events_onshell(decay_all_events):
             # store information about the decay matrix elements
             fill_all_me(self, "decay")
 
+        self.write_spin_basis_tag()
         logger.info('Done %.4g' % (time.time()-start))
 
         return self.all_me

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -324,6 +324,21 @@ class MadSpinOptions(banner.ConfigFile):
                        "offered to each decaying SPIN-1/2 particle. '0' is unphysical "
                        "for a fermion and is dropped from its choices; 'T' is its full "
                        "helicity basis, i.e. that particle summed over.")
+        self.add_param('consider_axial', False,
+                       comment="density spin modes only. Include the AXIAL "
+                       "('{A}') direction in the spin basis of each decaying "
+                       "particle, i.e. use the full four-dimensional basis of "
+                       "an off-shell massive vector rather than its three "
+                       "physical polarisations. This is the MadSpin home of "
+                       "what used to be the global MG5 option of the same "
+                       "name: MadSpin passes '--allow_axial' on to every "
+                       "'output standalone' it generates, so the directories "
+                       "and the convolution can never disagree about the size "
+                       "of the basis. A directory built with one value of this "
+                       "option cannot be reused (set ms_dir / use_old_dir) with "
+                       "the other -- MadSpin refuses that rather than "
+                       "convoluting a four-index density against a "
+                       "three-state matrix element.")
         self.add_param('density_debug', False, comment='Turn on check against full ME calculation')
         self.add_param('density_tolerance', 1E-4, comment='Tolerance for deviation between density and full ME')
         self.add_param('decay_event_mult', 1E0, comment='Produce more events than needed so that MadSpin does not have to regenerate decay events')
@@ -2018,6 +2033,12 @@ class MadSpinInterface(extended_cmd.Cmd):
                         decay2['path'] = decay2['path'].replace(generate_all.path_me, self.options['ms_dir'])
             generate_all.path_me = self.options['ms_dir'] # directory can have been move
             generate_all.ms_dir = generate_all.path_me
+
+        # the reused directory has its spin basis baked in (the NHEL table and
+        # the ALLOW_HEL rows of GET_DENSITY); refuse to convolute it with a
+        # basis of a different size. 'consider_axial' is a card option, not a
+        # banner one, so the directory carries its own record of it.
+        generate_all.check_spin_basis_tag(self.options['consider_axial'])
         
         if not hasattr(self.banner, 'param_card'):
             self.banner.charge_card('slha')

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -5,6 +5,21 @@ ANNOUNCEMENT:
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
 3.7.2 (XX/XX/XX):
+    OM: the axial polarisation brace '{A}' now has a real external wavefunction and
+        can be put on an off-shell final-state particle ("generate p p > z{A}* h"),
+        not only on an internal line. VXXXXX (aloha_functions.f, its loop variant and
+        vxxxxx.cc) implements the historical HELAS nhel = 4 scalar state
+        eps^mu = p^mu/vmass, and since the off-shell '*' makes the writer pass
+        sqrt(p.p) rather than the pole mass, an external axial leg is the unit vector
+        eps_A^mu = p^mu/sqrt(p.p) -- the fourth direction of an orthonormal tetrad
+        with the three physical polarisations, which is what a four-by-four spin
+        density matrix in that basis needs. Because the state is unphysical it is
+        only written when asked for: "output standalone MYDIR --allow_axial"
+        (Fortran standalone family only; the C++ writer has no off-shell external
+        leg). From MadSpin the same choice is the new MadSpin card option
+        'consider_axial', which passes the flag to the standalone outputs MadSpin
+        generates and is recorded in the generated directory so that a reused
+        'ms_dir'/'use_old_dir' cannot mix two different spin bases.
     OM: MadSpin: the run_card me_frame and polbeam1/polbeam2 are now honoured by the
         density-based spinmodes (onshell/PA/madspin/full) and no longer only by the
         legacy madspin_v1/onshell_v1 paths.

--- a/aloha/template_files/aloha_functions.f
+++ b/aloha/template_files/aloha_functions.f
@@ -804,6 +804,8 @@ c       real    p(0:3)         : four-momentum of vector boson
 c       real    vmass          : mass          of vector boson
 c       integer nhel = -1, 0, 1: helicity      of vector boson
 c                                (0 is forbidden if vmass=0.0)
+c                     4        : axial/scalar state eps^mu = p^mu/vmass
+c                                (the '{A}' polarization; final state only)
 c       integer nsv  = -1 or 1 : +1 for final, -1 for initial
 c
 c output:
@@ -872,23 +874,39 @@ c#endif
       vc(1) = dcmplx(p(0),p(3))*nsv
       vc(2) = dcmplx(p(1),p(2))*nsv
 
-c#ifdef HELAS_CHECK
-c nhel=4 option for scalar polarization
-c      if( nhel.eq.4 ) then
-c         if( vmass.eq.rZero ) then
-c            vc(1) = rOne
-c            vc(2) = p(1)/p(0)
-c            vc(3) = p(2)/p(0)
-c            vc(4) = p(3)/p(0)
-c         else
-c            vc(1) = p(0)/vmass
-c            vc(2) = p(1)/vmass
-c            vc(3) = p(2)/vmass
-c            vc(4) = p(3)/vmass
-c         endif
-c         return
-c      endif
-c#endif
+c     nhel = 4 is the axial (scalar) polarization '{A}': the fourth,
+c     unphysical direction of the massive-vector basis, eps^mu = p^mu/vmass.
+c     It completes the three physical polarizations into an orthonormal
+c     tetrad of the momentum-dependent basis:
+c
+c        eps_A.eps_A = +1   eps_i.eps_i = -1   eps_A.eps_i = 0
+c
+c     which is what makes a four-by-four spin density matrix in this basis
+c     meaningful. The normalization is therefore fixed by the SAME vmass the
+c     three physical states are built with -- for an off-shell external leg
+c     ("z{A}*") the caller passes sqrt(p.p), not the pole mass, so this is
+c     eps_A^mu = p^mu/sqrt(p.p) there. No nsv factor: the axial state is
+c     only allowed on a final-state leg (nsv = +1).
+c
+c     vmass = 0 keeps the historical HELAS BRST-check convention
+c     eps^mu = p^mu/p(0), which is NOT normalized (p.p = 0); it exists so
+c     that a gauge check can feed the momentum in as a wavefunction.
+c
+c     This mirrors aloha/template_files/wavefunctions.py:vxxxxx exactly.
+      if( nhel.eq.4 ) then
+         if( vmass.eq.rZero ) then
+            vc(3) = dcmplx( rOne )
+            vc(4) = dcmplx( p(1)/p(0) )
+            vc(5) = dcmplx( p(2)/p(0) )
+            vc(6) = dcmplx( p(3)/p(0) )
+         else
+            vc(3) = dcmplx( p(0)/vmass )
+            vc(4) = dcmplx( p(1)/vmass )
+            vc(5) = dcmplx( p(2)/vmass )
+            vc(6) = dcmplx( p(3)/vmass )
+         endif
+         return
+      endif
 
       if ( vmass.ne.rZero ) then
 

--- a/aloha/template_files/aloha_functions_loop.f
+++ b/aloha/template_files/aloha_functions_loop.f
@@ -1426,23 +1426,26 @@ c     Convention for loop computations
       vc(3) = dcmplx(p(2),0.D0)*nsv
       vc(4) = dcmplx(p(3),0.D0)*nsv
 
-c#ifdef HELAS_CHECK
-c nhel=4 option for scalar polarization
-c      if( nhel.eq.4 ) then
-c         if( vmass.eq.rZero ) then
-c            vc(1) = rOne
-c            vc(2) = p(1)/p(0)
-c            vc(3) = p(2)/p(0)
-c            vc(4) = p(3)/p(0)
-c         else
-c            vc(1) = p(0)/vmass
-c            vc(2) = p(1)/vmass
-c            vc(3) = p(2)/vmass
-c            vc(4) = p(3)/vmass
-c         endif
-c         return
-c      endif
-c#endif
+c     nhel = 4 is the axial (scalar) polarization '{A}', eps^mu = p^mu/vmass.
+c     See aloha/template_files/aloha_functions.f for the convention: the
+c     normalization uses the SAME vmass as the three physical states, so an
+c     off-shell external leg (which is called with sqrt(p.p)) gets the unit
+c     vector p^mu/sqrt(p.p). Here vc(1:4) holds the momentum and vc(5:8) the
+c     wavefunction, so the components go in vc(5:8).
+      if( nhel.eq.4 ) then
+         if( vmass.eq.rZero ) then
+            vc(5) = dcmplx( rOne )
+            vc(6) = dcmplx( p(1)/p(0) )
+            vc(7) = dcmplx( p(2)/p(0) )
+            vc(8) = dcmplx( p(3)/p(0) )
+         else
+            vc(5) = dcmplx( p(0)/vmass )
+            vc(6) = dcmplx( p(1)/vmass )
+            vc(7) = dcmplx( p(2)/vmass )
+            vc(8) = dcmplx( p(3)/vmass )
+         endif
+         return
+      endif
 
       if ( vmass.ne.rZero ) then
 

--- a/aloha/template_files/vxxxxx.cc
+++ b/aloha/template_files/vxxxxx.cc
@@ -13,6 +13,28 @@ void vxxxxx(double p[4],double vmass,int nhel,int nsv, complex<double> vc[6]){
   pt =min(pp,sqrt(pt2));
   vc[0] = complex<double>(p[0]*nsv,p[3]*nsv);
   vc[1] = complex<double>(p[1]*nsv,p[2]*nsv);
+  // nhel = 4 is the axial (scalar) polarization '{A}': eps^mu = p^mu/vmass,
+  // the fourth direction completing the three physical polarizations into an
+  // orthonormal tetrad (eps_A.eps_A = +1). The normalization uses the SAME
+  // vmass the physical states use, so an off-shell external leg -- which is
+  // called with sqrt(p.p) instead of the pole mass -- gets p^mu/sqrt(p.p).
+  // vmass = 0 keeps the historical HELAS BRST-check convention p^mu/p[0].
+  // Mirrors aloha_functions.f and wavefunctions.py.
+  if (nhel == 4){
+    if (vmass == 0.0){
+      vc[2] = complex<double>(1.0,0.0);
+      vc[3] = complex<double>(p[1]/p[0],0.0);
+      vc[4] = complex<double>(p[2]/p[0],0.0);
+      vc[5] = complex<double>(p[3]/p[0],0.0);
+    }
+    else{
+      vc[2] = complex<double>(p[0]/vmass,0.0);
+      vc[3] = complex<double>(p[1]/vmass,0.0);
+      vc[4] = complex<double>(p[2]/vmass,0.0);
+      vc[5] = complex<double>(p[3]/vmass,0.0);
+    }
+    return;
+  }
   if (vmass != 0.0){
     hel0 = 1.0-std::abs(hel);
     if( pp == 0.0 ){ 

--- a/madgraph/core/base_objects.py
+++ b/madgraph/core/base_objects.py
@@ -2099,6 +2099,27 @@ def polarization_to_string(polarization):
                     for p in polarization])
 
 
+def polarization_to_helicities(polarization):
+    """Translate a leg 'polarization' list into the helicity values that go
+    into the NHEL table and are handed to the HELAS wavefunction routines.
+
+    All the physical entries (-1,0,1 and the spin-3/2, spin-2 ones) already
+    *are* helicity values and pass straight through. The only entry that has
+    to be translated is the axial/scalar state '{A}', which the process parser
+    stores as 99 -- an out-of-band tag chosen so that it cannot collide with a
+    helicity -- while VXXXXX (aloha_functions.f) has always called that state
+    nhel = 4. 4 is not free at Leg level, where it is the '{G}' brace, but
+    '{G}' has no external wavefunction at all and is refused on any external
+    leg, so no external polarization list can ever contain a literal 4 and the
+    two meanings never meet.
+
+    Use this -- never the raw list -- wherever a polarization becomes a
+    helicity, so that the NHEL table and the ALLOW_HEL rows of a density
+    matrix cannot end up on opposite sides of the translation."""
+
+    return [Leg.polarization_to_helicity.get(p, p) for p in polarization]
+
+
 #===============================================================================
 # Leg
 #===============================================================================
@@ -2122,6 +2143,11 @@ class Leg(PhysicsObject):
                                      9: 'S',   # scalar = axial + width
                                      99: 'A',  # axial/auxiliary
                                      }
+
+    # Leg-level polarization value -> HELAS helicity value (the integer that
+    # ends up in the NHEL table and is passed to VXXXXX/IXXXXX/...).
+    # See polarization_to_helicities() above for why 99 -> 4 is safe.
+    polarization_to_helicity = {99: 4}
 
     def default_setup(self):
         """Default values for all properties"""

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -708,28 +708,29 @@ class HelasWavefunction(base_objects.PhysicsObject):
                             "leg of the process." % propagator_only[value])
                     if 99 in leg.get('polarization'):
                         # The axial/scalar polarization {A} of a massive vector
-                        # is the k^mu piece of its *propagator*; it vanishes
-                        # identically for an on-shell particle. On an external
-                        # leg it is therefore only meaningful together with the
-                        # off-shell '*' syntax -- and even then the generated
-                        # code for it does not exist yet (see below).
+                        # is the k^mu direction: the fourth basis vector, not
+                        # one of the three physical polarizations. It only has
+                        # a meaning off shell, and the off-shell '*' syntax is
+                        # also what fixes its normalisation -- the external
+                        # call passes sqrt(p.p) rather than the pole mass, so
+                        # VXXXXX returns eps_A^mu = p^mu/sqrt(p.p), the unit
+                        # vector completing the physical three into an
+                        # orthonormal tetrad. (The amplitude on that direction
+                        # is k.J, which is zero only for a conserved current,
+                        # i.e. for massless daughters -- not in general.)
+                        if leg.get('state') is False:
+                            # An initial-state axial leg is what MadSpin's
+                            # decay-side matrix element would need (there the
+                            # decaying particle is leg 1). Not enabled yet:
+                            # the density-matrix side of that does not exist.
+                            raise InvalidCmd(
+                                "The axial polarization {A} is not supported "
+                                "for an initial-state particle.")
                         if not leg.get('offshell'):
                             raise InvalidCmd(
                                 "polarization A only valid for propagator, or "
                                 "for an off-shell final-state particle written "
                                 "\"z{A}*\" (star after the brace).")
-                        raise InvalidCmd(
-                            "The axial polarization {A} of an off-shell "
-                            "final-state particle is accepted by the process "
-                            "syntax but is NOT implemented in the generated "
-                            "code yet: there is no external wavefunction for "
-                            "it (aloha/template_files/aloha_functions.f, "
-                            "VXXXXX), no helicity entry in the NHEL table and "
-                            "no fourth index in the MadSpin density matrix. "
-                            "Generating this process would silently produce a "
-                            "wrong number, so it is refused instead. Use {A} "
-                            "on a particle that is decayed further (the "
-                            "propagator case) until that support lands.")
                 # Set fermion flow state. Initial particle and final
                 # antiparticle are incoming, and vice versa for
                 # outgoing
@@ -4885,21 +4886,29 @@ class HelasMatrixElement(base_objects.PhysicsObject):
 
         process = self.get('processes')[0]
         model = process.get('model')
-        hel_per_part = [ wf.get('polarization') if wf.get('polarization') 
+        # polarization_to_helicities: a polarization list is a list of *braces*,
+        # not of helicities. '{A}' is stored as 99 and has to become the HELAS
+        # nhel = 4 before it reaches the NHEL table. Must stay in step with
+        # get_helicity_per_particle below -- GET_DENSITY matches the two against
+        # each other, and a mismatch makes every density identically zero.
+        hel_per_part = [ base_objects.polarization_to_helicities(wf.get('polarization'))
+                        if wf.get('polarization')
                         else model.get('particle_dict')[\
                                   wf.get('pdg_code')].get_helicity_states(allow_reverse)
             for wf in self.get_external_wavefunctions()]
         return itertools.product(*hel_per_part)
-    
+
     def get_helicity_per_particle(self):
         """give the allowed helicity for each external particle"""
-        
+
         if not self.get('processes'):
             return None
 
         process = self.get('processes')[0]
         model = process.get('model')
-        hel_per_part = [ wf.get('polarization') if wf.get('polarization') 
+        # same translation as get_helicity_matrix -- see there
+        hel_per_part = [ base_objects.polarization_to_helicities(wf.get('polarization'))
+                        if wf.get('polarization')
                         else model.get('particle_dict')[\
                                   wf.get('pdg_code')].get_helicity_states()
             for wf in self.get_external_wavefunctions()]

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -497,6 +497,12 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("      --jamp_optim=[True|False]: [madevent(default:True)|standalone(default:False)] allows a more efficient code computing the color-factor.")
         logger.info("      --t_strategy: [madevent] allows to change ordering strategy for t-channel.")
         logger.info("      --hel_recycling=False: [madevent] forbids helicity recycling optimization")
+        logger.info("      --density=i[,j,...]: [standalone] also write GET_DENSITY, the spin density matrix")
+        logger.info("        of the external particle(s) at position i (,j,...) of the process.")
+        logger.info("      --allow_axial: [standalone] permit the axial polarisation '{A}' on an off-shell")
+        logger.info("        final-state particle ('generate p p > z{A}* h'). That is the fourth,")
+        logger.info("        unphysical direction of a massive vector's spin basis, eps^mu = p^mu/sqrt(p.p),")
+        logger.info("        so it is never written without this flag.")
         logger.info("   Examples:",'$MG:color:GREEN')
         logger.info("       output",'$MG:color:GREEN')
         logger.info("       output standalone MYRUN -f",'$MG:color:GREEN')
@@ -769,7 +775,7 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info(" > '{G}','{H}','{Q}','{W}','{S}' select a piece of the *propagator* of a massive vector")
         logger.info("   and are only valid on a particle that is decayed further (an internal line).")
         logger.info(" > '{A}' is the same on an internal line; on a final-state particle it also needs the")
-        logger.info("   off-shell '*' syntax and 'set consider_axial True'.")
+        logger.info("   off-shell '*' syntax, and an output that enables it ('output standalone --allow_axial').")
         logger.info(" > Users need to set 'group_subprocesses False', 'nhel=1' (run_card), and 'me_frame' (run_card)")
         logger.info(" > For the proces 'p p > w+ z j j, w+ > l+ vl, z > l+ l-', the WZ rest frame is given by me_frame = [3,4,5,6]")
         logger.info(" > For further details, see appendices of [arXiv:1912.01725] and [arXiv:2512.10015],")
@@ -904,10 +910,6 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info("deactivates mixed expansion support at NLO, goes back to MG5aMCv2 behavior")
         logger.info("acknowledged_v3.1_syntax <value>",'$MG:color:GREEN') 
         logger.info("if set to True allows to use syntax which have change meaning between 3.0 and 3.1 version")
-        logger.info("consider_axial <value>",'$MG:color:GREEN')
-        logger.info(" > (default: False) allow the axial/scalar polarisation {A} on a FINAL-STATE")
-        logger.info(" > particle. Only meaningful together with the off-shell '*' syntax")
-        logger.info(" > ('generate p p > z{A}* z'), since {A} vanishes for an on-shell particle.")
           
 #===============================================================================
 # CheckValidForCmd
@@ -1596,7 +1598,6 @@ This will take effect only in a NEW terminal
                                           'loop_optimized_output',\
                                           'loop_color_flows',\
                                           'include_lepton_initiated_processes',\
-                                          'consider_axial',\
                                           'low_mem_multicore_nlo_generation']:
             args.append('True')
 
@@ -1646,7 +1647,7 @@ This will take effect only in a NEW terminal
             if not args[1].isdigit():
                 raise self.InvalidCmd('%s values should be a integer' % args[0])
             
-        if args[0] in ['loop_optimized_output', 'loop_color_flows', 'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion', 'consider_axial']:
+        if args[0] in ['loop_optimized_output', 'loop_color_flows', 'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
             try:
                 args[1] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
             except Exception:
@@ -1796,6 +1797,129 @@ This will take effect only in a NEW terminal
                     self._export_dir = '.'
 
         self._export_dir = os.path.realpath(self._export_dir)
+
+        self.check_axial_output(args)
+
+    # Output formats whose generated code can host an off-shell external leg
+    # (the '*' syntax) and therefore an axial external state. The Fortran
+    # writer feeds VXXXXX sqrt(p.p) instead of the pole mass for such a leg
+    # (helas_call_writers.generate_external_wavefunction); the C++ writer has
+    # no equivalent -- it always passes mME[i] -- so standalone_cpp/gpu are
+    # deliberately absent.
+    _axial_export_formats = ['standalone', 'standalone_msP', 'standalone_msF',
+                             'standalone_rw', 'matrix']
+
+    @staticmethod
+    def collect_axial_external_legs(amps):
+        """Return the final-state legs carrying '{A}' that really stay
+        external, i.e. that are NOT handed over to a decay chain.
+
+        '{A}' on a decayed leg is the historical propagator use and needs
+        nothing; '{A}' on a genuine external leg is the new thing that has to
+        be asked for. Telling them apart means walking the amplitude tree,
+        because for a decay-chain amplitude the decays hang off the *amplitude*
+        (DecayChainAmplitude['decay_chains']) and not always off the Process.
+        """
+
+        def processes_of(obj):
+            """the core Process(es) an amplitude object stands for"""
+            if isinstance(obj, diagram_generation.DecayChainAmplitude):
+                out = []
+                for sub in obj.get('amplitudes'):
+                    out.extend(processes_of(sub))
+                return out
+            try:
+                proc = obj.get('process')
+            except Exception:
+                return []
+            return [proc] if proc else []
+
+        axial_legs = []
+
+        def scan_process(proc, decayed_ids):
+            decayed = set(decayed_ids)
+            for decay in proc.get('decay_chains'):
+                for leg in decay.get('legs'):
+                    if not leg.get('state'):
+                        decayed.add(leg.get('id'))
+            for leg in proc.get('legs'):
+                if 99 in leg.get('polarization') and leg.get('state') \
+                   and leg.get('id') not in decayed:
+                    axial_legs.append(leg)
+            for decay in proc.get('decay_chains'):
+                scan_process(decay, set())
+
+        def scan_amplitude(obj, decayed_ids):
+            if isinstance(obj, diagram_generation.DecayChainAmplitude):
+                decayed = set(decayed_ids)
+                for chain in obj.get('decay_chains'):
+                    for proc in processes_of(chain):
+                        for leg in proc.get('legs'):
+                            if not leg.get('state'):
+                                decayed.add(leg.get('id'))
+                for sub in obj.get('amplitudes'):
+                    scan_amplitude(sub, decayed)
+                for chain in obj.get('decay_chains'):
+                    scan_amplitude(chain, set())
+                return
+            for proc in processes_of(obj):
+                scan_process(proc, decayed_ids)
+
+        for amp in amps:
+            scan_amplitude(amp, set())
+        return axial_legs
+
+    def check_axial_output(self, args):
+        """The axial polarisation '{A}' on a genuinely final-state leg is an
+        unphysical basis direction: not one of the three polarisations of a
+        massive vector, but the fourth column a spin density matrix needs off
+        shell -- and not something anyone wants by accident. Writing it out
+        therefore requires an explicit '--allow_axial' on the output line.
+
+        This is the *output*-level gate. It replaces the former global
+        'consider_axial' MadGraph option, which was the wrong home for it: the
+        choice belongs to the code being written (an output option) and to
+        MadSpin (a MadSpin card option, which makes MadSpin add '--allow_axial'
+        to the 'output standalone' lines it issues itself).
+        """
+
+        if self._export_format == 'aloha' or not self._curr_amps:
+            return
+
+        axial_legs = self.collect_axial_external_legs(self._curr_amps)
+        if not axial_legs:
+            return
+
+        if '--allow_axial' not in args and \
+           not any(a.startswith('--allow_axial=') for a in args):
+            raise self.InvalidCmd(
+                'The axial polarization {A} was requested on a final-state '
+                'particle. This is the fourth, unphysical direction of a '
+                'massive vector\'s spin basis (the extra column of an '
+                'off-shell spin density matrix), not one of the three '
+                'polarizations, so it is not written out unless you ask for '
+                'it explicitly:\n'
+                '   output standalone MYDIR --allow_axial\n'
+                'From MadSpin, use "set consider_axial True" in the MadSpin '
+                'card instead -- MadSpin then passes the flag on to the '
+                'standalone outputs it generates.')
+
+        if self._export_format not in self._axial_export_formats:
+            raise self.InvalidCmd(
+                'The axial polarization {A} on a final-state particle needs '
+                'the off-shell "*" external leg, which only the Fortran '
+                'standalone outputs support (%s). It cannot be written for '
+                'the "%s" output.'
+                % (', '.join(self._axial_export_formats), self._export_format))
+
+        if aloha.unitary_gauge == 3:
+            raise self.InvalidCmd(
+                'The axial polarization {A} on a final-state particle is not '
+                'available in the Feynman-diagram gauge (gauge = FD): there '
+                'the massive-vector wavefunction carries an extra Goldstone '
+                'component (aloha_functions_fd.f, VFDXXXX) whose value for '
+                'the axial state is not defined. Use the unitary or Feynman '
+                'gauge.')
 
 
     def check_compute_widths(self, args):
@@ -2621,7 +2745,7 @@ class CompleteForCmd(cmd.CompleteCmd):
                 except Exception as error:
                     print(error)
             if 'standalone' in args:
-                possible_options_full = list(possible_options_full) + ['--prefix=int', '--prefix=proc', '--density=']
+                possible_options_full = list(possible_options_full) + ['--prefix=int', '--prefix=proc', '--density=', '--allow_axial']
 
             # Directory continuation
             if args[-1].endswith(os.path.sep):
@@ -2701,8 +2825,7 @@ class CompleteForCmd(cmd.CompleteCmd):
             if args[1] in ['complex_mass_scheme',\
                            'loop_optimized_output', 'loop_color_flows',\
                            'include_lepton_initiated_processes',\
-                           'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion',\
-                           'consider_axial']:
+                           'low_mem_multicore_nlo_generation', 'nlo_mixed_expansion']:
                 return self.list_completion(text, ['False', 'True', 'default'])
             elif args[1] in ['group_subprocesses']:
                 return self.list_completion(text, ['False', 'True', 'Auto', 'gpu', 'nlo'])
@@ -3046,8 +3169,7 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                     'max_t_for_channel',
                     'zerowidth_tchannel',
                     'default_unset_couplings',
-                    'nlo_mixed_expansion',
-                    'consider_axial'
+                    'nlo_mixed_expansion'
                     ]
     _valid_nlo_modes = ['all','real','virt','sqrvirt','tree','noborn','LOonly', 'only']
     _valid_sqso_types = ['==','<=','=','>']
@@ -3130,7 +3252,6 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                           'max_t_for_channel': 99, # means no restrictions
                           'zerowidth_tchannel': True,
                           'nlo_mixed_expansion':True,
-                          'consider_axial': False,
                         }
 
     options_madevent = {'automatic_html_opening':True,
@@ -3339,8 +3460,8 @@ This implies that with decay chains:
                 raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
 
             # Check the propagator-only polarization braces: {G},{H},{Q},{W}
-            # and {S} are internal-line only, and {A} needs 'consider_axial'
-            # plus the off-shell '*' unless the leg is decayed further.
+            # and {S} are internal-line only, and {A} needs the off-shell '*'
+            # unless the leg is decayed further.
             self.check_propagator_polarization(myprocdef)
 
             #Check that we do not have situation like z{T} z
@@ -4903,13 +5024,20 @@ This implies that with decay chains:
         *propagator* carries off shell (arXiv:1908.08454). Three cases:
 
         * '{A}' on a particle that is decayed further ('t > w+{A} b,
-          w+ > ta+ vt') is the historical propagator use. Always allowed, and
-          unaffected by 'consider_axial'.
+          w+ > ta+ vt') is the historical propagator use. Always allowed.
         * '{A}' on a genuinely final-state particle is only meaningful with the
-          off-shell '*' syntax, because the axial polarisation vanishes
-          identically for an on-shell particle. It additionally needs
-          'set consider_axial True'.
-        * '{A}' on an initial-state particle is never meaningful.
+          off-shell '*' syntax. A massive vector has three physical
+          polarisations; the axial direction is the fourth one, outside that
+          spectrum, and the star is what gives the leg the virtuality that
+          normalises it (eps_A^mu = p^mu/sqrt(p.p), not p^mu/M_pole). Note
+          that the *amplitude* on that direction is not generally zero on
+          shell -- it is proportional to k.J, which vanishes only when the
+          current J is conserved, i.e. for massless daughters. Whether such a
+          process may then be *written out* is decided at output time by
+          'output standalone --allow_axial' (check_output), not here.
+        * '{A}' on an initial-state particle is refused. (The one place it
+          would make sense is MadSpin's decay-side matrix element, where the
+          decaying particle IS leg 1; that is not wired up yet.)
 
         '{G}', '{H}', '{Q}', '{W}' and '{S}' (pol=4,5,6,7,9). Each of these
         names a rank-two piece of the propagator numerator, complete with its
@@ -4960,16 +5088,20 @@ This implies that with decay chains:
                 continue
             if not leg.get('offshell'):
                 raise self.InvalidCmd(
-                    'The axial polarization {A} of a final-state particle is '
-                    'identically zero on shell, so it requires the off-shell '
-                    '"*" syntax (write "z{A}*", the star after the brace). '
+                    'The axial polarization {A} is not one of the three '
+                    'polarizations of an on-shell massive vector: it is the '
+                    'fourth, k^mu direction, which only has a meaning off '
+                    'shell. It therefore requires the off-shell "*" syntax '
+                    '(write "z{A}*", the star after the brace) -- which is '
+                    'also what normalises it to the leg\'s own virtuality, '
+                    'eps_A^mu = p^mu/sqrt(p.p), instead of to the pole mass. '
                     'Without a star, {A} is only valid for a particle that is '
                     'decayed further, i.e. for a propagator.')
-            if not self.options['consider_axial']:
-                raise self.InvalidCmd(
-                    'The axial polarization {A} of a final-state particle is '
-                    'disabled by default. Use "set consider_axial True" to '
-                    'enable it.')
+            # NB: there is deliberately no further gate here. Whether the
+            # axial external state may actually be *written out* is an output
+            # question, not a generation one, and is answered by the
+            # 'output standalone --allow_axial' flag (check_output) and, for
+            # MadSpin, by its card's 'consider_axial'.
 
         for decay in procdef.get('decay_chains'):
             self.check_propagator_polarization(decay)
@@ -8866,28 +8998,6 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         self.check_set(args)
         self.options[args[0]] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
         
-    def help_set2_consider_axial(self):
-        logger.info("consider_axial <value>",'$MG:color:GREEN')
-        logger.info(" > (default: False) allow the axial/scalar polarisation {A}")
-        logger.info("   of a massive spin-one particle to be requested on a")
-        logger.info("   FINAL-STATE particle, which is only meaningful together")
-        logger.info("   with the off-shell '*' syntax: 'generate p p > z{A}* z'.")
-        logger.info("   {A} is identically zero for an on-shell particle, so the")
-        logger.info("   star is mandatory. See arXiv:1908.08454.")
-        logger.info("   {A} on a particle that is decayed further (the propagator")
-        logger.info("   case, 'generate t > w+{A} b, w+ > ta+ vt') is always")
-        logger.info("   allowed and does not need this option.")
-
-    def set2_consider_axial(self, args, log=True):
-        """Set whether the axial/scalar polarisation {A} may be requested on a
-        final-state particle (which additionally requires the off-shell '*').
-        Default is False.
-        Example: set consider_axial True
-        """
-        args = ['consider_axial'] + args
-        self.check_set(args)
-        self.options[args[0]] = banner_module.ConfigFile.format_variable(args[1], bool, args[0])
-
     def help_set2_zerowidth_tchannel(self):
         logger.info("zerowidth_tchannel <value>",'$MG:color:GREEN')
         logger.info(" > (default: True) [Used ONLY for tree-level output with madevent]")

--- a/madgraph/interface/master_interface.py
+++ b/madgraph/interface/master_interface.py
@@ -381,6 +381,9 @@ class Switcher(object):
     def check_propagator_polarization(self, *args, **opts):
         return self.cmd.check_propagator_polarization(self, *args, **opts)
 
+    def check_axial_output(self, *args, **opts):
+        return self.cmd.check_axial_output(self, *args, **opts)
+
     def check_open(self, *args, **opts):
         return self.cmd.check_open(self, *args, **opts)
         
@@ -629,9 +632,6 @@ class Switcher(object):
 
     def help_set2_output_dependencies(self, *args, **opts):
         return self.cmd.help_set2_output_dependencies(self, *args, **opts)
-
-    def help_set2_consider_axial(self, *args, **opts):
-        return self.cmd.help_set2_consider_axial(self, *args, **opts)
 
     def help_set2_zerowidth_tchannel(self, *args, **opts):
         return self.cmd.help_set2_zerowidth_tchannel(self, *args, **opts)

--- a/madgraph/iolibs/helas_call_writers.py
+++ b/madgraph/iolibs/helas_call_writers.py
@@ -2077,6 +2077,24 @@ class PythonUFOHelasCallWriter(UFOHelasCallWriter):
 
 
 
+    @staticmethod
+    def external_mass_argument(wf):
+        """The second argument of an external wavefunction routine.
+
+        Normally the pole-mass parameter name. When the leg carries the
+        off-shell '*' syntax its momentum is deliberately not on the pole, and
+        the routine must be handed sqrt(p.p) instead -- exactly what the
+        Fortran writer (generate_external_wavefunction) already does. This is
+        also what fixes the normalisation of the axial polarisation '{A}':
+        VXXXXX returns p^mu/vmass, so with vmass = sqrt(p.p) the axial state
+        is the unit vector p^mu/sqrt(p.p) rather than p^mu/M_pole."""
+
+        if not wf.get('offshell'):
+            return wf.get('mass')
+        n = wf.get('number_external') - 1
+        return 'abs(p[%d][0]**2-p[%d][1]**2-p[%d][2]**2-p[%d][3]**2)**0.5' \
+               % (n, n, n, n)
+
     def generate_helas_call(self, argument, gauge_check=False):
         """Routine for automatic generation of Python Helas calls
         according to just the spin structure of the interaction.
@@ -2123,6 +2141,7 @@ class PythonUFOHelasCallWriter(UFOHelasCallWriter):
                 else:
                     call = call + "%s,hel[%d],"
             call = call + "%+d)"
+            mass_arg = self.external_mass_argument
             if argument.get('spin') == 1:
                 call_function = lambda wf: call % \
                                 (wf.get('me_id')-1,
@@ -2134,7 +2153,7 @@ class PythonUFOHelasCallWriter(UFOHelasCallWriter):
                     call_function = lambda wf: call % \
                                 (wf.get('me_id')-1,
                                  wf.get('number_external')-1,
-                                 wf.get('mass'),
+                                 mass_arg(wf),
                                  wf.get('number_external')-1,
                                  # For boson, need initial/final here
                                  (-1)**(wf.get('state') == 'initial'))
@@ -2149,7 +2168,7 @@ class PythonUFOHelasCallWriter(UFOHelasCallWriter):
                 call_function = lambda wf: call % \
                                 (wf.get('me_id')-1,
                                  wf.get('number_external')-1,
-                                 wf.get('mass'),
+                                 mass_arg(wf),
                                  wf.get('number_external')-1,
                                  # For fermions, need particle/antiparticle
                                  -(-1)**wf.get_with_flow('is_part'))

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -22,6 +22,7 @@ import madgraph.core.base_objects as base_objects
 import MadSpin.interface_madspin as ms_cmd
 import madgraph.interface.extended_cmd as ext_cmd
 import madgraph.various.misc as misc
+import math
 import os
 import logging
 
@@ -329,29 +330,32 @@ class TestValidCmd(unittest.TestCase):
         self.do('generate v{0T} v{0} > w+ w-')
         self.assertEqual(len(cmd._curr_amps), 2)
 
-    def test_consider_axial_default(self):
-        """the axial option exists, is a MadGraph option, and is off."""
+    def test_consider_axial_is_not_a_madgraph_option(self):
+        """'consider_axial' is deliberately NOT a global MG5 option: whether
+        the axial state may be written out is an *output* question
+        ('output standalone --allow_axial') and, for MadSpin, a MadSpin card
+        option. See check_axial_output()."""
         cmd = self.cmd
-        self.assertIn('consider_axial', cmd.options_madgraph)
-        self.assertEqual(cmd.options_madgraph['consider_axial'], False)
-        self.assertIn('consider_axial', cmd._set_options)
-        self.assertEqual(cmd.options['consider_axial'], False)
+        self.assertNotIn('consider_axial', cmd.options_madgraph)
+        self.assertNotIn('consider_axial', cmd.options)
+        self.assertNotIn('consider_axial', cmd._set_options)
+        self.assertRaises(madgraph.InvalidCmd,
+                          cmd.exec_cmd, 'set consider_axial True')
+        # ... it lives in the MadSpin card instead
+        import MadSpin.interface_madspin as ms_interface
+        self.assertIn('consider_axial', ms_interface.MadSpinOptions())
 
     @test_aloha.set_global()
     def test_generate_axial_polarisation(self):
-        """{A} on a FINAL-STATE particle: needs the off-shell '*' AND
-        'set consider_axial True'. On a particle that is decayed further it
-        stays the (unconditional) propagator syntax it always was."""
+        """{A} on a FINAL-STATE particle needs the off-shell '*'. Generation
+        itself is then unconditional; it is the OUTPUT that has to be asked
+        for it explicitly with '--allow_axial'."""
         import madgraph.core.helas_objects as helas_objects
 
         cmd = self.cmd
         self.do('import model sm')
-        original = cmd.options['consider_axial']
         try:
-            # --- option off (the default) -------------------------------
-            cmd.options['consider_axial'] = False
-
-            # no star: {A} is identically zero on shell
+            # no star: '{A}' is not a polarisation of an on-shell particle
             self.assertRaises(madgraph.InvalidCmd,
                               self.do, 'generate p p > z{A} h')
             try:
@@ -359,24 +363,16 @@ class TestValidCmd(unittest.TestCase):
             except madgraph.InvalidCmd as error:
                 self.assertIn('off-shell', str(error))
 
-            # star but option off
-            self.assertRaises(madgraph.InvalidCmd,
-                              self.do, 'generate p p > z{A}* h')
-            try:
-                self.do('generate p p > z{A}* h')
-            except madgraph.InvalidCmd as error:
-                self.assertIn('consider_axial', str(error))
-
-            # initial state is never meaningful
+            # initial state is refused (MadSpin's decay-side ME would want
+            # it one day; it is not wired up)
             self.assertRaises(madgraph.InvalidCmd,
                               self.do, 'generate z{A}* z > w+ w-')
 
-            # the propagator syntax does not go through the option at all
+            # the propagator syntax is unchanged
             self.do('generate t > w+{A} b, w+ > ta+ vt')
             self.assertTrue(cmd._curr_amps)
 
-            # --- option on ----------------------------------------------
-            cmd.options['consider_axial'] = True
+            # with the star, generation goes through with no option at all
             self.do('generate p p > z{A}* h')
             self.assertTrue(cmd._curr_amps)
             legs = cmd._curr_amps[0].get('process').get('legs')
@@ -385,16 +381,85 @@ class TestValidCmd(unittest.TestCase):
             self.assertTrue(axial[0].get('state'))
             self.assertTrue(axial[0].get('offshell'))
 
-            # ... but the generated code for it does not exist yet, so the
-            # matrix element refuses rather than producing a wrong number.
-            try:
-                helas_objects.HelasMultiProcess(cmd._curr_amps)
-            except madgraph.InvalidCmd as error:
-                self.assertIn('not implemented', str(error).lower())
-            else:
-                self.fail('axial final state built a matrix element')
+            # and the matrix element now builds: '{A}' has an external
+            # wavefunction (VXXXXX with nhel = 4).
+            me = helas_objects.HelasMultiProcess(
+                cmd._curr_amps).get('matrix_elements')[0]
+
+            # the NHEL table carries 4 (the HELAS scalar-polarisation
+            # convention), NEVER the raw Leg-level 99
+            hel_matrix = list(me.get_helicity_matrix())
+            values = set(h for row in hel_matrix for h in row)
+            self.assertIn(4, values)
+            self.assertNotIn(99, values)
+
+            # get_helicity_per_particle -- what fills the ALLOW_HEL rows of
+            # GET_DENSITY -- must agree with it, otherwise GET_DENSITY's outer
+            # loop matches nothing and every density comes back zero
+            per_part = me.get_helicity_per_particle()
+            for i, choices in enumerate(per_part):
+                self.assertEqual(set(choices),
+                                 set(row[i] for row in hel_matrix))
+            self.assertNotIn(99, [h for c in per_part for h in c])
         finally:
-            cmd.options['consider_axial'] = original
+            cmd.exec_cmd('generate p p > t t~')
+
+    def test_polarization_to_helicities(self):
+        """the one place where a polarization brace becomes a helicity."""
+        import madgraph.core.base_objects as base_objects
+        # physical entries pass through
+        self.assertEqual(
+            base_objects.polarization_to_helicities([1, -1, 0]), [1, -1, 0])
+        # '{A}' (99) becomes the HELAS scalar polarisation nhel = 4
+        self.assertEqual(base_objects.polarization_to_helicities([99]), [4])
+        self.assertEqual(
+            base_objects.polarization_to_helicities([1, -1, 0, 99]),
+            [1, -1, 0, 4])
+        # order is preserved: GET_DENSITY takes ALLOW_HEL(1) from the first
+        # entry and matches it against the NHEL table
+        self.assertEqual(
+            base_objects.polarization_to_helicities([99, 1, -1, 0]),
+            [4, 1, -1, 0])
+
+    @test_aloha.set_global()
+    def test_axial_output_needs_allow_axial(self):
+        """'{A}' on a final state is only written out when the output line
+        asks for it."""
+        cmd = self.cmd
+        self.do('import model sm')
+        try:
+            self.do('generate t > w+{A}* b')
+            legs = cmd.collect_axial_external_legs(cmd._curr_amps)
+            self.assertEqual(len(legs), 1)
+
+            # no flag -> refused, and the message names the flag
+            try:
+                cmd.check_output(['standalone', '/tmp/should_not_exist', '-f'])
+            except madgraph.InvalidCmd as error:
+                self.assertIn('--allow_axial', str(error))
+            else:
+                self.fail('output accepted {A} without --allow_axial')
+
+            # flag, but a format with no off-shell external leg support
+            try:
+                cmd.check_output(['standalone_cpp', '/tmp/should_not_exist',
+                                  '-f', '--allow_axial'])
+            except madgraph.InvalidCmd as error:
+                self.assertIn('standalone', str(error))
+            else:
+                self.fail('standalone_cpp accepted an off-shell {A} leg')
+
+            # flag + fortran standalone -> accepted
+            cmd.check_output(['standalone', '/tmp/should_not_exist', '-f',
+                              '--allow_axial'])
+
+            # a '{A}' that is a propagator is not an external leg and needs
+            # nothing
+            self.do('generate t > w+{A} b, w+ > ta+ vt')
+            self.assertEqual(cmd.collect_axial_external_legs(cmd._curr_amps),
+                             [])
+            cmd.check_output(['standalone', '/tmp/should_not_exist', '-f'])
+        finally:
             cmd.exec_cmd('generate p p > t t~')
 
     @test_aloha.set_global()
@@ -474,9 +539,7 @@ class TestValidCmd(unittest.TestCase):
         and 3". They must print the brace letter instead."""
         cmd = self.cmd
         self.do('import model sm')
-        original = cmd.options['consider_axial']
         try:
-            cmd.options['consider_axial'] = True
             self.do('generate p p > z{A}* h')
             proc = cmd._curr_amps[0].get('process')
             self.assertIn('z{A}*', proc.nice_string(prefix=False))
@@ -498,27 +561,109 @@ class TestValidCmd(unittest.TestCase):
                 self.assertIn(expected, proc.input_string())
                 self.assertNotIn(',', proc.input_string())
         finally:
-            cmd.options['consider_axial'] = original
             cmd.exec_cmd('generate p p > t t~')
 
-    def test_set_consider_axial(self):
-        """'set consider_axial' parses like the other boolean MG5 options."""
-        cmd = self.cmd
-        original = cmd.options['consider_axial']
-        try:
-            cmd.exec_cmd('set consider_axial True')
-            self.assertEqual(cmd.options['consider_axial'], True)
-            cmd.exec_cmd('set consider_axial False')
-            self.assertEqual(cmd.options['consider_axial'], False)
-            # bare 'set consider_axial' means True, like complex_mass_scheme
-            cmd.exec_cmd('set consider_axial')
-            self.assertEqual(cmd.options['consider_axial'], True)
-            cmd.exec_cmd('set consider_axial default')
-            self.assertEqual(cmd.options['consider_axial'], False)
-            self.assertRaises(madgraph.InvalidCmd,
-                              cmd.exec_cmd, 'set consider_axial banana')
-        finally:
-            cmd.options['consider_axial'] = original
+
+
+class TestAxialWavefunction(unittest.TestCase):
+    """The external wavefunction of the axial polarisation '{A}'.
+
+    HELAS has always called that state nhel = 4. It is eps_A^mu = p^mu/vmass,
+    and for the off-shell external leg '{A}' needs, vmass is sqrt(p.p) -- so
+    eps_A is the unit vector p^mu/sqrt(p.p) that completes the three physical
+    polarisations into an orthonormal tetrad."""
+
+    def test_python_wavefunction(self):
+        """the reference implementation: aloha/template_files/wavefunctions.py"""
+        import aloha.template_files.wavefunctions as wavefunctions
+
+        Q = 60.
+        p = [0., 21., -33.5, 44.7]
+        p[0] = math.sqrt(p[1]**2 + p[2]**2 + p[3]**2 + Q**2)
+        metric = [1., -1., -1., -1.]
+
+        def dot(a, b):
+            return sum(metric[i] * a[i] * b[i] for i in range(4))
+
+        eps = {}
+        for nhel in (-1, 0, 1, 4):
+            wf = wavefunctions.vxxxxx(p, Q, nhel, 1)
+            eps[nhel] = [complex(wf[i]) for i in (2, 3, 4, 5)]
+
+        # the axial state IS p^mu / sqrt(p.p)
+        for i in range(4):
+            self.assertAlmostEqual(eps[4][i].real, p[i] / Q, 10)
+            self.assertAlmostEqual(eps[4][i].imag, 0., 12)
+
+        # ... a unit TIMELIKE vector, where the physical ones are spacelike
+        self.assertAlmostEqual(
+            dot(eps[4], [c.conjugate() for c in eps[4]]).real, 1., 10)
+        for nhel in (-1, 0, 1):
+            self.assertAlmostEqual(
+                dot(eps[nhel], [c.conjugate() for c in eps[nhel]]).real, -1., 10)
+            # ... and orthogonal to it (the physical states are transverse
+            # to p, the axial one is along p)
+            self.assertAlmostEqual(
+                abs(dot(eps[nhel], [c.conjugate() for c in eps[4]])), 0., 10)
+
+    def test_fortran_and_cpp_templates_have_a_live_branch(self):
+        """The nhel = 4 branch used to sit commented out inside a disabled
+        '#ifdef HELAS_CHECK' -- and with the OLD component indices, writing
+        over vc(1:2) which now hold the momentum. Guard both."""
+        import madgraph
+
+        files = {'aloha_functions.f': ('vc(3)', 'vc(4)', 'vc(5)', 'vc(6)'),
+                 # the loop convention puts the momentum in vc(1:4)
+                 'aloha_functions_loop.f': ('vc(5)', 'vc(6)', 'vc(7)', 'vc(8)'),
+                 }
+        for name, components in files.items():
+            path = os.path.join(madgraph.MG5DIR, 'aloha', 'template_files', name)
+            text = open(path).read()
+            start = text.index('      subroutine vxxxxx')
+            end = text.index('\n      subroutine ', start + 10)
+            body = text[start:end]
+            live = [l for l in body.split('\n')
+                    if not l.startswith('c') and 'nhel.eq.4' in l]
+            self.assertTrue(live, '%s has no live nhel = 4 branch' % name)
+            branch = body[body.index(live[0]):]
+            branch = branch[:branch.index('endif')]
+            for comp in components:
+                self.assertIn(comp + ' = ', branch,
+                              '%s: nhel = 4 does not fill %s' % (name, comp))
+
+        path = os.path.join(madgraph.MG5DIR, 'aloha', 'template_files',
+                            'vxxxxx.cc')
+        text = open(path).read()
+        self.assertIn('nhel == 4', text)
+        for comp in ('vc[2]', 'vc[3]', 'vc[4]', 'vc[5]'):
+            self.assertIn(comp, text)
+
+    def test_offshell_leg_is_called_with_the_virtuality(self):
+        """Both external-wavefunction writers must feed sqrt(p.p), not the
+        pole mass, to a leg carrying the off-shell '*'. That is what makes the
+        axial state p^mu/sqrt(p.p)."""
+        import madgraph.core.base_objects as base_objects
+        import madgraph.core.helas_objects as helas_objects
+        import madgraph.iolibs.helas_call_writers as helas_call_writers
+        import madgraph.interface.master_interface as master
+
+        mgcmd = master.MasterCmd()
+        mgcmd.exec_cmd('import model sm')
+        mgcmd.exec_cmd('generate t > w+{A}* b')
+        me = helas_objects.HelasMultiProcess(
+            mgcmd._curr_amps).get('matrix_elements')[0]
+        wf = [w for w in me.get_external_wavefunctions()
+              if w.get('polarization') == [99]][0]
+
+        fortran = helas_call_writers.FortranUFOHelasCallWriter(
+            mgcmd._curr_model).get_wavefunction_call(wf)
+        self.assertIn('SQRT(P(0,2)**2', fortran)
+        self.assertNotIn('MDL_MW', fortran)
+
+        python = helas_call_writers.PythonUFOHelasCallWriter(
+            mgcmd._curr_model).get_wavefunction_call(wf)
+        self.assertIn('p[1][0]**2', python)
+        self.assertNotIn('MW', python)
 
 
 class TestExtendedCmd(unittest.TestCase):


### PR DESCRIPTION
**Milestone 2 of 4.** Stacked on #386, which is stacked on #387. Gives `{A}` a
real external wavefunction, wires it through the standalone output and the
density matrix, and removes the "not implemented" wall #387 put in.

## The two decisions, both settled by measurement

**Normalisation: `eps_A^mu = p^mu / sqrt(p.p)`** — the leg's own virtuality, not
the pole mass and not the propagator's factors. The three physical states of an
off-shell external leg are *already* built with `sqrt(p.p)` (that is what the star
does), so this is the unique choice making the four an orthonormal tetrad:
`eps_A.eps_A = +1`, `eps_i.eps_i = -1`, `eps_A.eps_i = 0` — what a 4x4 density
matrix in that basis requires. **The data discriminates it**: the measured
`Q = 20 -> 140` ratio is `0.0071087892`; `p/sqrt(p.p)` predicts `0.0071087892`,
`p/M_pole` predicts `0.3483306696`. No new code was needed — `VXXXXX` returns
`p^mu/vmass` and the off-shell call already supplies `sqrt(p.p)`.

**Integer mapping: 99 -> 4, translated at exactly one place.** New
`base_objects.polarization_to_helicities()` is the only point where a brace
becomes a helicity; `get_helicity_matrix` (NHEL) and `get_helicity_per_particle`
(ALLOW_HEL) both call it. HELAS has always called this state `nhel = 4`; 99 is a
Leg-level tag. The clash with `{G}` = 4 is harmless *because of #386*: `{G}` has no
external wavefunction and is refused on any external leg, so no external
polarisation list can hold a literal 4.

## What changed

- **Fortran**: live `nhel == 4` branch in `aloha_functions.f` and the loop variant.
  The dormant block was not merely disabled, it was **wrong** — it wrote `vc(1:4)`,
  the old four-component convention, where today's layout holds the momentum.
  Uncommenting it verbatim yields garbage. Rewritten to `vc(3:6)` / `vc(5:8)`,
  matching `wavefunctions.py`. `aloha_functions_fd.f` left alone and `gauge = FD`
  refused instead — its 7th Goldstone component has no defined axial value.
- **C++**: branch added to `vxxxxx.cc`, but `--allow_axial` refuses
  `standalone_cpp`/`gpu`: that writer always passes `mME[i]`, so it has no
  off-shell external leg and would silently use the pole mass.
- **A real pre-existing bug fixed**: `PythonUFOHelasCallWriter` ignored `offshell`
  and passed the pole-mass symbol, so Python and Fortran disagreed on *every*
  off-shell external leg. Fixing it is what makes the Python path a valid
  cross-check.

## Options — `consider_axial` moves out of `options_madgraph`

Per the user it is not a global MadGraph option. Two homes now:
`output standalone MYDIR --allow_axial` (Fortran standalone family only), and a
**MadSpin card option**. MadSpin issues its own `output standalone … --density=1`
for production *and* decay, so it appends `--allow_axial` to both from the one
card option — the directories and the convolution cannot disagree. Directory
*reuse* is the remaining hole, so the generated dir records its basis in
`spin_basis.txt` and both reuse routes (`use_old_dir`, `ms_dir`) refuse a mismatch
loudly.

## Validation — `t > w+{T0A}* b`, massive daughters

The axial column couples as `k.J` and **vanishes by current conservation for
massless daughters**: `e+ e- > z{A}*` returns exactly `0.0`. Confirmed, and it is
why every existing `{A}` test uses `w+ > ta+ vt`.

Three independent anchors on the axial column: bit-identical to
`wavefunctions.py` with `eps.eps = +1.000000000000` and full summed ME rel.diff
**0.0e+00**; **≤ 1.1e-13** against an analytic `Sum|M|^2` for `Q = 5…168 GeV`; and
**≤ 5e-9** against the pre-existing `1A` propagator over `Q = 10…160`, with the new
external state supplying the middle factor. The axial sum is boost invariant to 13
digits where the longitudinal one is not, so the two are genuinely different
states.

**Density-matrix ordering**: `--density=2` gives a non-degenerate 4x4 with a live
axial column. Keeping a physical helicity first turns out **not** to be what
matters — the pathological order reproduces the same matrix, permuted, digit for
digit. The real failure mode is `get_helicity_matrix` and `get_helicity_per_particle`
*diverging* (99 in one, 4 in the other, no NHEL row ever matches, all zeros);
routing both through one helper prevents it, with a unit test asserting they agree.

## Tests

`-p U test_cmd` **24 OK** (20 on base); `test_madspin -t0` 485 OK; full `-p U` 1268,
only the pre-existing scipy error.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable generation and spin-density-matrix support for normalized off-shell axial vector states while making configuration and directory reuse basis-safe.

New Features:
- Add a functional axial `{A}` external wavefunction for off-shell final-state vectors across supported standalone generation paths.
- Support axial states in helicity tables, density matrices, and MadSpin-generated production and decay matrix elements.

Bug Fixes:
- Correct Python external-wavefunction generation to use an off-shell leg's virtuality instead of its pole mass, aligning it with the Fortran implementation.
- Prevent reuse of MadSpin matrix-element directories when their stored spin basis differs from the current configuration.

Enhancements:
- Move axial-state enablement from the global MadGraph setting to an explicit standalone output flag and a MadSpin card option, with validation for unsupported output formats and gauges.
- Unify polarization-to-helicity conversion so axial state tag 99 consistently maps to HELAS helicity 4.

Documentation:
- Update command help and release notes to document axial standalone output and MadSpin configuration.

Tests:
- Add coverage for axial wavefunction normalization, template implementations, virtuality handling, output gating, helicity mapping, and density-matrix consistency.