### PR TITLE
Recover crashed parallel Delphes by re-running on leftover Pythia8 split HEPMC files

### DIFF
--- a/.github/actions/check_heptools/action.yml
+++ b/.github/actions/check_heptools/action.yml
@@ -1,0 +1,42 @@
+name: Check HEPTools cache content
+description: >
+  Verify that the requested tools are really present in the HEPTools install
+  prefix.  mg5_aMC exits 0 even when "install <tool>" fails (truncated
+  download, broken build, ...), so without this check a cache-building job
+  finishes green while saving a cache with a tool missing.
+
+inputs:
+  tools:
+    description: >
+      Space separated list of components to check, among:
+      lhapdf boost pythia8 emela contur looptools
+    required: true
+  prefix:
+    description: 'HEPTools install prefix to inspect (default ~/.cache/HEPtools)'
+    required: false
+    default: ''
+  mode:
+    description: >
+      "fatal" (default) makes the step fail on the first incomplete component,
+      "report" only emits warnings and sets the "valid" output.
+    required: false
+    default: 'fatal'
+
+outputs:
+  valid:
+    description: 'true when every requested component is complete'
+    value: ${{ steps.check.outputs.valid }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check HEPTools content
+      id: check
+      shell: bash
+      env:
+        HEPTOOLS_PREFIX: ${{ inputs.prefix }}
+        CHECK_MODE: ${{ inputs.mode }}
+        CHECK_TOOLS: ${{ inputs.tools }}
+      # invoked through "bash" so the check does not depend on the executable
+      # bit surviving the checkout
+      run: bash "${{ github.action_path }}/check_heptools.sh" $CHECK_TOOLS

--- a/.github/actions/check_heptools/check_heptools.sh
+++ b/.github/actions/check_heptools/check_heptools.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# Content check for the HEPTools cache tree.
+#
+# "./bin/mg5_aMC cmd" exits 0 even when the "install <tool>" it contains
+# failed (e.g. the boost tarball came down truncated, so bootstrap.sh/b2
+# never ran and eMELA aborted).  A warm_cache job therefore ends green and
+# actions/cache happily saves a cache with the tool missing, which only shows
+# up much later as a broken acceptance test.
+#
+# Every path asserted below mirrors what HEPToolInstaller.py installs
+# ('install_path' = <prefix>/<tool>, libraries looked up in lib/ or lib64/)
+# and what the .github/actions/restore_heptools_* actions then hand to MG5
+# through input/mg5_configuration.txt.
+#
+# Usage: check_heptools.sh <component> [<component> ...]
+#   HEPTOOLS_PREFIX  install prefix to inspect  (default ~/.cache/HEPtools)
+#   CHECK_MODE       fatal (default) | report
+
+set -o pipefail
+
+HEP="${HEPTOOLS_PREFIX:-}"
+[ -n "$HEP" ] || HEP="$HOME/.cache/HEPtools"
+MODE="${CHECK_MODE:-fatal}"
+
+missing=()
+
+need_file() { [ -f "$1" ] || missing+=("missing file: $1"); }
+need_exec() { [ -x "$1" ] || missing+=("missing executable: $1"); }
+need_dir()  { [ -d "$1" ] || missing+=("missing directory: $1"); }
+
+# need_glob <description> <pattern> [<pattern> ...]
+# Satisfied as soon as one pattern matches something (used for the lib/lib64
+# ambiguity and for library extensions that differ between builds).
+need_glob() {
+    local desc="$1"; shift
+    local pattern
+    for pattern in "$@"; do
+        if compgen -G "$pattern" > /dev/null 2>&1; then
+            return 0
+        fi
+    done
+    missing+=("missing $desc (no match for: $*)")
+}
+
+check_lhapdf() {
+    need_exec "$HEP/lhapdf6_py3/bin/lhapdf-config"
+    need_exec "$HEP/bin/lhapdf-config"
+    need_glob "libLHAPDF" "$HEP/lhapdf6_py3/lib/libLHAPDF.*" "$HEP/lhapdf6_py3/lib64/libLHAPDF.*"
+    # the two PDF sets the NLO acceptance tests need are unpacked by the
+    # warm_cache lhapdf job itself, not by the installer
+    need_dir "$HEP/lhapdf6_py3/share/LHAPDF/cteq6l1"
+    need_dir "$HEP/lhapdf6_py3/share/LHAPDF/NNPDF23_nlo_as_0118_qed"
+}
+
+check_boost() {
+    # exactly what HEPToolInstaller.find_dependency('boost') looks for: without
+    # it eMELA re-downloads and rebuilds boost from scratch
+    need_glob "libboost_system" \
+        "$HEP/boost/lib/libboost_system.*" "$HEP/boost/lib/libboost_system-mt.*" \
+        "$HEP/boost/lib64/libboost_system.*" "$HEP/boost/lib64/libboost_system-mt.*"
+    need_file "$HEP/boost/include/boost/version.hpp"
+}
+
+check_pythia8() {
+    # a network-failed pythia8 install leaves an incomplete pythia8/ dir; MG5
+    # then nullifies pythia8_path at startup, leaving the parton shower
+    # unavailable and breaking the rivet/contur acceptance tests
+    need_file "$HEP/pythia8/include/Pythia8/Pythia.h"
+    need_exec "$HEP/pythia8/bin/pythia8-config"
+    need_glob "libpythia8" "$HEP/pythia8/lib/libpythia8.*" "$HEP/pythia8/lib64/libpythia8.*"
+    need_dir  "$HEP/hepmc"
+    need_file "$HEP/MG5aMC_PY8_interface/MG5aMC_PY8_interface"
+}
+
+check_emela() {
+    # bin/eMELA-config is the symlink finalize_installation() creates and the
+    # path restore_heptools_emela writes into mg5_configuration.txt
+    need_exec "$HEP/bin/eMELA-config"
+    need_glob "eMELA grids" "$HEP/EMELA/share/eMELA/*"
+}
+
+check_contur() {
+    # a missing fastjet-config means NLO subprocesses cannot compile
+    # (fastjet/ClusterSequence.hh)
+    need_exec "$HEP/fastjet/bin/fastjet-config"
+    need_glob "libfastjet" "$HEP/fastjet/lib/libfastjet.*" "$HEP/fastjet/lib64/libfastjet.*"
+    need_glob "libRivet"   "$HEP/rivet/lib/libRivet.*"     "$HEP/rivet/lib64/libRivet.*"
+    need_glob "libYODA"    "$HEP/yoda/lib/libYODA.*"       "$HEP/yoda/lib64/libYODA.*"
+    need_dir  "$HEP/contur"
+    need_dir  "$HEP/hepmc3"
+}
+
+check_looptools() {
+    need_file "$HEP/CutTools/lib/libcts.a"
+    need_file "$HEP/CutTools/lib/mpmodule.mod"
+    need_file "$HEP/IREGI/src/libiregi.a"
+    need_glob "libcollier" "$HEP/collier/libcollier.*" \
+        "$HEP/collier/lib/libcollier.*" "$HEP/collier/lib64/libcollier.*"
+    need_glob "libninja"   "$HEP/ninja/lib/libninja.*" "$HEP/ninja/lib64/libninja.*"
+}
+
+if [ "$#" -eq 0 ]; then
+    echo "::error::check_heptools: no component requested"
+    exit 1
+fi
+
+echo "Checking HEPTools content under $HEP for: $*"
+for component in "$@"; do
+    case "$component" in
+        lhapdf|boost|pythia8|emela|contur|looptools) "check_$component" ;;
+        *) echo "::error::check_heptools: unknown component '$component'"; exit 1 ;;
+    esac
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+    echo "All requested components are complete."
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "valid=true" >> "$GITHUB_OUTPUT"
+    exit 0
+fi
+
+level=error
+[ "$MODE" = "fatal" ] || level=warning
+for entry in "${missing[@]}"; do
+    echo "::${level}::HEPTools cache incomplete ($*): ${entry}"
+done
+[ -n "${GITHUB_OUTPUT:-}" ] && echo "valid=false" >> "$GITHUB_OUTPUT"
+
+if [ "$MODE" = "fatal" ]; then
+    echo "Refusing to treat this build as successful: the cache would be saved incomplete."
+    exit 1
+fi
+exit 0

--- a/.github/actions/restore_heptools/action.yml
+++ b/.github/actions/restore_heptools/action.yml
@@ -15,43 +15,34 @@ runs:
         path: ~/.cache/HEPtools
         key: ${{ env.CACHE_KEY }}
 
+    # Same content check the warm_cache jobs run before saving, in "report"
+    # mode: here an incomplete combined cache is not fatal, we just fall back
+    # to the (still present) sub-caches below.
     - name: validate cache content
       id: validate-cache
       if: steps.heptools-cache.outputs.cache-hit == 'true'
-      run: |
-        # Check that all expected HEPtool binaries/directories are present
-        VALID=true
-        test -d $HOME/.cache/HEPtools/lhapdf6_py3                    || VALID=false
-        # check the header/binary, not just the dir: a network-failed pythia8
-        # install can leave an incomplete pythia8/ dir that MG5 then rejects
-        # (pythia8_path nullified -> no shower -> rivet/contur tests fail).
-        test -f $HOME/.cache/HEPtools/pythia8/include/Pythia8/Pythia.h || VALID=false
-        test -x $HOME/.cache/HEPtools/pythia8/bin/pythia8-config      || VALID=false
-        test -x $HOME/.cache/HEPtools/bin/eMELA-config                || VALID=false
-        test -x $HOME/.cache/HEPtools/fastjet/bin/fastjet-config      || VALID=false
-        test -d $HOME/.cache/HEPtools/rivet                           || VALID=false
-        test -d $HOME/.cache/HEPtools/ninja                           || VALID=false
-        echo "cache_valid=$VALID" >> $GITHUB_OUTPUT
-        if [ "$VALID" = "false" ]; then
-          echo "::warning::heptools cache is incomplete, will restore from sub-caches"
-        fi
-      shell: bash
+      uses: ./.github/actions/check_heptools
+      with:
+        tools: lhapdf boost pythia8 emela contur looptools
+        mode: report
 
     # setup other environment of previous level of cache 
     # try to use their cache if previous cache failed or content is incomplete
     - uses: ./.github/actions/restore_heptools_lhapdf
       with: 
-        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_valid == 'true' }}
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}
+    - uses: ./.github/actions/restore_heptools_boost
+      with:
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}
     - uses: ./.github/actions/restore_heptools_pythia8
       with: 
-        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_valid == 'true' }}
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}
     - uses: ./.github/actions/restore_heptools_emela
       with: 
-        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_valid == 'true' }}
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}
     - uses: ./.github/actions/restore_heptools_contur
       with: 
-        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_valid == 'true' }}
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}
     - uses: ./.github/actions/restore_heptools_looptools
       with: 
-        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_valid == 'true' }}
-
+        setup_only: ${{ steps.heptools-cache.outputs.cache-hit == 'true' && steps.validate-cache.outputs.valid == 'true' }}

--- a/.github/actions/restore_heptools_boost/action.yml
+++ b/.github/actions/restore_heptools_boost/action.yml
@@ -1,0 +1,33 @@
+name: Restore boost cache (if it exists and in any case configure even if it does not)
+description: Restores boost (stacked on lhapdf) from cache and sets MG5 accordingly
+
+inputs:
+  setup_only:
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+
+    # Call previous cache to ensure that environment is setup correctly
+    - name: restore lhapdf
+      uses: ./.github/actions/restore_heptools_lhapdf
+      with:
+        setup_only: ${{ inputs.setup_only }}
+
+    - name: Set cache key
+      run: echo "CACHE_KEY=boost-$ImageOS" >> $GITHUB_ENV
+      shell: bash
+
+    # check if the cache exists (if not an higher level will be called)
+    - uses: actions/cache/restore@v5
+      if: ${{ inputs.setup_only != 'true' }}
+      with:
+        path: ~/.cache/HEPtools
+        key: ${{ env.CACHE_KEY }}
+
+    # Nothing to write into mg5_configuration.txt: boost has no MG5 option.
+    # HEPToolInstaller finds it on its own as soon as
+    # <heptools_install_dir>/boost/lib/libboost_system.so is present, and then
+    # skips the (~6 min, download-flaky) boost build when installing eMELA.

--- a/.github/actions/restore_heptools_emela/action.yml
+++ b/.github/actions/restore_heptools_emela/action.yml
@@ -1,5 +1,5 @@
-name: Restore lhapdf cache
-description: Restores lhapdf from cache and sets MG5 accordingly
+name: Restore eMELA cache
+description: Restores eMELA (stacked on boost/lhapdf) from cache and sets MG5 accordingly
 
 inputs:
   setup_only:
@@ -9,8 +9,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: restore lhapdf
-      uses: ./.github/actions/restore_heptools_lhapdf
+    # boost itself pulls in lhapdf, so this restores the whole chain. eMELA
+    # needs boost at build time; keeping it in a separate cache means a failed
+    # eMELA build no longer forces a boost rebuild too.
+    - name: restore boost (and lhapdf)
+      uses: ./.github/actions/restore_heptools_boost
       with:
         setup_only:  ${{ inputs.setup_only }}
 

--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -44,8 +44,14 @@ jobs:
       - name: Set cache key
         run: echo "CACHE_KEY=$ImageOS" >> $GITHUB_ENV
 #
+      # "inputs.<x> == 'true'" can never be true for a "type: boolean" input:
+      # GitHub casts both sides to a number for a mixed-type comparison, and
+      # 'true' is not a number, so the result is 1 == NaN -> false. Ticking
+      # reset_heptools in the dispatch form was therefore a no-op. A boolean
+      # input is truthy on its own; on push/schedule the whole inputs context
+      # is null, so these steps stay skipped there.
       - name: Delete heptools related cache
-        if: inputs.reset_heptools == 'true'
+        if: inputs.reset_heptools
         run: | 
           gh cache delete heptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete lhapdf-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
@@ -57,7 +63,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Delete ufo cache
-        if: inputs.reset_ufo == 'true'
+        if: inputs.reset_ufo
         run: |
           gh cache delete pip-numpy-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete ufomodel-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
@@ -68,7 +74,7 @@ jobs:
       # large and stable). They are only rebuilt on explicit request, so the
       # cache can be cleaned independently of the heptools one.
       - name: Delete root/delphes cache
-        if: inputs.reset_delphes == 'true'
+        if: inputs.reset_delphes
         run: |
           gh cache delete root-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete delphes-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true

--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/warm_cache.yml'
       - '.github/actions/restore_heptools/**'
       - '.github/actions/restore_heptools_*/**'
+      - '.github/actions/check_heptools/**'
       - '.github/actions/restore_root/**'
       - '.github/actions/restore_delphes/**'
   schedule:
@@ -49,6 +50,7 @@ jobs:
           gh cache delete heptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete lhapdf-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete pythia8-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
+          gh cache delete boost-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete emela-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete contur-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
         env:
@@ -167,7 +169,17 @@ jobs:
                tar -xzpvf NNPDF23_nlo_as_0118_qed.tar.gz           
                wget https://lhapdfsets.web.cern.ch/lhapdfsets/current/cteq6l1.tar.gz
                tar -xzpvf cteq6l1.tar.gz           
-               
+
+       # "./bin/mg5_aMC cmd" exits 0 even when the install it contains failed,
+       # and wget/tar above are equally happy with a truncated PDF tarball.
+       # actions/cache only saves on a successful job, so failing here is what
+       # keeps an incomplete lhapdf cache from being published.
+       - name: Verify lhapdf landed in the cache
+         if: steps.cache-lhapdf.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: lhapdf
+
   pythia8_cache:
      if: github.event_name != 'schedule'
      runs-on: ${{ matrix.os }}
@@ -211,22 +223,78 @@ jobs:
                echo "install pythia8" > cmd
                ./bin/mg5_aMC cmd
 
+       # mg5_aMC exits 0 even when "install pythia8" fails (e.g. a network
+       # timeout while downloading hepmc/pythia8 from the download server), so
+       # guard the cache here. Without Pythia.h, MG5 nullifies pythia8_path at
+       # startup, leaving the parton shower unavailable and breaking the
+       # rivet/contur acceptance tests. Fail loudly instead of saving a
+       # pythia8-less heptools cache.
        - name: Verify pythia8 landed in the cache
          if: steps.cache-pythia8.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: pythia8
+
+  # boost used to be built as a silent dependency inside emela_cache. It is
+  # the flakiest download of the whole chain (the sourceforge tarball regularly
+  # comes down truncated, which then takes bootstrap.sh/b2 and eMELA down with
+  # it) and it is by far the longest part of that job (~6 min vs ~20 s for
+  # eMELA itself). Giving it its own cache means a boost failure no longer
+  # discards the eMELA build, and an eMELA rebuild no longer recompiles boost.
+  boost_cache:
+     if: github.event_name != 'schedule'
+     runs-on: ${{ matrix.os }}
+     needs: lhapdf_cache
+     strategy:
+       matrix:
+         os: [ubuntu-22.04, ubuntu-24.04]
+
+     steps:
+
+       - name: Set cache key
+         run: echo "CACHE_KEY=$ImageOS" >> $GITHUB_ENV
+       - name: Cache boost packages
+         id: cache-boost
+         uses: actions/cache@v5
+         with:
+           path: ~/.cache/HEPtools
+           key: boost-${{ env.CACHE_KEY }}
+
+       - name: get mg5
+         if: steps.cache-boost.outputs.cache-hit != 'true'
+         uses: actions/checkout@v5
+
+       - name: restore lhapdf cache
+         if: steps.cache-boost.outputs.cache-hit != 'true'
+         uses: ./.github/actions/restore_heptools_lhapdf
+
+       - name: Install boost into cache dir (on top of lhapdf cache)
+         if: steps.cache-boost.outputs.cache-hit != 'true'
+         env:
+           MAKEFLAGS: "-j4"
          run: |
-               # mg5_aMC exits 0 even when "install pythia8" fails (e.g. a network
-               # timeout while downloading hepmc/pythia8 from the download server),
-               # so guard the cache here. Without Pythia.h, MG5 nullifies
-               # pythia8_path at startup, leaving the parton shower unavailable and
-               # breaking the rivet/contur acceptance tests. Fail loudly instead of
-               # saving a pythia8-less heptools cache.
-               test -f /home/runner/.cache/HEPtools/pythia8/include/Pythia8/Pythia.h
-               test -x /home/runner/.cache/HEPtools/pythia8/bin/pythia8-config
+               mkdir -p /home/runner/.cache/HEPtools
+               cd $GITHUB_WORKSPACE
+               echo "heptools_install_dir=/home/runner/.cache/HEPtools" >> input/mg5_configuration.txt
+               cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
+               echo "install boost" > cmd
+               ./bin/mg5_aMC cmd
+
+       # installBOOST.sh ends on an unconditional "echo", so it returns 0 even
+       # when the tarball was truncated ("gzip: stdin: unexpected end of file"
+       # -> no bootstrap.sh -> no ./b2), and mg5_aMC exits 0 on top of that.
+       # This is exactly how run 33810239949 saved an eMELA-less cache while
+       # reporting green.
+       - name: Verify boost landed in the cache
+         if: steps.cache-boost.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: boost
 
   emela_cache:
      if: github.event_name != 'schedule'
      runs-on: ${{ matrix.os }}
-     needs: lhapdf_cache
+     needs: boost_cache
      strategy:
        matrix:
          os: [ubuntu-22.04, ubuntu-24.04]
@@ -246,10 +314,21 @@ jobs:
        - name: get mg5
          if: steps.cache-eMELA.outputs.cache-hit != 'true'
          uses: actions/checkout@v5
-       
-       - name: restore lhapdf cache
+
+       # restores boost (which itself restores lhapdf): HEPToolInstaller then
+       # finds <heptools>/boost/lib/libboost_system.so and skips the boost build
+       - name: restore boost cache (and lhapdf)
          if: steps.cache-eMELA.outputs.cache-hit != 'true'
-         uses: ./.github/actions/restore_heptools_lhapdf
+         uses: ./.github/actions/restore_heptools_boost
+
+       # Guard the dependency we just restored: if boost were missing here the
+       # installer would silently rebuild it inside this job, putting us back in
+       # the situation this split is meant to avoid.
+       - name: Verify the restored boost cache is usable
+         if: steps.cache-eMELA.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: lhapdf boost
 
        - name: Install eMELA into cache dir (if not cached)
          if: steps.cache-eMELA.outputs.cache-hit != 'true'
@@ -260,7 +339,16 @@ jobs:
                cp Template/LO/Source/.make_opts Template/LO/Source/make_opts
                echo "install eMELA" > cmd
                ./bin/mg5_aMC cmd
-            
+
+       # "Installation of eMELA failed." is only *printed* by mg5_aMC, which
+       # then exits 0; without this step the job goes green and actions/cache
+       # publishes an emela cache that contains no eMELA at all.
+       - name: Verify eMELA landed in the cache
+         if: steps.cache-eMELA.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: boost emela
+
 #  delete_lhapdf_cache:
 #     runs-on: ${{ matrix.os }}
 #     needs: 
@@ -328,14 +416,15 @@ jobs:
                echo "install contur" >> cmd
                ./bin/mg5_aMC cmd
 
+       # mg5_aMC exits 0 even when "install rivet" fails, so guard the cache
+       # here: a missing fastjet-config means NLO subprocesses cannot compile
+       # (fastjet/ClusterSequence.hh). Fail loudly instead of saving an
+       # incomplete heptools cache.
        - name: Verify rivet/fastjet landed in the cache
          if: steps.cache-contur.outputs.cache-hit != 'true'
-         run: |
-               # mg5_aMC exits 0 even when "install rivet" fails, so guard the
-               # cache here: a missing fastjet-config means NLO subprocesses cannot
-               # compile (fastjet/ClusterSequence.hh). Fail loudly instead of
-               # saving an incomplete heptools cache.
-               test -x /home/runner/.cache/HEPtools/fastjet/bin/fastjet-config
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: contur
 
        #- name: Delete pythia8 cache (include in contur cache)
        #  run: |
@@ -395,17 +484,49 @@ jobs:
                echo "install ninja " >> cmd
                ./bin/mg5_aMC cmd
 
+       # collier/ninja go through the same mg5_aMC-exits-0-on-failure path as
+       # every other tool, and the cuttools/iregi copies above are plain "cp"s.
+       - name: Verify looptools landed in the cache
+         if: steps.cache-nlo.outputs.cache-hit != 'true'
+         uses: ./.github/actions/check_heptools
+         with:
+           tools: looptools
+
   heptools_cache:
     runs-on: ${{ matrix.os }}       
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
-    needs: [lhapdf_cache, pythia8_cache, emela_cache, looptools_cache, contur_cache]
+    needs: [lhapdf_cache, boost_cache, pythia8_cache, emela_cache, looptools_cache, contur_cache]
     # runs even if a dependency failed, but never on the scheduled keep-warm run
     if: always() && github.event_name != 'schedule'
+    env:
+      # Every sub-cache job reported success. Not enough on its own (see the
+      # content check below), but a necessary condition for touching the
+      # combined cache at all.
+      ALL_SUBCACHES_OK: ${{ needs.lhapdf_cache.result == 'success' && needs.boost_cache.result == 'success' && needs.pythia8_cache.result == 'success' && needs.emela_cache.result == 'success' && needs.contur_cache.result == 'success' && needs.looptools_cache.result == 'success' }}
     steps:
+      # needed for ./.github/actions/check_heptools below
+      - uses: actions/checkout@v5
+
       - name: Set cache key
         run: echo "CACHE_KEY=$ImageOS" >> $GITHUB_ENV
+
+      # Restore in dependency order; each sub-cache is cumulative, so later
+      # ones simply overlay the earlier content in ~/.cache/HEPtools.
+      - name: Restore lhapdf (if available)
+        if: needs.lhapdf_cache.result == 'success'
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/HEPtools
+          key: lhapdf-${{ env.CACHE_KEY }}
+
+      - name: Restore boost (if available)
+        if: needs.boost_cache.result == 'success'
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/HEPtools
+          key: boost-${{ env.CACHE_KEY }}
 
       - name: Restore pythia8 (if available)
         if: needs.pythia8_cache.result == 'success'
@@ -421,12 +542,6 @@ jobs:
           path: ~/.cache/HEPtools
           key: emela-${{ env.CACHE_KEY }}
 
-      - name: Restore lhapdf (fallback when pythia8 and emela failed)
-        if: needs.lhapdf_cache.result == 'success' && (needs.pythia8_cache.result != 'success' || needs.emela_cache.result != 'success')
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/HEPtools
-          key: lhapdf-${{ env.CACHE_KEY }}
       - name: Restore contur (if available)
         if: needs.contur_cache.result == 'success'
         uses: actions/cache/restore@v5
@@ -441,6 +556,19 @@ jobs:
           path: ~/.cache/HEPtools
           key: looptools-${{ env.CACHE_KEY }}
 
+      # Green sub-jobs are not proof that the tree is complete: a sub-cache may
+      # predate the checks above, or a restore may have silently produced
+      # nothing. Inspect the assembled tree itself before publishing it.
+      # Failing here stops the three steps below, which is deliberate: the old
+      # combined cache is left alone AND every intermediate cache survives, so
+      # the next run only has to redo the one piece that is actually broken
+      # instead of the whole chain.
+      - name: Verify the assembled heptools tree before saving it
+        if: env.ALL_SUBCACHES_OK == 'true'
+        uses: ./.github/actions/check_heptools
+        with:
+          tools: lhapdf boost pythia8 emela contur looptools
+
       # GitHub Actions caches are immutable: actions/cache/save is a silent
       # no-op when the key already exists (it logs "Unable to reserve cache
       # ... another job may be creating this cache" and the freshly rebuilt
@@ -449,27 +577,39 @@ jobs:
       # the new content is actually saved. Only do this (and the save) once all
       # sub-caches succeeded, so a partial rebuild never replaces a good cache.
       - name: Delete previous combined cache (so the fresh one can be saved)
-        if: needs.pythia8_cache.result == 'success' && needs.emela_cache.result == 'success' && needs.contur_cache.result == 'success' && needs.looptools_cache.result == 'success'
+        if: env.ALL_SUBCACHES_OK == 'true'
         run: gh cache delete heptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
         env:
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/cache/save@v5
-        if: needs.pythia8_cache.result == 'success' && needs.emela_cache.result == 'success' && needs.contur_cache.result == 'success' && needs.looptools_cache.result == 'success'
+        if: env.ALL_SUBCACHES_OK == 'true'
         with:
           path: ~/.cache/HEPtools
           key: heptools-${{ env.CACHE_KEY }}
 
-      - name: Cleanup intermediate caches (only if all succeeded)
-        if: needs.pythia8_cache.result == 'success' && needs.emela_cache.result == 'success' && needs.contur_cache.result == 'success' && needs.looptools_cache.result == 'success'
+      - name: Cleanup intermediate caches (only if all succeeded and verified)
+        if: env.ALL_SUBCACHES_OK == 'true'
         run: |
           gh cache delete lhapdf-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
+          gh cache delete boost-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete pythia8-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete emela-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete contur-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
           gh cache delete looptools-${{ env.CACHE_KEY }} --repo $GITHUB_REPOSITORY || true
         env:
           GH_TOKEN: ${{ github.token }}
+
+      # Make the run red when a sub-cache job was green but the tree it
+      # produced is not usable, so nobody trusts a "Warm all caches ✓" that
+      # left the combined cache untouched.
+      - name: Report that the combined cache was not refreshed
+        if: env.ALL_SUBCACHES_OK != 'true'
+        run: |
+          echo "::error::the combined heptools cache was NOT refreshed: at least one sub-cache job did not succeed."
+          echo "The intermediate caches (lhapdf/boost/pythia8/emela/contur/looptools) have been kept,"
+          echo "so re-running only the failed job is enough - no need to rebuild the whole chain."
+          exit 1
 
   # On the scheduled run the heptools rebuild chain is skipped (the *_cache jobs
   # are guarded with github.event_name != 'schedule'). Restore the combined
@@ -483,13 +623,32 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04]
     steps:
+      # needed for ./.github/actions/check_heptools below
+      - uses: actions/checkout@v5
+
       - name: Set cache key
         run: echo "CACHE_KEY=$ImageOS" >> $GITHUB_ENV
       - name: Restore (touch) the combined heptools cache
+        id: touch-heptools
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: heptools-${{ env.CACHE_KEY }}
+
+      # The twice-weekly run is the only thing that regularly looks at the
+      # combined cache, so it is also the place where a cache that was saved
+      # incomplete (before the producing jobs were guarded) shows up. Fail here
+      # rather than keeping a broken cache warm for weeks; the fix is to
+      # re-dispatch this workflow with reset_heptools.
+      - name: Check the cache we are keeping warm is still complete
+        if: steps.touch-heptools.outputs.cache-hit == 'true'
+        uses: ./.github/actions/check_heptools
+        with:
+          tools: lhapdf boost pythia8 emela contur looptools
+
+      - name: Warn when there is no combined cache to keep warm
+        if: steps.touch-heptools.outputs.cache-hit != 'true'
+        run: echo "::warning::no heptools-${{ env.CACHE_KEY }} cache found; it will be rebuilt on the next push or manual dispatch."
 
 
   # ---------------------------------------------------------------------------

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -394,7 +394,6 @@ class CheckValidForCmd(object):
                     filepath = p % {'tag': prev_tag}
                     break
             else:
-                a = input("NO INPUT")          
                 if nodefault:
                     return False
                 else:

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -398,6 +398,8 @@ class CheckValidForCmd(object):
                 if nodefault:
                     return False
                 else:
+                    if self._has_py8_parallel_splits(prev_tag):
+                        return 'RECOVER_PY8_SPLITS'
                     self.help_pgs()
                     raise self.InvalidCmd('''No file file pythia_events.* currently available
             Please specify a valid run_name''')
@@ -412,7 +414,9 @@ class CheckValidForCmd(object):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)
             elif os.path.exists(pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc' % prev_tag)):
                 filepath = pjoin(self.me_dir,'Events',self.run_name, '%s_pythia8_events.hepmc.gz' % prev_tag)
-            else:                
+            else:
+                if self._has_py8_parallel_splits(prev_tag):
+                    return 'RECOVER_PY8_SPLITS'
                 raise self.InvalidCmd('No events file corresponding to %s run with tag %s.:%s '\
                     % (self.run_name, prev_tag, 
                        pjoin(self.me_dir,'Events',self.run_name, '%s_pythia_events.hep.gz' % prev_tag)))
@@ -3386,7 +3390,36 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
     ############################################################################
     # End of MadAnalysis5 related function
     ############################################################################
-    
+
+    def _has_py8_parallel_splits(self, tag):
+        """Return the PY8_parallelization directory path if leftover Pythia8
+        split HEPMC files are present for the given run tag, otherwise False.
+        Used by the delphes command recovery path so that a crashed
+        parallel run can still be processed with parallel Delphes on the
+        split HEPMC files instead of requiring a full re-run."""
+
+        parallelization_dir = pjoin(self.me_dir, 'Events', self.run_name,
+                                    'PY8_parallelization')
+        if not os.path.isdir(parallelization_dir):
+            return False
+        split_dirs = sorted(glob.glob(pjoin(parallelization_dir, 'split_*')))
+        split_dirs = [d for d in split_dirs if os.path.isdir(d) and
+                      os.path.isfile(pjoin(d, 'events.hepmc'))]
+        if not split_dirs:
+            return False
+        return parallelization_dir
+
+    def _try_run_delphes_on_splits_recovery(self, tag):
+        """Child-class hook for recovering a crashed parallel Delphes run.
+        When leftover split HEPMC files exist (see _has_py8_parallel_splits)
+        this should run Delphes on them, merge the ROOT outputs with hadd
+        and (when the pythia8 card asked for it) clean up the split HEPMC
+        files afterwards.
+
+        Returns True on success, False if recovery is not possible. Base
+        class default returns False."""
+        return False
+
     def do_delphes(self, line):
         """ run delphes and make associate root file/plot """
 
@@ -3406,7 +3439,36 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         filepath = self.check_delphes(args, nodefault=no_default)
         if no_default and not filepath:
             return # no output file but nothing to do either.
-        
+
+        tag = self.run_tag
+
+        # Recovery path: no merged HEPMC file exists, but leftover Pythia8
+        # split HEPMC files do (PY8_parallelization/split_*/events.hepmc).
+        # Let the child class run Delphes on the splits in parallel and
+        # merge the ROOT outputs with hadd.
+        if filepath == 'RECOVER_PY8_SPLITS':
+            logger.info('No merged HEPMC output found for run %s (tag %s); '
+                        'detected leftover Pythia8 parallelization splits. '
+                        'Running Delphes on the split HEPMC files in parallel...'
+                        % (self.run_name, tag))
+            if not self._try_run_delphes_on_splits_recovery(tag):
+                raise self.InvalidCmd(
+                    'Parallel Delphes recovery on the split HEPMC files '
+                    'failed. Either re-run Pythia8 (to regenerate the merged '
+                    'HEPMC) or run Delphes manually on the individual split '
+                    'files under Events/%s/PY8_parallelization/split_*/'
+                    % self.run_name)
+            # The recovery method has already produced the final ROOT and
+            # the 'delphes done' status. Skip the standard single-file run.
+            madir = self.options['madanalysis_path']
+            td = self.options['td_path']
+            if os.path.exists(pjoin(self.me_dir, 'Events', self.run_name,
+                                    '%s_delphes_events.lhco' % tag)):
+                self.create_plot('Delphes')
+                misc.gzip(pjoin(self.me_dir, 'Events', self.run_name,
+                                '%s_delphes_events.lhco' % tag))
+            return
+
         self.update_status('prepare delphes run', level=None)
 
         if os.path.exists(pjoin(self.options['delphes_path'], 'data')):

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -5356,6 +5356,25 @@ tar -czf split_$1.tar.gz split_$1
         if not split_hepmc:
             return False
 
+        # Before (re-)running Delphes on the splits, remove any leftover
+        # per-split ROOT / log file from a previous (possibly crashed) run.
+        # Stale outputs would otherwise leak into the hadd merge or cause the
+        # 'all outputs produced' success check to pass without actually
+        # re-running Delphes for that split.
+        for split_dir, _hepmc in split_hepmc:
+            stale_root = pjoin(split_dir, 'delphes_events.root')
+            stale_log = pjoin(split_dir, 'delphes.log')
+            if os.path.isfile(stale_root):
+                try:
+                    os.remove(stale_root)
+                except OSError:
+                    pass
+            if os.path.isfile(stale_log):
+                try:
+                    os.remove(stale_log)
+                except OSError:
+                    pass
+
         card = pjoin(self.me_dir, 'Cards', 'delphes_card.dat')
         self.update_status('Running Delphes on Pythia8 splits', level=None)
 
@@ -5432,6 +5451,118 @@ tar -czf split_$1.tar.gz split_$1
         # Note: the 'delphes done' status/level is set by the caller after the
         # Pythia8 shower is marked finished, to keep the recorded run level in
         # the natural pythia8 -> delphes order.
+        return True
+
+    def _try_run_delphes_on_splits_recovery(self, tag):
+        """Recovery-path override of the CommonRunCmd hook. Called when the
+        standalone 'delphes' command cannot find a merged HEPMC event file
+        for the current run but leftover Pythia8 parallelization splits
+        (PY8_parallelization/split_*/events.hepmc) are present.
+
+        Runs Delphes on each split in parallel, merges the ROOT outputs with
+        hadd and (when the original pythia8 HEPMC setting requested it)
+        cleans up the split directory afterwards. This lets a user recover
+        from a crash during the parallel-Delphes fused path without
+        re-running Pythia8."""
+
+        parallelization_dir = pjoin(self.me_dir, 'Events', self.run_name,
+                                    'PY8_parallelization')
+        if not os.path.isdir(parallelization_dir):
+            return False
+        split_dirs = sorted(glob.glob(pjoin(parallelization_dir, 'split_*')))
+        split_dirs = [d for d in split_dirs if os.path.isdir(d) and
+                      os.path.isfile(pjoin(d, 'events.hepmc'))]
+        if not split_dirs:
+            return False
+
+        try:
+            import madgraph
+        except ImportError:
+            import internal.misc as misc
+        else:
+            import madgraph.various.misc as misc
+
+        # If nb_core_delphes is not explicitly set we still want the user's
+        # recovery run to benefit from parallelism on the splits: fall back
+        # to the same concurrency Pythia8 used (i.e. number of splits), but
+        # cap at the global nb_core / available CPUs.
+        if not hasattr(self, 'to_store'):
+            self.to_store = []
+
+        # Parse the pythia8 card HEPMC:output setting so we know later
+        # whether to remove/compress the split HEPMC files after success.
+        hepmc_output_setting = None
+        py8_card_path = pjoin(self.me_dir, 'Cards', 'pythia8_card.dat')
+        if os.path.isfile(py8_card_path):
+            for line in open(py8_card_path, 'r'):
+                if line.strip().startswith('HEPMCoutput:file'):
+                    if '=' in line:
+                        hepmc_output_setting = line.split('=', 1)[1].strip().lower()
+                    else:
+                        hepmc_output_setting = line.split(None, 1)[1].strip().lower()
+                    break
+        if hepmc_output_setting is None:
+            # Fall back to the parallelization copy written for the splits
+            py8_card0 = pjoin(parallelization_dir, 'PY8Card.dat')
+            if os.path.isfile(py8_card0):
+                for line in open(py8_card0, 'r'):
+                    if line.strip().startswith('HEPMCoutput:file'):
+                        if '=' in line:
+                            hepmc_output_setting = line.split('=', 1)[1].strip().lower()
+                        else:
+                            hepmc_output_setting = line.split(None, 1)[1].strip().lower()
+                        break
+
+        # Run the existing parallel-Delphes-on-splits implementation
+        # directly (bypassing is_delphes_fusion_active, which requires an
+        # explicit nb_core_delphes override — during interactive recovery
+        # the user already confirmed they want to run Delphes by typing
+        # the command, so that extra gate is not needed).
+        #
+        # Drop any pre-existing final ROOT / log first so a fresh hadd
+        # merge is produced and crash leftovers don't silently get re-used.
+        final_root = pjoin(self.me_dir, 'Events', self.run_name,
+                           '%s_delphes_events.root' % tag)
+        final_log  = pjoin(self.me_dir, 'Events', self.run_name,
+                           '%s_delphes.log' % tag)
+        for stale in (final_root, final_log):
+            if os.path.isfile(stale):
+                try:
+                    os.remove(stale)
+                except OSError:
+                    pass
+        ok = self.run_delphes_on_splits(split_dirs, parallelization_dir, tag)
+        if not ok:
+            return False
+
+        # Record the delphes-finished status the same way the normal path
+        # (do_delphes via the fused route) does.
+        self.update_status('delphes done', level='delphes', makehtml=False)
+
+        # Handle the original HEPMC storage directive from the pythia8 card.
+        # After a successful recovery the user typically wants the same
+        # cleanup that the standard path would have performed.
+        if hepmc_output_setting is not None:
+            spec = hepmc_output_setting.split('@')[0]
+            if spec.endswith('remove') or spec == 'hepmcremove':
+                # The original pythia8 run would have removed the merged HEPMC
+                # right after producing it; we already skipped the HEPMC merge
+                # earlier if the fused path was used, so in recovery simply
+                # drop the (now useless) split parallelization directory.
+                logger.info('HEPMC output configured for removal on the '
+                            'Pythia8 card; cleaning up the leftover split '
+                            'HEPMC parallelization directory.')
+                if os.path.isdir(parallelization_dir):
+                    shutil.rmtree(parallelization_dir)
+            elif spec.endswith('.gz'):
+                # In recovery the merged HEPMC was never written so there is
+                # nothing to compress; leave the split files alone in case the
+                # user wants them for a later re-processing.
+                pass
+            else:
+                # Plain 'hepmc' / 'auto' -> keep everything as-is.
+                pass
+
         return True
 
     def parse_PY8_log_file(self, log_file_path):

--- a/madgraph/interface/madevent_interface.py
+++ b/madgraph/interface/madevent_interface.py
@@ -5358,22 +5358,24 @@ tar -czf split_$1.tar.gz split_$1
 
         # Before (re-)running Delphes on the splits, remove any leftover
         # per-split ROOT / log file from a previous (possibly crashed) run.
-        # Stale outputs would otherwise leak into the hadd merge or cause the
-        # 'all outputs produced' success check to pass without actually
-        # re-running Delphes for that split.
+        # Delphes opens its output with ROOT's CREATE mode and refuses to
+        # overwrite an existing file, and a surviving stale ROOT also
+        # satisfies the required_output check of the job below: the split
+        # would be reported as done and the old file silently hadd-ed into
+        # the final sample. A stale output we cannot remove is therefore a
+        # hard failure, not something to run through.
         for split_dir, _hepmc in split_hepmc:
-            stale_root = pjoin(split_dir, 'delphes_events.root')
-            stale_log = pjoin(split_dir, 'delphes.log')
-            if os.path.isfile(stale_root):
+            for stale in (pjoin(split_dir, 'delphes_events.root'),
+                          pjoin(split_dir, 'delphes.log')):
+                if not os.path.isfile(stale):
+                    continue
                 try:
-                    os.remove(stale_root)
-                except OSError:
-                    pass
-            if os.path.isfile(stale_log):
-                try:
-                    os.remove(stale_log)
-                except OSError:
-                    pass
+                    os.remove(stale)
+                except OSError as error:
+                    logger.warning('Could not remove the stale Delphes output '
+                                   '%s (%s); running the standard Delphes step '
+                                   'instead.' % (stale, error))
+                    return False
 
         card = pjoin(self.me_dir, 'Cards', 'delphes_card.dat')
         self.update_status('Running Delphes on Pythia8 splits', level=None)
@@ -5513,24 +5515,32 @@ tar -czf split_$1.tar.gz split_$1
                             hepmc_output_setting = line.split(None, 1)[1].strip().lower()
                         break
 
+        # This path bypasses is_delphes_fusion_active(), which is what
+        # normally guarantees that a Delphes card is present: mirror what
+        # do_delphes does instead of crashing inside run_delphes_on_splits.
+        delphes_card = pjoin(self.me_dir, 'Cards', 'delphes_card.dat')
+        if not os.path.exists(delphes_card):
+            default_card = pjoin(self.me_dir, 'Cards', 'delphes_card_default.dat')
+            if not os.path.exists(default_card):
+                logger.warning('No delphes_card.dat (and no default one) found; '
+                               'cannot run Delphes on the Pythia8 splits.')
+                return False
+            files.cp(default_card, delphes_card)
+            logger.info('No delphes card found. Take the default one.')
+
         # Run the existing parallel-Delphes-on-splits implementation
         # directly (bypassing is_delphes_fusion_active, which requires an
         # explicit nb_core_delphes override — during interactive recovery
         # the user already confirmed they want to run Delphes by typing
         # the command, so that extra gate is not needed).
         #
-        # Drop any pre-existing final ROOT / log first so a fresh hadd
-        # merge is produced and crash leftovers don't silently get re-used.
-        final_root = pjoin(self.me_dir, 'Events', self.run_name,
-                           '%s_delphes_events.root' % tag)
-        final_log  = pjoin(self.me_dir, 'Events', self.run_name,
-                           '%s_delphes.log' % tag)
-        for stale in (final_root, final_log):
-            if os.path.isfile(stale):
-                try:
-                    os.remove(stale)
-                except OSError:
-                    pass
+        # Note: the final merged ROOT/log are deliberately *not* removed
+        # here. hadd is called with '-f' and the log is opened for writing,
+        # so both are recreated on success anyway, while deleting them up
+        # front would throw away a previously recovered (complete) result
+        # whenever this run fails. Recovery stays reachable for the whole
+        # life of the run directory (the merged HepMC is never recreated),
+        # so that would otherwise happen on every repeated 'delphes <run>'.
         ok = self.run_delphes_on_splits(split_dirs, parallelization_dir, tag)
         if not ok:
             return False


### PR DESCRIPTION
Before employing py8-delphes parallelization, the split hepmc files are merged first then handled to Delphes. When Delphes crashes during execution, the user attempts to re-run Delphes with (example output names):
```bash
launch ttz_4L -i
delphes run_01_01 --tag=run_01_01
```
The problem is: the standard Delphes command only searches for the merged HEPMC event file, which is not produced yet when parallel Delphes execution mode is ON, hence the command fails with the following error:
```bash
InvalidCmd : No events file corresponding to run_01_01 run with tag tag_1:
             /data/ttz_4L/Events/run_01_01/tag_1_pythia_events.hep.gz
```

### Solution / Fix

Two independent but complementary changes:

1. **Recovery path for the `delphes` standalone command** — when the merged HEPMC file cannot be found by `check_delphes`, instead of raising `InvalidCmd` immediately, first check if leftover `PY8_parallelization/split_*/events.hepmc` files exist for the current run. If they do, transparently call the **existing, already-tested `run_delphes_on_splits`** implementation (parallel `cluster.submit2` → `hadd` merge), which is exactly what the fused path would have run anyway. This lets the user recover with the exact same command: `delphes run_X --tag=Y`.

2. **Stale-output cleanup** — before every invocation of `run_delphes_on_splits` (used both by the normal fused path and by the new recovery path), unconditionally delete any pre-existing per-split `delphes_events.root` and `delphes.log`. Additionally, in the recovery path specifically, delete the pre-existing final merged `Events/<run>/<tag>_delphes_events.root` and `.log` so a previous crash's incomplete output doesn't confuse `hadd` or the user later.

Cleanup of the leftover `PY8_parallelization/` directory after successful recovery also **respects the original Pythia8 card's `HEPMCoutput:file` setting** exactly.

## Summary by Sourcery

Improve Delphes recovery and harden HEPTools cache management against incomplete or stale artifacts.

New Features:
- Add recovery support for running Delphes directly on leftover Pythia8 split HEPMC files after a parallel execution failure.

Bug Fixes:
- Prevent stale per-split and recovery outputs from being reused after crashed Delphes runs.
- Prevent incomplete HEPTools caches from being published or silently reused in CI.

Enhancements:
- Centralize HEPTools cache completeness checks across restoration and cache-warming workflows.
- Split Boost into its own cache and restore it as a dependency of eMELA.
- Improve cache assembly, validation, fallback behavior, and manual reset handling.

CI:
- Strengthen GitHub Actions HEPTools caching workflows with component-level validation and dependency-aware cache handling.