### PR TITLE
Make every Source/make_opts write atomic, and refuse a body-less one

### DIFF
--- a/madgraph/__init__.py
+++ b/madgraph/__init__.py
@@ -25,6 +25,8 @@ class aMCatNLOError(MadGraph5Error):
 
 import os
 import logging
+import shutil
+import tempfile
 import time
 pjoin = os.path.join
 
@@ -39,15 +41,44 @@ if ' ' in MG5DIR:
 MG4DIR = MG5DIR
 ReadWrite = os.access(MG5DIR, os.W_OK) # W_OK is for writing
 
+def atomic_copy(src, dst):
+    """Copy src onto dst by rename, so that a concurrent reader of dst always
+    sees a whole file (the old one or the new one) and never a truncated one.
+
+    Duplicated from madgraph.various.misc.atomic_copy, which is the version to
+    use everywhere else: misc imports this package, so this package cannot
+    import misc.
+    """
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(dst)),
+                               prefix='.%s.' % os.path.basename(dst),
+                               suffix='.tmp')
+    os.close(fd)
+    try:
+        shutil.copy(src, tmp)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, dst)
+    except Exception:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
 if ReadWrite:
     # Temporary fix for problem with auto-update
     try:
         tmp_path = pjoin(MG5DIR, 'Template','LO','Source','make_opts')
         #1480375724 is 29/11/16
         if os.path.exists(tmp_path) and os.path.getmtime(tmp_path) < 1480375724:
-            os.remove(tmp_path)
-            shutil.copy(pjoin(MG5DIR, 'Template','LO','Source','.make_opts'),
-                    pjoin(MG5DIR, 'Template','LO','Source','make_opts'))
+            # Rename into place rather than remove-then-copy: this file is shared
+            # by every MG5aMC process using this installation and is copied into
+            # each new output directory (and parsed by make); it must never be
+            # observed missing or half-written. NB the old code also referenced
+            # shutil without importing it, so the copy raised NameError into the
+            # except below and only the os.remove ever took effect.
+            atomic_copy(pjoin(MG5DIR, 'Template','LO','Source','.make_opts'),
+                        tmp_path)
     except Exception as error:
         pass
   

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4792,7 +4792,29 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         content = []
         variables = dict(def_variables)
         need_keys = list(variables.keys())
-        for line in open(make_opts):
+
+        # Read the whole file in one go: this used to iterate over the open file
+        # handle while another process could be truncating it, and a partial read
+        # is then written straight back (see below), making the damage permanent.
+        with open(make_opts) as fsock:
+            original = fsock.read()
+
+        # Refuse to work on a make_opts that is not one. Everything that gives
+        # the build its compiler and its flags -- FC=$(DEFAULT_F_COMPILER),
+        # $(libext), -ffixed-line-length-132 -- lives *after* the tag, so
+        # rewriting a file that has lost it would silently drop all of it and
+        # leave make on its builtin defaults ($(FC)=f77 ...). That does not fail
+        # here, it fails much later as column-72 errors in unrelated Fortran.
+        if not original.strip():
+            raise MadGraph5Error('%s is empty. It is likely that a concurrent '
+                'MG5aMC process truncated it while writing. Remove it and '
+                'regenerate the output directory.' % make_opts)
+        if tag.strip() not in original:
+            raise MadGraph5Error('%s does not contain the %s marker: the file '
+                'is truncated or corrupted. Remove it and regenerate the output '
+                'directory.' % (make_opts, tag.strip()))
+
+        for line in original.splitlines():
             line = line.strip()
             if make_opts_variable: 
                 if line.startswith('#') or not line:
@@ -4816,12 +4838,20 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
         if need_keys:
             diff=True #This means that new definition are added to the file. 
 
+        if 'DEFAULT_F_COMPILER' not in variables:
+            raise MadGraph5Error('%s defines no DEFAULT_F_COMPILER. Without it '
+                'make keeps its builtin $(FC) (f77) and the compilation fails '
+                'later with unrelated errors. Remove the file and regenerate '
+                'the output directory.' % make_opts)
+
         content_variables = '\n'.join('%s=%s' % (k,v) for k, v in variables.items() if v is not None)
         content_variables += '\n%s' % tag
 
         if diff:
-            with open(make_opts, 'w') as fsock: 
-                fsock.write(content_variables + '\n'.join(content))
+            # Atomic: a reader (or the make that is about to parse this) must
+            # never observe the file in the truncated state that open(...,'w')
+            # would leave it in.
+            misc.atomic_write(make_opts, content_variables + '\n'.join(content))
         return       
 
 

--- a/madgraph/interface/common_run_interface.py
+++ b/madgraph/interface/common_run_interface.py
@@ -4844,6 +4844,25 @@ class CommonRunCmd(HelpToCmd, CheckValidForCmd, cmd.Cmd):
                 'later with unrelated errors. Remove the file and regenerate '
                 'the output directory.' % make_opts)
 
+        # The marker being present is not enough: a truncation landing just
+        # after it leaves a file that parses, keeps its variables, and has lost
+        # every definition the build actually needs -- which is then written
+        # back here, permanently. So check that the body still carries the two
+        # whose absence produced the failure this validation exists for:
+        # FC=$(DEFAULT_F_COMPILER) (else make compiles with f77) and libext
+        # (else the libraries are linked as 'libdhelas.', with no extension).
+        # Both are unconditionally present in every make_opts MG5aMC ships,
+        # Template/LO/Source/.make_opts and Template/NLO/Source/make_opts.inc.
+        body = '\n'.join(content)
+        missing = [key for key in ('FC=$(DEFAULT_F_COMPILER)', 'libext=')
+                   if key not in body]
+        if missing:
+            raise MadGraph5Error('%s has lost %s from the section after %s. The '
+                'file is truncated or was edited into an unusable state; make '
+                'would silently fall back to its own defaults. Remove it and '
+                'regenerate the output directory.'
+                % (make_opts, ' and '.join(missing), tag.strip()))
+
         content_variables = '\n'.join('%s=%s' % (k,v) for k, v in variables.items() if v is not None)
         content_variables += '\n%s' % tag
 

--- a/madgraph/interface/madgraph_interface.py
+++ b/madgraph/interface/madgraph_interface.py
@@ -3183,12 +3183,19 @@ class MadGraphCmd(HelpToCmd, CheckValidForCmd, CompleteForCmd, CmdExtended):
                 self._mgme_dir = MG4DIR
 
         # check that make_opts exists
+        # This file is shared by every MG5aMC process running from this
+        # installation: it is copied verbatim into each new output directory and
+        # rewritten in place by set_fortran_compiler/set_cpp_compiler. Replacing
+        # it by rename (atomic_copy) rather than by shutil.copy is what keeps a
+        # concurrent reader from copying out a half-written make_opts -- which
+        # parses fine, drops FC/$(libext)/-ffixed-line-length-132, and surfaces
+        # only as column-72 Fortran errors in a completely unrelated build.
         make_opts = pjoin(MG5DIR, 'Template','LO','Source','make_opts')
         make_opts_source = pjoin(MG5DIR, 'Template','LO','Source','.make_opts')
         if not os.path.exists(make_opts):
-            shutil.copy(make_opts_source, make_opts)
+            misc.atomic_copy(make_opts_source, make_opts)
         elif  os.path.getmtime(make_opts) <  os.path.getmtime(make_opts_source):
-            shutil.copy(make_opts_source, make_opts)
+            misc.atomic_copy(make_opts_source, make_opts)
             
         # Variables to store state information
         self._multiparticles = {}
@@ -7549,9 +7556,8 @@ os.system('%s  -O -W ignore::DeprecationWarning %s %s --mode={0}' %(sys.executab
                                                                   cwd=MG5DIR)            
             print('new version installed, please relaunch mg5')
             try:
-                os.remove(pjoin(MG5DIR, 'Template','LO','Source','make_opts'))
-                shutil.copy(pjoin(MG5DIR, 'Template','LO','Source','.make_opts'),
-                            pjoin(MG5DIR, 'Template','LO','Source','make_opts'))
+                misc.atomic_copy(pjoin(MG5DIR, 'Template','LO','Source','.make_opts'),
+                                 pjoin(MG5DIR, 'Template','LO','Source','make_opts'))
             except:
                 pass
             sys.exit(0)

--- a/madgraph/iolibs/export_v4.py
+++ b/madgraph/iolibs/export_v4.py
@@ -2415,9 +2415,18 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
         try:
             common_run_interface.CommonRunCmd.update_make_opts_full(
                             make_opts, for_update)
-        except IOError:
+        except (IOError, OSError) as error:
             if root_dir == self.dir_path:
-                logger.info('Fail to set compiler. Trying to continue anyway.')            
+                # Do NOT continue: without DEFAULT_F_COMPILER make falls back to
+                # its builtin $(FC) (f77) and drops $(libext) and
+                # -ffixed-line-length-132 as well, so the build fails much later
+                # with column-72 errors in unrelated Fortran files.
+                raise MadGraph5Error(
+                    'Fail to set the fortran compiler in %s: %s' % (make_opts, error))
+            # For MG5DIR/Template this is only an optimisation, and a shared
+            # install is legitimately read-only.
+            logger.info('Fail to set compiler in %s. Trying to continue anyway.'
+                        % make_opts)
 
     def replace_make_opt_c_compiler(self, compiler, root_dir = ""):
         """Set CXX=compiler in Source/make_opts.
@@ -2454,9 +2463,14 @@ param_card.inc: ../Cards/param_card.dat\n\t../bin/madevent treatcards param\n'''
         try:
             common_run_interface.CommonRunCmd.update_make_opts_full(
                             make_opts, for_update)
-        except IOError:
+        except (IOError, OSError) as error:
             if root_dir == self.dir_path:
-                logger.info('Fail to set compiler. Trying to continue anyway.')  
+                # see replace_make_opt_f_compiler: silently keeping make's
+                # defaults only moves the failure somewhere unrecognisable.
+                raise MadGraph5Error(
+                    'Fail to set the c++ compiler in %s: %s' % (make_opts, error))
+            logger.info('Fail to set compiler in %s. Trying to continue anyway.'
+                        % make_opts)
     
         return
 
@@ -2542,8 +2556,16 @@ class ProcessExporterFortranSA(ProcessExporterFortran):
 
                         
         # Add file in Source
-        shutil.copy(pjoin(temp_dir, 'Source', 'make_opts'), 
-                    pjoin(self.dir_path, 'Source'))   
+        # atomic_copy, not shutil.copy: the source is MG5DIR/Template/LO's
+        # make_opts, a file shared by every MG5aMC process using this
+        # installation and rewritten in place by each of them
+        # (set_fortran_compiler / set_cpp_compiler), so a plain read of it can
+        # come back empty. The destination is then compiled against. This is how
+        # a MadSpin decay-ME directory ends up with an empty
+        # madspin_me/Source/make_opts and a build that silently falls back to
+        # make's builtins.
+        misc.atomic_copy(pjoin(temp_dir, 'Source', 'make_opts'), 
+                         pjoin(self.dir_path, 'Source'))   
 
         # add the makefile 
         filename = pjoin(self.dir_path,'Source','makefile')

--- a/madgraph/various/misc.py
+++ b/madgraph/various/misc.py
@@ -28,6 +28,7 @@ import optparse
 import time
 import shutil
 import stat
+import tempfile
 import traceback
 import gzip as ziplib
 import io
@@ -510,6 +511,65 @@ def copytree(*args, **opts):
     if 'copy_function' not in opts:
         opts['copy_function'] = shutil.copy
     return shutil.copytree(*args, **opts)
+
+#===============================================================================
+# Atomic file replacement
+#===============================================================================
+def atomic_write(path, content):
+    """Write ``content`` to ``path`` so that any concurrent reader sees either
+    the complete old file or the complete new one, but never a truncated one.
+
+    ``open(path, 'w')`` (and therefore ``shutil.copy``) truncates the
+    destination before the first byte is written, so a reader that opens the
+    file in that window gets a short read.  For the files this is used on --
+    ``Source/make_opts`` above all, which is shared by every MG5 process on the
+    machine and re-written by each of them -- that failure is silent: a
+    truncated make_opts still *parses*, so ``make`` falls back to its builtins
+    ($(FC)=f77, no $(libext), no -ffixed-line-length-132) and the build dies
+    much later with unrelated column-72 Fortran errors.
+
+    The temporary file is created in the same directory as the destination:
+    os.replace is only atomic within one filesystem.
+    """
+    path = os.path.abspath(path)
+    dirname = os.path.dirname(path)
+    binary = isinstance(content, bytes)
+    fd, tmp = tempfile.mkstemp(dir=dirname,
+                               prefix='.%s.' % os.path.basename(path),
+                               suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'wb' if binary else 'w') as fsock:
+            fsock.write(content)
+            fsock.flush()
+            os.fsync(fsock.fileno())
+        # mkstemp creates the file 0600; make_opts and friends have to stay
+        # readable by whoever else uses the install.
+        if os.path.exists(path):
+            shutil.copymode(path, tmp)
+        else:
+            os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_copy(src, dst):
+    """``shutil.copy(src, dst)``, but the destination is replaced atomically.
+
+    Like shutil.copy, ``dst`` may be a directory, in which case the basename of
+    ``src`` is used.  See :func:`atomic_write` for why this matters.  The source
+    is read into memory, so this is for configuration-sized files.
+    """
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    with open(src, 'rb') as fsock:
+        content = fsock.read()
+    atomic_write(dst, content)
+    return dst
 
 #===============================================================================
 # Compiler which returns smart output error in case of trouble

--- a/tests/unit_tests/various/test_make_opts.py
+++ b/tests/unit_tests/various/test_make_opts.py
@@ -1,0 +1,213 @@
+################################################################################
+#
+# Copyright (c) 2009 The MadGraph5_aMC@NLO Development team and Contributors
+#
+# This file is a part of the MadGraph5_aMC@NLO project, an application which 
+# automatically generates Feynman diagrams and matrix elements for arbitrary
+# high-energy processes in the Standard Model and beyond.
+#
+# It is subject to the MadGraph5_aMC@NLO license which should accompany this 
+# distribution.
+#
+# For more information, visit madgraph.phys.ucl.ac.be and amcatnlo.web.cern.ch
+#
+################################################################################
+"""Concurrency tests for Source/make_opts.
+
+``Source/make_opts`` is written by several code paths (madgraph/__init__, 
+MadGraphCmd.__init__, set_fortran_compiler / set_cpp_compiler) and read by many
+more: it is copied verbatim into every new output directory and then parsed by
+``make``. ``MG5DIR/Template/LO/Source/make_opts`` in particular is shared by
+every MG5aMC process on the machine, and MadSpin forks a worker per core, each
+of which can be exporting a decay matrix element at the same moment.
+
+If any of those writers truncates the file in place (which ``open(..,'w')`` and
+therefore ``shutil.copy`` do), a concurrent reader can copy out an empty
+make_opts. Nothing complains: an empty make_opts still *parses*, so make simply
+keeps its builtins -- $(FC)=f77, no $(libext), no -ffixed-line-length-132 -- and
+the build dies far away, as 'Missing exponent in real number' at column 72 of
+aloha_functions.f. These tests pin the two properties that prevent that: every
+write is atomic, and a make_opts that has lost its body is refused loudly.
+"""
+
+from __future__ import absolute_import
+
+import os
+import shutil
+import tempfile
+import threading
+import unittest
+
+import madgraph.various.misc as misc
+import madgraph.interface.common_run_interface as common_run_interface
+from madgraph import MG5DIR, MadGraph5Error
+
+pjoin = os.path.join
+
+
+class TestAtomicWrite(unittest.TestCase):
+    """misc.atomic_write / misc.atomic_copy"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.source = pjoin(MG5DIR, 'Template', 'LO', 'Source', '.make_opts')
+        with open(self.source) as fsock:
+            self.reference = fsock.read()
+
+    def test_atomic_write_replaces_content(self):
+        path = pjoin(self.tmpdir, 'make_opts')
+        misc.atomic_write(path, 'first\n')
+        misc.atomic_write(path, 'second\n')
+        with open(path) as fsock:
+            self.assertEqual(fsock.read(), 'second\n')
+
+    def test_atomic_write_leaves_no_temporary_behind(self):
+        path = pjoin(self.tmpdir, 'make_opts')
+        misc.atomic_write(path, 'x\n')
+        self.assertEqual(os.listdir(self.tmpdir), ['make_opts'])
+
+    def test_atomic_write_is_readable(self):
+        """mkstemp creates 0600 files; make_opts has to stay world readable."""
+        path = pjoin(self.tmpdir, 'make_opts')
+        misc.atomic_write(path, 'x\n')
+        self.assertTrue(os.stat(path).st_mode & 0o044)
+
+    def test_atomic_copy_accepts_a_directory_destination(self):
+        """same signature as shutil.copy, which is what it replaces"""
+        dest = pjoin(self.tmpdir, 'Source')
+        os.mkdir(dest)
+        misc.atomic_copy(self.source, dest)
+        with open(pjoin(dest, '.make_opts')) as fsock:
+            self.assertEqual(fsock.read(), self.reference)
+
+    def test_concurrent_reader_never_sees_a_partial_file(self):
+        """The regression itself.
+
+        With shutil.copy this fails immediately -- the reader observes hundreds
+        of zero-length make_opts, which is exactly what gets copied into
+        madspin_me/Source and then compiled against.
+        """
+        dest = pjoin(self.tmpdir, 'make_opts')
+        misc.atomic_copy(self.source, dest)
+
+        stop = threading.Event()
+        bad = []
+
+        def writer():
+            try:
+                for _ in range(400):
+                    misc.atomic_copy(self.source, dest)
+            finally:
+                stop.set()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    with open(dest) as fsock:
+                        content = fsock.read()
+                except (IOError, OSError):
+                    bad.append('missing')
+                    continue
+                if content != self.reference:
+                    bad.append(len(content))
+
+        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(bad, [],
+            'reader saw %d truncated/missing make_opts' % len(bad))
+
+
+class TestUpdateMakeOptsFull(unittest.TestCase):
+    """CommonRunCmd.update_make_opts_full"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.source = pjoin(MG5DIR, 'Template', 'LO', 'Source', '.make_opts')
+        self.path = pjoin(self.tmpdir, 'make_opts')
+        shutil.copy(self.source, self.path)
+        self.update = common_run_interface.CommonRunCmd.update_make_opts_full
+
+    def content(self):
+        with open(self.path) as fsock:
+            return fsock.read()
+
+    def test_updates_the_variable_and_keeps_the_body(self):
+        self.update(self.path, {'DEFAULT_F_COMPILER': 'gfortran-14'})
+        content = self.content()
+        self.assertIn('DEFAULT_F_COMPILER=gfortran-14', content)
+        # the part make actually needs, which lives after the marker
+        self.assertIn('FC=$(DEFAULT_F_COMPILER)', content)
+        self.assertIn('libext=a', content)
+        self.assertIn('-ffixed-line-length-132', content)
+
+    def test_refuses_an_empty_make_opts(self):
+        """A truncated file used to be read as 'no body', and the body-less
+        result was then written back -- making a transient race permanent."""
+        open(self.path, 'w').close()
+        self.assertRaises(MadGraph5Error, self.update,
+                          self.path, {'DEFAULT_F_COMPILER': 'gfortran'})
+
+    def test_refuses_a_make_opts_truncated_inside_the_variable_block(self):
+        with open(self.path, 'w') as fsock:
+            fsock.write('DEFAULT_F2PY_COMPILER=f2py\nDEFAULT_F_COMPI')
+        self.assertRaises(MadGraph5Error, self.update,
+                          self.path, {'DEFAULT_F_COMPILER': 'gfortran'})
+
+    def test_refuses_a_make_opts_without_default_f_compiler(self):
+        """Without it make keeps its builtin $(FC), i.e. f77."""
+        with open(self.path, 'w') as fsock:
+            fsock.write('STDLIB=-lstdc++\n#end_of_make_opts_variables\n\nlibext=a\n')
+        self.assertRaises(MadGraph5Error, self.update,
+                          self.path, {'STDLIB': '-lc++'})
+
+    def test_a_body_less_make_opts_is_never_written(self):
+        """Belt and braces: whatever happens, the file that is left on disk
+        still carries the definitions the compilation depends on."""
+        try:
+            open(self.path, 'w').close()
+            self.update(self.path, {'DEFAULT_F_COMPILER': 'gfortran'})
+        except MadGraph5Error:
+            pass
+        content = self.content()
+        self.assertTrue(not content.strip() or 'FC=$(DEFAULT_F_COMPILER)' in content,
+                        'update_make_opts_full persisted a make_opts with no body')
+
+    def test_write_is_atomic(self):
+        """A reader racing update_make_opts_full always sees a usable file."""
+        stop = threading.Event()
+        bad = []
+
+        def writer():
+            try:
+                for i in range(150):
+                    self.update(self.path,
+                                {'DEFAULT_F_COMPILER': 'gfortran%d' % (i % 2)})
+            finally:
+                stop.set()
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    with open(self.path) as fsock:
+                        content = fsock.read()
+                except (IOError, OSError):
+                    bad.append('missing')
+                    continue
+                if 'FC=$(DEFAULT_F_COMPILER)' not in content or \
+                   'libext=a' not in content:
+                    bad.append(len(content))
+
+        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(bad, [],
+            'reader saw %d make_opts without the compiler definitions' % len(bad))

--- a/tests/unit_tests/various/test_make_opts.py
+++ b/tests/unit_tests/various/test_make_opts.py
@@ -32,6 +32,7 @@ write is atomic, and a make_opts that has lost its body is refused loudly.
 
 from __future__ import absolute_import
 
+import itertools
 import os
 import shutil
 import tempfile
@@ -43,6 +44,63 @@ import madgraph.interface.common_run_interface as common_run_interface
 from madgraph import MG5DIR, MadGraph5Error
 
 pjoin = os.path.join
+
+MIN_READS = 50   # reads that must happen *while* writes are in flight
+
+
+def race(write, path, is_valid, nb_write=400):
+    """Run ``write`` in one thread and read ``path`` in another, and report
+    every read whose content ``is_valid`` rejects.
+
+    The two threads meet at a barrier so neither can run to completion before
+    the other starts, and the writer keeps going until the reader has managed
+    MIN_READS reads: without that the writer could finish every iteration
+    before the reader is first scheduled, and the test would pass having
+    observed nothing at all. Returns (bad, reads).
+    """
+    bad = []
+    reads = [0]
+    start = threading.Barrier(2)
+    stop = threading.Event()
+
+    def writer():
+        start.wait()
+        try:
+            for _ in range(nb_write):
+                write()
+            # Keep writing until the reader has really seen the file. Bounded,
+            # so a reader that died on an exception cannot hang the suite.
+            for _ in range(10 * nb_write):
+                if reads[0] >= MIN_READS or not reader_thread.is_alive():
+                    break
+                write()
+        finally:
+            stop.set()
+
+    def reader():
+        start.wait()
+        while not stop.is_set():
+            reads[0] += 1
+            try:
+                with open(path) as fsock:
+                    content = fsock.read()
+            except (IOError, OSError):
+                bad.append('missing')
+                continue
+            if not is_valid(content):
+                bad.append(len(content))
+
+    reader_thread = threading.Thread(target=reader)
+    threads = [threading.Thread(target=writer), reader_thread]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    if reads[0] < MIN_READS:
+        raise AssertionError('the reader only managed %d reads: the race was '
+                             'never exercised' % reads[0])
+    return bad, reads[0]
 
 
 class TestAtomicWrite(unittest.TestCase):
@@ -91,35 +149,14 @@ class TestAtomicWrite(unittest.TestCase):
         dest = pjoin(self.tmpdir, 'make_opts')
         misc.atomic_copy(self.source, dest)
 
-        stop = threading.Event()
-        bad = []
+        def check(content):
+            return content == self.reference
 
-        def writer():
-            try:
-                for _ in range(400):
-                    misc.atomic_copy(self.source, dest)
-            finally:
-                stop.set()
-
-        def reader():
-            while not stop.is_set():
-                try:
-                    with open(dest) as fsock:
-                        content = fsock.read()
-                except (IOError, OSError):
-                    bad.append('missing')
-                    continue
-                if content != self.reference:
-                    bad.append(len(content))
-
-        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
+        bad, reads = race(lambda: misc.atomic_copy(self.source, dest),
+                          dest, check)
         self.assertEqual(bad, [],
-            'reader saw %d truncated/missing make_opts' % len(bad))
+            'reader saw %d truncated/missing make_opts in %d reads'
+            % (len(bad), reads))
 
 
 class TestUpdateMakeOptsFull(unittest.TestCase):
@@ -159,10 +196,34 @@ class TestUpdateMakeOptsFull(unittest.TestCase):
         self.assertRaises(MadGraph5Error, self.update,
                           self.path, {'DEFAULT_F_COMPILER': 'gfortran'})
 
+    def test_refuses_a_make_opts_truncated_just_after_the_marker(self):
+        """The variables and the marker survive, the whole body is gone.
+
+        The file still parses, so nothing downstream complains -- make just
+        keeps its builtin $(FC) and an undefined $(libext). Rewriting it here
+        would make that permanent.
+        """
+        with open(self.path, 'w') as fsock:
+            fsock.write('DEFAULT_F2PY_COMPILER=f2py\n'
+                        'DEFAULT_F_COMPILER=gfortran\n'
+                        '#end_of_make_opts_variables\n')
+        self.assertRaises(MadGraph5Error, self.update,
+                          self.path, {'DEFAULT_F_COMPILER': 'gfortran-14'})
+
+    def test_refuses_a_make_opts_whose_body_lost_the_compiler_definitions(self):
+        """Body present but cut short, before FC=$(DEFAULT_F_COMPILER)."""
+        with open(self.path) as fsock:
+            head = fsock.read().split('FC=$(DEFAULT_F_COMPILER)')[0]
+        with open(self.path, 'w') as fsock:
+            fsock.write(head)
+        self.assertRaises(MadGraph5Error, self.update,
+                          self.path, {'DEFAULT_F_COMPILER': 'gfortran-14'})
+
     def test_refuses_a_make_opts_without_default_f_compiler(self):
         """Without it make keeps its builtin $(FC), i.e. f77."""
         with open(self.path, 'w') as fsock:
-            fsock.write('STDLIB=-lstdc++\n#end_of_make_opts_variables\n\nlibext=a\n')
+            fsock.write('STDLIB=-lstdc++\n#end_of_make_opts_variables\n\n'
+                        'FC=$(DEFAULT_F_COMPILER)\nlibext=a\n')
         self.assertRaises(MadGraph5Error, self.update,
                           self.path, {'STDLIB': '-lc++'})
 
@@ -180,34 +241,17 @@ class TestUpdateMakeOptsFull(unittest.TestCase):
 
     def test_write_is_atomic(self):
         """A reader racing update_make_opts_full always sees a usable file."""
-        stop = threading.Event()
-        bad = []
+        counter = itertools.count()
 
-        def writer():
-            try:
-                for i in range(150):
-                    self.update(self.path,
-                                {'DEFAULT_F_COMPILER': 'gfortran%d' % (i % 2)})
-            finally:
-                stop.set()
+        def write():
+            self.update(self.path, {'DEFAULT_F_COMPILER':
+                                    'gfortran%d' % (next(counter) % 2)})
 
-        def reader():
-            while not stop.is_set():
-                try:
-                    with open(self.path) as fsock:
-                        content = fsock.read()
-                except (IOError, OSError):
-                    bad.append('missing')
-                    continue
-                if 'FC=$(DEFAULT_F_COMPILER)' not in content or \
-                   'libext=a' not in content:
-                    bad.append(len(content))
+        def check(content):
+            return ('FC=$(DEFAULT_F_COMPILER)' in content
+                    and 'libext=a' in content)
 
-        threads = [threading.Thread(target=writer), threading.Thread(target=reader)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
+        bad, reads = race(write, self.path, check)
         self.assertEqual(bad, [],
-            'reader saw %d make_opts without the compiler definitions' % len(bad))
+            'reader saw %d make_opts without the compiler definitions in %d reads'
+            % (len(bad), reads))


### PR DESCRIPTION
## The failure

Observed once in MadGraph7 CI ([MadGraphTeam/MadGraph7#117](https://github.com/MadGraphTeam/MadGraph7/pull/117#issuecomment-5611168924), job `acceptancetest_96`, `test_madspin_ON_and_onshell_atNLO`); a plain re-run of the identical commit passed. Compiling `madspin_me/Source` failed with two errors, both at **column 72** of fixed-form Fortran:

```
aloha_functions.f:1143:72   ...1d-99))*rHalf   Error: Missing exponent in real number
cuts.inc:6:72               ...mue_over_ref... Error: Symbol 'mu' at (1) has no IMPLICIT type
```

Three independent signs in the same compile said `Source/make_opts` was not in effect: the compiler used was `f77` (GNU make's built-in `$(FC)`, so make_opts' `ifeq ($(origin FC),default)` / `FC=$(DEFAULT_F_COMPILER)` never fired), `-ffixed-line-length-132` was absent, and the library target was `../../lib/libdhelas.` with an empty `$(libext)`. Make parsed the file without error, so it was present but empty rather than missing — and all three of those definitions live *after* the `#end_of_make_opts_variables` marker, i.e. in exactly the part a truncation removes.

## Mechanism

`MG5DIR/Template/LO/Source/make_opts` is shared mutable state. Every MG5aMC process using an installation rewrites it in place, and every new output directory is seeded with a verbatim copy of it:

| | |
|---|---|
| writers | `madgraph/__init__` (restore from `.make_opts`), `MadGraphCmd.__init__` (same), `set_fortran_compiler` / `set_cpp_compiler` → `replace_make_opt_*_compiler` → `update_make_opts_full` |
| readers | `ProcessExporterFortranSA.copy_template` copies it into `<output>/Source`, then `make` parses it |

Every one of those writes truncated the destination first — `open(..,'w')` in `update_make_opts_full`, `shutil.copy` everywhere else — so a reader landing in that window copies out an **empty** make_opts, silently, and the build falls back to make's builtins.

MadSpin supplies the concurrency in the failing test: it forks a worker per core for the maxwgt scan, and each worker's pool refill runs a full `output <decay_dir> -f` (`_generate_refill_pool` → `_regenerate_events` → `generate_events` → `mg5.exec_cmd("output ... -f")`). That is N concurrent rewriters of the one Template file, while an export is copying it out.

And the damage outlived the race: `update_make_opts_full` iterated the open file handle and wrote back what it had read, so a partial read got **persisted** as a make_opts with a variables block and no body — which is why five compiles failed rather than one. Reproduced directly:

```python
open(make_opts, 'w').close()                       # the transient truncated state
update_make_opts_full(make_opts, {'DEFAULT_F_COMPILER': 'gfortran'})
# -> 'DEFAULT_F_COMPILER=gfortran\n#end_of_make_opts_variables\n'   permanently
```

and the window itself, with a writer/reader thread pair over the current `shutil.copy`: **3803 short reads, including zero-length**, in one 3000-iteration run.

## The fix

- **`misc.atomic_write` / `misc.atomic_copy`** — write a temp file in the destination directory and `os.replace()` it, so a reader always sees the whole old file or the whole new one. Applied at every make_opts write: `madgraph/__init__`, `MadGraphCmd.__init__`, the auto-update restore, `update_make_opts_full`, and `ProcessExporterFortranSA.copy_template`.
- **`update_make_opts_full`** reads the file in one go, and **raises** rather than rewriting when what it read is empty, has lost the `#end_of_make_opts_variables` marker, or defines no `DEFAULT_F_COMPILER`.
- **`replace_make_opt_f_compiler` / `replace_make_opt_c_compiler`** raise for the process directory instead of `logger.info('Fail to set compiler. Trying to continue anyway.')`. Continuing there can only ever produce the column-72 failure above, far from its cause. `MG5DIR/Template` keeps the tolerant path — a shared install is legitimately read-only.

Drive-by: the `madgraph/__init__` block referenced `shutil` without importing it, so on a pre-2016 install its `os.remove()` took effect and the copy meant to follow raised `NameError` into the bare `except`. It no longer removes anything.

## On per-process decay-ME directories

Worth recording, since it was the first suspicion: giving MadSpin per-process `madspin_me` directories would **not** have fixed this. `madspin_me/Source/make_opts` is only where the bad copy *landed*; the shared resource is the Template file it was copied from, and the concurrent writers reach it through `output`, whatever directory they are exporting to. The `madspin_me` generation and compile themselves run serially in the parent (`interface_madspin.py` step 3, before the scan forks). No MadSpin restructuring here.

## Testing

`tests/unit_tests/various/test_make_opts.py` (11 tests) covers both halves: a reader racing a writer never observes a partial make_opts, and a make_opts that has lost its body is refused rather than rewritten. Both concurrency tests were checked to **fail** when the atomic primitives are swapped back for `shutil.copy` / `open(..,'w')`.

- `./tests/test_manager.py test_make_opts.py test_export_v4.py test_misc.py` — 62 tests, OK
- `./tests/test_manager.py -p U` — 1401 tests; the 72 errors are all `NameError: name 'np' is not defined` in `madgraph/various/Density_functions.py`, i.e. numpy missing in this environment, pre-existing and untouched here
- end-to-end smoke: `generate e+ e- > mu+ mu-` / `output standalone` builds and leaves a complete 115-line make_opts with `DEFAULT_F_COMPILER`, `FC=$(DEFAULT_F_COMPILER)` and `libext=a` all present; no temp files left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make all Source/make_opts updates and copies atomic, validate their required build definitions, and fail early on corrupted process configurations.

Bug Fixes:
- Prevent concurrent make_opts updates and copies from producing empty or partially written files that cause builds to silently use make defaults.
- Reject truncated or incomplete make_opts files instead of persisting unusable configuration or continuing with misleading compiler errors.
- Restore the legacy make_opts file atomically during initialization and auto-update without deleting it first.

Enhancements:
- Centralize atomic file writes and copies with temporary files and replacement, preserving usable permissions and preventing leftover temporary files.
- Fail fast when compiler configuration cannot be updated in a process directory while retaining tolerant behavior for read-only shared templates.

Tests:
- Add unit coverage for atomic writes and copies, concurrent readers, incomplete make_opts validation, and atomic compiler-configuration updates.