### PR TITLE
tests: stop collecting the MadSpin acceptance helper as a test

### DIFF
--- a/tests/acceptance_tests/test_madspin.py
+++ b/tests/acceptance_tests/test_madspin.py
@@ -233,7 +233,7 @@ class TestMadSpin(unittest.TestCase):
         self.assertLess(abs(pol[1]-pol[-1]), 2 * math.sqrt(pol[1]))
         self.assertLess(pol[0], pol[-1])
 
-    def test_one_mode(self, mode, particle_to_decay, name_input_file, name_scipt_file):
+    def _run_one_mode(self, mode, particle_to_decay, name_input_file, name_scipt_file):
         cwd = os.getcwd()
         index = name_input_file.find(".lhe")
         name_file_decayed = name_input_file[:index] + "_decayed" + name_input_file[index:]
@@ -305,20 +305,20 @@ class TestMadSpin(unittest.TestCase):
             It checks that there is no crash and that the decayed particles have a status of 2.
         """ 
 
-        self.test_one_mode("PA", [24, -24], 'test_madspin_loop_induced_PA.lhe.gz', 'test_loop_induced_PA')
-        self.test_one_mode("full", [24, -24], 'test_madspin_loop_induced_full.lhe.gz', 'test_loop_induced_full')
-        self.test_one_mode("onshell", [24, -24], 'test_madspin_loop_induced_onshell.lhe.gz', 'test_loop_induced_onshell')
-        self.test_one_mode("madspin", [24, -24], 'test_madspin_loop_induced_madspin.lhe.gz', 'test_loop_induced_madspin')
+        self._run_one_mode("PA", [24, -24], 'test_madspin_loop_induced_PA.lhe.gz', 'test_loop_induced_PA')
+        self._run_one_mode("full", [24, -24], 'test_madspin_loop_induced_full.lhe.gz', 'test_loop_induced_full')
+        self._run_one_mode("onshell", [24, -24], 'test_madspin_loop_induced_onshell.lhe.gz', 'test_loop_induced_onshell')
+        self._run_one_mode("madspin", [24, -24], 'test_madspin_loop_induced_madspin.lhe.gz', 'test_loop_induced_madspin')
 
     def test_madspin_tree_level(self):
         """ Tests that that the differrent mode of madspin work for tree-level processes.
             It checks that there is no crash and that the decayed particles have a status of 2.
         """ 
 
-        self.test_one_mode("PA", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_PA')
-        self.test_one_mode("full", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_full')
-        self.test_one_mode("onshell", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_onshell')
-        self.test_one_mode("madspin", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_madspin')
-        self.test_one_mode("none", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_none')
-        self.test_one_mode("madspin_v1", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_madspin_v1')
-        self.test_one_mode("onshell_v1", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_onshell_v1')
+        self._run_one_mode("PA", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_PA')
+        self._run_one_mode("full", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_full')
+        self._run_one_mode("onshell", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_onshell')
+        self._run_one_mode("madspin", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_madspin')
+        self._run_one_mode("none", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_none')
+        self._run_one_mode("madspin_v1", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_level_madspin_v1')
+        self._run_one_mode("onshell_v1", [6, -6], 'test_madspin_tree_level.lhe.gz', 'test_tree_onshell_v1')


### PR DESCRIPTION
`tests/acceptance_tests/test_madspin.py` has been exiting non-zero on **every** run, on every branch, for as long as the helper has carried its current name.

`test_one_mode` takes four positional arguments and is a helper — the eleven real tests call it with a spinmode, the particles to decay and two file names. But `unittest` collects by the `test` prefix, so it is *also* collected on its own, called with no arguments, and raises:

```
TypeError: test_one_mode() missing 4 required positional arguments:
           'mode', 'particle_to_decay', 'name_input_file', and 'name_scipt_file'
```

A suite that always reports `FAILED` is a suite nobody reads, which is the real cost here.

## The change

Renamed to `_run_one_mode`. The leading underscore is what does the work — any name keeping the `test` prefix would only relocate the bug. Twelve occurrences in one file: one definition, eleven call sites. No behaviour change to the eleven tests themselves.

## Verified pre-existing, not a regression

Run with `python tests/test_manager.py -p tests/acceptance_tests test_madspin` (it must go through `test_manager.py`; plain `unittest` errors immediately on `unittest.debug`):

| commit | result |
|---|---|
| `02ee49a59` (`madspin_density`) | `Ran 6 tests` — `FAILED (errors=1)` |
| `0a1007bc2` (an unrelated branch in flight) | `Ran 6 tests` — `FAILED (errors=1)`, identical |
| this branch | **`Ran 5 tests` — `OK`** |

The two failing runs are byte-identical, which is how the fault was confirmed to predate any work in flight.

Note this method does not exist on `3.7.3`, so the fix is fork-local and nothing needs to go upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent the MadSpin acceptance-test helper from being collected as an independent test, eliminating the spurious failure caused by missing arguments.