### PR TITLE
Do not inject vector.inc in NLO custom functions (bug #2147417)

### DIFF
--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -4,6 +4,9 @@ ANNOUNCEMENT:
    The 2.9.X LONG TERM STABLE version is now at end of life for bug fixing/support since December 2025.
    A new LTS (based on the current 3.5.X) is starting now and will act as the stable release for the coming years.
 
+3.8.0 (07/09/26):
+   OM: Bug fix custom files for cuts/scale/... were broken for NLO computation since 3.6.X
+
 3.7.3 (01/09/26):
     OM: MadSpin: the run_card me_frame and polbeam1/polbeam2 are now honoured by the
         density-based spinmodes (onshell/PA/madspin/full) and no longer only by the

--- a/UpdateNotes.txt
+++ b/UpdateNotes.txt
@@ -4,8 +4,8 @@ ANNOUNCEMENT:
    The 2.9.X LONG TERM STABLE version is now at end of life for bug fixing/support since December 2025.
    A new LTS (based on the current 3.5.X) is starting now and will act as the stable release for the coming years.
 
-3.8.0 (07/09/26):
-   OM: Bug fix custom files for cuts/scale/... were broken for NLO computation since 3.6.X
+3.8.0 (XX/XX/XX):
+   OM: Bug fix custom files for cuts/scale/... were broken for NLO computation since 3.6.0
 
 3.7.3 (01/09/26):
     OM: MadSpin: the run_card me_frame and polbeam1/polbeam2 are now honoured by the

--- a/madgraph/various/banner.py
+++ b/madgraph/various/banner.py
@@ -2827,6 +2827,10 @@ class RunCard(ConfigFile):
     default_autodef_file = 'run.inc'
     donewarning = []
     include_as_parameter = []
+    # list of the retro-compatibility fixes to apply on the user provided
+    # functions (see retro_compatible_custom_fct). Empty by default: each
+    # RunCard class opts-in for the fixes which make sense for its output.
+    retro_compatible_modes = []
 
     @classmethod
     def fill_post_set_from_blocks(cls):
@@ -3512,9 +3516,13 @@ class RunCard(ConfigFile):
             #avoid to systematically rewrite the file. -> write in tmp place
             fsock = file_writers.FortranWriter(pjoin(outdir, path+'.tmp'),'w')
             starttext = open(pjoin(outdir, path+'.orig')).read()
+            # only apply a retro-compatibility fix if the shipped version of the
+            # file does use the associated include itself. This prevents adding
+            # an include to a file where it is not available (and not needed).
+            mode = [m for m in self.retro_compatible_modes if m in starttext]
             fsock.remove_routine(starttext, to_mod[path][0])
             for text in to_mod[path][1]:
-                text = self.retro_compatible_custom_fct(text)
+                text = self.retro_compatible_custom_fct(text, mode=mode)
                 fsock.writelines(text)
             fsock.close()
             if not filecmp.cmp(pjoin(outdir, path), pjoin(outdir, path+'.tmp')):
@@ -3533,6 +3541,13 @@ class RunCard(ConfigFile):
 
     @staticmethod
     def retro_compatible_custom_fct(lines, mode=None):
+        """update a user provided routine (list of lines) to make it compatible
+           with the current version of the code.
+           mode is the list of fixes to apply, None means "all of them".
+           supported fixes:
+            - 'vector.inc': add the include of vector.inc (needed since 3.6 to
+              be able to include run.inc) if the routine does not have it.
+        """
 
         f77_type = ['real*8', 'integer', 'double precision', 'logical']
         function_pat = re.compile(r'^\s+(?:SUBROUTINE|(?:%(type)s)\s+function)\s+([a-zA-Z]\w*)' \
@@ -3540,9 +3555,9 @@ class RunCard(ConfigFile):
         include_pat = re.compile(r"\s+include\s+[\'\"]([\w\./]*)") 
         
         assert isinstance(lines, list)
-        sol = []
 
         if mode is None or 'vector.inc' in mode:
+            sol = []
             search = True
             for i,line in enumerate(lines[:]):
                 if search and re.search(include_pat, line):
@@ -3555,7 +3570,8 @@ class RunCard(ConfigFile):
                 sol.append(line)
                 if re.search(function_pat, line):
                     search = True
-        return sol
+            lines = sol
+        return lines
 
     def guess_entry_fromname(self, name, value):
         """
@@ -4339,6 +4355,10 @@ class RunCardLO(RunCard):
                       }
     
     include_as_parameter = ['vector.inc']
+    # since 3.6, run.inc dimensions arrays with VECSIZE_MEMMAX which is defined
+    # in vector.inc -> older (<3.6) user functions need that include to be added.
+    # This is meaningless for NLO where vector.inc does not exist at all.
+    retro_compatible_modes = ['vector.inc']
 
     if MG5DIR:
         default_run_card = pjoin(MG5DIR, "internal", "default_run_card_lo.dat")

--- a/tests/unit_tests/various/test_banner.py
+++ b/tests/unit_tests/various/test_banner.py
@@ -1084,6 +1084,88 @@ c
                 self.fail('InvalidRunCard should have been raised')
 
 
+    # the custom dynamical scale advertised in the FAQ (answers.launchpad.net/mg5amcnlo/+faq/3325)
+    custom_scale = """
+      double precision function user_dynamical_scale(P)
+      implicit none
+      include 'nexternal.inc'
+      double precision P(0:3, nexternal)
+      include 'run.inc'
+      character*80 temp_scale_id
+      common/ctemp_scale_id/temp_scale_id
+      double precision dot, pt
+      double precision xm2
+      xm2 = dot(P(0,3),P(0,3))
+      user_dynamical_scale = sqrt(xm2 + 0.5d0*(pt(P(0,3))**2 + pt(P(0,4))**2))
+      temp_scale_id = 'CHECKSCALE'
+      return
+      end
+        """
+
+    def test_custom_fcts_vector_inc_lo(self):
+        """a (pre 3.6) LO custom function including run.inc needs vector.inc to
+           be added since run.inc dimensions arrays with VECSIZE_MEMMAX"""
+
+        os.mkdir(pjoin(self.tmpdir,'SubProcesses'))
+        import madgraph.iolibs.files as files
+        files.cp(pjoin(MG5DIR,'Template','LO','SubProcesses','dummy_fct.f'), pjoin(self.tmpdir,'SubProcesses'))
+        open(pjoin(self.tmpdir, 'custom'),'w').write(self.custom_scale)
+
+        LO = bannermod.RunCardLO()
+        LO.edit_dummy_fct_from_file([pjoin(self.tmpdir, 'custom')], self.tmpdir)
+
+        new_text = open(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f')).read()
+        self.assertIn('CHECKSCALE', new_text)
+        fct = new_text[new_text.index('USER_DYNAMICAL_SCALE'):]
+        self.assertIn("INCLUDE 'vector.inc'", fct)
+        # and it has to be included *before* run.inc
+        self.assertLess(fct.index("INCLUDE 'vector.inc'"), fct.index("INCLUDE 'run.inc'"))
+
+    def test_custom_fcts_no_vector_inc_nlo(self):
+        """vector.inc does not exist in a NLO output (and run.inc does not need
+           it there): it must not be added to the user function.
+           see bug #2147417"""
+
+        os.mkdir(pjoin(self.tmpdir,'SubProcesses'))
+        import madgraph.iolibs.files as files
+        files.cp(pjoin(MG5DIR,'Template','NLO','SubProcesses','dummy_fct.f'), pjoin(self.tmpdir,'SubProcesses'))
+        open(pjoin(self.tmpdir, 'custom'),'w').write(self.custom_scale)
+
+        NLO = bannermod.RunCardNLO()
+        NLO.edit_dummy_fct_from_file([pjoin(self.tmpdir, 'custom')], self.tmpdir)
+
+        new_text = open(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f')).read()
+        # the function is correctly written ...
+        self.assertIn('CHECKSCALE', new_text)
+        self.assertIn('USER_DYNAMICAL_SCALE', new_text)
+        # ... but without any include of vector.inc (which does not exist at NLO)
+        self.assertNotIn('vector.inc', new_text.lower())
+
+        # cleaning still works
+        NLO.edit_dummy_fct_from_file([], self.tmpdir)
+        self.assertFalse(os.path.exists(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f.orig')))
+        new_text = open(pjoin(self.tmpdir,'SubProcesses','dummy_fct.f')).read()
+        self.assertNotIn('CHECKSCALE', new_text)
+
+    def test_retro_compatible_mode_selection(self):
+        """the guard on the shipped file: a fix is only applied if the original
+           file does use the corresponding include itself"""
+
+        # the static method itself is unchanged when explicitly asked for the fix
+        lines = ["      double precision function user_dynamical_scale(P)",
+                 "      implicit none",
+                 "      include 'run.inc'",
+                 "      end"]
+        self.assertIn("       include 'vector.inc'",
+                      bannermod.RunCard.retro_compatible_custom_fct(lines, mode=['vector.inc']))
+        # but an empty mode disables every fix
+        self.assertEqual(lines,
+                      bannermod.RunCard.retro_compatible_custom_fct(lines, mode=[]))
+
+        # LO opts-in for the vector.inc fix, NLO does not
+        self.assertIn('vector.inc', bannermod.RunCardLO.retro_compatible_modes)
+        self.assertNotIn('vector.inc', bannermod.RunCardNLO.retro_compatible_modes)
+
     def test_pdlabel_block(self):
         """ check that pdlabel handling is done correctly
             this include that check_validity works as expected for such parameter too """


### PR DESCRIPTION
Fixes [bug #2147417](https://bugs.launchpad.net/mg5amcnlo/+bug/2147417): a custom dynamical scale (or custom cuts) supplied through the run_card `custom_fcts` entry no longer compiles at NLO since 3.6.X.

## The problem

Since 3.6, LO's `run.inc` dimensions arrays with `VECSIZE_MEMMAX`, a `PARAMETER` defined in `Source/vector.inc`. `RunCard.retro_compatible_custom_fct()` therefore adds `include 'vector.inc'` in front of any `include 'run.inc'` it finds in a user routine, so that functions written for 3.5 keep compiling.

That method lives on the base `RunCard` class and was called unconditionally, so `RunCardNLO` inherited it too. But an (aMC@)NLO output:

- has **no `vector.inc` at all** (it is only written by the madevent exporter, `write_vector_size`);
- has a `run.inc` which does not use `VECSIZE_MEMMAX`;
- compiles `SubProcesses/` with only `-I. -I$(LIBDIR)`.

So the injected include breaks the compilation of `dummy_fct.f`:

```
dummy_fct.f:128:0:
  128 |       INCLUDE 'vector.inc'
Fatal Error: Cannot open included file 'vector.inc'
```

This affects every overridable NLO routine whose template body includes `run.inc` - `user_dynamical_scale` as reported, but also `dummy_cuts`, so custom NLO cuts are broken the same way.

## The fix

1. The retro-compatibility fixes to apply are now selected per RunCard class through a new `retro_compatible_modes` attribute: `[]` on the base class, `['vector.inc']` on `RunCardLO`. `RunCardNLO` inherits the empty list. This reuses the `mode` argument `retro_compatible_custom_fct()` already accepted but that nobody ever passed.

2. On top of that, `edit_dummy_fct_from_file()` only keeps a fix if the shipped (`.orig`) version of the file being edited does use the corresponding include itself, so a fix can never add an include which is not available in that output.

3. `retro_compatible_custom_fct()` used to build `sol = []` outside the `if mode ...` block and return it, so it returned an **empty list** when no fix was selected - silently dropping the whole user routine. It now returns its input unchanged in that case. (Latent before this PR, since `mode` was always `None`; the new unit test caught it.)

## Tests

Three new tests in `tests/unit_tests/various/test_banner.py`, all using the exact custom scale from [FAQ 3325](https://answers.launchpad.net/mg5amcnlo/+faq/3325):

- `test_custom_fcts_vector_inc_lo` - LO still gets `vector.inc`, and before `run.inc`;
- `test_custom_fcts_no_vector_inc_nlo` - NLO gets the function written correctly and no `vector.inc` anywhere; cleaning still restores the original;
- `test_retro_compatible_mode_selection` - the static method with an explicit / empty mode, and the per-class opt-in.

Checked end-to-end by running `edit_dummy_fct_from_file()` on both pristine `Template/{LO,NLO}/SubProcesses/dummy_fct.f` with the reporter's function.

Full unit suite: 1430 tests, the only 3 errors (`test_wj_loonly_gen`, `test_DensityMatrixObservables22`, `test_fks_ppzz_in_RS`) reproduce identically on pristine `3.8.0` and are unrelated.

## Notes

- Existing broken process directories self-heal: `dummy_fct.f` is rewritten from `dummy_fct.f.orig` on every card write, so users only need to re-run after upgrading.
- Workaround for users on a released 3.6.X/3.7.X: `touch SubProcesses/vector.inc` in the process directory (harmless, since NLO's `run.inc` never references `VECSIZE_MEMMAX`).
- The `UpdateNotes.txt` 3.8.0 date is left as `XX/XX/XX`, to be filled at release.
- Worth backporting to the 3.6/LTS line - the change applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix custom NLO routines so they compile without injecting the unavailable `vector.inc` include while retaining the required LO compatibility behavior.

Bug Fixes:
- Prevent NLO custom functions and cuts from receiving an unavailable `vector.inc` include, restoring compilation of custom NLO routines.
- Preserve user routines when no retro-compatibility fix is selected.

Enhancements:
- Select retro-compatibility fixes per run-card type and only apply them when the original template uses the associated include.

Documentation:
- Document the NLO custom-function compatibility fix in the update notes.

Tests:
- Add coverage for LO vector include injection, NLO exclusion, and retro-compatibility mode selection.
