### PR TITLE
MadSpin: convolve over the axial state as a fourth index (axial 3/4)

### DIFF
--- a/MadSpin/decay.py
+++ b/MadSpin/decay.py
@@ -5351,10 +5351,19 @@ class DensityMatrix:
         Symmetric restrictions are returned untouched, so nothing that existed
         before the interference mode can move; only a cross restriction defers
         to ``hel_restriction_trace``.
+
+        A trace restriction with *no* contraction restriction beside it is the
+        axial basis ('consider_axial'): the fourth basis direction eps_A is a
+        piece of the propagator numerator, not a state the resonance can be
+        produced in, so it belongs in the contraction but not in any trace.
+        That combination cannot arise from the pure-interference mode, which
+        never sets ``hel_restriction_trace`` without also setting
+        ``hel_restriction`` -- so an unrestricted matrix keeps returning None
+        and every pre-existing path stays bit-for-bit identical.
         """
         restriction = self.hel_restriction
         if restriction is None:
-            return None
+            return self.hel_restriction_trace
         if any(DensityMatrix._is_cross_restriction(entry)
                for entry in restriction):
             return self.hel_restriction_trace
@@ -5598,12 +5607,92 @@ class DensityMatrix:
         Built through the normal constructor, so it shares the cached helicity
         map with the real density matrices of the same basis and keeps the
         scalar_multiplication fast path available.
+
+        NOT valid on the axial basis ('consider_axial'). The flat diagonal is a
+        consequence of rotational invariance acting on the three physical
+        polarisations as a vector; eps_A = k/sqrt(k.k) is the rest-frame time
+        direction and is *invariant* under that group, so the phase-space
+        average is diag(a,a,a,b) with a process- and virtuality-dependent b/a
+        rather than delta/n. There is no cheap correct value for b, so the
+        axial basis refuses the schemes that need this object (the sequential
+        accept/reject) rather than biasing them -- see
+        MadSpinInterface._unweighting_mode.
         """
         array = np.zeros(dimension * (dimension + 1) // 2, dtype=np.complex64)
         # diagonal entries in the packed upper-triangular storage
         diag = [i * (2 * dimension - i + 1) // 2 for i in range(dimension)]
         array[diag] = 1.0 / dimension
         return cls(array, nchanging, all_helicity_combinations, dimension)
+
+    # The helicity label the axial ('{A}') basis direction carries inside a
+    # density matrix. It is HELAS' nhel = 4 -- the same integer VXXXXX reads
+    # and the same one base_objects.polarization_to_helicities() produces from
+    # the Leg-level 99 -- so that ALLOW_HEL and the helicity labels of this
+    # class speak the value the Fortran does.
+    AXIAL_HELICITY = 4
+
+    def weight_helicity(self, weights):
+        """A copy of this matrix with entry (i,j) of index k multiplied by
+        ``w_k(i) * w_k(j)``.
+
+        ``weights`` has one entry per changing helicity: either ``None`` (that
+        index untouched) or a ``{helicity: factor}`` mapping, factors defaulting
+        to 1.
+
+        This is how the axial direction enters the convolution. The massive
+        vector propagator MG5 writes is
+
+            (-g^{mu nu} + k^mu k^nu / M^2) / (k^2 - M^2 + i M Gamma)
+
+        and in the orthonormal tetrad of milestone 2 its numerator is diagonal:
+
+            sum_{lambda=-1,0,+1} eps_lambda^mu eps_lambda^{nu *}
+                + (Q^2 - M^2)/M^2  eps_A^mu eps_A^nu
+
+        (exactly ALOHA's '1A' custom propagator, create_aloha.get_custom_propa:
+        numerator (P^2-M^2) P^mu P^nu over P^2 M^2 times the same pole). So the
+        amplitude is sum_lambda c_lambda A_lambda B_lambda with c = 1 on the
+        three physical directions and c_A = (Q^2-M^2)/M^2, and the squared
+        amplitude carries c_i c_j on the (i,j) entry -- once, not once per
+        side. Note c_A is real and vanishes on shell: the axial direction is a
+        purely off-shell effect and the narrow-width limit of this whole
+        construction is the historical three-state one.
+
+        Because the weights are real and enter as c_i c_j, the weighted
+        contraction is still sum over spectators of |sum_lambda c_lambda
+        A_lambda B_lambda|^2 -- manifestly non-negative. Nothing here can make
+        the accept/reject weight change sign.
+        """
+        factors = np.ones(self.helicities.shape[0], dtype=np.float64)
+        touched = False
+        for k, table in enumerate(weights):
+            if not table:
+                continue
+            touched = True
+            for col in (2 * k, 2 * k + 1):
+                labels = self.helicities[:, col]
+                for hel, value in table.items():
+                    if value == 1.0:
+                        continue
+                    factors[labels == int(hel)] *= float(value)
+        if not touched:
+            return self
+        out = DensityMatrix.from_components(
+            self.helicities,
+            self.values * factors,
+            self.nchanging,
+            self.all_helicity_combinations,
+            self.dimension,
+            basis_id=self._basis_id,
+        )
+        out.hel_restriction = self.hel_restriction
+        out.hel_restriction_trace = self.hel_restriction_trace
+        # only the values changed: same labels, same row order, same basis. Keep
+        # the map so scalar_multiplication stays on its identical-map fast path
+        # (from_components drops it, which would silently move every axial run
+        # onto the slower sorted-alignment route).
+        out.map_density_matrix_ind = self.map_density_matrix_ind
+        return out
 
     def normalized(self):
         """Same matrix divided by its trace (Dhat = D / Tr D), i.e. on the same

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -32,6 +32,8 @@ if '__main__' == __name__:
     import sys
     sys.path.append(pjoin(os.path.dirname(__file__), '..'))
 
+import aloha
+import madgraph.core.base_objects as base_objects
 import madgraph.interface.extended_cmd as extended_cmd
 import madgraph.interface.madgraph_interface as mg_interface
 import madgraph.interface.master_interface as master_interface
@@ -1873,6 +1875,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         # beyond the spinmode check is behind that guard.)
         self._validate_pure_interference()
         self._validate_weighted_decay()
+        self._check_axial_compatibility()
         if self._density_spinmode():
             # read (and validate) the production polarisation braces now rather
             # than on the first event, deep inside a worker process
@@ -3682,6 +3685,23 @@ class MadSpinInterface(extended_cmd.Cmd):
                            "accept/reject (every partial weight of a staged "
                            "scheme is identically zero in this mode)")
             return self._announce_mode('joint', self.options['unweighting'])
+        if self.options.get('consider_axial'):
+            # Every staged scheme stands an undrawn decay slot in as
+            # DensityMatrix.identity, delta/n. That is a theorem about the
+            # three physical polarisations -- rotational invariance in the
+            # parent rest frame acts on them as a vector, so the average is
+            # flat -- and it is false for the axial direction, which is that
+            # frame's *time* axis and is invariant under the same group. The
+            # phase-space average is diag(a,a,a,b) with a b/a that depends on
+            # the process and on the virtuality, and there is no cheap way to
+            # get it. Falling back to the joint test costs speed; using
+            # delta/4 would cost correctness.
+            self._log_once('consider_axial_joint',
+                           "MadSpin: consider_axial forces the joint "
+                           "accept/reject (the staged schemes need the "
+                           "phase-space average of an undrawn decay, which is "
+                           "not flat once the axial direction is in the basis)")
+            return self._announce_mode('joint', self.options.get('unweighting'))
         if self._weighted_decay():
             # There is no accept/reject at all in this mode, so there is no
             # scheme to choose: the staged schemes exist only to split a test
@@ -7418,6 +7438,18 @@ class MadSpinInterface(extended_cmd.Cmd):
         decaying_spins = [self.model.get_particle(i).get('spin') for i in decaying_pdg]
         helicities = [hel_dict[i] for i in decaying_spins]
 
+        # 'consider_axial': a massive vector's spin basis gains the fourth,
+        # axial direction eps_A = k/sqrt(k.k). The value appended is HELAS'
+        # nhel = 4, which is what ALLOW_HEL hands GET_ALL_INTER and what
+        # VXXXXX reads -- and it is appended *last* on purpose, see _axial_pdgs
+        # for why the first entry of every basis has to stay a physical
+        # helicity.
+        axial_pdgs = self._axial_pdgs(decaying_pdg)
+        if axial_pdgs:
+            helicities = [list(h) + [madspin.DensityMatrix.AXIAL_HELICITY]
+                          if pdg in axial_pdgs else h
+                          for pdg, h in zip(decaying_pdg, helicities)]
+
         helicities, hel_restriction = self._apply_production_polarization(
                                                     decaying_pdg, helicities)
         # pure-interference mode replaces the symmetric restriction by a cross
@@ -7425,6 +7457,13 @@ class MadSpinInterface(extended_cmd.Cmd):
         # the (separate) normalising trace -- see _apply_pure_interference
         hel_restriction, hel_restriction_trace = self._apply_pure_interference(
                                     decaying_pdg, helicities, hel_restriction)
+        if axial_pdgs and hel_restriction_trace is None:
+            # keep the axial direction out of every trace (see
+            # _axial_trace_restriction). Only when the interference mode has
+            # not already claimed hel_restriction_trace for itself -- the two
+            # are refused together in _check_axial_compatibility.
+            hel_restriction_trace = self._axial_trace_restriction(
+                                    decaying_pdg, axial_pdgs, helicities)
 
         allowed_hel_pairs, allowed_hel = self.get_allowed_hel(helicities)
 
@@ -7442,9 +7481,155 @@ class MadSpinInterface(extended_cmd.Cmd):
             'hel_restriction': hel_restriction,
             'hel_restriction_trace': hel_restriction_trace,
             'pure_interference': bool(self._pure_interference_pdgs(decays_key)),
+            'axial_pdgs': axial_pdgs,
             'ncomb': len(allowed_hel_pairs),
             'dimension': math.prod(len(i) for i in helicities),
         }
+
+    # ------------------------------------------------------------------
+    # The axial ('{A}') basis direction -- 'consider_axial'
+    # ------------------------------------------------------------------
+
+    def _axial_pdgs(self, decaying_pdg):
+        """The decaying pdgs whose spin basis gains the axial direction, as a
+        frozenset. Empty -- and every axial code path dead -- unless the card
+        says ``set consider_axial True``.
+
+        Only a *massive vector* has one: the axial direction is the k^mu piece
+        of a massive spin-one propagator numerator. A massless vector's
+        propagator is -g^{mu nu} alone and a fermion or a scalar has no such
+        piece, so those bases are left exactly as they were.
+
+        NOTE on how the fourth state reaches the Fortran. MadSpin does NOT put
+        a '{A}' brace on the process lines it generates, and that is
+        deliberate. GET_ALL_INTER *overwrites* NHEL at the changing positions
+        from ALLOW_HEL before calling GET_AMP, so the value 4 never has to
+        appear in the process' NHEL table: that table is only used by
+        GET_DENSITY's outer loop to enumerate the spectator helicities, and it
+        filters on the *first* ALLOW_HEL combination -- which is why the axial
+        entry is appended last and every basis still starts on a physical
+        helicity. Keeping the brace off the process lines is what leaves NHEL,
+        the helicity-averaging IDEN and therefore SMATRIX untouched: the
+        production and decay matrix elements that form the *denominator* of the
+        MadSpin weight, and the decay pool those events were drawn from, stay
+        the physical three-state objects they have to be. A brace would have
+        added |A_axial|^2 to both of them and biased the accept/reject.
+        """
+        if not self.options.get('consider_axial'):
+            return frozenset()
+        out = set()
+        for pdg in set(decaying_pdg):
+            particle = self.model.get_particle(pdg)
+            if particle.get('spin') != 3:
+                continue
+            if particle.get('mass').lower() == 'zero':
+                continue
+            out.add(int(pdg))
+        return frozenset(out)
+
+    def _check_axial_compatibility(self):
+        """Refuse the combinations 'consider_axial' has not been thought
+        through with, up front, instead of quietly biasing them. Nothing here
+        fires unless the card sets the option, so a default run never reaches
+        any of it.
+        """
+        if not self.options.get('consider_axial'):
+            return
+        if self.options['spinmode'] not in ('madspin', 'full'):
+            raise self.InvalidCmd(
+                "MadSpin: 'consider_axial' needs an off-shell resonance and so "
+                "the 'madspin' (= 'full') spinmode. The axial direction is the "
+                "k^mu piece of the propagator numerator: it enters the "
+                "convolution with the coefficient (Q^2-M^2)/M^2, which is "
+                "identically zero on shell, and it is normalised by the leg's "
+                "own virtuality, which only the off-shell '*' process lines of "
+                "that spinmode carry. spinmode = %s would pay for a fourth "
+                "helicity index that cannot contribute."
+                % self.options['spinmode'])
+        if self._pure_interference():
+            raise self.InvalidCmd(
+                "MadSpin: 'consider_axial' and 'pure_interference' both claim "
+                "the trace that normalises the convolution -- the interference "
+                "block needs the *production* trace, the axial basis needs the "
+                "physical-polarisation one -- and the two have not been "
+                "reconciled. Please use one at a time.")
+        if self._production_polarization():
+            raise self.InvalidCmd(
+                "MadSpin: 'consider_axial' is not supported together with a "
+                "polarisation brace on the production process. A brace "
+                "restricts the convolution to a subspace of physical "
+                "polarisations, and what the axial direction of the propagator "
+                "numerator should then contribute is not defined.")
+        if self._polarization_weights_enabled():
+            raise self.InvalidCmd(
+                "MadSpin: 'consider_axial' is not supported together with "
+                "keep_weight_for_polarization_vector/_fermion. Those weights "
+                "are the same convolution with the helicity index projected "
+                "onto one physical polarisation, and they are meant to be read "
+                "as fractions of the full weight -- which they stop being as "
+                "soon as the full weight also carries the axial direction, "
+                "since no projection onto a physical polarisation can pick it "
+                "up. The set would no longer add up to one.")
+        if aloha.unitary_gauge == 3:
+            # same refusal as check_axial_output, reached differently: MadSpin
+            # puts no '{A}' brace on its process lines, so the output-level
+            # gate never sees an axial leg to refuse.
+            raise self.InvalidCmd(
+                "MadSpin: 'consider_axial' is not available in the "
+                "Feynman-diagram gauge (gauge = FD). There the massive-vector "
+                "wavefunction carries an extra Goldstone component "
+                "(aloha_functions_fd.f, VFDXXXX) whose value for the axial "
+                "state nhel = 4 is not defined, and VFDXXXX would return it "
+                "uninitialised. Use the unitary or Feynman gauge.")
+
+    def _axial_trace_restriction(self, decaying_pdg, axial_pdgs, helicities):
+        """The trace-only restriction that keeps the axial direction out of
+        every normalisation.
+
+        ``trace()`` answers "how much cross-section is there", and the axial
+        direction carries none: it is not a state the resonance can be produced
+        in, it is a piece of its propagator. The quantities the trace feeds --
+        ``prod_diag`` (the unpolarised production ME), ``dec_diag`` (the
+        unpolarised decay ME) and ``normalized()`` -- all have to stay the
+        physical three-state objects, both because that is what the events were
+        generated with and because ``density_debug`` checks them against
+        SMATRIX, which is three-state by construction.
+
+        Rides on ``hel_restriction_trace`` with ``hel_restriction`` left None,
+        so the contraction itself still runs over all four directions.
+        """
+        if not axial_pdgs:
+            return None
+        restriction = []
+        for pdg, basis in zip(decaying_pdg, helicities):
+            if pdg in axial_pdgs:
+                restriction.append(tuple(
+                    h for h in basis
+                    if h != madspin.DensityMatrix.AXIAL_HELICITY))
+            else:
+                restriction.append(None)
+        return madspin.DensityMatrix.normalize_hel_restriction(restriction)
+
+    def _axial_weights(self, decaying_pdg, axial_pdgs, virtualities):
+        """The per-index ``{helicity: factor}`` tables handed to
+        ``DensityMatrix.weight_helicity``: ``c_A = (Q^2 - M^2)/M^2`` on the
+        axial direction of every axial index, nothing on the others.
+
+        ``virtualities`` is the sampled sqrt(k.k) of each decaying particle, in
+        slot order. Q is the leg's own virtuality -- the same one that
+        normalises eps_A = k/Q (milestone 2) -- and M is the pole mass out of
+        the param_card, which is the mass ALOHA's OM2 = 1/M^2 puts in the
+        propagator numerator (a real pole mass, not the complex one).
+        """
+        weights = []
+        for pdg, q in zip(decaying_pdg, virtualities):
+            if pdg not in axial_pdgs or q is None:
+                weights.append(None)
+                continue
+            pole = self.banner.get('param_card', 'mass', abs(int(pdg))).value
+            c_axial = (float(q) ** 2 - pole ** 2) / (pole ** 2)
+            weights.append({madspin.DensityMatrix.AXIAL_HELICITY: c_axial})
+        return weights
 
     # ------------------------------------------------------------------
     # Production polarisation ({0}/{+}/{-}/{L}/{R}/{T} on the decaying leg)
@@ -7519,7 +7704,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                     if not leg.get('state'):
                         continue
                     pol = leg.get('polarization')
-                    pol = tuple(sorted(set(int(p) for p in pol))) if pol else None
+                    # a polarization list is a list of *braces*: '{A}' is 99 at
+                    # Leg level and has to become HELAS' nhel = 4 before it can
+                    # be compared with the helicity basis this class builds.
+                    # Same single translation point as the NHEL table and the
+                    # ALLOW_HEL rows use -- see base_objects.
+                    pol = tuple(sorted(set(
+                        base_objects.polarization_to_helicities(pol)))) \
+                        if pol else None
                     ids = [int(i) for i in leg.get('ids')]
                     for pdg in ids:
                         seq.setdefault(pdg, []).append(pol)
@@ -7564,7 +7756,9 @@ class MadSpinInterface(extended_cmd.Cmd):
     @staticmethod
     def _format_polarization_sequence(sequence):
         """A polarisation sequence as it reads in a process line, for errors."""
-        names = {(0,): '{0}', (1,): '{+}', (-1,): '{-}', (-1, 1): '{T}'}
+        names = {(0,): '{0}', (1,): '{+}', (-1,): '{-}', (-1, 1): '{T}',
+                 (4,): '{A}', (0, 4): '{0A}', (-1, 1, 4): '{TA}',
+                 (-1, 0, 1): '{T0}', (-1, 0, 1, 4): '{T0A}'}
         return ' '.join('(none)' if p is None else names.get(p, str(list(p)))
                         for p in sequence)
 
@@ -7654,7 +7848,9 @@ class MadSpinInterface(extended_cmd.Cmd):
                 raise self.InvalidCmd(
                     'MadSpin: the polarisation %s requested for particle %s is not '
                     'expressible in the helicity basis %s used by the density spin '
-                    'modes. Only {0}, {+}/{R}, {-}/{L} and {T} are supported.'
+                    'modes. Only {0}, {+}/{R}, {-}/{L}, {T} and -- with '
+                    '"set consider_axial True" on a massive vector -- {A} are '
+                    'supported.'
                     % (list(allowed), pdg, basis))
             kept = [h for h in basis if h in allowed]
             restriction.append(tuple(kept))
@@ -10104,6 +10300,25 @@ class MadSpinInterface(extended_cmd.Cmd):
                 prod_static)
         return decays
 
+    def _density_debug_propagator_ratio(self, decays, decay_dict):
+        """``prod(|Q^2-M^2+i M Gamma|^2 / (M Gamma)^2)`` over the decaying
+        resonances: what the full matrix element carries and what the density
+        convolution deliberately does not.
+
+        Exactly 1 when every resonance sits on its pole, so the pole-
+        approximation spinmodes -- the only ones for which ``density_debug``
+        ever said anything -- are untouched.
+        """
+        ratio = 1.0
+        for pdg, decay_list in decays.items():
+            pole = decay_dict[pdg][1]
+            width = decay_dict[pdg][0]
+            mw = pole * width
+            for dec in decay_list:
+                q2 = lhe_parser.FourMomentum(dec[0]).mass_sqr
+                ratio *= ((q2 - pole * pole) ** 2 + mw * mw) / (mw * mw)
+        return ratio
+
     def get_onshell_evt_and_wgt(self, production, decays, decay_dict, prod_density_cached=None, build_event=True):
         """ return the onshell wgt for the production event associated to the decays
             return also the full event with decay. 
@@ -10187,11 +10402,26 @@ class MadSpinInterface(extended_cmd.Cmd):
                 full_event = full_event.add_decays(decays)
             
                 #print(f"full event 2 = {full_event}")
-                if self.options['density_debug']:
+                if self.options['density_debug'] and \
+                        not getattr(self, '_density_debug_stale', False):
                     me1 = self.calculate_matrix_element(full_event)
+                    # The density path divides by the propagator denominator at
+                    # the *pole*, |i M Gamma|^2 (prod_denominators), because the
+                    # Breit-Wigner shape is supplied by the virtuality sampling
+                    # jacobian and must not be counted twice. The full matrix
+                    # element carries the real denominator
+                    # |Q^2-M^2+i M Gamma|^2 at the virtuality that was drawn.
+                    # So the two are the same number only on shell, and
+                    # comparing them raw made this check fail on the very first
+                    # off-shell trial of every 'madspin'/'full' run -- by
+                    # exactly this ratio, measured to 7 digits before it was put
+                    # in. Undo it, and what is left is the closure of the
+                    # density convolution itself.
+                    me1 = me1 * self._density_debug_propagator_ratio(
+                                                    decays, decay_dict)
                     #print(f"me1 = {me1} , me2 = {full_me} , ratio = {me1/full_me}")
                     if abs(1-me1/full_me) > self.options['density_tolerance']:
-                        print(f"full = {me1} , density = {full_me} , ratio = {me1/full_me}")	    
+                        print(f"full = {me1} , density = {full_me} , ratio = {me1/full_me}")
                         print(full_event)
                         print(production)
                         print(decays)
@@ -10208,12 +10438,28 @@ class MadSpinInterface(extended_cmd.Cmd):
                             else prod_diag
             production.me_wgt = production_me
 
-        if self.generate_all.mode == 'density' and self.options['density_debug']:
-            prod_me = self.calculate_matrix_element(production)
-            #print(f"prod_diag = {prod_diag} , prod_me = {prod_me}")
-            if abs(1-prod_diag/prod_me) > self.options['density_tolerance']:
-                print(f"prod_me = {prod_me} , prod_diag = {prod_diag} , ratio = {prod_diag/prod_me}")	    
-                raise RuntimeError("ERROR production matrix element from density does not match with diagonal")	     
+        if self.generate_all.mode == 'density' and self.options['density_debug'] \
+                and not getattr(self, '_density_debug_stale', False):
+            # NOT calculate_matrix_element(production) and NOT prod_diag. By
+            # this point `production` has had add_decays() run on it, so it is
+            # the *full* event and its matrix element is the 2 -> 4 one; and
+            # outside the pole approximation prod_diag is MEdenom_prod, the
+            # production matrix element at the momenta the event was generated
+            # with, deliberately a different phase-space point from the
+            # reshuffled one the density was built at. Between them those two
+            # made this check fail on every off-shell trial. Both sides are
+            # therefore taken from calculate_matrix_element_from_density, where
+            # the event is still production-only and the momenta are the
+            # density's own.
+            prod_me = getattr(self, '_density_debug_prod_me', None)
+            prod_trace = getattr(self, '_density_debug_prod_trace', None)
+            if prod_me is None or prod_trace is None:
+                prod_me = self.calculate_matrix_element(production)
+                prod_trace = prod_diag
+            #print(f"prod_trace = {prod_trace} , prod_me = {prod_me}")
+            if abs(1-prod_trace/prod_me) > self.options['density_tolerance']:
+                print(f"prod_me = {prod_me} , prod_trace = {prod_trace} , ratio = {prod_trace/prod_me}")
+                raise RuntimeError("ERROR production matrix element from density does not match with diagonal")
             if abs(1-dec_diag/decay_me_debug) > self.options['density_tolerance']:
                 print(f"decay_me = {decay_me_debug} , dec_diag = {dec_diag} , ratio = {dec_diag/decay_me_debug}")	    
                 raise RuntimeError("ERROR decay matrix element from density does not match with diagonal")	   
@@ -10462,6 +10708,9 @@ class MadSpinInterface(extended_cmd.Cmd):
         allowed_hel = prod_static['allowed_hel']
         ncomb = prod_static['ncomb']
         dimension = prod_static['dimension']
+        # empty unless 'consider_axial' put the fourth basis direction on a
+        # massive vector; every axial branch below is dead without it
+        axial_pdgs = prod_static.get('axial_pdgs') or frozenset()
 
         # ------------------------------------------------------------------
         # Normalization
@@ -10498,6 +10747,17 @@ class MadSpinInterface(extended_cmd.Cmd):
                                            'joint accept/reject')
         else:
             density_prod = prod_density_cached
+        if self.options['density_debug']:
+            # The max-weight scan reuses one production density across every
+            # phase-space draw of a production event (_joint_maxwgt_range),
+            # while an offshell (madspin/full) draw reshuffles the production
+            # onto its own virtuality every time -- so on those trials rho_prod
+            # and the full matrix element below describe different momenta and
+            # the closure check has nothing to say. The event loop itself does
+            # NOT reuse it outside the pole approximation, so this only ever
+            # skips scan trials.
+            self._density_debug_stale = (prod_density_cached is not None
+                                         and not density_pole_approximation)
 
         # ------------------------------------------------------------------
         # Symmetry factor:
@@ -10569,13 +10829,31 @@ class MadSpinInterface(extended_cmd.Cmd):
                                    else self._decay_frame_rest_leg(part, frame_boost)
                 )
 
+                if pdg in axial_pdgs:
+                    # keep the axial direction out of this slot's own trace --
+                    # dec_diag just below is the *physical* decay matrix
+                    # element, the denominator of the MadSpin weight -- and
+                    # then fold the propagator's axial coefficient
+                    # (Q^2-M^2)/M^2 into the matrix that gets contracted. See
+                    # _axial_trace_restriction and weight_helicity.
+                    density_dec_tmp.set_hel_restriction_trace(
+                        self._axial_trace_restriction(
+                            [pdg], axial_pdgs,
+                            [helicities[decaying_idx + i_decay_event]]))
+
+                if MEdenom_decay is None:
+                    dec_diag *= density_dec_tmp.trace().real
+
+                if pdg in axial_pdgs:
+                    q2 = lhe_parser.FourMomentum(current_decay_event[0]).mass_sqr
+                    density_dec_tmp = density_dec_tmp.weight_helicity(
+                        self._axial_weights([pdg], axial_pdgs,
+                                            [math.sqrt(abs(q2))]))
+
                 if density_dec is None:
                     density_dec = density_dec_tmp
                 else:
                     density_dec = density_dec.tensor_product(density_dec_tmp)
-
-                if MEdenom_decay is None:
-                    dec_diag *= density_dec_tmp.trace().real
                 density_iden_decay *= color * spin
                 prod_color *= color
                 # |D|^2 of the propagator denominator D = i*m*Gamma at the pole.
@@ -10638,9 +10916,17 @@ class MadSpinInterface(extended_cmd.Cmd):
         #print(f"production = {production}")
         #print(f"decays = {decays}")
         if MEdenom_prod is None:
-            prod_diag = density_prod.trace().real 
-        else: 
+            prod_diag = density_prod.trace().real
+        else:
             prod_diag = MEdenom_prod
+        if self.options['density_debug']:
+            # what get_onshell_evt_and_wgt's production check needs: the trace
+            # of the matrix built at *these* momenta, and the unpolarised
+            # production matrix element at those same momenta, taken while
+            # `production` is still production-only. Debug-only, so nothing
+            # pays for it in a real run.
+            self._density_debug_prod_trace = density_prod.trace().real
+            self._density_debug_prod_me = self.calculate_matrix_element(production)
         if MEdenom_decay is not None:
             dec_diag *= MEdenom_decay
         return me, density_prod, prod_diag, dec_diag, jac_reshuffle
@@ -10897,12 +11183,17 @@ class MadSpinInterface(extended_cmd.Cmd):
         # DensityMatrix.set_hel_restriction). None for the decay densities.
         if hel_restriction is not None:
             density_matrix.set_hel_restriction(hel_restriction)
-            # pure-interference mode only: the contraction runs over the
-            # interference block while trace()/normalized() keep using the
-            # production trace, which is the unrestricted one for the
-            # unpolarised production the mode requires (section 13.4).
-            if hel_restriction_trace is not None:
-                density_matrix.set_hel_restriction_trace(hel_restriction_trace)
+        # pure-interference mode: the contraction runs over the interference
+        # block while trace()/normalized() keep using the production trace,
+        # which is the unrestricted one for the unpolarised production the mode
+        # requires (section 13.4). 'consider_axial': a trace restriction with
+        # NO contraction restriction beside it, keeping the axial direction out
+        # of the normalisations while every row still takes part in the
+        # convolution (_axial_trace_restriction). Hence the two are set
+        # independently -- this used to be nested inside the branch above,
+        # which no caller could tell apart until the axial basis arrived.
+        if hel_restriction_trace is not None:
+            density_matrix.set_hel_restriction_trace(hel_restriction_trace)
         return density_matrix
 
 
@@ -11033,6 +11324,20 @@ class MadSpinInterface(extended_cmd.Cmd):
 
             # Valentin: we only pass here with the options 'onshell_v1' and 'madspin_v1' for which I kept only one madspin_me directory
             # it is not adapted to modes where the directories for production and decays are separated
+            if not hasattr(self, 'f2py_module') and \
+                    self.options['spinmode'] not in ['onshell_v1', 'madspin_v1']:
+                # ... except that 'density_debug' *does* reach here first: it
+                # evaluates the decay matrix elements at the top of
+                # get_onshell_evt_and_wgt, before the density path has had a
+                # chance to build the two-module list. Loading the single
+                # legacy module here would leave self.f2py_module a module
+                # rather than the [production, decay] pair the lambdas below
+                # index, and every density_debug run died on "'module' object
+                # is not subscriptable". Build the pair the way
+                # calculate_matrix_element_from_density does instead.
+                self.f2py_module = [0, 0]
+                self.pdg2prefix = [0, 0]
+                self.create_and_initialise_f2py_modules([0, 0], [0, 0], [0, 0])
             if not hasattr(self, 'f2py_module'):
                 sp_path = pjoin(self.path_me, self.ms_me_subdir, 'SubProcesses')
                 if sys.path[0] != sp_path:

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -5,6 +5,66 @@ ANNOUNCEMENT:
    A new LTS (based on current 3.5.X) is starting now and will act as stable release for the coming years.
 
 3.7.2 (XX/XX/XX):
+    OM: MadSpin's density-matrix convolution can now run over the *fourth*, axial
+        direction of a massive vector's spin basis ('set consider_axial True' in the
+        MadSpin card, off by default and bit-for-bit inert when off). The massive
+        vector propagator MG5 writes is (-g^{mu nu} + k^mu k^nu/M^2)/(k^2-M^2+iM*Gamma),
+        and in the orthonormal tetrad of the previous entry its numerator is diagonal:
+        the three physical polarisations with coefficient 1, plus eps_A eps_A with
+        coefficient (Q^2-M^2)/M^2 -- exactly ALOHA's '1A' custom propagator. So the
+        axial index enters the convolution with that real, virtuality-dependent
+        weight, applied once (as c_i c_j on the (i,j) entry, DensityMatrix.
+        weight_helicity), and NOT with the -1 that the completeness relation of
+        -g^{mu nu} alone would suggest. It vanishes on shell, which is why
+        'consider_axial' requires the off-shell spinmode 'madspin'/'full', and it
+        leaves the convolution manifestly non-negative -- no signed weight, no change
+        to the accept/reject.
+        The axial direction carries no cross-section, so it takes no part in any
+        trace: trace()/normalized(), and with them the production and decay matrix
+        elements that normalise the MadSpin weight, stay the physical three-state
+        objects (a trace-only helicity restriction, DensityMatrix.
+        set_hel_restriction_trace, with the contraction left unrestricted).
+        MadSpin does not put an '{A}' brace on the process lines it generates:
+        GET_ALL_INTER overwrites NHEL at the changing positions from ALLOW_HEL before
+        calling GET_AMP, so the fourth state reaches the amplitude without ever
+        entering the NHEL table -- which is what leaves SMATRIX, the helicity-
+        averaging IDEN and the decay pool untouched.
+        Measured with 'density_debug' on "u d~ > w+ h" with "w+ > ta+ vt" (massive
+        daughters and a production current that is not conserved at the W leg, so the
+        axial column is alive): over 345 trials the three-index convolution misses the
+        1e-4 closure tolerance against the full 2 -> 3 matrix element on 9% of them
+        (worst 3.3e-3), the four-index one on none (worst 1.5e-5, at the complex64
+        floor of the density storage). On "u u~ > w+ w-", where massless quarks make
+        the production current conserved and the axial column ~1e-3 of the physical
+        one, the worst case improves from 7.1e-5 to 2.6e-6.
+        'consider_axial' is refused together with 'pure_interference', with a
+        polarisation brace on the production process, with
+        keep_weight_for_polarization_vector/_fermion and in gauge = FD, and it falls
+        back to the joint accept/reject: the staged schemes stand an undrawn decay in
+        as DensityMatrix.identity = delta/n, which is a theorem about the three
+        physical polarisations only (eps_A is the rest-frame time direction and is
+        invariant under the rotations that make the physical average flat).
+    OM: '{A}' is now also accepted on an *initial*-state leg carrying the off-shell
+        star, i.e. on the decaying resonance of a 1 -> N process ("generate
+        w+{T0A}* > ta+ vt"). eps_A = p^mu/vmass is real, so unlike the transverse
+        states it is not conjugated for an incoming leg and VXXXXX's 'nsv' only signs
+        the momentum it stores; the star rule and the '--allow_axial' output gate are
+        the same as for a final-state leg.
+    OM: three fixes to MadSpin's 'density_debug' cross-check, which could not run at
+        all in the off-shell spinmodes before:
+        - it evaluates the decay matrix elements before the density path has built
+          its [production, decay] f2py module pair, and died on "'module' object is
+          not subscriptable";
+        - it compared the density weight, which divides by the propagator denominator
+          at the pole |i M Gamma|^2 (the Breit-Wigner shape being supplied by the
+          virtuality sampling jacobian), against a full matrix element carrying the
+          real |Q^2-M^2+iM Gamma|^2. The ratio is now divided out, which is a no-op
+          on shell;
+        - the production-diagonal check used calculate_matrix_element(production)
+          after add_decays() had turned that event into the full one, and compared it
+          against a prod_diag evaluated at the pre-reshuffling momenta. Both sides now
+          come from the density routine, at the density's own momenta. The check is
+          skipped on the max-weight-scan trials that reuse a stale production density.
     OM: the axial polarisation brace '{A}' now has a real external wavefunction and
         can be put on an off-shell final-state particle ("generate p p > z{A}* h"),
         not only on an internal line. VXXXXX (aloha_functions.f, its loop variant and

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -718,18 +718,17 @@ class HelasWavefunction(base_objects.PhysicsObject):
                         # orthonormal tetrad. (The amplitude on that direction
                         # is k.J, which is zero only for a conserved current,
                         # i.e. for massless daughters -- not in general.)
-                        if leg.get('state') is False:
-                            # An initial-state axial leg is what MadSpin's
-                            # decay-side matrix element would need (there the
-                            # decaying particle is leg 1). Not enabled yet:
-                            # the density-matrix side of that does not exist.
-                            raise InvalidCmd(
-                                "The axial polarization {A} is not supported "
-                                "for an initial-state particle.")
+                        # An initial-state axial leg is MadSpin's decay-side
+                        # matrix element, where the decaying resonance is leg
+                        # 1 ("w+{T0A}* > ta+ vt"). It obeys the same star rule
+                        # as a final-state one and needs no separate handling:
+                        # eps_A = p^mu/vmass is real, so unlike the transverse
+                        # states it is not conjugated for an incoming leg, and
+                        # VXXXXX's nsv only signs the momentum it stores.
                         if not leg.get('offshell'):
                             raise InvalidCmd(
                                 "polarization A only valid for propagator, or "
-                                "for an off-shell final-state particle written "
+                                "for an off-shell external particle written "
                                 "\"z{A}*\" (star after the brace).")
                 # Set fermion flow state. Initial particle and final
                 # antiparticle are incoming, and vice versa for

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -1843,8 +1843,16 @@ This will take effect only in a NEW terminal
                     if not leg.get('state'):
                         decayed.add(leg.get('id'))
             for leg in proc.get('legs'):
-                if 99 in leg.get('polarization') and leg.get('state') \
-                   and leg.get('id') not in decayed:
+                if 99 not in leg.get('polarization'):
+                    continue
+                # An *initial*-state axial leg is MadSpin's decay-side matrix
+                # element ("w+{T0A}* > ta+ vt", the decaying resonance as leg
+                # 1). It is external by construction -- nothing decays it --
+                # so it needs the same explicit '--allow_axial' as a
+                # final-state one, and 'decayed' does not apply to it.
+                if not leg.get('state'):
+                    axial_legs.append(leg)
+                elif leg.get('id') not in decayed:
                     axial_legs.append(leg)
             for decay in proc.get('decay_chains'):
                 scan_process(decay, set())
@@ -5035,9 +5043,21 @@ This implies that with decay chains:
           current J is conserved, i.e. for massless daughters. Whether such a
           process may then be *written out* is decided at output time by
           'output standalone --allow_axial' (check_output), not here.
-        * '{A}' on an initial-state particle is refused. (The one place it
-          would make sense is MadSpin's decay-side matrix element, where the
-          decaying particle IS leg 1; that is not wired up yet.)
+        * '{A}' on an initial-state particle follows exactly the same rule as
+          on a final-state one: it needs the star ("w+{T0A}* > ta+ vt"). That
+          spelling is a 1 -> N decay whose decaying resonance IS leg 1, i.e.
+          the shape of MadSpin's decay-side matrix element, and it is how a
+          four-state NHEL table can be written for one. Nothing about the state
+          changes the wavefunction: VXXXXX builds eps_A = p^mu/vmass, which is
+          real, and 'nsv' only flips the momentum it stores in vc(1:2) -- the
+          incoming and outgoing axial states are the same vector, where the
+          transverse ones are complex conjugates.
+
+          (MadSpin itself does not need the brace: GET_ALL_INTER overwrites
+          NHEL at the changing positions from ALLOW_HEL, so the fourth state
+          reaches GET_AMP without ever entering the NHEL table -- which is what
+          keeps SMATRIX and the helicity-averaging IDEN three-state. See
+          MadSpinInterface._axial_pdgs.)
 
         '{G}', '{H}', '{Q}', '{W}' and '{S}' (pol=4,5,6,7,9). Each of these
         names a rank-two piece of the propagator numerator, complete with its
@@ -5079,11 +5099,7 @@ This implies that with decay chains:
                            'final' if leg.get('state') else 'initial'))
             if axial not in pol:
                 continue
-            if not leg.get('state'):
-                raise self.InvalidCmd(
-                    'The axial polarization {A} is not supported for an '
-                    'initial-state particle.')
-            if decayed_ids.intersection(leg.get('ids')):
+            if leg.get('state') and decayed_ids.intersection(leg.get('ids')):
                 # propagator: the leg is replaced by the decay chain
                 continue
             if not leg.get('offshell'):

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -363,10 +363,30 @@ class TestValidCmd(unittest.TestCase):
             except madgraph.InvalidCmd as error:
                 self.assertIn('off-shell', str(error))
 
-            # initial state is refused (MadSpin's decay-side ME would want
-            # it one day; it is not wired up)
+            # an INITIAL-state '{A}' follows the same rule as a final-state
+            # one: it needs the star. That spelling is MadSpin's decay-side
+            # matrix element, where the decaying resonance is leg 1.
             self.assertRaises(madgraph.InvalidCmd,
-                              self.do, 'generate z{A}* z > w+ w-')
+                              self.do, 'generate w+{A} > ta+ vt')
+            self.do('generate w+{A}* > ta+ vt')
+            self.assertTrue(cmd._curr_amps)
+            init = [l for l in cmd._curr_amps[0].get('process').get('legs')
+                    if not l.get('state')]
+            self.assertEqual(len(init), 1)
+            self.assertEqual(init[0].get('polarization'), [99])
+            self.assertTrue(init[0].get('offshell'))
+            # ... and it builds, exactly like a final-state one: eps_A is real,
+            # so there is nothing for the incoming/outgoing conjugation to do
+            init_me = helas_objects.HelasMultiProcess(
+                cmd._curr_amps).get('matrix_elements')[0]
+            init_values = set(h for row in init_me.get_helicity_matrix()
+                              for h in row)
+            self.assertIn(4, init_values)
+            self.assertNotIn(99, init_values)
+            # an initial-state axial leg is external by construction, so
+            # '--allow_axial' still has to gate writing it out
+            self.assertEqual(
+                len(cmd.collect_axial_external_legs(cmd._curr_amps)), 1)
 
             # the propagator syntax is unchanged
             self.do('generate t > w+{A} b, w+ > ta+ vt')

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -40,6 +40,7 @@ import math
 import random
 
 import madgraph.core.base_objects as MG
+import madgraph.core.base_objects as base_objects
 import madgraph.various.misc as misc
 import MadSpin.decay as madspin
 import madgraph.various.lhe_parser as lhe_parser
@@ -9953,3 +9954,242 @@ class TestBreitWignerTruncation(unittest.TestCase):
         chain = self._chain([6])
         self.assertEqual(self._V1(-1, self.TABLE).bw_truncation_factor(chain),
                          self._V1(15, self.TABLE).bw_truncation_factor(chain))
+
+
+class TestAxialBasis(unittest.TestCase):
+    """'consider_axial': the fourth, axial direction eps_A = k/sqrt(k.k) of a
+    massive vector's spin basis, and the two things that keep it honest --
+    a weight of (Q^2-M^2)/M^2 in the contraction, and no place at all in any
+    trace."""
+
+    AXIAL = 4
+    BASIS = [-1, 0, 1, AXIAL]
+
+    def _density(self, hel, seed=0):
+        import numpy as np
+        rng = np.random.default_rng(seed)
+        n = len(hel)
+        arr = (rng.normal(size=n * (n + 1) // 2)
+               + 1j * rng.normal(size=n * (n + 1) // 2)).astype('complex64')
+        for i in range(n):
+            arr[i * (2 * n - i + 1) // 2] = abs(arr[i * (2 * n - i + 1) // 2])
+        return madspin.DensityMatrix(arr, 1, hel, n)
+
+    def test_axial_helicity_is_the_helas_integer(self):
+        """The label the density matrix uses must be the one VXXXXX reads and
+        the one base_objects translates '{A}' (99) into -- ALLOW_HEL is matched
+        against NHEL by value, so a disagreement would give an all-zero
+        density."""
+        self.assertEqual(madspin.DensityMatrix.AXIAL_HELICITY,
+                         base_objects.polarization_to_helicities([99])[0])
+
+    def test_trace_restriction_alone_drops_the_axial_diagonal(self):
+        """hel_restriction_trace with no hel_restriction beside it: the trace
+        loses the axial entry while the contraction keeps every row."""
+        import numpy as np
+        rho = self._density(self.BASIS, seed=1)
+        full = rho.trace()
+        rho.set_hel_restriction_trace([(-1, 0, 1)])
+        self.assertIsNone(rho.hel_restriction)
+        phys = rho.trace()
+        # exactly the axial diagonal entry, and nothing else, has gone
+        axial = rho.values[(rho.helicities[:, 0] == self.AXIAL)
+                           & (rho.helicities[:, 1] == self.AXIAL)][0]
+        self.assertAlmostEqual(complex(full - phys).real, complex(axial).real,
+                               places=5)
+        # the contraction is untouched by a trace-only restriction
+        other = self._density(self.BASIS, seed=2)
+        bare = self._density(self.BASIS, seed=1)
+        self.assertAlmostEqual(complex(rho.scalar_multiplication(other)).real,
+                               complex(bare.scalar_multiplication(other)).real,
+                               places=4)
+
+    def test_an_unrestricted_matrix_still_has_no_trace_restriction(self):
+        """The widening of _trace_restriction must not move anything that
+        existed before: no restriction of either kind is still None."""
+        rho = self._density(self.BASIS, seed=3)
+        self.assertIsNone(rho._trace_restriction())
+
+    def test_weight_helicity_scales_row_and_column(self):
+        """Entry (i,j) picks up c_i*c_j: that is what the propagator numerator
+        does to the squared amplitude, once and not once per side."""
+        import numpy as np
+        c = -0.37
+        rho = self._density(self.BASIS, seed=4)
+        out = rho.weight_helicity([{self.AXIAL: c}])
+        h = out.helicities
+        expect = np.ones(h.shape[0])
+        expect[h[:, 0] == self.AXIAL] *= c
+        expect[h[:, 1] == self.AXIAL] *= c
+        self.assertTrue(np.allclose(out.values, rho.values * expect,
+                                    rtol=1e-5, atol=1e-6))
+        # the axial-axial entry gets c^2, the physical block nothing
+        aa = (h[:, 0] == self.AXIAL) & (h[:, 1] == self.AXIAL)
+        phys = (h[:, 0] != self.AXIAL) & (h[:, 1] != self.AXIAL)
+        self.assertTrue(np.allclose(out.values[aa], rho.values[aa] * c * c,
+                                    rtol=1e-5, atol=1e-6))
+        self.assertTrue(np.allclose(out.values[phys], rho.values[phys]))
+
+    def test_weight_helicity_keeps_the_fast_path_and_the_restrictions(self):
+        rho = self._density(self.BASIS, seed=5)
+        rho.set_hel_restriction_trace([(-1, 0, 1)])
+        out = rho.weight_helicity([{self.AXIAL: 2.0}])
+        self.assertIs(out.map_density_matrix_ind, rho.map_density_matrix_ind)
+        self.assertEqual(out.hel_restriction_trace, rho.hel_restriction_trace)
+        self.assertIsNone(out.hel_restriction)
+
+    def test_weight_helicity_is_a_no_op_without_weights(self):
+        """Returns self, so nothing that does not ask for a weight pays for a
+        copy -- and so the unweighted path stays bit-for-bit identical."""
+        rho = self._density(self.BASIS, seed=6)
+        self.assertIs(rho.weight_helicity([None]), rho)
+        self.assertIs(rho.weight_helicity([{}]), rho)
+
+    def test_the_weighted_contraction_stays_non_negative(self):
+        """With real weights the convolution is still sum_s |sum_l c_l A_l B_l|^2,
+        so no signed-weight machinery is needed: unlike the -g^{mu nu}
+        completeness (which would put a minus sign on the axial index), the
+        propagator numerator is diagonal with real coefficients."""
+        import numpy as np
+        # a genuine rank-one (pure-state) pair, which is what one spectator /
+        # colour configuration contributes
+        rng = np.random.default_rng(7)
+        n = 4
+        for c in (-2.0, -0.3, 0.0, 0.5, 3.0):
+            A = rng.normal(size=n) + 1j * rng.normal(size=n)
+            B = rng.normal(size=n) + 1j * rng.normal(size=n)
+            w = np.array([1.0, 1.0, 1.0, c])
+            amp = np.sum(w * A * B)
+            rho_p = np.outer(A, A.conjugate())
+            rho_d = np.outer(B, B.conjugate())
+            got = np.sum(np.outer(w, w) * rho_p * rho_d)
+            self.assertAlmostEqual(got.real, abs(amp) ** 2, places=8)
+            self.assertGreaterEqual(got.real, 0.0)
+
+
+class TestAxialInterfaceGates(unittest.TestCase):
+    """The MadSpin-side bookkeeping of 'consider_axial': which pdgs get the
+    fourth direction, what weight it carries, and what the option refuses."""
+
+    AXIAL = madspin.DensityMatrix.AXIAL_HELICITY
+
+    class _Model(object):
+        def __init__(self, table):
+            self.table = table
+
+        def get_particle(self, pdg):
+            return self.table[abs(int(pdg))]
+
+    class _Particle(dict):
+        def get(self, key):
+            return self[key]
+
+    class _Value(object):
+        def __init__(self, v):
+            self.value = v
+
+    class _Banner(object):
+        def __init__(self, masses):
+            self.masses = masses
+
+        def get(self, card, block, pdg):
+            assert (card, block) == ('param_card', 'mass')
+            return TestAxialInterfaceGates._Value(self.masses[abs(int(pdg))])
+
+    def _stub(self, **options):
+        stub = object.__new__(interface_madspin.MadSpinInterface)
+        opts = {'consider_axial': True, 'spinmode': 'madspin',
+                'unweighting': 'auto', 'fixed_order': False}
+        opts.update(options)
+        stub.options = opts
+        stub.model = self._Model({
+            24: self._Particle({'spin': 3, 'mass': 'MW'}),      # massive vector
+            23: self._Particle({'spin': 3, 'mass': 'MZ'}),      # massive vector
+            22: self._Particle({'spin': 3, 'mass': 'ZERO'}),    # massless vector
+            6: self._Particle({'spin': 2, 'mass': 'MT'}),       # fermion
+            25: self._Particle({'spin': 1, 'mass': 'MH'}),      # scalar
+        })
+        stub.banner = self._Banner({24: 80.419, 23: 91.188})
+        return stub
+
+    def test_only_massive_vectors_get_the_axial_direction(self):
+        stub = self._stub()
+        self.assertEqual(stub._axial_pdgs([24, -24, 23]), frozenset({24, -24, 23}))
+        self.assertEqual(stub._axial_pdgs([6, 25, 22]), frozenset())
+
+    def test_nothing_at_all_without_the_option(self):
+        """The single gate everything else hangs off: with the option off the
+        set is empty and every axial branch is dead."""
+        stub = self._stub(consider_axial=False)
+        self.assertEqual(stub._axial_pdgs([24, 23, 6]), frozenset())
+        self.assertIsNone(stub._axial_trace_restriction([24], frozenset(),
+                                                        [[-1, 0, 1, 4]]))
+
+    def test_trace_restriction_names_the_physical_states_only(self):
+        stub = self._stub()
+        got = stub._axial_trace_restriction([24, 6], frozenset({24}),
+                                            [[-1, 0, 1, self.AXIAL], [1, -1]])
+        self.assertEqual(got, ((-1, 0, 1), None))
+
+    def test_axial_weight_is_the_propagator_coefficient(self):
+        """c_A = (Q^2-M^2)/M^2: zero on shell, and it is what the '1A' custom
+        propagator carries."""
+        stub = self._stub()
+        pole = 80.419
+        for q in (pole, 70.0, 95.0):
+            got = stub._axial_weights([24], frozenset({24}), [q])
+            self.assertEqual(list(got[0]), [self.AXIAL])
+            self.assertAlmostEqual(got[0][self.AXIAL],
+                                   (q * q - pole ** 2) / pole ** 2, places=12)
+        self.assertEqual(stub._axial_weights([24], frozenset({24}), [pole])[0],
+                         {self.AXIAL: 0.0})
+        # a non-axial index is left alone
+        self.assertEqual(stub._axial_weights([6], frozenset({24}), [173.0]),
+                         [None])
+
+    def test_the_option_forces_the_joint_accept_reject(self):
+        """DensityMatrix.identity is only a theorem for the three physical
+        polarisations, so the staged schemes are not available."""
+        stub = self._stub(unweighting='sequential')
+        stub._log_once = lambda *a, **k: None
+        stub._announce_mode = lambda mode, asked: mode
+        stub._pure_interference = lambda: {}
+        self.assertEqual(stub._unweighting_mode(True), 'joint')
+
+    def test_refusals(self):
+        for kwargs, needle in (({'spinmode': 'PA'}, 'off-shell resonance'),
+                               ({'spinmode': 'onshell'}, 'off-shell resonance')):
+            stub = self._stub(**kwargs)
+            stub._pure_interference = lambda: {}
+            stub._production_polarization = lambda: {}
+            stub._polarization_weights_enabled = lambda: False
+            self.assertRaises(Exception, stub._check_axial_compatibility)
+            try:
+                stub._check_axial_compatibility()
+            except Exception as error:
+                self.assertIn(needle, str(error))
+        # pure_interference and a production brace are refused too
+        stub = self._stub()
+        stub._pure_interference = lambda: {6: ((0,), (-1, 1))}
+        stub._production_polarization = lambda: {}
+        stub._polarization_weights_enabled = lambda: False
+        self.assertRaises(Exception, stub._check_axial_compatibility)
+        stub = self._stub()
+        stub._pure_interference = lambda: {}
+        stub._production_polarization = lambda: {24: ((0,),)}
+        stub._polarization_weights_enabled = lambda: False
+        self.assertRaises(Exception, stub._check_axial_compatibility)
+        # so are the polarisation-fraction weights: a projection onto a
+        # physical polarisation can never pick the axial direction up, so the
+        # fractions would stop adding up to one
+        stub = self._stub()
+        stub._pure_interference = lambda: {}
+        stub._production_polarization = lambda: {}
+        stub._polarization_weights_enabled = lambda: True
+        self.assertRaises(Exception, stub._check_axial_compatibility)
+        # and the clean combination goes through
+        stub = self._stub()
+        stub._pure_interference = lambda: {}
+        stub._production_polarization = lambda: {}
+        stub._polarization_weights_enabled = lambda: False
+        self.assertIsNone(stub._check_axial_compatibility())


### PR DESCRIPTION
**Milestone 3 of 4.** Stacked on #388. MadSpin convolves over **four** helicity
indices when `consider_axial` is on.

## The physics is not a minus sign

MadSpin does not factorise `-g^{mu nu}`; it factorises the **propagator**,
`(-g + kk/M^2)/(k^2 - M^2 + iMGamma)`. In the tetrad that numerator is diagonal
with coefficient 1 on the three physical directions and

```
c_A = (Q^2 - M^2) / M^2
```

on the axial one — literally ALOHA's `1A` custom propagator. The `-1` belongs to
`{G}`, the `-g` piece alone. So, against expectation:

- **`trace()` keeps its unsigned sum.** What changed is *which rows* it runs over:
  the axial direction carries no cross-section and takes no part in any
  normalisation. That is a **trace-only** restriction (`hel_restriction_trace` set,
  `hel_restriction` left `None`), so `prod_diag`/`dec_diag`/`normalized()` stay the
  physical three-state objects while the contraction runs over all four rows.
- **Positivity is not lost.** `c_i c_j` on the `(i,j)` entry keeps the contraction
  equal to `Sum_spectators |Sum_lambda c_lambda A_lambda B_lambda|^2`. No signed
  weight, no `|w|`/`copysign`, nothing in the accept/reject changes.
- `identity()` stays at `delta/n`, and `consider_axial` falls back to the joint
  accept/reject: `delta/n` is a theorem about the three physical polarisations,
  while `eps_A` is the rest-frame *time* direction, so the average is
  `diag(a,a,a,b)` with process- and virtuality-dependent `b/a`. `1/4` is not it.
- `c_A` vanishes on shell, so `consider_axial` requires `madspin`/`full`.

## How the fourth state reaches the ME — neither of the two obvious routes

`GET_ALL_INTER` **overwrites** `NHEL` at the changing positions from `ALLOW_HEL`
before calling `GET_AMP`; the NHEL table only enumerates *spectator* helicities for
`GET_DENSITY`'s outer loop. So appending `4` to MadSpin's own `hel_dict` suffices —
no brace on either side.

That is not merely simpler, it is the only correct route. Putting the fourth state
in the NHEL table would also put it in what `SMATRIX` sums and
`get_denominator_factor` averages over — and those unpolarised MEs are the
**denominator** of the MadSpin weight, generated with three states. A braced
directory would have added `|A_axial|^2` to both and biased the accept/reject.

(`{A}` on an initial-state leg is nonetheless now allowed, since the rule it
removes was simply wrong — `eps_A` is real, so unlike the transverse states it is
not conjugated for an incoming leg. MadSpin does not use it.)

## Closure: three indices vs four

`u d~ > w+ h`, `decay w+ > ta+ vt`, spinmode `madspin`, 345 trials. Massive
daughters **and** a production current that is not conserved at the `W` leg —
`u u~ > w+ w-` has massless quarks, so its production current *is* conserved and
its axial column is ~1e-3 of the physical one; it cannot discriminate.

| `abs(1 - ME_full/ME_density)` | median | p99 | max | > 1e-4 |
|---|---|---|---|---|
| three indices | 6.1e-06 | 1.4e-03 | **3.3e-03** | **9.0 %** |
| four indices | 1.8e-06 | 8.6e-06 | **1.5e-05** | **0.0 %** |

At the default tolerance the three-index run raises on the first percent-level
trial; the four-index run completes clean. The 2e-6 floor is `complex64` storage,
not physics.

`density_debug` needed three fixes before it could run at all in the off-shell
modes: it died with `'module' object is not subscriptable`; it compared a density
weight dividing by `|iMGamma|^2` against a full ME carrying
`|Q^2-M^2+iMGamma|^2`; and the production check ran `calculate_matrix_element`
*after* `add_decays()` had turned the event into the full one.

## Bit-identity with `consider_axial` off

Three jobs on the base and on this commit — `u d~ > w+ h`, a nested
`g g > t t~` / `t > w+ b, w+ > ta+ vt`, and `u u~ > w+ w-`. All three decayed LHE
files **byte-identical**, generated Fortran diffs clean.

## Refused combinations

Any spinmode but `madspin`/`full`; `pure_interference` (both want
`hel_restriction_trace`); a production polarisation brace;
`keep_weight_for_polarization_*` (lifted in milestone 4); `gauge = FD`.

## Tests

`test_madspin -t0` **498 OK** (485 on base, +13). `-p U test_cmd` 24 OK. Full
`-p U` 1284, only the pre-existing scipy error. One existing test flipped:
`test_generate_axial_polarisation` asserted an initial-state `{A}*` is refused —
the rule this milestone deliberately reverses.

## Known, not fixed here

`_joint_maxwgt_range` reuses one production density across draws that each
reshuffle onto a new virtuality, so those trials compare different phase-space
points (median 1.5 %, up to 42 %). It masked this closure signal for hours.
`density_debug` now skips those trials rather than papering over it; assessed
separately on `claude/ms-joint-scan-assess`.

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend MadSpin’s off-shell density convolution to account for the fourth axial vector-propagator direction without altering physical-state normalization or legacy behavior.

New Features:
- Add optional axial-state convolution for massive off-shell vector resonances when `consider_axial` is enabled, including the propagator-dependent axial coefficient.
- Allow off-shell initial-state axial polarization syntax needed for decay-side matrix elements.

Bug Fixes:
- Correct density-debug validation for off-shell propagator normalization, production-event timing, module initialization, and stale phase-space comparisons.

Enhancements:
- Keep axial states in contractions while excluding them from physical cross-section traces and force joint accept/reject unweighting to preserve normalization.
- Reject unsupported combinations of axial convolution with incompatible spin modes, interference, production polarization, polarization weights, and Feynman-diagram gauge.
- Preserve existing behavior bit-for-bit when axial consideration is disabled.

Documentation:
- Document the axial-state treatment, compatibility restrictions, and off-shell behavior in the update notes.

Tests:
- Add comprehensive unit coverage for axial helicity handling, trace restrictions, propagator weighting, positivity, interface gates, and polarization parsing.