### PR TITLE
warm_cache: only the default branch may delete or re-save the caches

### DIFF
--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -1,4 +1,20 @@
 # .github/workflows/warm-caches.yml
+#
+# Only the default branch (3.x) may delete or (re)save the shared caches.
+#
+# A GitHub Actions cache is readable from the branch that created it and from
+# the default branch, and nowhere else, while "gh cache delete <key>" removes
+# the entry for *every* ref. A run on a feature or release branch that deleted
+# heptools-$KEY and saved it again therefore did not refresh the cache: it moved
+# it out of 3.x and into that branch, and every other branch started missing it.
+# That is not hypothetical -- runs on madspin_density (2026-09-03) and on 3.8.0
+# (2026-09-04) each took the heptools caches away and left ~20 NLO/MadLoop/
+# shower acceptance jobs failing on every other branch until 3.x rebuilt them.
+#
+# The push trigger above fires on any branch that touches these paths, so the
+# guard has to live on the steps that mutate the cache rather than on the
+# trigger: the delete/save steps below are gated on refs/heads/3.x. Runs on
+# other branches still build and verify everything, they just do not write.
 name: Warm all caches
 
 permissions:
@@ -51,7 +67,7 @@ jobs:
       # input is truthy on its own; on push/schedule the whole inputs context
       # is null, so these steps stay skipped there.
       - name: Delete heptools related cache
-        if: inputs.reset_heptools
+        if: inputs.reset_heptools && github.ref == 'refs/heads/3.x'
         run: | 
           gh cache delete heptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete lhapdf-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
@@ -63,7 +79,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Delete ufo cache
-        if: inputs.reset_ufo
+        if: inputs.reset_ufo && github.ref == 'refs/heads/3.x'
         run: |
           gh cache delete pip-numpy-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete ufomodel-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
@@ -74,7 +90,7 @@ jobs:
       # large and stable). They are only rebuilt on explicit request, so the
       # cache can be cleaned independently of the heptools one.
       - name: Delete root/delphes cache
-        if: inputs.reset_delphes
+        if: inputs.reset_delphes && github.ref == 'refs/heads/3.x'
         run: |
           gh cache delete root-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete delphes-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
@@ -583,19 +599,19 @@ jobs:
       # the new content is actually saved. Only do this (and the save) once all
       # sub-caches succeeded, so a partial rebuild never replaces a good cache.
       - name: Delete previous combined cache (so the fresh one can be saved)
-        if: env.ALL_SUBCACHES_OK == 'true'
+        if: env.ALL_SUBCACHES_OK == 'true' && github.ref == 'refs/heads/3.x'
         run: gh cache delete heptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
         env:
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/cache/save@v5
-        if: env.ALL_SUBCACHES_OK == 'true'
+        if: env.ALL_SUBCACHES_OK == 'true' && github.ref == 'refs/heads/3.x'
         with:
           path: ~/.cache/HEPtools
           key: heptools-${{ env.CACHE_KEY }}
 
       - name: Cleanup intermediate caches (only if all succeeded and verified)
-        if: env.ALL_SUBCACHES_OK == 'true'
+        if: env.ALL_SUBCACHES_OK == 'true' && github.ref == 'refs/heads/3.x'
         run: |
           gh cache delete lhapdf-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete boost-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true


### PR DESCRIPTION
## Problem

A GitHub Actions cache is readable from the branch that created it and from the default branch, and nowhere else. But `gh cache delete <key>` removes the entry for **every** ref.

`warm_cache.yml` deletes the previous combined cache so the freshly rebuilt one can actually be saved (caches are immutable, so `cache/save` is a silent no-op otherwise). On the default branch that is exactly right. On any other branch it does something quite different: it removes the `3.x`-scoped entry and saves the rebuilt one under *that branch's* ref, so the cache is not refreshed, it is **moved**, and every other branch starts missing it.

The `push:` trigger fires on any branch touching `warm_cache.yml` or the `restore_*` actions, so this is easy to hit by accident.

It has happened twice in two days:

| when | run on | effect |
|---|---|---|
| 2026-09-03 19:57 | `madspin_density` | `heptools-ubuntu22/24` moved off `3.x` |
| 2026-09-04 22:53 | `3.8.0` | moved off `3.x` again |

Each time, every other branch got

```
Cache not found for input keys: heptools-ubuntu22
Cache not found for input keys: lhapdf-ubuntu22
Cache not found for input keys: pythia8-ubuntu22
...
/home/runner/.cache/HEPtools/bin/lhapdf-config does not seem to correspond to a valid lhapdf-config executable
/home/runner/.cache/HEPtools/ninja/lib does not seem to correspond to a valid ninja lib
```

and 20-26 acceptance jobs failed, all the NLO/aMC@NLO, MadLoop, emela, contur and delphes ones, until `warm_cache` was dispatched on `3.x` again. On PR #332 this produced 21 failures on one push and 26 on the next, none of them related to the code under review.

## Change

Gate the six cache-mutating steps on `github.ref == 'refs/heads/3.x'`:

- the three `reset_*` delete steps in `delete-cache`
- `Delete previous combined cache`
- the combined `actions/cache/save@v5`
- `Cleanup intermediate caches`

A run on another branch still builds and verifies every sub-cache, it just does not write. That keeps the workflow testable from a branch (which is what the `push:` path filter is for) without letting it take the caches away from the rest of the repository.

Also adds a header comment recording why the guard is there, so it does not get removed later as redundant.

## Note on scope

This stops caches being *moved*. A non-default run can still create a branch-scoped **sub**-cache when a key is absent for every ref, via the `actions/cache@v5` post-step in the `*_cache` jobs. That is harmless (it never removes another ref's entry) and the cleanup step on `3.x` reclaims those keys. Converting those to `restore` plus a gated `save` would be a larger refactor; happy to do it separately if you want the branch-scoped writes gone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
