### PR TITLE
MadSpin: evaluate the density denominator in the me_frame

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -9050,6 +9050,35 @@ class MadSpinInterface(extended_cmd.Cmd):
         parents = {slot: finals[slot_to_index[slot]] for slot in order}
         return rho_off, jac_reshuffle, slot_mass, parents, frame_boost
 
+    def _onshell_production_norm(self, production, prod_static):
+        """|M_prod|^2 on shell, in the frame the density modes quantise in.
+
+        The denominator of the offshell mass-set weight (sequential) and of the
+        joint weight. Without a frame boost this is exactly
+        ``calculate_matrix_element`` -- same value, same normalisation -- so
+        nothing changes there. With one (a polarisation brace, polarised beams,
+        a polarisation-weight request, the pure-interference mode) the
+        *restricted* matrix element is not Lorentz invariant and the lab-frame
+        value is a different projection from the one the numerator is built
+        from, so the trace of the on-shell rho *in that frame* is taken instead.
+
+        Evaluated on a round-tripped copy, like ``_upfront_production``'s
+        ``prod_off``, so the two sides of the ratio see the same %.10e
+        truncation.
+        """
+        frame_boost = self._frame_boost(production)
+        if frame_boost is None:
+            return self.calculate_matrix_element(production)
+        prod_on = lhe_parser.Event(str(production))
+        rho_on = self.get_density(prod_on, prod_static['position'],
+                                  prod_static['allowed_hel'],
+                                  prod_static['ncomb'],
+                                  prod_static['dimension'],
+                                  frame_boost=self._frame_boost(prod_on),
+                                  hel_restriction=prod_static.get('hel_restriction'),
+                                  hel_restriction_trace=prod_static.get('hel_restriction_trace'))
+        return rho_on.trace().real
+
     def _sequential_offshell(self):
         """Whether the sequential accept/reject runs its offshell (madspin/full)
         branch: the production density is evaluated at reshuffled momenta, so the
@@ -9741,7 +9770,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         if offshell:
             me_prod_on = getattr(production, 'me_wgt', None)
             if not me_prod_on:
-                me_prod_on = self.calculate_matrix_element(production)
+                # The denominator has to be the same quantity as the numerator,
+                # in the same frame: Tr(rho_off) is built in the me_frame while
+                # calculate_matrix_element hands the matrix element the LAB
+                # momenta, and a helicity-restricted matrix element is not
+                # Lorentz invariant.  Unpolarised runs have no frame boost and
+                # keep the matrix-element call, bit for bit.
+                me_prod_on = self._onshell_production_norm(production,
+                                                           prod_static)
                 production.me_wgt = me_prod_on
             if not me_prod_on:
                 # a production event with no matrix element cannot be normalised
@@ -10686,7 +10722,12 @@ class MadSpinInterface(extended_cmd.Cmd):
             if not density_pole_approximation:
                 # compute the denominator and then reshuffle the event before 
                 # computing the numerator 
-                MEdenom_prod = self.calculate_matrix_element(production)  
+                # same frame-consistency fix as on the sequential mass
+                # stage: the numerator is the contraction of the (possibly
+                # restricted) production density built in the me_frame, so the
+                # denominator cannot be the lab-frame matrix element.
+                MEdenom_prod = self._onshell_production_norm(production,
+                                                             prod_static)
                 MEdenom_decay = 1.0              
                 for key in decays:
                     for dec in decays[key]:

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -129,7 +129,12 @@ def _borrow_frame_helpers(namespace):
     """
     for name in ('_beampol', '_frame_boost', '_needs_frame_axis',
                  '_polarization_weight_labels',
-                 '_polarization_weights_enabled'):
+                 '_polarization_weights_enabled',
+                 # the density denominator is taken in the same frame as the
+                 # numerator, so it is guarded by _frame_boost too: with no
+                 # boost it is exactly calculate_matrix_element, which is what
+                 # every stub here provides
+                 '_onshell_production_norm'):
         namespace[name] = inspect.getattr_static(
             interface_madspin.MadSpinInterface, name)
     namespace['InvalidCmd'] = interface_madspin.MadSpinInterface.InvalidCmd
@@ -678,6 +683,164 @@ class TestFrameBoost(unittest.TestCase):
         self.assertEqual((boost.E, boost.px, boost.py, boost.pz),
                          (500., 0., 0., 0.))
         self.assertEqual(stub._boost_momenta(momenta, boost), momenta)
+
+
+class TestOnshellProductionNorm(unittest.TestCase):
+    """``_onshell_production_norm``: |M_prod|^2 on shell, which is the
+    denominator of the offshell mass-set weight (the sequential accept/reject's
+    mass stage) and of the joint density weight.
+
+    The numerator on both paths is a contraction of the production density,
+    and the density modes build that in the ``me_frame``. So as soon as a
+    helicity index is *projected* -- a production brace, polarised beams, a
+    polarisation-weight request, the pure-interference mode -- the denominator
+    cannot be ``calculate_matrix_element``, which hands the matrix element the
+    LAB momenta: a restricted matrix element is not Lorentz invariant, and the
+    two sides of the ratio would then be different projections. The guard is
+    ``_frame_boost``, the same one the numerator goes through, so an
+    unpolarised run has no boost and keeps the matrix-element call bit for bit.
+    """
+
+    # what the density basis carries; only forwarded, never interpreted here
+    STATIC = {'position': [1, 2], 'allowed_hel': [], 'ncomb': 4,
+              'dimension': 4, 'hel_restriction': 'restrict',
+              'hel_restriction_trace': 'trace'}
+
+    ME = 7.0            # what calculate_matrix_element answers ...
+    TRACE = 11.0        # ... and what Tr(rho_on) does, so the two never alias
+
+    class _Rho(object):
+        """The one thing the norm asks a density for. The imaginary part is
+        non-zero on purpose: the trace of a hermitian rho is real, but the
+        stubbed value is not, and taking .real is what the shipped code does."""
+        def __init__(self, value):
+            self.value = value
+        def trace(self):
+            return complex(self.value, 3.0)
+
+    def _stub(self, frame_id=6, **frame):
+        """_FrameStub -- which already carries the frame helpers and the norm --
+        plus the two calls the norm can end on, each counted."""
+        outer = self
+        frame.setdefault('beampol', (0., 0.))
+
+        class Stub(_FrameStub):
+            def __init__(self):
+                _FrameStub.__init__(self, frame_id, **frame)
+                self.me_calls = []
+                self.density_calls = []
+
+            def get_pdir(self, event):
+                # 2 -> 2 in the matrix element's own ordering, which is what
+                # _rambo_event writes out
+                return None, ([21, 21], [6, -6]), None, None, None
+
+            def calculate_matrix_element(self, event):
+                self.me_calls.append(event)
+                return outer.ME
+
+            def get_density(self, event, position, allow_hel, ncomb, dimension,
+                            **opts):
+                self.density_calls.append((event, position, allow_hel, ncomb,
+                                           dimension, opts))
+                return outer._Rho(outer.TRACE)
+
+        return Stub()
+
+    def _production(self):
+        """A genuine LHE event, boosted off the partonic CM so that the frame
+        is something other than the lab and the %.10e round trip below is
+        actually visible."""
+        return _rambo_event(2, 800.0, [173.0, 173.0], random.Random(7),
+                            boost=0.4)
+
+    def test_unpolarised_stays_the_matrix_element(self):
+        """No projection, no boost, and then the denominator is the matrix
+        element it always was -- same call, same event object, same value. This
+        is the claim that the change is inert for every unpolarised run."""
+        stub, production = self._stub(), self._production()
+        self.assertIsNone(stub._frame_boost(production))
+        self.assertEqual(stub._onshell_production_norm(production, self.STATIC),
+                         self.ME)
+        self.assertEqual(len(stub.me_calls), 1)
+        self.assertIs(stub.me_calls[0], production)
+        self.assertEqual(stub.density_calls, [])
+
+    def test_a_projection_takes_the_trace_of_rho_instead(self):
+        """With a production brace the answer is Tr(rho_on) taken in the frame,
+        and the lab-frame matrix element is not consulted at all."""
+        stub = self._stub(prodpol={6: (0,)})
+        production = self._production()
+        self.assertEqual(stub._onshell_production_norm(production, self.STATIC),
+                         self.TRACE)
+        self.assertEqual(stub.me_calls, [])
+        self.assertEqual(len(stub.density_calls), 1)
+        _, position, allow_hel, ncomb, dimension, opts = stub.density_calls[0]
+        self.assertEqual((position, allow_hel, ncomb, dimension),
+                         (self.STATIC['position'], self.STATIC['allowed_hel'],
+                          self.STATIC['ncomb'], self.STATIC['dimension']))
+        # the restriction is what makes the frame observable in the first
+        # place; forwarding the basis but dropping it would put the trace of
+        # the *unrestricted* rho under a restricted numerator
+        self.assertEqual(opts['hel_restriction'],
+                         self.STATIC['hel_restriction'])
+        self.assertEqual(opts['hel_restriction_trace'],
+                         self.STATIC['hel_restriction_trace'])
+        self.assertIsNotNone(opts['frame_boost'])
+
+    def test_the_guard_is_frame_boost(self):
+        """Which branch is taken follows ``_frame_boost`` and nothing else, for
+        each of the four things that switch the frame on. Pinned together so
+        the denominator cannot drift away from the numerator, which goes
+        through the same guard."""
+        for kwargs in (dict(),
+                       dict(beampol=(80., 0.)),
+                       dict(prodpol={6: (0,)}),
+                       dict(vector=['0']),
+                       dict(fermion=['+']),
+                       dict(pure_interference='w+ = 0 T')):
+            stub, production = self._stub(**kwargs), self._production()
+            boosted = stub._frame_boost(production) is not None
+            self.assertEqual(bool(kwargs), boosted, kwargs)
+            got = stub._onshell_production_norm(production, self.STATIC)
+            self.assertEqual(got, self.TRACE if boosted else self.ME, kwargs)
+            self.assertEqual(bool(stub.density_calls), boosted, kwargs)
+            self.assertEqual(bool(stub.me_calls), not boosted, kwargs)
+
+    def test_the_density_runs_on_the_round_tripped_copy(self):
+        """rho_on is taken on ``Event(str(production))``, like
+        ``_upfront_production``'s ``prod_off``, so both sides of the ratio see
+        the same %.10e truncation -- and the frame is re-derived from that copy
+        rather than carried over from the original.
+
+        The re-derivation is not cosmetic. ``frame_id`` selecting a single leg
+        stores that leg's momentum in ``rest_leg_mom``, and it is later matched
+        with ``==`` on floats (``_decay_frame_rest_leg``), so a boost built from
+        the untruncated original would silently stop matching and leave the leg
+        off the branch that forces it exactly to rest.
+        """
+        stub = self._stub(frame_id=8, prodpol={6: (0,)})   # leg 3 alone
+        production = self._production()
+        stub._onshell_production_norm(production, self.STATIC)
+        event, _, _, _, _, opts = stub.density_calls[0]
+        self.assertIsNot(event, production)
+        self.assertEqual(str(event), str(lhe_parser.Event(str(production))))
+
+        rest = opts['frame_boost'].rest_leg_mom
+        copied = [p for p in event if int(p.status) == 1][0]
+        self.assertEqual(rest, (copied.E, copied.px, copied.py, copied.pz))
+        original = [p for p in production if int(p.status) == 1][0]
+        self.assertNotEqual(rest, (original.E, original.px, original.py,
+                                   original.pz))
+
+    def test_the_production_event_is_left_alone(self):
+        """The norm is called on an event the caller goes on to reshuffle, so
+        it may not touch it: the copy is what gets handed to get_density."""
+        stub = self._stub(prodpol={6: (0,)})
+        production = self._production()
+        before = str(production)
+        stub._onshell_production_norm(production, self.STATIC)
+        self.assertEqual(str(production), before)
 
 
 class TestEvent(unittest.TestCase):


### PR DESCRIPTION
## The symptom

A polarised LO run with the **stock cards** decays no events at all:

```
generate p p > z{0} z{0}
output; launch          # default run_card (me_frame = 1, 2), MadSpin: set spinmode madspin
```

| `p p > z{0} z{0}`, 2000 events | 3.8.0 today | with this PR |
|---|---|---|
| sequential maximum weight | **9.477e+06** | **5.145** |
| decay stage | **0 events after 19 min on 18 cores** | **2000/2000 in 1.81 s** |

No user action arms it. The default partonic-CM frame is itself a large boost in the lab at 13 TeV (median beta = 0.93 over the sample), and for a 2 -> 2 production `me_frame = 1 2` and `3 4` are the same boost.

## The cause

The offshell mass-set weight is `Tr(rho_off) / |M_prod|^2`. The numerator is built in the `me_frame`; the denominator came from `calculate_matrix_element`, which hands the matrix element the **lab** momenta. A helicity-restricted matrix element is not Lorentz invariant, so the two sides are different projections.

For an unpolarised production the trace is invariant under the basis change a boost induces, and the two agree - which is why **only polarised runs are affected**.

Measured over 138 production events: the lab-frame restricted `|M|^2` spans 4.2e9 while the `me_frame` trace spans 4.2e2; the ratio has median 453 and max 3.5e9, and Spearman(beta, ratio) = 0.93. A handful of events with a near-vanishing lab projection set the global bound, after which every ordinary event accepts at ~1e-6.

`{0}` on a massive vector is the pathological case, because eps_L ~ p/m makes the lab projection collapse.

## The fix

`_onshell_production_norm` returns `calculate_matrix_element` **unchanged when there is no frame boost**, and otherwise the trace of the on-shell rho in the same frame with the same restriction. Applied at both density call sites: the sequential mass stage and the joint weight.

## Why this is new in 3.8.0

In 3.7.3, `spinmode = madspin` was the fortran v1 driver: `frame_id` is passed *into* `driver.f`, which boosts the whole event once, so numerator and denominator share a frame by construction. That file has no `get_density` at all. 3.8.0 makes the density path the default (the legacy driver becoming `madspin_v1`), so **existing polarised cards move onto the broken path silently**.

The symptom was seen during development and read as a property of the joint scheme - `_auto_unweighting_mode` has a docstring recording `t{+}t~{+}` at 112-6300 trials/event under `joint` against 8-9 under `sequential`. That is this bug, on a fermion helicity where `sequential` happened to survive it.

## Validation

- **Unpolarised regression: none.** A plain `p p > z z` + MadSpin run decays **byte-identically** with and without the patch (`_frame_boost` is None, so the matrix-element call is kept bit for bit). With polarisation weights on an unpolarised production - where the boost *is* active - the decayed LHE differs in one event weight in the 8th digit out of 2000, the same quantity through a different entry point.
- **Unpolarised trace is invariant as it must be**: ratio 1.0000 on all 12750 evaluations with beta up to 0.999.
- **Closure**: the fixed sample gives `f0 = 2 - 5<cos^2 theta*> = 1.010 +- 0.017` against 1.0 for a pure-longitudinal production.

## Note for the release

`_auto_unweighting_mode` routes polarised productions to `sequential` on numbers measured with the broken denominator. That rule should be re-derived before release - with the fix, `joint` is no longer catastrophic and is competitive per trial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct MadSpin production-weight normalization for polarized decays by matching the denominator to the density numerator’s reference frame.

Bug Fixes:
- Fix MadSpin polarized production weights by evaluating the on-shell production denominator in the same frame as the production density numerator.
- Preserve existing matrix-element normalization behavior for runs without a frame boost.

Enhancements:
- Apply frame-consistent production normalization to both sequential mass weighting and joint density weighting.
- Use round-tripped production events and forward helicity restrictions when constructing the on-shell density trace.

Tests:
- Add unit coverage for unpolarized and polarized normalization paths, frame selection, event round-tripping, restriction forwarding, and input-event immutability.

## Tests

CI caught that factoring the denominator out into `_onshell_production_norm` broke `TestPAUpFrontMass.test_the_offshell_spinmodes_never_ask_for_a_per_event_bound`. That is the test-file's own borrow guard doing its job: the stubs borrow individual methods off `MadSpinInterface`, and the one that drives the offshell branch was standing in for the denominator by patching `calculate_matrix_element`, which the code no longer calls. The new method is now borrowed through `_borrow_frame_helpers` — its guard *is* `_frame_boost`, which that helper already provides, and with no boost it is exactly the matrix-element call the fixture was replacing, so the fixture keeps testing what it did before.

The branch this PR actually introduces had no coverage, so `TestOnshellProductionNorm` was added for it:

- an unpolarised run keeps the matrix-element call, on the very same event object, and never touches `get_density` — the bit-for-bit claim above, pinned;
- each of the four projections (`beampol`, a production brace, a polarisation-weight request, `pure_interference`) switches it to `Tr(rho_on)` instead, and the branch taken follows `_frame_boost` and nothing else, so the denominator cannot drift away from the numerator;
- the density basis *and* the helicity restriction are forwarded — forwarding the basis alone would put the trace of the unrestricted rho under a restricted numerator;
- `rho_on` is taken on the `%.10e` round trip, like `_upfront_production`'s `prod_off`, with the frame re-derived from *that* copy: `rest_leg_mom` is later matched with `==` on floats in `_decay_frame_rest_leg`, so a boost built from the untruncated original would silently stop matching.

Each of those was mutation-checked against the shipped code. `./tests/test_manager.py test_madspin test_lhe_parser -t0` (the CI job) is green at 566 tests.
