### PR TITLE
Report an error in a command file to the shell instead of exiting zero

### DIFF
--- a/.github/workflows/acceptancetest.yml
+++ b/.github/workflows/acceptancetest.yml
@@ -173,6 +173,25 @@ jobs:
 
 
 
+  acceptancetest_13b:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == true
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/checkout_mg5
+      - uses: ./.github/actions/restore-pip-cache
+
+      # Runs a set of commands using the runners shell
+      - name: test one of the test test_exit_status_for_failing_command_file
+        run: |
+            cd $GITHUB_WORKSPACE
+            ./tests/test_manager.py test_exit_status_for_failing_command_file test_exit_status_for_valid_command_file test_loop_induced_without_import_model -pA -t0 -l INFO
+
+
+
   acceptancetest_14:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04

--- a/bin/mg5_aMC
+++ b/bin/mg5_aMC
@@ -229,5 +229,10 @@ try:
 except Exception as error:
     pass
 
+# A command file interrupted by an error has to be reported to the shell.
+# (in interactive mode the user did see the error already and nothing is set)
+if getattr(cmd_line, 'exit_status', 0):
+    sys.exit(1)
+
 
     

--- a/madgraph/interface/extended_cmd.py
+++ b/madgraph/interface/extended_cmd.py
@@ -908,6 +908,10 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
     keyboard_stop_msg = """stopping all current operation
             in order to quit the program please enter exit"""
 
+    # status to return to the shell. set to one when a command file is
+    # interrupted by an error (see stop_on_error)
+    exit_status = 0
+
     if MADEVENT:
         plugin_path = []
     else:
@@ -1381,17 +1385,35 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 return False
             
         #stop the execution if on a non interactive mode
+        return self.stop_on_error()
+
+
+
+    def stop_on_error(self):
+        """Check if the failing command has to stop the execution, i.e. if it
+        does not come from an interactive prompt but from a command file.
+        In that case, also flag the run as failed on the root interface such
+        that the launcher can exit with a non zero status. Otherwise a script
+        driving MG5aMC has no way to know that a command did crash."""
+
+        stop = False
         if self.use_rawinput == False or self.inputfile:
-            return True
+            stop = True
         elif self.mother:
             if self.mother.use_rawinput is False:
-                return True
-                
+                stop = True
+
             elif self.mother.mother:
                 if self.mother.mother.use_rawinput is False:
-                    return True 
-        
-        return False
+                    stop = True
+
+        if stop:
+            cmd = self
+            while getattr(cmd, 'mother', None):
+                cmd = cmd.mother
+            cmd.exit_status = 1
+
+        return stop
 
 
 
@@ -1419,19 +1441,13 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
                 return False
 
         #stop the execution if on a non interactive mode
-        if self.use_rawinput == False or self.inputfile:
+        if self.stop_on_error():
             return True
-        elif self.mother:
-            if self.mother.use_rawinput is False:
-                return True
-            elif self.mother.mother:
-                if self.mother.mother.use_rawinput is False:
-                    return True                
-            
+
         # Remove failed command from history
         self.history.pop()
         return False
-    
+
     def nice_config_error(self, error, line):
         if self.child:
             return self.child.nice_user_error(error, line)
@@ -1474,16 +1490,10 @@ class Cmd(CheckCmd, HelpCmd, CompleteCmd, BasicCmd):
 
         
         #stop the execution if on a non interactive mode
-        if self.use_rawinput == False or self.inputfile:
+        if self.stop_on_error():
             return True
-        elif self.mother:
-            if self.mother.use_rawinput is False:
-                return True
-            elif self.mother.mother:
-                if self.mother.mother.use_rawinput is False:
-                    return True                             
 
-        # Remove failed command from history                                            
+        # Remove failed command from history
         if self.history:
             self.history.pop()
         return False

--- a/madgraph/interface/loop_interface.py
+++ b/madgraph/interface/loop_interface.py
@@ -302,6 +302,14 @@ class CommonLoopInterface(mg_interface.MadGraphCmd):
         if isinstance(coupling_type,str):
             coupling_type = [coupling_type,]
 
+        # For [noborn=..] this function is called before check_generate, so the
+        # default model might not be loaded yet (this is the case for a command
+        # file since preloop is then not called). Load it here, the code below
+        # takes care of upgrading it to the associated loop model.
+        if not self._curr_model:
+            logger.info("No model currently active, so we import the Standard Model")
+            self.do_import('model sm')
+
 ##        if coupling_type!= ['QCD'] and loop_type not in ['virtual','noborn']:
 ##            c = ' '.join(coupling_type)
 ##            raise self.InvalidCmd('MG5aMC can only handle QCD at NLO accuracy.\n We can however compute loop with [virt=%s].\n We can also compute cross-section for loop-induced processes with [noborn=%s]' % (c,c))

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -8701,6 +8701,8 @@ in the MG5aMC option 'samurai' (instead of leaving it to its default 'auto')."""
         or: set crash_on_error False [Default]
         or: set crash_on_error never [never crash]
         if crash_on_error is True, the code will stop with a non zero exit code.
+        Note that when reading a command file, an error always stops the
+        execution and returns a non zero exit code (use 'never' to bypass this).
         """
 
         args = ['crash_on_error'] + args

--- a/tests/acceptance_tests/test_cmd.py
+++ b/tests/acceptance_tests/test_cmd.py
@@ -1660,3 +1660,78 @@ P1_qq_wp_wp_lvl
         self.assertIn("200       = nevents", run_card)
         os.chdir(cwd)
         
+
+#===============================================================================
+# TestCmdFileErrorStatus
+#===============================================================================
+class TestCmdFileErrorStatus(unittest.TestCase):
+    """Check that an error occuring while reading a command file is reported
+    to the shell via the exit code. In interactive mode the user does see the
+    error and can react to it, but a script driving mg5_aMC has no other way
+    to know that nothing was actually generated."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='mg5_exit_status_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def write_script(self, *lines):
+        """write a mg5 command file in the temporary directory"""
+
+        path = pjoin(self.tmpdir, 'cmd.mg5')
+        fsock = open(path, 'w')
+        fsock.write('\n'.join(lines) + '\n')
+        fsock.close()
+        return path
+
+    def run_script(self, path):
+        """run mg5_aMC on that command file and return the exit code"""
+
+        devnull = open(os.devnull, 'w')
+        try:
+            return subprocess.call([sys.executable,
+                                    pjoin(MG5DIR, 'bin', 'mg5_aMC'),
+                                    '-f', path],
+                                   stdout=devnull, stderr=subprocess.STDOUT,
+                                   cwd=self.tmpdir)
+        finally:
+            devnull.close()
+
+    def test_exit_status_for_failing_command_file(self):
+        """a command file interrupted by an error returns a non zero status"""
+
+        out_dir = pjoin(self.tmpdir, 'PROC_failing')
+        path = self.write_script('import model a_model_which_does_not_exist',
+                                 'generate e+ e- > mu+ mu-',
+                                 'output %s' % out_dir)
+
+        self.assertNotEqual(self.run_script(path), 0)
+        self.assertFalse(os.path.exists(out_dir))
+
+    def test_exit_status_for_valid_command_file(self):
+        """a command file which succeeds still returns a zero status"""
+
+        out_dir = pjoin(self.tmpdir, 'PROC_valid')
+        path = self.write_script('import model sm',
+                                 'generate e+ e- > mu+ mu-',
+                                 'output %s' % out_dir)
+
+        self.assertEqual(self.run_script(path), 0)
+        self.assertTrue(os.path.exists(out_dir))
+
+    def test_loop_induced_without_import_model(self):
+        """[noborn=..] validates the model before check_generate, so no model
+        is loaded yet when running from a command file (preloop is not called
+        in that mode). The default model has to be loaded --and upgraded to
+        loop_sm-- instead of crashing."""
+
+        path = self.write_script('generate g g > z z [noborn=QCD]')
+
+        cmd = Cmd.MasterCmd()
+        cmd.use_rawinput = False
+        cmd.run_cmd('import %s' % path)
+
+        self.assertEqual(cmd._curr_model.get('name'), 'loop_sm')
+        self.assertEqual(len(cmd._curr_amps), 1)
+        self.assertEqual(cmd.exit_status, 0)


### PR DESCRIPTION
## The problem: mg5_aMC exits 0 after a command file that generated nothing

Running a command file, MG5aMC already stops as soon as a command fails: the
error is printed and the remaining lines are listed as `command not executed`.
What it does *not* do is tell the shell. `bin/mg5_aMC` returns 0 either way, so
anything driving MG5aMC from a script (validation drivers, CI, batch
submission) is told that a run which produced nothing did succeed.

The visible symptom is "nothing happened": no output directory, no failed
command, no non-zero status to key off. In the session that found this, a
committed driver script could not have produced its own recorded log, and that
went unnoticed for months.

### Two independent sightings

Both are loop-induced processes generated from a command file with no
`import model` line, and both crash inside `loop_interface.validate_model` with
`AttributeError: 'NoneType' object has no attribute 'get'` while `mg5_aMC`
still exits 0:

```
# sighting 1
set auto_convert_model T
generate g g > e+ e- mu+ mu- / a [noborn=QCD]
output PROC

# sighting 2
generate g g > z z [noborn=QCD]
output PROC
```

`set auto_convert_model T` turned out to be a red herring: sighting 2 has no
`set` at all and fails identically. What both share is that no model is loaded.

## Why `validate_model` sees `None`

`_curr_model` is genuinely unset (its class default), not a model that failed to
resolve.

* Interactively, `preloop` runs `import model sm`, so a model always exists.
  Reading a command file, `preloop` is never called.
* Every other generation path recovers from that: `CheckValidForCmd.check_generate`
  lazily does `self.do_import('model sm')` when `_curr_model` is empty.
* `[noborn=..]` is the one path that does not reach it. `master_interface.do_add`
  calls `self.cmd.validate_model(...)` *before* delegating to `do_add`/`check_add`/
  `check_generate`, so `validate_model` dereferences `None`.

This also explains why the `[QCD]` sibling was reported unaffected — the
difference is structural (`noborn` vs `all`), not sample-dependent. `[QCD]`
takes the `do_add` route, gets the lazy `import model sm`, and `validate_model`
then upgrades it to `loop_sm` normally.

`validate_model` now performs the same lazy load as `check_generate`, and the
existing sm -> loop_sm upgrade below it takes over unchanged.

## Why the exit code was 0, and how wide it is

The class is not limited to loop-induced processes: **every** failing command in
a command file exited 0 (`import model <typo>`, `generate p p > <typo>`, ...).

The interactive/batch distinction already existed in the code — the three
`nice_error_handling` / `nice_user_error` / `nice_config_error` handlers each end
with the same block returning `True` (stop) when the command did not come from
the prompt. That block is now factorised into `Cmd.stop_on_error()`, which
additionally flags the root interface so `bin/mg5_aMC` can `sys.exit(1)`. The
swallow looks like an oversight rather than a decision: the deliberate knob is
`crash_on_error`, whose own help already promises a non-zero exit code, and
`set crash_on_error never` still bypasses the whole mechanism (verified: run
continues past the error and exits 0).

Not changed here, and worth deciding separately: an *unrecognised* command in a
script is only a warning (`Cmd.default`), so the script keeps going and still
exits 0. And the MadEvent-side launchers (`bin/generate_events`, `bin/madevent`)
do not read the new flag, although the interfaces now set it.

## Tests

`tests/acceptance_tests/test_cmd.py::TestCmdFileErrorStatus`, asserting on exit
codes and on whether the output directory exists — not on log text.

| test | before | after |
| --- | --- | --- |
| `test_exit_status_for_failing_command_file` | FAIL (`0 == 0`) | ok |
| `test_exit_status_for_valid_command_file` | ok | ok |
| `test_loop_induced_without_import_model` | ERROR (`AttributeError`) | ok |

A CI job is added for the three.

Suites run locally on the same machine, unmodified `3.7.3` vs this branch
(sequentially, they share paths under `/tmp`):

* the `unittest.yml` interface list (`test_the_exit_from_child_cmd`,
  `test_InvalidCmd`, `test_v31_syntax_crash`, `test_cleaning_history`, ...):
  25 tests OK before, 25 tests OK after.
* the acceptance interface set (`test_config test_draw test_generate
  test_import_model test_check_generate_optimize test_define_order
  test_invalid_operations_for_{add,generate,output} test_save_load
  test_output_{madevent,standalone}_directory`): 12 tests, 1 failure
  (`test_output_madevent_directory`) **identically before and after** — it is
  pre-existing on `fb8ece13a` and environmental (it asserts on a generated
  `matrix1.jpg`, and this machine has no jpeg toolchain).

Both sightings now run to completion end to end: exit 0 and the output
directory is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
