### PR TITLE
MadSpin: key the joint decay symmetry factor on the channel, not the drawn final state

### DIFF
--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -1669,6 +1669,51 @@ class MadSpinInterface(extended_cmd.Cmd):
             out //= math.factorial(repeat)
         return out
 
+    @staticmethod
+    def _decay_symmetry_factor(decays):
+        """The decay symmetry factor of the joint weight's denominator:
+        ``prod_groups prod_k n_k! / N!`` over the parent pdgs whose N identical
+        parents were *dealt* their decay channels, n_k counting the dealt
+        channels.
+
+        It is the reciprocal of :meth:`_assignment_multiplicity`, and it is
+        there for the same reason: a positional deal (``_draw_one_decay``'s
+        middle rule, which fires when the card gives a pdg exactly as many
+        channels as the event has identical parents) generates ONE of the
+        ``N!/prod_k n_k!`` assignments, so the rate owes their number. The same
+        multiplicity is what the branching ratio multiplies in for
+        ``kind == 'mult_split'``.
+
+        It must be keyed on the CHANNEL, and only on a dealt one. When the N
+        parents instead draw independently from one pool -- a single merged
+        decay line, ``define lp = e+ mu+`` / ``decay z > lp lm``, which is
+        ``kind == 'mult_cumul'`` and whose branching ratio carries no
+        multiplicity factor either -- the draw already samples every
+        assignment and there is nothing to compensate. Keying it on the drawn
+        *final state*, as it used to be, cannot tell the two apart: it doubled
+        the weight of every trial whose two Z decayed to different flavours and
+        gave ``p p > z z`` an e+e-mu+mu- : 4e : 4mu composition of 4:1:1 in
+        place of 2:1:1.
+
+        A decay event that did not come from ``_draw_one_decay`` carries no
+        tag; untagged means "not dealt", which leaves the factor at 1.
+        """
+        out = 1.0
+        for decay_event_list in decays.values():
+            nb = len(decay_event_list)
+            if nb < 2:
+                continue
+            if not all(getattr(evt, 'ms_positional', False)
+                       for evt in decay_event_list):
+                continue
+            counts = collections.Counter(getattr(evt, 'ms_channel', None)
+                                         for evt in decay_event_list)
+            sym = 1
+            for repeat in counts.values():
+                sym *= math.factorial(repeat)
+            out *= sym / float(math.factorial(nb))
+        return out
+
     def _resolve_group_rates(self, gen_jobs, channel_widths):
         """Branching ratio of the grouped particles, and each group's share.
 
@@ -6620,8 +6665,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         # the final state the channel happened to produce: one merged line
         # (`define lp = e+ mu+` / `decay z > lp lm`) is a single channel whose
         # events carry several different final states.
-        decay.ms_channel = decay_file_nb
-        decay.ms_positional = positional
+        try:
+            decay.ms_channel = decay_file_nb
+            decay.ms_positional = positional
+        except AttributeError:
+            # a decay pool that yields something without a __dict__ (the unit
+            # tests use plain strings). Nothing to tag; the symmetry factor's
+            # getattr default then leaves the factor at 1.
+            pass
         return decay
 
     
@@ -10825,35 +10876,14 @@ class MadSpinInterface(extended_cmd.Cmd):
         else:
             density_prod = prod_density_cached
 
-        # ------------------------------------------------------------------
-        # Symmetry factor:
-        # For each parent-PDG group of N identical parents whose decay channels
-        # were *dealt* positionally, with channel multiplicities {n_k}, the
-        # factor that belongs to the denominator is:
-        #   sym_group = (Π_k n_k!) / (N!)
-        # and sym_factor_decay = Π_groups sym_group.
-        #
-        # What it compensates: when the card gives this pdg exactly N decay
-        # lines, `_draw_one_decay` hands line i to the i-th parent, so only ONE
-        # of the N!/Π_k n_k! assignments is ever generated and the rate owes
-        # their number -- the same `_assignment_multiplicity` the branching
-        # ratio applies for kind == 'mult_split'.
-        #
-        # Why it is keyed on the channel and gated on `ms_positional`: when the
-        # N parents instead draw independently from one pool (a single merged
-        # decay line -- `define lp = e+ mu+` / `decay z > lp lm` -- which is
-        # kind == 'mult_cumul', and whose branching ratio carries no
-        # multiplicity factor either), the draw already samples every
-        # assignment, so there is nothing to compensate. Keying this on the
-        # drawn final state, as it was, cannot tell the two apart: it doubled
-        # the weight of every trial whose two Z decayed to different flavours
-        # and turned the 2:1:1 of e+e-mu+mu- : 4e : 4mu into 4:1:1 -- against
-        # 2.0000 for sigma(p p > z z, (z > e+ e-), (z > mu+ mu-)) /
-        # sigma(p p > z z, z > e+ e-) and against both `sequential` and
-        # `madspin_v1`. The same keying also keeps the factor right when two
-        # dealt lines happen to share a final state.
-        # ------------------------------------------------------------------
-        sym_factor_decay = 1.0
+        # Decay symmetry factor: Π_k n_k!/N! per parent pdg whose N identical
+        # parents were DEALT their channels, n_k counting the dealt channels.
+        # It compensates the one assignment a positional deal generates out of
+        # N!/Π_k n_k! of them; parents that draw from a single merged pool
+        # sample the assignments themselves and take no factor. Full rationale,
+        # and what keying it on the drawn final state used to cost, in
+        # _decay_symmetry_factor.
+        sym_factor_decay = self._decay_symmetry_factor(decays)
 
         # ------------------------------------------------------------------
         # Build total decay density matrix as tensor product
@@ -10863,20 +10893,6 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         for pdg, decay_event_list in decays.items():
             N = len(decay_event_list)
-
-            # decay symmetry for this PDG group -- only for a positional deal
-            # (see the block comment above). An event that did not come from
-            # `_draw_one_decay` carries no tag; False is then the right default,
-            # since only that method ever deals.
-            if N > 1 and all(getattr(evt, 'ms_positional', False)
-                             for evt in decay_event_list):
-                chan_counts = collections.Counter(
-                    getattr(evt, 'ms_channel', None) for evt in decay_event_list)
-                sym = 1
-                for nk in chan_counts.values():
-                    if nk > 1:
-                        sym *= math.factorial(nk)
-                sym_factor_decay *= (sym / float(math.factorial(N)))
 
             # particle properties for this parent PDG
             width = decay_dict[pdg][0]

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -6533,12 +6533,24 @@ class MadSpinInterface(extended_cmd.Cmd):
         if nb_decay == 0:
             return None #nothing to do for this particle
         # Determine the file to read in order to get the decay [decay_file]
+        # ``positional`` records which of the three rules below picked the
+        # channel: True only for the middle one, where the card gives this pdg
+        # exactly as many channels as the event has identical parents and the
+        # i-th parent is *dealt* the i-th channel. That is the only case in
+        # which a single assignment stands for several, and the only case whose
+        # rate owes the assignment multiplicity -- see the decay symmetry factor
+        # in calculate_matrix_element_from_density, which reads it back off the
+        # returned event. The other two rules draw (from one merged pool, or
+        # across channels by cross-section) and so sample the assignments
+        # themselves.
+        positional = False
         if nb_decay == 1:
             decay_file_nb = keys[0]
             decay_file = channels[decay_file_nb]
         elif ids.count(particle.pdg) == nb_decay:
             decay_file_nb = keys[ids[:i].count(particle.pdg)]
             decay_file = channels[decay_file_nb]
+            positional = True
         else:
             #need to select the file according to the associate cross-section
             r = random.random()
@@ -6603,8 +6615,15 @@ class MadSpinInterface(extended_cmd.Cmd):
                             'ms_refill_%d' % self._refill_nb)
                 decay_file = evt_decayfile[particle.pdg][decay_file_nb]
                 continue
+        # Which channel this decay came from, and whether it was dealt or drawn.
+        # The decay symmetry factor of the joint weight needs the channel, not
+        # the final state the channel happened to produce: one merged line
+        # (`define lp = e+ mu+` / `decay z > lp lm`) is a single channel whose
+        # events carry several different final states.
+        decay.ms_channel = decay_file_nb
+        decay.ms_positional = positional
         return decay
-        
+
     
     def get_maxwgt_for_onshell(self, orig_lhe, evt_decayfile, decay_dict):
         """determine the maximum weight for the onshell (or similar) strategy"""
@@ -10808,22 +10827,34 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         # ------------------------------------------------------------------
         # Symmetry factor:
-        # For each parent-PDG group with N identical parents and decay-channel
-        # multiplicities {n_k}, the factor that belongs to the denominator is:
+        # For each parent-PDG group of N identical parents whose decay channels
+        # were *dealt* positionally, with channel multiplicities {n_k}, the
+        # factor that belongs to the denominator is:
         #   sym_group = (Π_k n_k!) / (N!)
         # and sym_factor_decay = Π_groups sym_group.
+        #
+        # What it compensates: when the card gives this pdg exactly N decay
+        # lines, `_draw_one_decay` hands line i to the i-th parent, so only ONE
+        # of the N!/Π_k n_k! assignments is ever generated and the rate owes
+        # their number -- the same `_assignment_multiplicity` the branching
+        # ratio applies for kind == 'mult_split'.
+        #
+        # Why it is keyed on the channel and gated on `ms_positional`: when the
+        # N parents instead draw independently from one pool (a single merged
+        # decay line -- `define lp = e+ mu+` / `decay z > lp lm` -- which is
+        # kind == 'mult_cumul', and whose branching ratio carries no
+        # multiplicity factor either), the draw already samples every
+        # assignment, so there is nothing to compensate. Keying this on the
+        # drawn final state, as it was, cannot tell the two apart: it doubled
+        # the weight of every trial whose two Z decayed to different flavours
+        # and turned the 2:1:1 of e+e-mu+mu- : 4e : 4mu into 4:1:1 -- against
+        # 2.0000 for sigma(p p > z z, (z > e+ e-), (z > mu+ mu-)) /
+        # sigma(p p > z z, z > e+ e-) and against both `sequential` and
+        # `madspin_v1`. The same keying also keeps the factor right when two
+        # dealt lines happen to share a final state.
         # ------------------------------------------------------------------
         sym_factor_decay = 1.0
 
-        # Canonical decay-channel signature: sorted final-state PDGs only.
-        def _decay_signature(dec_evt):
-            pdgs = []
-            for p in dec_evt:
-                if p.status == 1:
-                    pdgs.append(int(p.pid))
-            pdgs.sort()
-            return tuple(pdgs)
-        
         # ------------------------------------------------------------------
         # Build total decay density matrix as tensor product
         # ------------------------------------------------------------------
@@ -10833,22 +10864,19 @@ class MadSpinInterface(extended_cmd.Cmd):
         for pdg, decay_event_list in decays.items():
             N = len(decay_event_list)
 
-            # decay symmetry for this PDG group
-            if N > 1:
-                # Fast path for N==2 avoids building multiplicity maps.
-                if N == 2:
-                    if _decay_signature(decay_event_list[0]) != _decay_signature(decay_event_list[1]):
-                        sym_factor_decay *= 0.5
-                else:
-                    sig_counts = {}
-                    for evt in decay_event_list:
-                        sig = _decay_signature(evt)
-                        sig_counts[sig] = sig_counts.get(sig, 0) + 1
-                    sym = 1
-                    for nk in sig_counts.values():
-                        if nk > 1:
-                            sym *= math.factorial(nk)
-                    sym_factor_decay *= (sym / float(math.factorial(N)))
+            # decay symmetry for this PDG group -- only for a positional deal
+            # (see the block comment above). An event that did not come from
+            # `_draw_one_decay` carries no tag; False is then the right default,
+            # since only that method ever deals.
+            if N > 1 and all(getattr(evt, 'ms_positional', False)
+                             for evt in decay_event_list):
+                chan_counts = collections.Counter(
+                    getattr(evt, 'ms_channel', None) for evt in decay_event_list)
+                sym = 1
+                for nk in chan_counts.values():
+                    if nk > 1:
+                        sym *= math.factorial(nk)
+                sym_factor_decay *= (sym / float(math.factorial(N)))
 
             # particle properties for this parent PDG
             width = decay_dict[pdg][0]

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -9650,6 +9650,14 @@ class MadSpinInterface(extended_cmd.Cmd):
                 if mass is not None:
                     copy[0].new_mass = mass
                     copy[0].reshuffle_info = decay[0].reshuffle_info
+                # which channel the draw dealt this slot, so the joint route
+                # recomputed here gets the same decay symmetry factor the real
+                # joint route would (a constant either way, and this check only
+                # asks for proportionality -- but there is no reason to make it
+                # compare two different weights)
+                for tag in ('ms_channel', 'ms_positional'):
+                    if hasattr(decay, tag):
+                        setattr(copy, tag, getattr(decay, tag))
                 decays_copy[pdg].append(copy)
                 slot += 1
         # the Breit-Wigner sampling jacobians: the joint path folds them in

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -1431,6 +1431,120 @@ class TestDrawOneDecay(unittest.TestCase):
         return out
 
 
+class TestDecaySymmetryFactor(unittest.TestCase):
+    """_decay_symmetry_factor: the prod_k n_k!/N! of the joint weight's
+    denominator, and the tags _draw_one_decay leaves for it.
+
+    The factor compensates a positional DEAL, where the card gives a pdg
+    exactly as many decay channels as the event has identical parents and one
+    generated assignment stands for N!/prod_k n_k! of them. It must therefore
+    be keyed on the channel each parent was dealt, not on the final state that
+    channel happened to produce: one merged decay line (`define lp = e+ mu+` /
+    `decay z > lp lm`) is a single channel whose events carry several different
+    final states, and the parents draw from it independently -- the draw
+    samples the assignments itself, so there is nothing to compensate. Keying
+    the factor on the final state doubled the weight of every trial whose two Z
+    decayed to different flavours and gave `p p > z z` an
+    e+e-mu+mu- : 4e : 4mu composition of 4:1:1 in place of 2:1:1.
+    """
+
+    class _Part(object):
+        def __init__(self, pid):
+            self.pid = pid
+            self.pdg = pid
+            self.status = 1
+
+    class _Decay(object):
+        """A decay event the draw can tag (the pools of TestDrawOneDecay yield
+        plain strings, which have no __dict__)."""
+        def __init__(self, tag):
+            self.tag = tag
+
+    class _Pool(object):
+        def __init__(self, tag, cross=1.0):
+            self.tag = tag
+            self.n = 0
+            self.cross = cross
+        def __next__(self):
+            self.n += 1
+            return TestDecaySymmetryFactor._Decay('%s:%s' % (self.tag, self.n))
+
+    class _Stub(object):
+        get_decay_from_file = interface_madspin.MadSpinInterface.get_decay_from_file
+        _draw_all_decays = interface_madspin.MadSpinInterface._draw_all_decays
+        _draw_one_decay = interface_madspin.MadSpinInterface._draw_one_decay
+        _draw_decay_group = interface_madspin.MadSpinInterface._draw_decay_group
+        efficiency = 0.5
+
+    factor = staticmethod(interface_madspin.MadSpinInterface._decay_symmetry_factor)
+
+    def _draw(self, nb_parents, nb_channels):
+        production = [self._Part(23) for _ in range(nb_parents)]
+        evt_decayfile = {23: dict((i, self._Pool('c%d' % i))
+                                 for i in range(nb_channels))}
+        return self._Stub().get_decay_from_file(production, evt_decayfile, 10)
+
+    def test_one_merged_channel_for_two_parents_takes_no_factor(self):
+        """`decay z > lp lm` with two Z: both draw from the same pool, so the
+        draw already samples (ee,mumu) and (mumu,ee). This is the case the old
+        final-state keying got wrong."""
+        decays = self._draw(2, 1)
+        self.assertEqual([d.ms_channel for d in decays[23]], [0, 0])
+        self.assertEqual([d.ms_positional for d in decays[23]], [False, False])
+        self.assertEqual(self.factor(decays), 1.0)
+
+    def test_two_dealt_channels_for_two_parents_take_one_half(self):
+        """`decay z > e+ e-` + `decay z > mu+ mu-`: parent i is dealt channel i,
+        so only one of the two assignments is ever generated."""
+        decays = self._draw(2, 2)
+        self.assertEqual([d.ms_channel for d in decays[23]], [0, 1])
+        self.assertEqual([d.ms_positional for d in decays[23]], [True, True])
+        self.assertEqual(self.factor(decays), 0.5)
+
+    def test_three_dealt_channels_for_three_parents(self):
+        decays = self._draw(3, 3)
+        self.assertEqual([d.ms_channel for d in decays[23]], [0, 1, 2])
+        self.assertEqual(self.factor(decays), 1 / 6.)
+
+    def test_a_single_parent_never_takes_a_factor(self):
+        for nb_channels in (1, 2):
+            self.assertEqual(self.factor(self._draw(1, nb_channels)), 1.0)
+
+    def test_the_factor_is_keyed_on_the_channel_not_the_final_state(self):
+        """Two parents dealt two channels that happen to produce the same final
+        state still owe the 1/2! -- and two parents drawing repeatedly from one
+        channel owe nothing however different their final states are. Neither
+        is visible to a final-state signature."""
+        dealt = {23: [self._Decay('same'), self._Decay('same')]}
+        for i, dec in enumerate(dealt[23]):
+            dec.ms_channel, dec.ms_positional = i, True
+        self.assertEqual(self.factor(dealt), 0.5)
+
+        drawn = {23: [self._Decay('ee'), self._Decay('mumu')]}
+        for dec in drawn[23]:
+            dec.ms_channel, dec.ms_positional = 0, False
+        self.assertEqual(self.factor(drawn), 1.0)
+
+    def test_two_parents_dealt_the_same_channel_twice_cancel(self):
+        """n_k! / N! = 2!/2! = 1 when both dealt channels are the same one."""
+        decays = {23: [self._Decay('a'), self._Decay('b')]}
+        for dec in decays[23]:
+            dec.ms_channel, dec.ms_positional = 7, True
+        self.assertEqual(self.factor(decays), 1.0)
+
+    def test_an_untagged_decay_takes_no_factor(self):
+        """Anything that did not come from _draw_one_decay was not dealt."""
+        self.assertEqual(self.factor({23: ['a', 'b']}), 1.0)
+
+    def test_several_pdgs_multiply(self):
+        decays = {}
+        for pdg in (23, 6):
+            decays[pdg] = [self._Decay('x'), self._Decay('y')]
+            for i, dec in enumerate(decays[pdg]):
+                dec.ms_channel, dec.ms_positional = i, True
+        self.assertEqual(self.factor(decays), 0.25)
+
+
 class TestDrawOffshellMass(unittest.TestCase):
     """_draw_offshell_mass: one resonance virtuality, owned by the decay that
     carries it.


### PR DESCRIPTION
## The symptom

`p p > z z` + MadSpin with one merged decay line covering both lepton flavours:

```
define lp = e+ mu+
define lm = e- mu-
decay z > lp lm
```

writes the wrong flavour composition. The e+e-mu+mu- share of 20000 written events, all arms fed the *same* production events, seed 91919:

| arm | eemumu | 4e | 4mu |
|---|---|---|---|
| `sequential` | 0.4960 +- 0.0035 | 0.2524 | 0.2516 |
| **`joint`** | **0.6654 +- 0.0033** | 0.1666 | 0.1679 |
| `madspin_v1` | 0.4965 +- 0.0035 | 0.2527 | 0.2508 |
| `spinmode onshell` | 0.4996 +- 0.0035 | 0.2485 | 0.2519 |

i.e. `eemumu : 4e : 4mu` = 4:1:1 under joint against 2:1:1 everywhere else. **`auto` selects joint at two decaying particles**, so the default run is the wrong one. The total decayed cross section is identical in every offshell arm (4.1863672e-02 pb) — the bug redistributes between flavour channels, it does not renormalise.

## Ground truth: the ratio is exactly 2

Direct MadGraph, no MadSpin involved. `p p > z z, (z > e+ e-), (z > mu+ mu-)` against `p p > z z, z > e+ e-`, same run_card, same seed, **all lepton cuts zeroed** (the 4e state has 4 same-flavour l+l- pairs against the mixed state's 2, so any `drll`/`mmll` breaks the very ratio under test):

```
sigma(mixed) = 2.090300e-02 +- 3.41e-05 pb
sigma(same)  = 1.045200e-02 +- 1.70e-05 pb        ratio = 2.0000
```

Why exactly 2, from the generated code: both are the same 6-point amplitude (`NEXTERNAL=6`, `NCOMB=64`, `NGRAPHS=2`; e and mu massless with equal couplings). The only difference is `DATA IDEN/36/` versus `DATA IDEN/72/`.

**Where the 1/2! belongs.** In the phase-space integration of an *explicitly generated* same-flavour process, compensating the amplitude's sum over lepton pairings. A MadSpin per-event weight contains no such sum — each Z owns its decay and the pairing is fixed by construction — so there is nothing for a 1/2! to compensate. In event-counting terms, which is what a MadSpin sample is: N physical ZZ events with independently decaying Z give `B_e^2 : B_mu^2 : 2 B_e B_mu` = 1:1:2.

MadSpin gets this right when the channels are spelled out. `decay z > e+ e-` plus `decay z > mu+ mu-`, against `decay z > e+ e-` alone, **both through joint**: 2.0932334e-02 / 1.0465918e-02 = **2.00005**, each within 0.14% of the direct-MadGraph absolute numbers. Only the merged-line form goes wrong.

## The cause

`MadSpin/interface_madspin.py`, `calculate_matrix_element_from_density`:

```python
if N == 2:
    if _decay_signature(decay_event_list[0]) != _decay_signature(decay_event_list[1]):
        sym_factor_decay *= 0.5
```

The factor is keyed on the **drawn final state**. It is legitimate only as compensation for a *positional deal*: when the card gives a pdg exactly as many decay lines as the event has identical parents, `_draw_one_decay` hands line *i* to parent *i*, so one assignment stands for `N!/prod(n_k!)` of them — the reciprocal of the `_assignment_multiplicity` the branching ratio already applies for `kind == 'mult_split'`.

Keyed on the final state it cannot tell that case from a single **merged** pool (`kind == 'mult_cumul'`), where both parents draw independently and the multiplicity is already sampled. So it fires where the multiplicity has been counted once already, giving the mixed-flavour chains a spurious factor 2.

Note it is a *constant* in the case it exists for — and a constant cancels against the maximum weight — so it did nothing where it was intended to act, and only bit where it should not have.

**Scope**: needs two or more identical parents of the same pdg (`decays` is keyed on `particle.pdg`, so `p p > t t~` with a merged lepton decay has N=1 each and is unaffected), one merged decay line spanning several final states, and the offshell joint scheme. `sequential` and `onshell` never reach this call site.

## The fix

`_draw_one_decay` tags the event it returns with `ms_channel` / `ms_positional`; the symmetry factor is keyed on the **channel** and applied only to a dealt one. Extracted as `_decay_symmetry_factor` next to `_assignment_multiplicity`, whose reciprocal it is. The tags are carried into the events `_check_weight_identity` rebuilds.

| | eemumu share | trials/event |
|---|---|---|
| joint, before | 0.6654 +- 0.0033 | 8.84 |
| **joint, after** | **0.4999 +- 0.0035** | 6.40 |

Side effect: the spurious 2 on half the trials was inflating the joint maximum weight, so unweighting efficiency goes 0.1131 -> 0.1562.

**Unchanged where the ambiguity cannot arise** — re-run through joint, before vs after, decayed LHE bodies compared **byte for byte**:

- `decay z > e+ e-` + `decay z > mu+ mu-` (mixed flavour only — the positional case the factor exists for): identical, sigma = 2.0932334e-02 pb.
- `decay z > e+ e-` alone: identical, sigma = 1.0465918e-02 pb.
- `sequential`: bit-identical (9921/5047/5032).

553 MadSpin unit tests pass, including 8 new ones pinning the factor.

## MadSpin's own check already knew

`set sequential_debug True` recomputes the joint weight per accepted chain and requires the chain/joint ratio to be constant:

- before: `CRITICAL: the weight identity FAILED on 20000 accepted chains ... relative spread of the ratio 0.332, mean 205243868.4`
- after: `INFO: weight identity verified ... constant to 1.75e-07` (the float32 floor of the single-precision densities)

0.332 is precisely one factor 2 on half the chains: ratio R on same-flavour and R/2 on mixed gives mean 0.75R (0.75 x 272939749.6 = 204704812 against the measured 205243868) and spread 1/3. **The bug was diagnosable from inside MadSpin with one card line** — the check is simply off by default, and only `sequential` runs it. Whether `joint` should also run it on a sample of chains is worth a decision.

## Not covered

- **The `@` decay-group path was not exercised.** This patch makes the weight factor 1 when a group hands one line to two identical parents (previously it varied with the drawn final state). I did not verify the group's branching ratio in that configuration: `_resolve_group_rates` divides by `gen_jobs[pdg]['totwidth'] ** len(indices)`, which for one line covering two parents looks one power of the width short. Possibly unreachable; worth a separate look.
- **NLO was not run.** Nothing in the factor is LO-specific, so an NLO run with the same card shape should behave identically — but that is an inference, not a measurement.
- `spinmode onshell` is structurally out of reach (it goes through `calculate_matrix_element(full_event)`) and measures 0.4996, but its own IDEN normalisation was not separately audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix MadSpin joint-decay symmetry weighting so merged channels produce the correct flavour ratios without reducing unweighting efficiency.

Bug Fixes:
- Correct the MadSpin joint-decay flavour composition for merged decay channels by applying symmetry factors according to the assigned decay channel rather than the generated final state.

Enhancements:
- Track decay-channel assignment metadata through joint-weight calculations and weight-identity checks, while preserving existing behaviour for positional and unaffected decay schemes.

Tests:
- Add unit coverage for merged channels, positional assignments, multiple identical parents, untagged decays, and combined parent-PDG symmetry factors.