### PR TITLE
MadSpin: fork every worker that a channel owner can name

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6141,6 +6141,7 @@ class MadSpinInterface(extended_cmd.Cmd):
         before this was in place) fall back to striding it, which is correct but
         makes every worker parse everything."""
         local = {}
+        strided = []   # (channel, nb of pool files) for every fallback below
         for pdg, channels in evt_decayfile.items():
             local[pdg] = {}
             for file_nb, evtfile in channels.items():
@@ -6152,8 +6153,10 @@ class MadSpinInterface(extended_cmd.Cmd):
                     # split, but not into exactly nb_core files: stride the WHOLE
                     # chained pool. ``evtfile.name`` is only its first file, so
                     # striding that would strand every other file's events.
+                    strided.append(((pdg, file_nb), len(paths)))
                     reader = _StridedEvents(_ChainedEvents(paths), shard_id, nb_core)
                 else:
+                    strided.append(((pdg, file_nb), 1))
                     fresh = lhe_parser.EventFile(evtfile.name)
                     reader = _StridedEvents(fresh, shard_id, nb_core)
                 # The worker that OWNS this channel reads its slice ~10% short so
@@ -6168,6 +6171,21 @@ class MadSpinInterface(extended_cmd.Cmd):
                         reader = _LimitedEvents(reader,
                                                 int(math.floor((1.0 - frac) * n)))
                 local[pdg][file_nb] = reader
+        if strided:
+            # Say it out loud rather than degrade quietly: from here on this
+            # worker parses the other workers' decay events too. Normally this
+            # means the pool predates the per-worker split; it also fires when a
+            # phase caps its worker count below the count the pool was written
+            # with (see _scan_maxwgt_parallel), which is accepted and cheap.
+            logger.debug(
+                "MadSpin worker %s of %s: decay pool holds %s file(s), not %s "
+                "-- striding the chained pool for %s of %s channel(s) instead "
+                "of opening this worker's own file (correct, but every worker "
+                "then parses every worker's decay events)",
+                shard_id, nb_core,
+                '/'.join(str(n) for n in sorted(set(n for _, n in strided))),
+                nb_core, len(strided),
+                sum(len(c) for c in evt_decayfile.values()))
         return local
 
     def _init_owner_refill(self, evt_decayfile, seed_base):
@@ -7101,6 +7119,27 @@ class MadSpinInterface(extended_cmd.Cmd):
         # if exactly nb_core workers run, which is why the slices are balanced
         # (below) rather than ceil-chunked, and why nb_core is capped at the
         # number of probe events here as well as at the call sites.
+        #
+        # The cap has an accepted cost. It only ever bites when the production
+        # file itself holds fewer events than nb_core (both call sites already
+        # round the probe count up to a multiple of nb_core, so len(events) is
+        # otherwise >= nb_core), and when it does, the decay pool has already
+        # been written with _decay_pool_split() == the UNCAPPED count: the pool
+        # then has more files than there are workers, _reopen_decay_pool sees
+        # len(paths) != nb_core, drops the own-file fast path and strides the
+        # chained pool, so every worker parses every worker's decay events.
+        # That is correct (the stripes stay disjoint), one-off (the refills go
+        # through _open_refill_slice, which keys on this post-cap count, so they
+        # are unaffected) and small: measured at 0.04-0.18 s for 16-64 workers
+        # over a scan-sized pool. _reopen_decay_pool logs it at debug level.
+        # It is left alone deliberately. Re-splitting the pool to match would
+        # tie the pool's shape to whichever phase caps first -- it is written
+        # once, before the scan, and shared with the unweighting, which caps to
+        # a different count. Keeping a second, uncapped count just for pool
+        # addressing would reinstate exactly the divergence between "number of
+        # pool files" and "modulus of _channel_owner" that let the scan name an
+        # owner no worker was forked for, i.e. the 3600 s refill hang this cap
+        # exists to prevent. A rounding error is the cheaper of the two.
         nb_core = max(1, min(int(nb_core), len(events)))
         ranges = self._balanced_ranges(len(events), nb_core)
 

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -4454,7 +4454,11 @@ class MadSpinInterface(extended_cmd.Cmd):
     def _read_worker_status(self, worker_id):
         """(state, [target]) tuple for ``worker_id``, or None if unreadable."""
         try:
-            parts = open(self._status_path(worker_id)).read().split()
+            # closed explicitly: this is polled ten times a second for as long
+            # as MADSPIN_REFILL_WAIT, in every worker and once per hop of the
+            # wait-for chain
+            with open(self._status_path(worker_id)) as fsock:
+                parts = fsock.read().split()
         except (IOError, OSError):
             return None
         if not parts:
@@ -6056,6 +6060,31 @@ class MadSpinInterface(extended_cmd.Cmd):
                            base_out, exc)
         logger.info('Done so far. output written in %s' % base_out)
 
+    @staticmethod
+    def _balanced_ranges(nb_item, nb_core):
+        """``nb_core`` contiguous ``(start, stop)`` slices of ``range(nb_item)``
+        whose lengths differ by at most one -- the first ``nb_item % nb_core``
+        get one extra item.
+
+        Contrast ``ceil(nb_item / nb_core)``-sized chunks, which give the last
+        cores nothing whenever the division is uneven: 75 items on 16 cores is
+        fifteen chunks of five and one empty. An empty slice is not merely an
+        idle core, because the shard id doubles as the worker id that
+        :meth:`_channel_owner` deals channels out to -- a worker that is never
+        forked can still be named as a channel's owner, and whoever waits on it
+        waits for ever. Balanced slices keep every id live. When ``nb_item`` is a
+        multiple of ``nb_core`` -- what both max-weight scans arrange, by
+        rounding their probe size up -- this is the same split as before."""
+        nb_core = max(1, int(nb_core))
+        base, extra = divmod(int(nb_item), nb_core)
+        ranges, start = [], 0
+        for sid in range(nb_core):
+            stop = start + base + (1 if sid < extra else 0)
+            if stop > start:
+                ranges.append((start, stop))
+            start = stop
+        return ranges
+
     def _split_production(self, orig_lhe, nb_core, base_out):
         """Split the production event file into up to ``nb_core`` contiguous
         shard files (bannerless: the worker's EventFile tolerates a missing
@@ -7064,20 +7093,30 @@ class MadSpinInterface(extended_cmd.Cmd):
         import multiprocessing as mp
         import json
         base = '%s.maxwgt' % orig_lhe.name
-        chunk = int(math.ceil(len(events) / float(nb_core)))
-        # contiguous slices; the last cores get nothing if events < nb_core
-        ranges = [(sid * chunk, min((sid + 1) * chunk, len(events)))
-                  for sid in range(nb_core)]
-        ranges = [(a, b) for (a, b) in ranges if a < b]
-        # Keep the ORIGINAL nb_core as the pool-addressing count: the decay pool
-        # was split into nb_core files, and each worker must address it with that
-        # same count so it opens *its* file (paths[shard_id]). Reducing it to the
-        # number of non-empty ranges made len(paths) != nb_core, which dropped
-        # every worker onto the striding fallback -- reading only the first file.
-        # Trailing empty shards are simply not launched (their files go unused by
-        # the scan, which is fine -- the pool is generated uniformly).
+        # ``nb_core`` is the pool-addressing count -- the decay pool was split
+        # into that many files and each worker must address it with the same
+        # count to open *its* file (paths[shard_id]) instead of falling back to
+        # striding. It is ALSO the modulus of _channel_owner, so every id it can
+        # name has to belong to a worker that is actually forked. Both hold only
+        # if exactly nb_core workers run, which is why the slices are balanced
+        # (below) rather than ceil-chunked, and why nb_core is capped at the
+        # number of probe events here as well as at the call sites.
+        nb_core = max(1, min(int(nb_core), len(events)))
+        ranges = self._balanced_ranges(len(events), nb_core)
 
         self._clear_worker_status(nb_core)   # fresh status board for this phase
+        # Belt and braces: should a slice ever come back empty anyway, mark the
+        # worker that will not be forked as DONE. A missing status file is
+        # indistinguishable from a worker that has not published yet, so a
+        # waiter blocked on such an owner would sit out MADSPIN_REFILL_WAIT
+        # (3600s by default) and then kill the scan; 'D' makes the fail-safe in
+        # _worker_refill fire at once instead.
+        for sid in range(len(ranges), nb_core):
+            try:
+                with open(self._status_path(sid), 'w') as f:
+                    f.write('D')
+            except (IOError, OSError):
+                pass
         mpctx = mp.get_context('fork')
         procs, out_paths = [], []
         for sid, (start, stop) in enumerate(ranges):

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -9773,6 +9773,269 @@ class TestRefillPoolIsCompleteBeforeItIsPublished(unittest.TestCase):
         self.assertFalse(os.path.exists(pool + '.mspool'))
 
 
+def _scan_probe_shard(shard_id, nb_core, events, start, stop, evt_decayfile,
+                      build_worker, out_path):
+    """Stand-in for ``_scan_maxwgt_shard_entry``: reports the worker id and the
+    slice of the probe events it was given, and publishes 'D' on the way out
+    exactly as the real entry does in its ``finally``.
+
+    A second copy of the JSON is left at ``<out_path>.kept`` because
+    ``_scan_maxwgt_parallel`` deletes the shard files once it has read them."""
+    worker = build_worker(shard_id, nb_core)
+    try:
+        payload = {'per_event': [[float(shard_id)]], 'z_samples': {},
+                   'shard_id': shard_id, 'nb_core': nb_core,
+                   'start': start, 'stop': stop}
+        _write_shard_payload(out_path, payload)
+    finally:
+        worker._set_status('D')
+
+
+def _scan_refill_shard(shard_id, nb_core, events, start, stop, evt_decayfile,
+                       build_worker, channel, out_path):
+    """Stand-in worker that runs its decay pool out at once and goes through the
+    REAL ``_worker_refill`` for ``channel``.
+
+    Everything the wait logic consults is the shipped code -- ``_channel_owner``,
+    ``_read_worker_status``, ``_wait_cycle_to_self``, the published-generation
+    marker. Only the two ends are stood in for: generating a pool (a madevent
+    run) and opening the refilled slice, neither of which this is about."""
+    worker = build_worker(shard_id, nb_core)
+    try:
+        worker._worker_refill(channel[0], channel[1], 1000)
+        payload = {'refilled': True, 'why': None}
+    except Exception as exc:
+        payload = {'refilled': False, 'why': str(exc)}
+    payload.update({'per_event': [[float(shard_id)]], 'z_samples': {},
+                    'shard_id': shard_id, 'nb_core': nb_core})
+    try:
+        _write_shard_payload(out_path, payload)
+    finally:
+        worker._set_status('D')
+
+
+def _write_shard_payload(out_path, payload):
+    import json
+    for path in (out_path, out_path + '.kept'):
+        with open(path, 'w') as fsock:
+            json.dump(payload, fsock)
+
+
+class TestMaxWeightScanForksEveryWorkerAnOwnerCanName(unittest.TestCase):
+    """The parallel max-weight scan must fork a worker for every id it lets
+    ``_channel_owner`` name.
+
+    ``nb_core`` reaches the workers as the *pool-addressing* count: the decay
+    pool was split into that many files and a worker opens ``paths[id]``. The
+    same number is the modulus of :meth:`_channel_owner`, so it also fixes which
+    worker is the sole (re)generator of each decay channel.
+
+    The scan used to cut the probe events into ``ceil(N / nb_core)``-sized
+    chunks while still handing out the original ``nb_core``. At the shipped
+    default of 75 probe events the trailing chunks come out empty -- one worker
+    never forked on 16 cores, three on 18, seven on 32 -- and yet those ids stay
+    nameable as owners. A live worker that runs its pool out on such a channel
+    then waits on a process that does not exist, and neither fail-safe rescues
+    it: ``_read_worker_status`` returns ``None`` (which is not ``('D',)``) for a
+    status file nobody ever wrote, and ``_wait_cycle_to_self`` finds no chain to
+    follow. The worker waits out ``MADSPIN_REFILL_WAIT`` -- an hour by default --
+    and takes the scan down with it."""
+
+    NB_EVENT = 75           # the Nevents_for_max_weight default
+    NB_CORE = (16, 18, 32)  # 1, 3 and 7 ids left unforked, respectively
+
+    class _Named(object):
+        """Stands in for the production EventFile, of which the scan only uses
+        the name (to build its shard-file paths)."""
+        def __init__(self, name):
+            self.name = name
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp(prefix='ms_scan_')
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    # ------------------------------------------------------------- the sides
+
+    def _parent(self):
+        """The parent side of the scan: the real ``_scan_maxwgt_parallel`` and
+        the status-board helpers it uses."""
+        interface = interface_madspin.MadSpinInterface
+
+        class Parent(object):
+            _scan_maxwgt_parallel = interface._scan_maxwgt_parallel
+            _balanced_ranges = staticmethod(interface._balanced_ranges)
+            _clear_worker_status = interface._clear_worker_status
+            _read_worker_status = interface._read_worker_status
+            _status_path = interface._status_path
+
+        parent = Parent()
+        parent.path_me = self.tmpdir
+        return parent
+
+    def _worker_factory(self, channel_keys=()):
+        """The child side: a worker carrying the real owner/waiter machinery,
+        with pool generation and slice opening stood in for."""
+        interface = interface_madspin.MadSpinInterface
+        tmpdir = self.tmpdir
+
+        class Worker(object):
+            # verbatim -- this is what is under test
+            _worker_refill = interface._worker_refill
+            _channel_owner = interface._channel_owner
+            _wait_cycle_to_self = interface._wait_cycle_to_self
+            _read_worker_status = interface._read_worker_status
+            _set_status = interface._set_status
+            _status_path = interface._status_path
+            _published_gen = staticmethod(interface._published_gen)
+            _publish_gen = staticmethod(interface._publish_gen)
+            _decay_dir = staticmethod(interface._decay_dir)
+
+            def _owner_generate(self, pdg, decay_file_nb, target_gen, needed):
+                """madevent's job; here only the marker the waiters poll."""
+                self._publish_gen(self._decay_dir(tmpdir, pdg, decay_file_nb),
+                                  target_gen)
+
+            def _open_refill_slice(self, decay_dir, gen, owner):
+                return ('slice', decay_dir, gen)
+
+        def build(shard_id, nb_core):
+            worker = Worker()
+            worker.path_me = tmpdir
+            worker.options = {'ms_dir': None}
+            worker.seed = 11
+            worker._shard_tag = shard_id
+            worker._shard_nb_core = nb_core
+            worker._channel_keys = list(channel_keys)
+            worker._pool_gen = {}
+            worker._owner_undersize = 0.10
+            worker._refill_seed_base = 42
+            worker._set_status('R')
+            return worker
+
+        return build
+
+    def _run_scan(self, parent, nb_core, entry, extra):
+        """Run the real scan; return ``{shard_id: payload}`` over the workers
+        that actually ran."""
+        import json
+        lhe = self._Named(pjoin(self.tmpdir, 'production.lhe'))
+        parent._scan_maxwgt_parallel(lhe, list(range(self.NB_EVENT)), {},
+                                     nb_core, entry, extra)
+        seen = {}
+        for sid in range(nb_core):
+            path = '%s.maxwgt.shard%d.json.kept' % (lhe.name, sid)
+            if os.path.exists(path):
+                with open(path) as fsock:
+                    seen[sid] = json.load(fsock)
+        return seen
+
+    # ------------------------------------------------------------- the split
+
+    def test_the_slices_cover_every_worker_and_every_event(self):
+        """Every worker gets a non-empty contiguous slice, the slices tile the
+        probe events exactly, and no two differ in size by more than one."""
+        for nb_core in self.NB_CORE:
+            ranges = interface_madspin.MadSpinInterface._balanced_ranges(
+                self.NB_EVENT, nb_core)
+            self.assertEqual(len(ranges), nb_core, 'nb_core=%s' % nb_core)
+            self.assertEqual(ranges[0][0], 0)
+            self.assertEqual(ranges[-1][1], self.NB_EVENT)
+            for (_, stop), (start, _) in zip(ranges, ranges[1:]):
+                self.assertEqual(stop, start)
+            sizes = [b - a for a, b in ranges]
+            self.assertTrue(min(sizes) >= 1)
+            self.assertTrue(max(sizes) - min(sizes) <= 1)
+
+    def test_an_even_split_is_diced_exactly_as_it_was_before(self):
+        """Both scans round their probe size up to a multiple of nb_core, so the
+        usual case divides evenly -- and there these are the very slices the
+        ceil-chunking produced. No sample is silently re-diced by the fix."""
+        for nb_core in self.NB_CORE:
+            nb_event = 4 * nb_core
+            chunk = nb_event // nb_core
+            self.assertEqual(
+                interface_madspin.MadSpinInterface._balanced_ranges(
+                    nb_event, nb_core),
+                [(sid * chunk, (sid + 1) * chunk) for sid in range(nb_core)])
+
+    # -------------------------------------------------------- the regression
+
+    def test_every_id_an_owner_can_take_belongs_to_a_worker_that_ran(self):
+        """The parent side of the regression: at the default 75 probe events the
+        scan must fork all 16 / 18 / 32 workers, since any of those ids can come
+        back from ``_channel_owner``."""
+        build = self._worker_factory()
+        for nb_core in self.NB_CORE:
+            seen = self._run_scan(self._parent(), nb_core,
+                                  _scan_probe_shard, (build,))
+            self.assertEqual(sorted(seen), list(range(nb_core)),
+                             'nb_core=%s' % nb_core)
+            covered = []
+            for payload in seen.values():
+                covered.extend(range(payload['start'], payload['stop']))
+            self.assertEqual(sorted(covered), list(range(self.NB_EVENT)))
+
+    def test_no_id_an_owner_can_take_reads_back_as_an_unwritten_status(self):
+        """The waiter's view of the same invariant, and the one that decides
+        whether it hangs: every id ``_channel_owner`` can return has a status
+        file to read. A missing one is exactly what ``_worker_refill`` cannot
+        tell apart from an owner that is simply not finished yet."""
+        build = self._worker_factory()
+        for nb_core in self.NB_CORE:
+            parent = self._parent()
+            self._run_scan(parent, nb_core, _scan_probe_shard, (build,))
+            missing = [wid for wid in range(nb_core)
+                       if parent._read_worker_status(wid) is None]
+            self.assertEqual(missing, [], 'nb_core=%s' % nb_core)
+
+    def test_a_worker_that_runs_out_is_not_left_waiting_on_a_missing_owner(self):
+        """The failure itself, end to end, in a couple of seconds rather than
+        the hour it takes in the field.
+
+        Every worker of a 16-core scan over the default 75 probe events runs its
+        pool out on the one channel whose owner is the last worker id, and goes
+        through the real ``_worker_refill``. With ``MADSPIN_REFILL_WAIT`` cut
+        down, a worker waiting on an owner that was never forked comes back
+        having given up; the scan must instead see every worker refilled."""
+        nb_core = 16
+        keys = [(6, nb) for nb in range(nb_core)]
+        channel = keys[nb_core - 1]   # owner == nb_core-1, the unforked id
+        for pdg, decay_file_nb in keys:
+            os.makedirs(interface_madspin.MadSpinInterface._decay_dir(
+                self.tmpdir, pdg, decay_file_nb))
+        build = self._worker_factory(keys)
+        self.assertEqual(build(0, nb_core)._channel_owner(*channel),
+                         nb_core - 1)
+        previous = os.environ.get('MADSPIN_REFILL_WAIT')
+        os.environ['MADSPIN_REFILL_WAIT'] = '5'
+        try:
+            seen = self._run_scan(self._parent(), nb_core, _scan_refill_shard,
+                                  (build, channel))
+        finally:
+            if previous is None:
+                del os.environ['MADSPIN_REFILL_WAIT']
+            else:
+                os.environ['MADSPIN_REFILL_WAIT'] = previous
+        gave_up = dict((sid, payload['why'])
+                       for sid, payload in seen.items()
+                       if not payload['refilled'])
+        self.assertEqual(gave_up, {})
+        self.assertEqual(sorted(seen), list(range(nb_core)))
+
+    def test_an_unforked_id_is_marked_done_so_nobody_waits_out_the_timeout(self):
+        """Belt and braces. Should a slice ever come back empty anyway, the
+        parent leaves 'D' on that id: a missing status file is indistinguishable
+        from an owner still working, so a waiter would sit out
+        ``MADSPIN_REFILL_WAIT``, whereas 'D' fires the fail-safe at once."""
+        parent = self._parent()
+        lhe = self._Named(pjoin(self.tmpdir, 'production.lhe'))
+        # no probe events at all: nothing to fork, but the ids stay addressable
+        parent._scan_maxwgt_parallel(lhe, [], {}, 4, _scan_probe_shard,
+                                     (self._worker_factory(),))
+        self.assertEqual(parent._read_worker_status(0), ('D',))
+
+
 class TestBreitWignerTruncation(unittest.TestCase):
     """The BW_cut window keeps only part of each resonance's Breit-Wigner, and
     the reported cross-section has to say so.

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -945,6 +945,92 @@ class TestStridedEvents(unittest.TestCase):
         self.assertEqual(self._drain(strided), [])
 
 
+class TestReopenDecayPoolFallback(unittest.TestCase):
+    """_reopen_decay_pool drops its own-file fast path when the decay pool does
+    not hold exactly nb_core files (e.g. a phase capped its worker count below
+    the count the pool was written with, see _scan_maxwgt_parallel). That is
+    correct but makes every worker parse every worker's decay events, so it must
+    not happen silently: the fallback logs at debug level, naming both counts."""
+
+    _BANNER = ('<LesHouchesEvents version="1.0">\n<init>\n'
+               '  2212 2212 6.5e+03 6.5e+03 0 0 247000 247000 -4 1\n'
+               '  1.0e+00 1.0e-03 1.0e+00 1\n</init>\n')
+    _EVENT = (
+        '<event>\n'
+        ' 2      0 +1.0000000e+00 1.72500000e+02 7.54677100e-03 1.25643300e-01\n'
+        '        6 -1    0    0  501    0 +0.0000000000e+00 +0.0000000000e+00'
+        ' +0.0000000000e+00 1.7250000000e+02 1.7250000000e+02 0.0000e+00 1.0000e+00\n'
+        '        5  1    1    1  501    0 +0.0000000000e+00 +0.0000000000e+00'
+        ' +0.0000000000e+00 4.7000000000e+00 4.7000000000e+00 0.0000e+00 -1.0000e+00\n'
+        '</event>\n')
+
+    class _Stub(object):
+        """Only what _reopen_decay_pool touches; the own-file branch asks for
+        the channel owner, the fallback branch asks for nothing."""
+        _owner_undersize = 0.0
+        def _channel_owner(self, pdg, file_nb):
+            return -1          # never this shard: skip the undersize trimming
+
+    def setUp(self):
+        import tempfile
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+
+    def _pool(self, nb_file, nb_event=4):
+        paths = []
+        for i in range(nb_file):
+            path = pjoin(self.tmpdir, 'pool_%d.lhe' % i)
+            with open(path, 'w') as fsock:
+                fsock.write(self._BANNER)
+                fsock.write(self._EVENT * nb_event)
+                fsock.write('</LesHouchesEvents>\n')
+            paths.append(path)
+        return {6: {0: interface_madspin._ChainedEvents(paths)}}
+
+    def _reopen(self, evt_decayfile, shard_id, nb_core):
+        return interface_madspin.MadSpinInterface._reopen_decay_pool(
+            self._Stub(), evt_decayfile, shard_id, nb_core)
+
+    @staticmethod
+    def _capture(callback):
+        """Run ``callback`` with a record-collecting handler on the module
+        logger; return (result, [messages])."""
+        import logging
+        records = []
+        class _Collect(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+        logger = logging.getLogger('decay.stdout')
+        handler = _Collect()
+        level, propagate = logger.level, logger.propagate
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        try:
+            return callback(), records
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(level)
+            logger.propagate = propagate
+
+    def test_matching_count_opens_own_file_and_stays_quiet(self):
+        """len(paths) == nb_core: the fast path, and nothing to report."""
+        pool = self._pool(3)
+        local, records = self._capture(lambda: self._reopen(pool, 1, 3))
+        self.assertNotIsInstance(local[6][0],
+                                 interface_madspin._StridedEvents)
+        self.assertEqual([m for m in records if 'striding' in m], [])
+
+    def test_mismatched_count_strides_and_says_so(self):
+        """len(paths) != nb_core: stride the chained pool, and log both counts
+        so the degradation is visible instead of silent."""
+        pool = self._pool(3)
+        local, records = self._capture(lambda: self._reopen(pool, 0, 2))
+        self.assertIsInstance(local[6][0], interface_madspin._StridedEvents)
+        message = '\n'.join(records)
+        self.assertIn('holds 3 file(s), not 2', message)
+        self.assertIn('striding', message)
+
+
 
 class TestDensityIdentity(unittest.TestCase):
     """DensityMatrix.identity / normalized: the primitives that let the


### PR DESCRIPTION
`_scan_maxwgt_parallel` keeps `nb_core` at the **pool-addressing** count while forking **fewer** workers, so `_channel_owner` can return an id belonging to a worker that was never forked — a phantom owner.

Neither fail-safe catches it:

- `_read_worker_status(id)` returns `None`, which is not `('D',)`;
- `_wait_cycle_to_self(id)` returns `False`.

The live worker then blocks for the `MADSPIN_REFILL_WAIT` default of **3600 s** and dies, taking the run with it.

## When it fires

Not on a long LO production file. Both call sites round `nevents` up to a multiple of `nb_core`, so when the sample is long enough the chunking is even and no phantom exists. A sweep over `2 <= C <= 64`, `C <= N < 400` confirms every phantom case has `N` not a multiple of `C`.

The reachable triggers are:

- a production sample shorter than the rounded probe size — 80 / 90 / 96 events at 16 / 18 / 32 cores;
- **`fixed_order` mode**, where `get_maxwgt_for_onshell` reads *event-groups*, so the count is the group count and falls short on ordinary NLO samples.

Deterministic, and it fires on the first refill that exhausts a channel the phantom owns.

## Reproduced

Three levels against the shipped functions:

1. `ceil(75/nb_core)` chunking leaves unforked ids: 1 on 16 cores, 3 on 18, 7 on 32.
2. The real `_scan_maxwgt_parallel` with 75 probe events and `nb_core=16`: workers `0..14` report in, `_channel_owner` still returns `15`.
3. The real `_worker_refill` with owner 15: `_read_worker_status(15)` returns `None`, `_wait_cycle_to_self(15)` returns `False`, then it blocks for the full wait and raises.

`_run_onshell_parallel` is unaffected — it reassigns `nb_core = len(shard_paths)` before `_clear_worker_status` and forking, so its two counts agree.

## The fix

`_balanced_ranges(nb_item, nb_core)` produces `nb_core` contiguous slices whose sizes differ by at most one, replacing the ceil-chunking, with `nb_core` clamped to `len(events)` inside the callee rather than relying on the call sites.

This removes the conflation at its source: `_shard_nb_core` is simultaneously the pool-file count and the `_channel_owner` modulus, and those are only coherent if exactly that many workers run.

**Where the split is already even it produces the identical slices**, so no currently-working configuration has its sample re-diced; there is a test asserting this. It also fixes an incidental imbalance — 75/16 was fifteen workers with 5 events and one idle, and is now 4-5 each across 16.

Two alternatives were considered and rejected as the primary fix:

- *reducing `nb_core` to the fork count* — the existing comment warns against this, correctly: `nb_core` is the pool-addressing count, and lowering it makes `len(paths) != nb_core` in `_reopen_decay_pool`, dropping every worker onto the striding fallback;
- *rewriting `_read_worker_status` to distinguish "no such worker" from "not finished"* — the deepest change, but it needs a roster the parent publishes and it touches the polling path of live machinery to fix a condition that should not arise.

The second point is taken in its lowest-risk form: if a slice ever comes back empty anyway, the parent now stamps `'D'` on that id, so `_worker_refill`'s **existing** fail-safe (owner is DONE but never produced, so generate it myself) fires immediately instead of the wait being unbounded. Any future route to a phantom becomes a warning rather than an hour-long death.

Incidental: `_read_worker_status` opened the status file without closing it, in a path polled 10x/s for up to an hour. Now uses a context manager; semantically identical.

## Tests

Six new tests in `TestMaxWeightScanForksEveryWorkerAnOwnerCanName`, asserting on observable outcomes rather than log text, ~1.1-1.8 s total. The end-to-end one drives a 16-core scan over 75 probe events through the **real** `_worker_refill`, `_channel_owner`, `_read_worker_status` and `_wait_cycle_to_self`, with only "run madevent" and "open the slice" stood in for.

Verified red-before / green-after behaviourally: with `_balanced_ranges` present but `_scan_maxwgt_parallel` reverted to ceil-chunking, 4 of 6 fail and the end-to-end one reports a worker giving up on owner 15. Run 5x post-fix, no flakiness.

Unit suite: **532 to 538, OK**.

## Downstream

The affected block is byte-identical to the copy vendored into `MadGraphTeam/MadGraph7`, so fixing it here reaches both; MadGraph7 picks it up on its next vendor merge rather than needing its own patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure every worker addressable during MadSpin max-weight scans is forked and can service its assigned channels without hanging.

Bug Fixes:
- Prevent MadSpin max-weight scans from assigning channels to workers that were never forked, eliminating refill hangs caused by phantom owners.
- Mark any unexpectedly empty worker slots as completed so refill fail-safes trigger immediately instead of waiting for the full timeout.

Enhancements:
- Balance max-weight scan event ranges across all configured workers while preserving existing splits for evenly divisible samples.
- Make decay-pool fallback behavior observable through debug logging and close polled worker-status files safely.

Tests:
- Add regression coverage for balanced worker ranges, worker ownership/status consistency, refill behavior, empty-worker safeguards, and decay-pool fallback logging.