### PR TITLE
MG5: refuse the propagator-only polarisation braces {G},{H},{Q},{W},{S} on an external leg

### DIFF
--- a/madgraph/core/base_objects.py
+++ b/madgraph/core/base_objects.py
@@ -2088,6 +2088,21 @@ class ParamCardVariable(ModelVariable):
 #===============================================================================
 # Leg
 #===============================================================================
+def polarization_to_string(polarization):
+    """Render a leg 'polarization' list as the brace content of a process
+    string. The propagator-only entries (4,5,6,7,9,99) are printed as the
+    letters the parser understands ('G','H','Q','W','S','A') rather than as
+    their raw integers, which the parser rejects ("polarization are between
+    -3 and 3"). This is what makes nice_string()/input_string() round-trip."""
+
+    # no separator: the process parser reads the brace character by character
+    # (and a ',' inside a brace additionally confuses the decay-chain split on
+    # ','), so '{0S}' round-trips where '{0,S}' does not.
+    return ''.join([Leg.propagator_only_polarizations.get(p, str(p))
+                    for p in polarization])
+
+
+#===============================================================================
 class Leg(PhysicsObject):
     """Leg object: id (Particle), number, I/F state, flag from_group
     """
@@ -2096,6 +2111,18 @@ class Leg(PhysicsObject):
     # See [arXiv:1912.01725] for definitions (fermions,vectors) and
     # [arXiv:2512.10015] for extensions (vectors)
     list_of_allowed_polarizations = [-1, 1, 2,-2, 3,-3, 0, 4, 5, 6, 7, 9, 99]
+
+    # Polarizations that only exist as a piece of the *propagator* numerator
+    # of a massive vector (see aloha/create_aloha.py, the "1X" forms) and that
+    # therefore have no external-wavefunction counterpart. Values are the
+    # brace letters accepted by the process parser.
+    propagator_only_polarizations = {4: 'G',   # -metric
+                                     5: 'H',   # Theta
+                                     6: 'Q',   # q^mu q^nu / q^2
+                                     7: 'W',   # -metric + qq/(M^2-iM*W)
+                                     9: 'S',   # scalar = axial + width
+                                     99: 'A',  # axial/auxiliary
+                                     }
 
     def default_setup(self):
         """Default values for all properties"""
@@ -3192,7 +3219,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R} '
                 else:
-                    mystr = mystr + '{%s} ' %','.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s} ' % polarization_to_string(leg.get('polarization'))   
             else:
                 mystr = mystr + ' '
             #mystr = mystr + '(%i) ' % leg['number']
@@ -3327,7 +3354,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R} '
                 else:
-                    mystr = mystr + '{%s} ' %','.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s} ' % polarization_to_string(leg.get('polarization'))   
             else:
                 mystr = mystr + ' '
              
@@ -3422,7 +3449,7 @@ class Process(PhysicsObject):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R} '
                 else:
-                    mystr = mystr + '{%s} ' %','.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s} ' % polarization_to_string(leg.get('polarization'))   
             else:
                 mystr = mystr + ' '
             prevleg = leg
@@ -4040,7 +4067,7 @@ class ProcessDefinition(Process):
                 elif leg.get('polarization') == [1]:
                     mystr = mystr + '{R}'
                 else:
-                    mystr = mystr + '{%s} ' %''.join([str(p) for p in leg.get('polarization')])   
+                    mystr = mystr + '{%s} ' % polarization_to_string(leg.get('polarization'))   
             else:
              mystr = mystr + ' '
             #mystr = mystr + '(%i) ' % leg['number']

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -683,6 +683,24 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 if self['state'] == 'final' and self.get('pdg_code') in decay_ids:
                     self.set('decay', True)
                 else:
+                    # Braces that name a piece of the propagator numerator of a
+                    # massive vector have no external wavefunction: the integer
+                    # would end up in the NHEL table and VXXXXX would silently
+                    # return a meaningless vector. The command interface
+                    # already refuses them (validate_propagator_polarization);
+                    # this catches the direct-API path as well.
+                    propagator_only = \
+                        base_objects.Leg.propagator_only_polarizations
+                    for value in leg.get('polarization'):
+                        # 99 ('{A}') keeps its own, pre-existing message below
+                        if value == 99 or value not in propagator_only:
+                            continue
+                        raise InvalidCmd(
+                            "The polarization {%s} is a piece of a massive "
+                            "vector propagator, not a polarization vector: "
+                            "it is only valid on a particle that is decayed "
+                            "further (an internal line), not on an external "
+                            "leg of the process." % propagator_only[value])
                     if 99 in leg.get('polarization'):
                         raise Exception("polarization A only valid for propagator.")
                 # Set fermion flow state. Initial particle and final

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -766,6 +766,8 @@ class HelpToCmd(cmd.HelpCmd):
         logger.info(" > Example: generate t{L} > w+{T} b{R}, w+ > ta+ vt",'$MG:color:GREEN')
         logger.info(" > Example: generate p p > z{T} z{A}, z > e+ e-",'$MG:color:GREEN')
         logger.info(" > Example: generate p p > z{0} z{T}, z > e+ e-, z > mu+ mu-",'$MG:color:GREEN')
+        logger.info(" > '{G}','{H}','{Q}','{W}','{S}' select a piece of the *propagator* of a massive vector")
+        logger.info("   and are only valid on a particle that is decayed further (an internal line).")
         logger.info(" > Users need to set 'group_subprocesses False', 'nhel=1' (run_card), and 'me_frame' (run_card)")
         logger.info(" > For the proces 'p p > w+ z j j, w+ > l+ vl, z > l+ l-', the WZ rest frame is given by me_frame = [3,4,5,6]")
         logger.info(" > For further details, see appendices of [arXiv:1912.01725] and [arXiv:2512.10015],")
@@ -3318,7 +3320,12 @@ This implies that with decay chains:
             # existing processes
             if self._curr_amps and self._curr_amps[0].get_ninitial() != \
                myprocdef.get_ninitial() and not standalone_only:
-                raise self.InvalidCmd("Can not mix processes with different number of initial states.")               
+                raise self.InvalidCmd("Can not mix processes with different number of initial states.")
+
+            # Check the propagator-only polarization braces: {G},{H},{Q},{W}
+            # and {S} name a piece of a propagator numerator and are valid on
+            # an internal line only.
+            self.validate_propagator_polarization(myprocdef)
 
             #Check that we do not have situation like z{T} z
             if not myprocdef.check_polarization():
@@ -4818,6 +4825,73 @@ This implies that with decay chains:
         args = self.split_arg(line)
         args.insert(0, 'process')
         self.do_add(" ".join(args))
+
+    # The braces that name a piece of the *propagator* numerator of a massive
+    # vector and nothing else: they have no external-wavefunction counterpart
+    # (there is no VXXXXX helicity for them), so on a genuine external leg the
+    # integer would be written straight into the NHEL table and VXXXXX would
+    # quietly return a meaningless vector. See aloha/create_aloha.py for the
+    # numerators ("1G", "1H", ...) and [arXiv:2512.10015] for the definitions.
+    # '{A}' (99) is deliberately absent: it is already refused on an external
+    # leg by HelasWavefunction and keeps that behaviour unchanged here.
+    PROPAGATOR_ONLY_POLARIZATIONS = {4: ('G', 'the metric piece -g^{mu nu}'),
+                                     5: ('H', 'the Theta projector'),
+                                     6: ('Q', 'the q^mu q^nu / q^2 tensor'),
+                                     7: ('W', 'the Ward-protected full '
+                                              'propagator'),
+                                     9: ('S', 'the scalar piece '
+                                              '(axial + finite width)'),
+                                     }
+
+    def validate_propagator_polarization(self, procdef):
+        """Validate the propagator-only polarization braces of a
+        ProcessDefinition and of its decay chains.
+
+        '{G}', '{H}', '{Q}', '{W}' and '{S}' (pol=4,5,6,7,9) each name a
+        rank-two piece of the propagator numerator of a massive vector,
+        complete with its 1/(q^2-M^2+iM*Gamma) pole; none of them is a
+        polarisation vector, and no external wavefunction for them exists
+        (VXXXXX only knows nhel = -1,0,+1).
+
+        They are therefore allowed on a leg that is handed over to a decay
+        chain -- the propagator use, 't > w+{G} b, w+ > ta+ vt' -- and refused
+        on a genuine external leg of the process, initial or final. There is
+        no option to enable them on an external leg: there is nothing to
+        enable. Without this check the raw integer reached the NHEL table and
+        the generated code silently returned a wrong number.
+
+        Raises InvalidCmd; returns None.
+        """
+        if procdef is None:
+            return
+        # pdgs that this level hands over to a decay chain: those legs become
+        # internal propagators, which is the case these braces were written for.
+        decayed_ids = set()
+        for decay in procdef.get('decay_chains'):
+            for leg in decay.get('legs'):
+                if not leg.get('state'):
+                    decayed_ids.update(leg.get('ids'))
+
+        for leg in procdef.get('legs'):
+            if decayed_ids.intersection(leg.get('ids')):
+                # propagator: the leg is replaced by the decay chain
+                continue
+            for value in leg.get('polarization'):
+                if value not in self.PROPAGATOR_ONLY_POLARIZATIONS:
+                    continue
+                tag, what = self.PROPAGATOR_ONLY_POLARIZATIONS[value]
+                raise self.InvalidCmd(
+                    'The polarization {%s} is %s of a massive vector '
+                    'propagator, not a polarization vector: it exists '
+                    'only for an internal line. It is allowed on a '
+                    'particle that is decayed further (write '
+                    '"t > w+{%s} b, w+ > ta+ vt"), and is not allowed on '
+                    '%s-state particle of the process.'
+                    % (tag, what, tag,
+                       'a final' if leg.get('state') else 'an initial'))
+
+        for decay in procdef.get('decay_chains'):
+            self.validate_propagator_polarization(decay)
 
     def extract_process(self, line, proc_number = 0, overall_orders = {},
                         avoid_squared_orders=False):

--- a/tests/unit_tests/interface/test_cmd.py
+++ b/tests/unit_tests/interface/test_cmd.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 import unittest
 import madgraph
 import madgraph.interface.master_interface as cmd
+import madgraph.core.base_objects as base_objects
 import MadSpin.interface_madspin as ms_cmd
 import madgraph.interface.extended_cmd as ext_cmd
 import madgraph.various.misc as misc
@@ -327,6 +328,105 @@ class TestValidCmd(unittest.TestCase):
         
         self.do('generate v{0T} v{0} > w+ w-')
         self.assertEqual(len(cmd._curr_amps), 2)
+
+    @test_aloha.set_global()
+    def test_generate_propagator_only_polarisation(self):
+        """{G},{H},{Q},{W},{S} name a piece of the propagator *numerator* of a
+        massive vector; there is no external wavefunction for them. They stay
+        valid on a leg that is decayed further and are refused everywhere
+        else."""
+        import madgraph.core.helas_objects as helas_objects
+
+        cmd = self.cmd
+        self.do('import model sm')
+        tags = ['G', 'H', 'Q', 'W', 'S']
+        try:
+            for tag in tags:
+                # --- refused on a genuine final state ------------------
+                proc = 'generate p p > z{%s} h' % tag
+                self.assertRaises(madgraph.InvalidCmd, self.do, proc)
+                try:
+                    self.do(proc)
+                except madgraph.InvalidCmd as error:
+                    self.assertIn('{%s}' % tag, str(error))
+                    self.assertIn('propagator', str(error))
+                    self.assertIn('decayed further', str(error))
+                    self.assertIn('final-state particle', str(error))
+
+                # --- refused on an initial state ----------------------
+                self.assertRaises(madgraph.InvalidCmd,
+                                  self.do, 'generate z{%s} z > w+ w-' % tag)
+                try:
+                    self.do('generate z{%s} z > w+ w-' % tag)
+                except madgraph.InvalidCmd as error:
+                    self.assertIn('initial-state particle', str(error))
+
+                # --- still fine as a propagator -----------------------
+                self.do('generate t > w+{%s} b, w+ > ta+ vt' % tag)
+                self.assertTrue(cmd._curr_amps)
+
+            # the combined '{0S}' brace (pol=[0,9], propagator form P1LS) is
+            # covered by the same rule through its '9' entry
+            self.assertRaises(madgraph.InvalidCmd,
+                              self.do, 'generate p p > z{0S} h')
+            self.do('generate t > w+{0S} b, w+ > ta+ vt')
+            self.assertTrue(cmd._curr_amps)
+
+            # the walk recurses into the decay chains: here the '{G}' sits one
+            # level down, on a w+ that is itself never decayed
+            self.assertRaises(
+                madgraph.InvalidCmd, self.do,
+                'generate p p > t t~, t > w+{G} b, t~ > w- b~')
+
+            # the guard is duplicated one layer down, for the direct-API path
+            # that does not go through the command interface at all
+            legs = base_objects.LegList([
+                base_objects.Leg({'id': 2, 'state': False, 'number': 1}),
+                base_objects.Leg({'id': -2, 'state': False, 'number': 2}),
+                base_objects.Leg({'id': 23, 'state': True, 'number': 3,
+                                  'polarization': [4]}),
+                base_objects.Leg({'id': 25, 'state': True, 'number': 4}),
+                ])
+            try:
+                helas_objects.HelasWavefunction(legs[2], 0,
+                                                cmd._curr_model)
+            except madgraph.InvalidCmd as error:
+                self.assertIn('{G}', str(error))
+                self.assertIn('propagator', str(error))
+            else:
+                self.fail('HelasWavefunction accepted a {G} external leg')
+        finally:
+            cmd.exec_cmd('generate p p > t t~')
+
+    @test_aloha.set_global()
+    def test_propagator_polarisation_round_trip(self):
+        """nice_string()/input_string()/base_string() used to print the raw
+        integer ({4}, {99}, ...), which the parser rejects with "polarization
+        are between -3 and 3" -- so a printed process line could not be read
+        back. They must print the brace letter instead."""
+        cmd = self.cmd
+        self.do('import model sm')
+        try:
+            # the propagator braces print their letter, including the
+            # combined '{0S}' which must not grow a comma (a ',' inside the
+            # brace also breaks the decay-chain split on ',')
+            for tag, expected in (('G', 'w+{G}'), ('H', 'w+{H}'),
+                                  ('Q', 'w+{Q}'), ('W', 'w+{W}'),
+                                  ('S', 'w+{S}'), ('A', 'w+{A}'),
+                                  ('0S', 'w+{0S}')):
+                self.do('generate t > w+{%s} b, w+ > ta+ vt' % tag)
+                proc = cmd._curr_amps[0].get('amplitudes')[0].get('process')
+                self.assertIn(expected, proc.nice_string(prefix=False))
+                self.assertIn(expected, proc.input_string())
+                self.assertIn(expected, proc.base_string())
+                self.assertNotIn(',', proc.input_string())
+                # and the printed string is accepted back by the parser.
+                # 'proc' is the core amplitude, so re-attach the decay that
+                # makes the brace legal in the first place.
+                self.do('generate %s, w+ > ta+ vt' % proc.input_string())
+                self.assertTrue(cmd._curr_amps)
+        finally:
+            cmd.exec_cmd('generate p p > t t~')
 
 
 class TestExtendedCmd(unittest.TestCase):


### PR DESCRIPTION
## What this prevents

`{G}`(4), `{H}`(5), `{Q}`(6), `{W}`(7) and `{S}`(9) each name a rank-two piece of the **propagator numerator** of a massive vector -- the metric, the Theta projector, the `q^mu q^nu / q^2` tensor, the Ward-protected full propagator and the scalar piece -- complete with its `1/(q^2-M^2+iM*Gamma)` pole (see `aloha/create_aloha.py`, the `"1X"` forms). None of them is a polarisation vector, and no external wavefunction for them exists: `VXXXXX` only knows `nhel = -1,0,+1`.

Put on a genuine external leg they were nevertheless **accepted**, and the raw integer went straight into the `NHEL` table.

## Why it is worth having on a release branch: the failure is silent

This is not a crash that a user would notice and report. On pristine `3.8.0`, `generate p p > z{G} h` followed by `output standalone` produces:

```fortran
DATA (NHEL(I,   1),I=1,4) / 1,-1, 4, 0/
CALL VXXXXX(P(0,3),MDL_MZ,NHEL(3),+1*IC(3),W(1,3))
```

`VXXXXX` is then handed `hel = 4`, computes `hel0 = 1 - |hel| = -3`, and returns a vector that is neither normalised nor transverse. The generated code compiles, `check_sa` runs, and it prints

```
Matrix element =    4.4798136454760450E-003  GeV^  0
```

A number, with no crash and no warning. That silent-corruption path -- a plausible typo or a misreading of the polarisation docs yielding a physics result that is quietly wrong -- is the reason this belongs on a release branch rather than only on a development branch. Initial-state legs behaved the same way.

The defect is **not** new: it predates the current development branches and is present on 3.7.x and on `3.8.0`.

## The change

* A decay-chain-aware walk (`validate_propagator_polarization`) over the `ProcessDefinition` and its decay chains refuses these braces on an external leg. A leg that is handed over to a decay chain -- the propagator use, `generate t > w+{G} b, w+ > ta+ vt` -- keeps working unchanged. There is no option to enable them on an external leg: there is nothing to enable.
* The same guard is repeated in `HelasWavefunction`, for the direct-API path that never reaches the command interface.
* `{A}` (99) is deliberately **not** part of the new veto: it is already refused on an external leg by `HelasWavefunction`, and that behaviour is unchanged here.

The helper is a plain internal validator on the process definition, not the argument-validation counterpart of a `do_` command, so it deliberately does not carry the `check_` prefix and does not appear in the `master_interface` Switcher -- matching the existing `validate_model` / `extract_process` precedent. `master_interface.py` is untouched by this PR.

### Round-trip fix

`nice_string()` / `input_string()` / `base_string()` printed the raw integer (`{4}`, `{99}`, `{0,9}`), which the parser rejects with *"polarization are between -3 and 3"* -- so a printed process line could not be read back. They now print the brace letter with no separator (`{G}`, `{A}`, `{0S}`), which is exactly the syntax the parser accepts; a `,` inside a brace additionally breaks the decay-chain split on `,`. `shell_string()` is left alone so that `P<n>_...` directory names do not change.

## Tests

Two new tests in `tests/unit_tests/interface/test_cmd.py`:

* `test_generate_propagator_only_polarisation` -- each tag refused on a final state and on an initial state, still accepted as a propagator, the combined `{0S}` brace covered through its `9` entry, the walk recursing into decay chains, and the `HelasWavefunction` direct-API guard.
* `test_propagator_polarisation_round_trip` -- the brace letter is printed by all three printers, carries no comma, and is parsed back successfully.

Both were confirmed to **fail** on pristine `b7687064b` with only the test file applied (`InvalidCmd not raised by do`; `'w+{G}' not found in 't > w+{4} b'`) and to pass with the fix.

Suites run on pristine `3.8.0` and on this branch, with identical results apart from the two new tests:

| suite | pristine `b7687064b` | this branch |
|---|---|---|
| full unit (`-p U`) | 762 tests, 4 failures + 1 error | 764 tests, same 4 failures + same 1 error |
| acceptance `tests/acceptance_tests/test_cmd.py` | 28 tests, 1 failure + 1 error | identical |
| acceptance `test_polarization_top_decay` | -- | OK |
| unit `tests/unit_tests/interface/test_cmd.py` | -- | 15 tests, OK |

Every failure listed above is pre-existing on `3.8.0` and unrelated to this change (JAMP sign formatting in the loop/EW IO goldens; `test_write_model` is an order-dependent `import usrmod` test that passes in isolation). None is introduced or fixed here.

## Scope

Self-contained against `3.8.0`: no MadSpin content, no axial/`consider_axial` content, and no dependency on any other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)