### PR TITLE
ProcessDefinition.nice_string: keep the space after an offshell leg

### DIFF
--- a/madgraph/core/base_objects.py
+++ b/madgraph/core/base_objects.py
@@ -4076,9 +4076,8 @@ class ProcessDefinition(Process):
                 else:
                     mystr = mystr + '{%s}' % polarization_to_string(leg.get('polarization'))
             if leg.get('offshell'):
-                mystr += '*'   
-            else:
-                mystr = mystr + ' '
+                mystr += '*'
+            mystr = mystr + ' '
             #mystr = mystr + '(%i) ' % leg['number']
             prevleg = leg
 

--- a/tests/unit_tests/core/test_base_objects.py
+++ b/tests/unit_tests/core/test_base_objects.py
@@ -2067,6 +2067,78 @@ class ProcessDefinitionTest(unittest.TestCase):
                                         [[1],[],[1],[-1],[1],[-1,1]])
         self.assertFalse(temp_process.check_polarization())
 
+    def _offshell_pol_legs(self, leg_class, id_key, combo, offshell_last=False):
+        """Build a 'c c~ > c c~' leg list where one final leg carries the
+        polarization/offshell combination given by 'combo'."""
+
+        pol, offshell = combo
+        specs = [(3, False, {}), (-3, False, {}),
+                 (3, True, {'polarization': pol, 'offshell': offshell}),
+                 (-3, True, {})]
+        if offshell_last:
+            specs[2], specs[3] = specs[3], specs[2]
+
+        legs = []
+        for pdg, state, extra in specs:
+            leg = leg_class()
+            leg.set('state', state)
+            leg.set(id_key, [pdg] if id_key == 'ids' else pdg)
+            for key, value in extra.items():
+                leg.set(key, value)
+            legs.append(leg)
+        return legs
+
+    def test_nice_string_offshell_and_polarization(self):
+        """Every combination of the '*' (offshell) and '{...}' (polarization)
+        leg decorations must render with the leg separated from the next one by
+        a space, and the four renderers must agree on the spelling.
+
+        Regression test: ProcessDefinition.nice_string() used to attach the
+        trailing space in the 'else' branch of the offshell test, so an offshell
+        leg was glued to its neighbour ('c*c~') and, when it was the last leg,
+        the final "remove last space" slice ate the '*' altogether."""
+
+        combos = [([], False), ([-1, 1], False), ([], True), ([-1, 1], True)]
+        goals = ['c c~ > c c~',
+                 'c c~ > c{T} c~',
+                 'c c~ > c* c~',
+                 'c c~ > c{T}* c~']
+
+        for combo, goal in zip(combos, goals):
+            procdef = base_objects.ProcessDefinition({
+                'legs': base_objects.MultiLegList(
+                    self._offshell_pol_legs(base_objects.MultiLeg, 'ids', combo)),
+                'model': self.mymodel})
+            self.assertEqual('Process: ' + goal, procdef.nice_string())
+
+            process = base_objects.Process({
+                'legs': base_objects.LegList(
+                    self._offshell_pol_legs(base_objects.Leg, 'id', combo)),
+                'model': self.mymodel})
+            self.assertEqual('Process: ' + goal, process.nice_string())
+            self.assertEqual(goal, process.input_string())
+            self.assertEqual(goal, process.base_string())
+
+    def test_nice_string_offshell_last_leg(self):
+        """An offshell last leg must keep its '*': the 'remove last space'
+        slice at the end of nice_string() must chop a space, not the marker."""
+
+        for combo, goal in zip([([], True), ([-1, 1], True)],
+                               ['c c~ > c~ c*', 'c c~ > c~ c{T}*']):
+            procdef = base_objects.ProcessDefinition({
+                'legs': base_objects.MultiLegList(
+                    self._offshell_pol_legs(base_objects.MultiLeg, 'ids',
+                                            combo, offshell_last=True)),
+                'model': self.mymodel})
+            self.assertEqual('Process: ' + goal, procdef.nice_string())
+
+            process = base_objects.Process({
+                'legs': base_objects.LegList(
+                    self._offshell_pol_legs(base_objects.Leg, 'id',
+                                            combo, offshell_last=True)),
+                'model': self.mymodel})
+            self.assertEqual('Process: ' + goal, process.nice_string())
+
     def test_representation(self):
         """Test process object string representation."""
 


### PR DESCRIPTION
`ProcessDefinition.nice_string()` renders an offshell leg without the separating space, and drops the `*` entirely when the offshell leg is last.

```python
            if leg.get('offshell'):
                mystr += '*'
            else:
                mystr = mystr + ' '
```

The `else` belongs to the polarization test above it. `f631152bf` ("allow for the star syntax") inserted the offshell check between the two and silently re-parented it. The three sibling renderers — `Process.nice_string`, `Process.input_string`, `Process.base_string` — all emit `*` and then an unconditional space.

## Why it is not only cosmetic

`nice_string()` ends with `mystr = mystr[:-1]  # Remove last space`. With no trailing space to remove, that slice eats the `*`.

| combination | before | after |
|---|---|---|
| plain | `z a` | `z a` |
| polarization only | `z{T} a` | `z{T} a` |
| offshell only | `z*a` | `z* a` |
| both | `z{T}*a` | `z{T}* a` |
| **offshell as last leg** | **`a z`** | `a z*` |

Fed back through `extract_process`, which tokenises on whitespace:

- `u u~ > z*a` → `InvalidCmd: No particle z*a in model` — loud;
- `u u~ > z{T}*a` → `InvalidCmd: A space is required after the "}" symbol` — loud;
- `u u~ > a z*` → rendered `u u~ > a z`, which **re-parses cleanly as a different, onshell process** — silent.

So a user copying a process line out of MG5's own `display` or logs either gets a baffling error for something MG5 had just printed, or silently generates the onshell process believing they asked for the offshell one.

No automated in-tree path re-parses this. Every call site holding a `ProcessDefinition` (`diagram_generation.py:1919`, `process_checks.py:2067`, `fks_base.py:184`) is logging or error text; `loop_interface.py:868` does rebuild and re-execute `add process %s`, but `ProcessDefinition.__iter__` yields `Process` objects and so hits a correct renderer, as does the `auto_dsig.f` path. The exposure is the human round-trip, which `polarization_to_string`'s docstring describes as intended.

## The change

Five lines to three, matching the three siblings. This repairs the last-leg case for free, since the `[:-1]` slice now has a space to chop. Verified through the live parser: `u u~ > z* a`, `u u~ > z{T}* a` and `u u~ > a z*` all round-trip with their `offshell` flags preserved.

## Tests

Two new tests in `tests/unit_tests/core/test_base_objects.py::ProcessDefinitionTest`, both failing before the change:

- `test_nice_string_offshell_and_polarization` — all four decorations across all four renderers, 16 assertions;
- `test_nice_string_offshell_last_leg` — the `*`-eaten-by-the-slice case.

No existing test moved: nothing in the tree asserted on a `nice_string()` containing an offshell leg.

| suite | before | after |
|---|---|---|
| `tests/unit_tests/core` | 245 OK | **247 OK** |
| `tests/unit_tests/madspin` | 532 OK | **532 OK** |

The bug is pre-existing on `madspin_density`, not introduced by the recent `3.8.0` merge. Note the `*` syntax is currently parse-and-store only — `leg['offshell']` is read by `helas_objects.py:681` and `diagram_generation.py:1798` but nothing acts on it physically yet — so no released behaviour changes; this repairs the display and round-trip contract ahead of the feature that will use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix process string rendering so offshell legs retain their marker and remain correctly separated from adjacent legs.

Bug Fixes:
- Preserve spacing and offshell markers in ProcessDefinition.nice_string(), including when an offshell leg is the final leg, so displayed process strings round-trip correctly.

Tests:
- Add regression coverage for offshell and polarization combinations across process renderers, including offshell final-leg cases.