### PR TITLE
[3.5.x] Do not apply the beam polarization twice (bug #2148181)

### DIFF
--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -4633,10 +4633,12 @@ class ProcessExporterFortranME(ProcessExporterFortran):
         if self.beam_polarization == [True, True]:
             replace_dict['beam_polarization'] = """
                          DO JJ=1,nincoming
+c NB_SPIN_STATE_IN/2 avoids a double counting
+c of an explicit polarisation in the process
                IF(POL(JJ).NE.1d0.AND.NHEL(JJ,I).EQ.INT(SIGN(1d0,POL(JJ)))) THEN
-                 T=T*ABS(POL(JJ))
+                 T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
                ELSE IF(POL(JJ).NE.1d0)THEN
-                 T=T*(2d0-ABS(POL(JJ)))
+                 T=T*(2d0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2d0
                ENDIF
              ENDDO
             """
@@ -4646,10 +4648,12 @@ class ProcessExporterFortranME(ProcessExporterFortran):
                 if self.beam_polarization[i]:
                     replace_dict['beam_polarization'] = """
                                    ! handling only one beam polarization here. Second beam can be handle via the pdf.
+c NB_SPIN_STATE_IN/2 avoids a double counting
+c of an explicit polarisation in the process
                                    IF(POL(%(bid)i).NE.1d0.AND.NHEL(%(bid)i,I).EQ.INT(SIGN(1d0,POL(%(bid)i)))) THEN
-                 T=T*ABS(POL(%(bid)i))
+                 T=T*ABS(POL(%(bid)i))*NB_SPIN_STATE_IN(%(bid)i)/2d0
                ELSE IF(POL(%(bid)i).NE.1d0)THEN
-                 T=T*(2d0-ABS(POL(%(bid)i)))
+                 T=T*(2d0-ABS(POL(%(bid)i)))*NB_SPIN_STATE_IN(%(bid)i)/2d0
                ENDIF """ % {'bid': i+1}
 
 

--- a/madgraph/iolibs/template_files/matrix_loop_induced_madevent.inc
+++ b/madgraph/iolibs/template_files/matrix_loop_induced_madevent.inc
@@ -100,6 +100,10 @@ C
     REAL*8 POL(2)
     COMMON/TO_POLARIZATION/ POL
 
+    INTEGER NB_SPIN_STATE_IN(2)
+    DATA  NB_SPIN_STATE_IN /%(nb_spin_state1)i,%(nb_spin_state2)i/
+    COMMON /NB_HEL_STATE/ NB_SPIN_STATE_IN
+
     logical read_grid_file
     common/read_grid_file/read_grid_file
 
@@ -205,10 +209,12 @@ C Of course this option can also not be used for polarized beams.
                 ENDDO
 
 				DO JJ=1,nincoming
+c NB_SPIN_STATE_IN/2 avoids a double counting
+c of an explicit polarisation in the process
                	     IF(POL(JJ).NE.1d0.AND.NHEL(JJ,I).EQ.INT(SIGN(1d0,POL(JJ)))) THEN
-                         T=T*ABS(POL(JJ))
+                         T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
                      ELSE IF(POL(JJ).NE.1d0)THEN
-                         T=T*(2d0-ABS(POL(JJ)))
+                         T=T*(2d0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2d0
                      ENDIF
                   ENDDO
 			      IF (ISUM_HEL.NE.0) then
@@ -267,9 +273,9 @@ C           The helicity configuration was chosen already by genps and put in a 
 
 		     DO JJ=1,nincoming
                 IF(POL(JJ).NE.1d0.AND.NHEL(JJ,I).EQ.INT(SIGN(1d0,POL(JJ)))) THEN
-                  T=T*ABS(POL(JJ))
+                  T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
                 ELSE IF(POL(JJ).NE.1d0)THEN
-                  T=T*(2d0-ABS(POL(JJ)))
+                  T=T*(2d0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2d0
                 ENDIF
              ENDDO
 

--- a/madgraph/iolibs/template_files/matrix_loop_induced_madevent_group.inc
+++ b/madgraph/iolibs/template_files/matrix_loop_induced_madevent_group.inc
@@ -106,6 +106,9 @@ C
  
     REAL*8 POL(2)
     COMMON/TO_POLARIZATION/ POL
+
+    INTEGER NB_SPIN_STATE_IN(2)
+    COMMON /NB_HEL_STATE/ NB_SPIN_STATE_IN
     
     INTEGER          ISUM_HEL
     LOGICAL                    MULTI_CHANNEL
@@ -216,10 +219,12 @@ C Of course this option can also not be used for polarized beams.
             ENDDO
 
 			DO JJ=1,nincoming
+c NB_SPIN_STATE_IN/2 avoids a double counting
+c of an explicit polarisation in the process
                IF(POL(JJ).NE.1d0.AND.NHEL(JJ,I).EQ.INT(SIGN(1d0,POL(JJ)))) THEN
-                  T=T*ABS(POL(JJ))
+                  T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
                ELSE IF(POL(JJ).NE.1d0)THEN
-                  T=T*(2d0-ABS(POL(JJ)))
+                  T=T*(2d0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2d0
                ENDIF
             ENDDO
 			IF (ISUM_HEL.NE.0.and.DS_get_dim_status('Helicity').eq.0.and.ALLOW_HELICITY_GRID_ENTRIES) then
@@ -281,9 +286,9 @@ C           The helicity configuration was chosen already by genps and put in a 
 
 			DO JJ=1,nincoming
               IF(POL(JJ).NE.1d0.AND.NHEL(JJ,I).EQ.INT(SIGN(1d0,POL(JJ)))) THEN
-                T=T*ABS(POL(JJ))
+                T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
               ELSE IF(POL(JJ).NE.1d0)THEN
-                T=T*(2d0-ABS(POL(JJ)))
+                T=T*(2d0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2d0
               ENDIF
             ENDDO
 

--- a/madgraph/iolibs/template_files/matrix_madevent_v4.inc
+++ b/madgraph/iolibs/template_files/matrix_madevent_v4.inc
@@ -37,9 +37,9 @@ c
     LOGICAL GOODHEL(NCOMB)
     INTEGER NTRY
     common/BLOCK_GOODHEL/NTRY,GOODHEL
-    integer nb_spin_state(2)
-    data  nb_spin_state /%(nb_spin_state1)i,%(nb_spin_state2)i/
-    common /nb_hel_state/ nb_spin_state
+    integer nb_spin_state_in(2)
+    data  nb_spin_state_in /%(nb_spin_state1)i,%(nb_spin_state2)i/
+    common /nb_hel_state/ nb_spin_state_in
 C  
 C LOCAL VARIABLES 
 C  

--- a/madgraph/loop/loop_exporters.py
+++ b/madgraph/loop/loop_exporters.py
@@ -3150,6 +3150,13 @@ class LoopInducedExporterME(LoopProcessOptimizedExporterFortranSA):
         replace_dict['beamone_helavgfactor'], replace_dict['beamtwo_helavgfactor'] =\
                                        matrix_element.get_beams_hel_avg_factor()
 
+        # number of helicity states actually kept for each beam (can be reduced
+        # by an explicit polarisation in the process definition). Used to avoid
+        # applying the beam polarisation of the run_card on top of it.
+        s1, s2 = matrix_element.get_spin_state_initial()
+        replace_dict['nb_spin_state1'] = s1
+        replace_dict['nb_spin_state2'] = s2
+
         # Extract helicity lines
         helicity_lines = self.get_helicity_lines(matrix_element)
         replace_dict['helicity_lines'] = helicity_lines

--- a/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_group/matrix1.f
+++ b/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_group/matrix1.f
@@ -168,11 +168,13 @@ C     ----------
             T=MATRIX1(P ,NHEL(1,I),JC(1),I)
 
             DO JJ=1,NINCOMING
+C             NB_SPIN_STATE_IN/2 avoids a double counting
+C             of an explicit polarisation in the process
               IF(POL(JJ).NE.1D0.AND.NHEL(JJ,I).EQ.INT(SIGN(1D0,POL(JJ))
      $         )) THEN
-                T=T*ABS(POL(JJ))
+                T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2D0
               ELSE IF(POL(JJ).NE.1D0)THEN
-                T=T*(2D0-ABS(POL(JJ)))
+                T=T*(2D0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2D0
               ENDIF
             ENDDO
 
@@ -233,11 +235,13 @@ C        in a common block defined in genps.inc.
 
 
         DO JJ=1,NINCOMING
+C         NB_SPIN_STATE_IN/2 avoids a double counting
+C         of an explicit polarisation in the process
           IF(POL(JJ).NE.1D0.AND.NHEL(JJ,I).EQ.INT(SIGN(1D0,POL(JJ))))
      $      THEN
-            T=T*ABS(POL(JJ))
+            T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2D0
           ELSE IF(POL(JJ).NE.1D0)THEN
-            T=T*(2D0-ABS(POL(JJ)))
+            T=T*(2D0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2D0
           ENDIF
         ENDDO
 

--- a/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_nogroup/matrix.f
+++ b/tests/input_files/IOTestsComparison/IOExportV4IOTest/export_matrix_element_v4_madevent_nogroup/matrix.f
@@ -39,9 +39,9 @@ C
       LOGICAL GOODHEL(NCOMB)
       INTEGER NTRY
       COMMON/BLOCK_GOODHEL/NTRY,GOODHEL
-      INTEGER NB_SPIN_STATE(2)
-      DATA  NB_SPIN_STATE /2,2/
-      COMMON /NB_HEL_STATE/ NB_SPIN_STATE
+      INTEGER NB_SPIN_STATE_IN(2)
+      DATA  NB_SPIN_STATE_IN /2,2/
+      COMMON /NB_HEL_STATE/ NB_SPIN_STATE_IN
 C     
 C     LOCAL VARIABLES 
 C     
@@ -124,11 +124,13 @@ C     ----------
             T=MATRIX(P ,NHEL(1,I),JC(1))
 
             DO JJ=1,NINCOMING
+C             NB_SPIN_STATE_IN/2 avoids a double counting
+C             of an explicit polarisation in the process
               IF(POL(JJ).NE.1D0.AND.NHEL(JJ,I).EQ.INT(SIGN(1D0,POL(JJ))
      $         )) THEN
-                T=T*ABS(POL(JJ))
+                T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2D0
               ELSE IF(POL(JJ).NE.1D0)THEN
-                T=T*(2D0-ABS(POL(JJ)))
+                T=T*(2D0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2D0
               ENDIF
             ENDDO
 
@@ -179,11 +181,13 @@ C        in a common block defined in genps.inc.
         T=MATRIX(P ,NHEL(1,I),JC(1))
 
         DO JJ=1,NINCOMING
+C         NB_SPIN_STATE_IN/2 avoids a double counting
+C         of an explicit polarisation in the process
           IF(POL(JJ).NE.1D0.AND.NHEL(JJ,I).EQ.INT(SIGN(1D0,POL(JJ))))
      $      THEN
-            T=T*ABS(POL(JJ))
+            T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2D0
           ELSE IF(POL(JJ).NE.1D0)THEN
-            T=T*(2D0-ABS(POL(JJ)))
+            T=T*(2D0-ABS(POL(JJ)))*NB_SPIN_STATE_IN(JJ)/2D0
           ENDIF
         ENDDO
 


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/mg5amcnlo/+bug/2148181 (reported by Richard Ruiz).

## The bug

`ve{L} d > e- u` gives exactly twice the cross section of `ve d > e- u`.

Reproduced on `3.5.17` (`eb1eecb03`):

| process | run_card `polbeam1` | cross section |
|---|---|---|
| `ve d > e- u`    | -100 (auto) | 93.22 +- 0.78 pb |
| `ve{L} d > e- u` | -100 (auto) | 186.4 +- 1.56 pb |

## Cause

Two independent mechanisms select the left-handed neutrino, and both were applied:

* the process definition `ve{L}` reduces the spin-averaging denominator, `get_denominator_factor()` in `madgraph/core/helas_objects.py` uses `len(leg.get('polarization'))` instead of the number of helicity states. `IDEN` goes from 12 to 6 and `NCOMB` from 16 to 8;
* `RunCard.create_default_for_process()` automatically sets `polbeam1 = -100` for a neutrino beam, and the generated `matrix<i>.f` reweights each helicity by `POL(JJ)`, which is `+-2` for a 100% polarized beam.

Hence the extra factor 2.

## Fix

`POL(JJ)` is really `2 x (fraction of the beam in that helicity)`; the `2` is there to undo the `1/2` of the initial-state spin average. When the process definition already restricts that beam to a single helicity state, there is no `1/2` left to undo, so the reweighting has to be rescaled by `NB_SPIN_STATE_IN(JJ)/2`:

```fortran
T=T*ABS(POL(JJ))*NB_SPIN_STATE_IN(JJ)/2d0
```

This normalization was already present in the helicity-recycling template (`matrix_madevent_group_v4_hel.inc`, introduced in 05946d470) but had never been propagated to the other madevent templates. This PR applies it to:

* the grouped and non-grouped madevent output (`beam_polarization` snippet in `export_v4.py`, both the two-beam and the single-beam variant);
* `matrix_loop_induced_madevent.inc` and `matrix_loop_induced_madevent_group.inc`, which hardcode the same block. The non-grouped loop-induced template now declares the common block itself, filled from the new `nb_spin_state1/2` entries of the loop-induced `replace_dict`.

`matrix_madevent_v4.inc` renames its common-block variable `nb_spin_state` to `nb_spin_state_in` (the name the grouped template already uses), so that the shared code snippet compiles in both.

Rather than forbidding the combination, this keeps `polbeam` meaningful and composable: for a partially polarized beam the weight becomes the actual helicity fraction instead of twice it.

## Validation

Full `generate_events` runs, same run_card in each pair:

| process | `polbeam1` | before | after |
|---|---|---|---|
| `ve d > e- u`      | -100 | 93.22 +- 0.78 pb | 93.22 +- 0.78 pb |
| `ve{L} d > e- u`   | -100 | **186.4 +- 1.56 pb** | **93.22 +- 0.78 pb** |
| `e- e+ > mu+ mu-`      | -100 | | 0.1145 +- 0.0002 pb |
| `e-{L} e+ > mu+ mu-`   | -100 | | 0.1145 +- 0.0002 pb |
| `e- e+ > mu+ mu-` (no group)    | -100 | | 0.1139 +- 0.0002 pb |
| `e-{L} e+ > mu+ mu-` (no group) | -100 | | 0.1139 +- 0.0002 pb |

Unpolarized processes are untouched: `NB_SPIN_STATE_IN = 2` gives a factor 1.

Also checked:

* `generate g g > h [noborn=QCD]` output, grouped and non-grouped, `make matrix1.o` / `make matrix.o` compile clean;
* subprocess grouping keeps polarized and unpolarized processes in separate `P*` directories (`generate ve d > e- u` + `add process ve{L} s > e- c` gives `P1` with `NB_SPIN_STATE /2,2/` and `P2` with `/1,2/`), so the per-directory common block is always consistent;
* the two `IOExportV4IOTest` madevent reference files are updated;
* `tests/test_manager.py -p tests/unit_tests`: 665 tests, the only failures are the pre-existing python 3.14 signed-zero `JAMP` mismatches and the unrelated `test_usermod` import error, all present before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent beam polarization from being double-counted when process definitions restrict incoming helicity states.

Bug Fixes:
- Correct beam-polarization normalization so explicitly polarized process definitions no longer receive the beam polarization factor twice.
- Preserve correct cross sections for unpolarized and partially polarized beams across grouped, non-grouped, and loop-induced generated processes.

Enhancements:
- Propagate the number of retained initial-state helicity states through loop-induced exports and standardize the shared helicity-state common-block name.

Tests:
- Update madevent reference outputs to reflect the corrected polarization normalization.