### PR TITLE
MadSpin: fix the onshell_v1 identical-particle factor, and assert the flavour composition

### DIFF
--- a/.github/actions/restore_heptools_contur/action.yml
+++ b/.github/actions/restore_heptools_contur/action.yml
@@ -30,7 +30,21 @@ runs:
         echo "rivet_path = /home/runner/.cache/HEPtools/rivet" >>  input/mg5_configuration.txt
         echo "yoda_path = /home/runner/.cache/HEPtools/yoda" >>  input/mg5_configuration.txt
         echo "contur_path = /home/runner/.cache/HEPtools/contur" >>  input/mg5_configuration.txt
-        echo "fastjet = /home/runner/.cache/HEPtools/fastjet/bin/fastjet-config" >>  input/mg5_configuration.txt
+        # Only point MG5 at fastjet if it is really there.  The cache restore
+        # above is best-effort (fail-on-cache-miss is false, and warm_cache
+        # deletes the contur/heptools caches ~30 min before it re-saves them,
+        # so any job starting in that window gets nothing), and a fastjet-config
+        # that does not exist makes every aMC@NLO SubProcess compile
+        # fastjetfortran_madfks_full.cc and die on a missing
+        # fastjet/ClusterSequence.hh.  Without the line MG5 uses fjcore, which
+        # is a working fallback: the contur/rivet jobs still fail, loudly and on
+        # their own, but the numbered acceptance jobs no longer fail with them.
+        FJ=/home/runner/.cache/HEPtools/fastjet/bin/fastjet-config
+        if [ -x "$FJ" ]; then
+          echo "fastjet = $FJ" >>  input/mg5_configuration.txt
+        else
+          echo "::warning::$FJ missing (cache miss?) - leaving MG5 on fjcore"
+        fi
       shell: bash
 
     - name: set pythonpath for ubuntu22

--- a/MadSpin/interface_madspin.py
+++ b/MadSpin/interface_madspin.py
@@ -1714,6 +1714,84 @@ class MadSpinInterface(extended_cmd.Cmd):
             out *= sym / float(math.factorial(nb))
         return out
 
+    @staticmethod
+    def _decay_process_signature(decay_event):
+        """A hashable stand-in for "which decay process is this?".
+
+        The multiset of (status, pdg) over the whole decay event, so the
+        intermediate resonances of a multi-step chain count too and
+        ``w+ > l+ vl`` is not confused with a direct three-body decay to the
+        same final state. It is the runtime counterpart of
+        :func:`HelasMatrixElement.check_equal_decay_processes`, which is what
+        MG5 uses when it decides how many of a decay-chain process's chains are
+        identical.
+        """
+        return tuple(sorted((int(p.status), int(p.pid)) for p in decay_event))
+
+    @classmethod
+    def _decay_chain_identical_factor(cls, production, decays):
+        """The identical-particle factor the *legacy on-shell* (``onshell_v1``)
+        weight has to divide out of its production x decay matrix element.
+
+        That mode is the only one that gets its numerator from a separately
+        generated decay-chain matrix element -- ``|M(p p > z z, z > e+ e-,
+        z > mu+ mu-)|^2`` -- while its denominator uses the *undecayed*
+        production matrix element. Both are MG5 matrix elements, so both are
+        already divided by their own ``IDEN``, and the identical-particle part
+        of the two IDENs does not match:
+
+          * the production process ``p p > z z`` has two identical Z, so its
+            IDEN carries a 2 (``S_prod``);
+          * the decay-chain process carries ``identical_decay_chain_factor``
+            (``helas_objects.py``), which is ``n!`` over *identical chains*:
+            2 when both Z were drawn to ``e+ e-``, 1 when one went to ``e+ e-``
+            and the other to ``mu+ mu-``.
+
+        So the raw ratio ``full_me / production_me`` comes out twice as large
+        for a mixed-flavour draw as for a same-flavour one, purely from
+        bookkeeping. With one merged decay line (``define lp = e+ mu+`` /
+        ``decay z > lp lm``) that turns the e+e-mu+mu- : 4e : 4mu composition
+        into 4:1:1 where it must be 2:1:1 -- the ratio of the two decayed cross
+        sections, which is exactly 2.0000 in direct MadGraph (the 6-point
+        amplitude is the same, only ``DATA IDEN`` differs, 36 against 72).
+
+        Returned factor: ``prod_pdg (prod_k n_k! / N_pdg!)``, with ``N_pdg`` the
+        number of production final-state legs of that pdg (which is what MG5's
+        ``non_chain_factor`` drops from the full process, and what the
+        production IDEN keeps) and ``n_k`` the number of chains of that pdg
+        sharing a decay-process signature. Multiplying the numerator by it
+        leaves a weight with no identical-particle factor anywhere -- which is
+        what the density modes have for free, since they build the numerator by
+        contracting the *same* production density they divide by.
+
+        Note that this is keyed on the drawn FINAL STATE, the opposite of
+        :meth:`_decay_symmetry_factor`, and for the opposite reason: there the
+        code was inventing a symmetry factor that the sampling had already
+        taken care of, here it is undoing one that MG5's matrix-element
+        generator really did apply.
+
+        Cases where it is 1 and nothing moves: a single decaying particle of a
+        given pdg (``p p > t t~`` -- ``t`` and ``t~`` are separate keys, N=1
+        each), and any run in which every event draws the same signatures (two
+        explicit decay lines, or a single non-merged one), where it is a
+        constant and cancels against the maximum weight.
+        """
+        out = 1.0
+        for pdg, decay_event_list in decays.items():
+            if not decay_event_list:
+                continue
+            nb_prod = sum(1 for p in production
+                          if int(p.status) == 1 and int(p.pid) == pdg)
+            if nb_prod < 2:
+                continue
+            counts = collections.Counter(cls._decay_process_signature(evt)
+                                         for evt in decay_event_list)
+            iden = 1
+            for repeat in counts.values():
+                iden *= math.factorial(repeat)
+            out *= iden / float(math.factorial(nb_prod))
+        return out
+
     def _resolve_group_rates(self, gen_jobs, channel_widths):
         """Branching ratio of the grouped particles, and each group's share.
 
@@ -10500,10 +10578,17 @@ class MadSpinInterface(extended_cmd.Cmd):
 
         # Calculate production*decay ME
         if self.generate_all.mode == 'onshell':
+            # MG5 builds the identical-particle factor of the *decay-chain*
+            # process into its IDEN, and it depends on which final state the
+            # chains were drawn to; the production ME in the denominator
+            # carries the factor of the undecayed process instead. Divide the
+            # mismatch out before the two are combined -- see
+            # _decay_chain_identical_factor.
+            iden_ratio = self._decay_chain_identical_factor(production, decays)
             full_event = lhe_parser.Event(str(production))
             full_event = full_event.add_decays(decays)
             #print(f"full_event = {full_event}")
-            full_me = self.calculate_matrix_element(full_event)
+            full_me = self.calculate_matrix_element(full_event) * iden_ratio
             #print(f"full_me = {full_me}")
         else:
             #offshell mode

--- a/madgraph/interface/amcatnlo_run_interface.py
+++ b/madgraph/interface/amcatnlo_run_interface.py
@@ -5541,8 +5541,35 @@ PYTHIA8LINKLIBS=%(pythia8_prefix)s/lib/libpythia8.a -lz -ldl"""%{'pythia8_prefix
         else:
             self.make_opts_var['pineappl'] = ""
 
+        # Setting fastjet_config makes makefile_fks_dir build
+        # fastjetfortran_madfks_full.cc, which #includes
+        # "fastjet/ClusterSequence.hh" and asks fastjet-config for its cxxflags
+        # and libs.  A path that does not answer therefore turns the documented
+        # fjcore fallback (the else branch of that makefile) into a hard
+        # compilation error for every P* directory.  The option is read
+        # verbatim out of Cards/me5_configuration.txt and, unlike
+        # MadGraphCmd.set2_fastjet, was never re-validated here, so a stale or
+        # broken entry took the whole run down with an unrelated-looking
+        # "A compilation Error occurs when trying to compile .../P0_...".
+        # Check it the same way the shower setup above already does, and fall
+        # back to fjcore when it does not run.
         if 'fastjet' in list(self.options.keys()) and self.options['fastjet']:
-            self.make_opts_var['fastjet_config'] = self.options['fastjet']
+            try:
+                p = subprocess.Popen([self.options['fastjet'], '--version'],
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+                p.communicate()
+                valid_fastjet = (p.returncode == 0)
+            except Exception:
+                valid_fastjet = False
+            if valid_fastjet:
+                self.make_opts_var['fastjet_config'] = self.options['fastjet']
+            else:
+                logger.warning('%s does not run: it is not a valid ' % \
+                    self.options['fastjet'] + 'fastjet-config. Compiling the ' +
+                    'Subprocesses with fjcore instead.\n Set the correct path ' +
+                    'with "set fastjet /PATH/TO/fastjet-config" if you need ' +
+                    'the full FastJet.')
 
         # add the make_opts_var to make_opts
         self.update_make_opts()

--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -1008,6 +1008,20 @@ def assert_efficiency_ordering(test, results,
     2. ``onshell_decay_chain`` and ``onshell_density`` agree with each other
        within ``close_rel_tol`` (relative), and both are *better* (higher
        efficiency) than the pole approximation ``PA_density``.
+
+       Rule 2a is in practice much stronger than its tolerance: the two are
+       the same physics reached by different code (a full decay-chain matrix
+       element against a contraction of production and decay densities), so
+       on pure on-shell kinematics they compute the *same* weight and, off
+       one production sample with one seed, write bit-identical files. On the
+       ZZ run both sit at 0.2269 (10000/44080) to the trial. That is why this
+       rule was the one that broke when the joint-weight flavour fix moved
+       ``onshell_density`` (0.1776 -> 0.2269) and left ``onshell_decay_chain``
+       behind at 0.1776 -- 22% apart, and correctly rejected. The rule did
+       *not* encode the buggy behaviour and its tolerance has not been
+       touched; it is left at ``close_rel_tol`` rather than tightened to an
+       equality because nothing guarantees the identity once a mode reshuffles
+       or the two paths acquire different RNG consumption.
     3. ``madspin_density`` sits *between* ``full_decay_chain`` and
        ``PA_density``. Uses ``madspin_density_slack`` (default 0.05, absolute)
        rather than ``slack`` because the same ttbar 10k run showed the new

--- a/tests/parallel_tests/madspin_comparator.py
+++ b/tests/parallel_tests/madspin_comparator.py
@@ -857,6 +857,114 @@ def assert_multiplicities_consistent(test, results, pdgs, n_sigma=4):
                     % (pdg, la, na, lb, nb, abs(na - nb), n_sigma, na + nb))
 
 
+def lepton_flavour_shares(result, flavours=(11, 13), nb_leptons=4):
+    """How the ``nb_leptons``-lepton final state splits over lepton flavours.
+
+    Returns ``(counts, nevents)``. The key is the per-flavour multiplicity in
+    the order of ``flavours``, particle and antiparticle together -- so for
+    ``flavours=(11, 13)`` and ``nb_leptons=4``:
+
+        ``(2, 2)``  e+e-mu+mu-
+        ``(4, 0)``  e+e-e+e-
+        ``(0, 4)``  mu+mu-mu+mu-
+
+    Any event that does not carry exactly ``nb_leptons`` of them is keyed
+    ``None``, so a caller can tell "the composition moved" from "the sample is
+    not what I thought it was".
+
+    This is the flavour information ``assert_multiplicities_consistent`` throws
+    away: it counts finals per PDG, and per-PDG counts cannot see the
+    composition at all. Both 2:1:1 and 4:1:1 give exactly one electron per
+    event on average (2*0.25 + 1*0.5 = 1 either way), so no per-PDG count
+    distinguishes them, and neither does any pair-wise comparison built on
+    them.
+    """
+    counts = collections.Counter()
+    nevents = 0
+    for event in result.open_lhe():
+        nevents += 1
+        per_flavour = [0] * len(flavours)
+        for particle in event:
+            if particle.status != 1:
+                continue
+            for i, flavour in enumerate(flavours):
+                if abs(particle.pdg) == flavour:
+                    per_flavour[i] += 1
+        key = tuple(per_flavour)
+        counts[key if sum(per_flavour) == nb_leptons else None] += 1
+    return counts, nevents
+
+
+def assert_flavour_shares(test, results, expected, flavours=(11, 13),
+                          nb_leptons=4, n_sigma=4, min_events=200):
+    """Every mode's lepton-flavour composition must match ``expected``.
+
+    ``expected`` maps a :func:`lepton_flavour_shares` key to the fraction of
+    events it must hold, and the fractions must sum to 1 -- every event is
+    required to fall in one of the named categories, so a mode that silently
+    stopped producing the final state fails here rather than passing on an
+    empty numerator.
+
+    The tolerance is ``n_sigma`` binomial standard deviations,
+    ``sqrt(p(1-p)/N)`` on the measured fraction. It is a tolerance on
+    *counting noise only*: the expected fractions are exact numbers, not
+    calibrated ones, so there is nothing else for the bound to absorb. With
+    N = 10000 and p = 0.5 that is 2 percentage points, against the 17 points
+    that separate the two compositions this test exists to tell apart.
+
+    Why this assertion exists.  MadSpin writes a unit-weight sample, so its
+    composition has to be the ratio of the decayed cross sections, and that
+    ratio is a property of the matrix elements alone -- no MadSpin involved.
+    For ``p p > z z`` with one merged decay line (``define lp = e+ mu+`` /
+    ``decay z > lp lm``) and massless leptons of equal coupling, each Z decays
+    independently with B_e = B_mu, so
+
+        P(4e) : P(4mu) : P(e+e-mu+mu-) = B_e^2 : B_mu^2 : 2 B_e B_mu = 1:1:2.
+
+    Direct MadGraph agrees exactly: ``p p > z z, (z > e+ e-), (z > mu+ mu-)``
+    and ``p p > z z, z > e+ e-`` are generated from the *same* 2-graph
+    6-point amplitude and differ only in ``DATA IDEN`` (36 against 72), so
+    sigma(mixed)/sigma(same) = 2.0000 to every printed digit.
+
+    Four of the five modes once wrote 4:1:1 instead, from two independent
+    identical-particle-factor bugs, and the test suite could not see it:
+    ``assert_multiplicities_consistent`` is blind to the composition (see
+    :func:`lepton_flavour_shares`), and every other assertion here compares
+    modes against *each other*, which is no help when they are wrong in the
+    same way. This one compares against a number MadSpin had no part in.
+    """
+    total_expected = sum(expected.values())
+    assert abs(total_expected - 1.0) < 1e-9, (
+        'expected shares must cover every event, got %s' % total_expected)
+    for label, result in sorted(results.items()):
+        counts, nevents = lepton_flavour_shares(
+            result, flavours=flavours, nb_leptons=nb_leptons)
+        test.assertGreaterEqual(
+            nevents, min_events,
+            '%s wrote only %d events -- too few for a share test'
+            % (label, nevents))
+        classified = sum(counts[key] for key in expected)
+        test.assertEqual(
+            classified, nevents,
+            '%s: %d of %d events fall outside the expected flavour '
+            'categories %s (composition: %s)'
+            % (label, nevents - classified, nevents, sorted(expected),
+               dict(counts)))
+        for key, want in sorted(expected.items()):
+            got = counts[key] / float(nevents)
+            tol = n_sigma * math.sqrt(want * (1.0 - want) / nevents)
+            _logger.info('[%s] flavour share %s = %.4f (expected %.4f +- %.4f)',
+                         label, key, got, want, tol)
+            test.assertLess(
+                abs(got - want), tol,
+                '%s: flavour share %s = %.4f (%d/%d), expected %.4f, '
+                'off by %.1f binomial sigma (tolerance %.4f = %g sigma). '
+                'Full composition: %s'
+                % (label, key, got, counts[key], nevents, want,
+                   abs(got - want) / max(tol / n_sigma, 1e-12), tol, n_sigma,
+                   dict(counts)))
+
+
 def assert_efficiency_close(test, result_a, result_b, rel_tol=0.15):
     """Compare two modes' unweighting efficiencies. Both must be populated; if
     either is missing the test fails loudly so we don't silently skip a

--- a/tests/parallel_tests/test_madspin_factory.py
+++ b/tests/parallel_tests/test_madspin_factory.py
@@ -21,6 +21,12 @@ MadSpin density-mode table, and then asserts:
     * each LHE is well-formed;
     * global branching ratios agree across modes;
     * lepton/quark final-state multiplicities agree within Poisson noise;
+    * where the final state has a flavour composition (the ZZ four-lepton
+      state), that composition matches the ratio of the decayed cross
+      sections -- a number computed from matrix elements alone, with no
+      MadSpin in it. Every other assertion here compares modes against each
+      other, which is no help when several are wrong in the same way; see
+      ``assert_flavour_shares``;
     * efficiency pairs that are physically expected to match -- old default
       vs. PA+density-reshuffled, and traditional onshell vs. PA-without-
       reshuffling -- match within ``EFF_TOL`` (15% to start; widen per the
@@ -66,6 +72,7 @@ from tests.parallel_tests.madspin_comparator import (
     assert_cross_sections_consistent,
     assert_efficiency_close,
     assert_efficiency_ordering,
+    assert_flavour_shares,
     assert_identity_ratios_agree,
     assert_lhe_well_formed,
     assert_multiplicities_consistent,
@@ -301,6 +308,16 @@ class MadSpinFactoryTest(_MadSpinFactoryBase):
         results = self._run_all_modes(factory)
         assert_multiplicities_consistent(
             self, results, pdgs=[11, -11, 13, -13])
+        # The composition of the four-lepton state, which the per-PDG counts
+        # above provably cannot see: both 2:1:1 and 4:1:1 give one electron
+        # per event. With one merged decay line and B_e = B_mu each Z decays
+        # independently, so 4e : 4mu : e+e-mu+mu- = 1 : 1 : 2 -- and direct
+        # MadGraph puts sigma(mixed)/sigma(same) at exactly 2.0000 (same
+        # 6-point amplitude, DATA IDEN 36 against 72). See
+        # assert_flavour_shares.
+        assert_flavour_shares(
+            self, results,
+            expected={(2, 2): 0.50, (4, 0): 0.25, (0, 4): 0.25})
         self._check_efficiency_pairs(results)
         offshell_results = {
             k: v for k, v in results.items()

--- a/tests/unit_tests/madspin/test_madspin.py
+++ b/tests/unit_tests/madspin/test_madspin.py
@@ -11171,3 +11171,108 @@ class TestReusedMsDirParameters(unittest.TestCase):
         self._build(ms_dir=self.tmpdir)
         self.assertTrue(os.path.exists(pjoin(self.tmpdir,
                                              'ms_param_card.dat')))
+
+
+class TestDecayChainIdenticalFactor(unittest.TestCase):
+    """_decay_chain_identical_factor: the identical-particle bookkeeping the
+    legacy on-shell mode (`spinmode onshell_v1`) has to undo.
+
+    That mode alone takes its numerator from a separately generated
+    decay-chain matrix element and its denominator from the *undecayed*
+    production one. MG5 divides each by its own IDEN, and the
+    identical-particle parts do not match: `p p > z z` carries a 2 for the two
+    identical Z, while `p p > z z, z > e+ e-, z > mu+ mu-` carries
+    `identical_decay_chain_factor` -- 2 when the two chains are the same
+    process, 1 when they are not (IDEN 72 against 36 in the generated
+    matrix.f). So the mixed-flavour draw came out twice as heavy as the
+    same-flavour one for no physical reason, and a merged decay line
+    (`define lp = e+ mu+` / `decay z > lp lm`) wrote e+e-mu+mu- : 4e : 4mu as
+    4:1:1 where the ratio of decayed cross sections is 2:1:1.
+
+    Keyed on the drawn FINAL STATE -- the opposite of _decay_symmetry_factor,
+    because here MG5's generator really did apply the factor.
+    """
+
+    class _Part(object):
+        def __init__(self, pid, status=1):
+            self.pid = pid
+            self.pdg = pid
+            self.status = status
+
+    factor = staticmethod(
+        interface_madspin.MadSpinInterface._decay_chain_identical_factor)
+
+    @staticmethod
+    def _decay(*pids):
+        """A 1 -> N decay event: the parent (status 2) and its children."""
+        return [TestDecayChainIdenticalFactor._Part(pids[0], status=2)] + \
+               [TestDecayChainIdenticalFactor._Part(p) for p in pids[1:]]
+
+    def _zz(self, first, second):
+        production = [self._Part(2, status=-1), self._Part(-2, status=-1),
+                      self._Part(23), self._Part(23)]
+        decays = {23: [self._decay(23, *first), self._decay(23, *second)]}
+        return self.factor(production, decays)
+
+    def test_two_z_to_different_flavours_take_one_half(self):
+        """IDEN 36 for the chain process against 72 for the production: the
+        raw ratio is 2 too big."""
+        self.assertEqual(self._zz((-11, 11), (-13, 13)), 0.5)
+
+    def test_two_z_to_the_same_flavour_take_nothing(self):
+        """IDEN 72 on both sides -- already consistent."""
+        self.assertEqual(self._zz((-11, 11), (-11, 11)), 1.0)
+
+    def test_the_two_together_restore_the_2_to_1_ratio(self):
+        """The whole point: same-flavour and mixed end up on the same footing,
+        so the merged-line composition is 2:1:1."""
+        self.assertEqual(self._zz((-11, 11), (-13, 13)) /
+                         self._zz((-11, 11), (-11, 11)), 0.5)
+
+    def test_a_single_decaying_particle_takes_nothing(self):
+        """`p p > t t~`: t and t~ are separate keys with one parent each, so
+        no identical-chain factor exists on either side."""
+        production = [self._Part(21, status=-1), self._Part(21, status=-1),
+                      self._Part(6), self._Part(-6)]
+        decays = {6: [self._decay(6, 5, 24, -11, 12)],
+                  -6: [self._decay(-6, -5, -24, 1, -2)]}
+        self.assertEqual(self.factor(production, decays), 1.0)
+
+    def test_intermediate_resonances_separate_two_chains(self):
+        """The signature is the whole decay event, not just its final state:
+        `w+ > l+ vl` and a direct three-body decay to the same leptons are
+        different processes to MG5's check_equal_decay_processes."""
+        production = [self._Part(21, status=-1), self._Part(21, status=-1),
+                      self._Part(6), self._Part(6)]
+        two_step = self._decay(6, 5, 24, -11, 12)
+        three_body = [self._Part(6, status=2), self._Part(5),
+                      self._Part(-11), self._Part(12)]
+        self.assertEqual(self.factor(production, {6: [two_step, two_step]}), 1.0)
+        self.assertEqual(self.factor(production, {6: [two_step, three_body]}),
+                         0.5)
+
+    def test_three_identical_parents(self):
+        production = [self._Part(21, status=-1), self._Part(21, status=-1)] + \
+                     [self._Part(23) for _ in range(3)]
+        ee, mm = self._decay(23, -11, 11), self._decay(23, -13, 13)
+        # 3!/3! : all three the same process
+        self.assertEqual(self.factor(production, {23: [ee, ee, ee]}), 1.0)
+        # 2!1!/3!
+        self.assertEqual(self.factor(production, {23: [ee, ee, mm]}), 1 / 3.)
+
+    def test_an_undecayed_identical_leg_still_counts(self):
+        """MG5's non_chain_factor drops *every* leg whose pdg is decayed, so
+        the production factor to undo is n! over all of them, not over the
+        ones that were drawn a decay."""
+        production = [self._Part(21, status=-1), self._Part(21, status=-1),
+                      self._Part(23), self._Part(23)]
+        decays = {23: [self._decay(23, -11, 11)]}
+        self.assertEqual(self.factor(production, decays), 0.5)
+
+    def test_several_pdgs_multiply(self):
+        production = [self._Part(21, status=-1), self._Part(21, status=-1),
+                      self._Part(23), self._Part(23),
+                      self._Part(24), self._Part(24)]
+        decays = {23: [self._decay(23, -11, 11), self._decay(23, -13, 13)],
+                  24: [self._decay(24, -11, 12), self._decay(24, -13, 14)]}
+        self.assertEqual(self.factor(production, decays), 0.25)


### PR DESCRIPTION
Follow-up to #408, which merged while `test_short_madspin_zz` was failing.

## The regression #408 left behind

#408 fixed the joint decay symmetry factor, which corrected the e+e-mu+mu- share in four of the five modes the test compares. `onshell_decay_chain` was left at 4:1:1, so the modes that had been consistently wrong together now disagree:

| mode | before #408 | after #408 | **this PR** | truth |
|---|---|---|---|---|
| `full_decay_chain` | 0.4922 | 0.4922 | 0.4922 | 0.50 |
| `onshell_decay_chain` | 0.6667 | **0.6667** | **0.5051** | 0.50 |
| `onshell_density` | 0.6667 | 0.5031 | 0.5031 | 0.50 |
| `madspin_density` | 0.6578 | 0.4968 | 0.4968 | 0.50 |
| `PA_density` | 0.6607 | 0.4990 | 0.4990 | 0.50 |

Ground truth is direct MadGraph with no MadSpin involved: `sigma(mixed)/sigma(same) = 2.0000` exactly, the same 6-point amplitude with `DATA IDEN/36/` against `/72/`.

**Root cause.** `onshell_v1` is the only mode that takes its numerator from a separately generated decay-chain matrix element while its denominator uses the *undecayed* production matrix element. Both are MG5 matrix elements, so both arrive pre-divided by their own `IDEN`, and the identical-particle parts do not cancel: the production `p p > z z` carries a 2 for the two identical Z, while the decay-chain process carries `identical_decay_chain_factor` (`helas_objects.py`), which is n! over *identical chains* — 2 for same-flavour, 1 for mixed. That residual 2 is the 4:1:1.

This is a different mechanism from #408's (a symmetry factor keyed on the drawn final state): same symptom, unrelated cause.

## Test changes

**The test could not have caught any of this.** `assert_multiplicities_consistent` counts per-PDG finals, and both 2:1:1 and 4:1:1 give exactly 1.0 electron per event — it is provably blind to the flavour share. What failed was an *efficiency* assertion, an indirect symptom.

So this PR adds a real four-lepton composition assertion, checked against 2:1:1 with a binomial tolerance, for every mode — the assertion that would have caught this class of bug. `assert_multiplicities_consistent` is kept; it is insufficient, not wrong. The third commit records what the onshell efficiency rule actually measures.

**No tolerance was widened.**

Verified: `test_short_madspin_zz` passes in 146.7 s with `onshell_decay_chain` and `onshell_density` bit-identical again; whole unit suite 1390 OK; `test_madspin` 561 OK.

## Two CI commits, separable

`652ca17ef` and `52f06a2cc` do not touch MadSpin and can be split out or dropped.

While attributing the 13 red acceptance jobs on the 3.8.0 tip, it turned out **they were not a code regression at all** — rerunning the failed jobs of run `34362685144` at the identical commit `901080da4`, with no changes, came back green. The cause is a cache race: `warm_cache.yml` deletes `heptools-$ImageOS` and re-saves ~30 minutes later, the keys carry no content hash so they are shared across branches, and the 3.8.0 push landed inside that window. Failing jobs log `Cache not found for input keys: heptools-ubuntu22` where the previous green run logs a cache hit.

The damage is not the miss itself: `.github/actions/restore_heptools_contur/action.yml` writes `fastjet = ~/.cache/HEPtools/fastjet/bin/fastjet-config` into `input/mg5_configuration.txt` **unconditionally** (the `if: setup_only != 'true'` guard is on the restore step, not the config write). `makefile_fks_dir:13` then does `ifdef fastjet_config` and every aMC@NLO SubProcess compile dies on `fastjet/ClusterSequence.hh: No such file or directory`.

`652ca17ef` fixes a genuine latent MG5 bug behind that: `set_configuration` only `isdir`-checks keys ending in `_path`, and the config chain ends by re-reading `input/mg5_configuration.txt`, so a fastjet that `set2_fastjet` already rejected at start-up ("we will use fjcore instead") comes back unvalidated at run time. The fix mirrors what the shower setup already does. A working fastjet is unaffected. `52f06a2cc` makes the CI action write the line only when the binary is executable.

Not attempted: the same unconditional-write pattern exists in `restore_heptools_lhapdf`, `_pythia8`, `_emela` and `_looptools`. Only fastjet is guarded here, because it is the one that poisons *unrelated* jobs. Stopping `warm_cache` from leaving a 30-minute hole in shared, unhashed keys is a CI-ownership decision, not one to make in this PR.

## Not applicable, checked

Two MadGraph7 fixes were considered and neither applies. **#107** (declare `virtgranny_red` EXTERNAL in `genps_fks.f`) is **already present** in 3.8.0 at `Template/NLO/SubProcesses/genps_fks.f:297` — MadGraph7 had lost it, this lineage never did. **#114** (`get_density` flavour ordering) targets merged-PDG flavour grouping, which does not exist here: zero occurrences of `apply_flavor_grouping`, `merged_particles`, `merged_map`, `_revert_merged`, `FLAV_TABLE` or `get_flavor_index`. It gates itself on merged particles being present, so it would be a literal no-op.

## Why `madspin_factory` never blocked a 3.8.0 push

`madspin_parallel.yml` fires on `push` only for the literal branch `3.x`, plus every `pull_request`. So the regression was invisible on 3.8.0 pushes and surfaced only in PR checks — it failed identically on #408's own checks and, five minutes after the caches came back, on PR #332 (`onia_pwave`, base 3.8.0) once that picked #408 up. Both failures are byte-identical, the test being seed-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix MadSpin on-shell identical-particle weighting and make CI robust to unavailable FastJet caches.

Bug Fixes:
- Correct the legacy MadSpin on-shell weighting so identical-particle factors no longer distort mixed- versus same-flavour decay rates.
- Fall back to fjcore when the configured FastJet executable is missing or invalid, preventing unrelated aMC@NLO compilation failures.

Enhancements:
- Validate FastJet configuration at compile time before enabling FastJet-dependent builds.
- Document the efficiency comparison rule for the on-shell MadSpin modes.

CI:
- Avoid writing a stale FastJet configuration path into CI jobs after a cache miss.

Tests:
- Add unit coverage for identical decay-chain factors across flavour, resonance, multiplicity, and partially decayed-particle cases.
- Add a MadSpin integration assertion that validates the expected four-lepton flavour composition for every mode.