### PR TITLE
CI: stop failed warm_cache runs leaking the repo past its cache quota

### DIFF
--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -82,6 +82,61 @@ jobs:
       # reset_heptools in the dispatch form was therefore a no-op. A boolean
       # input is truthy on its own; on push/schedule the whole inputs context
       # is null, so these steps stay skipped there.
+      # Intermediate caches (lhapdf/boost/pythia8/emela/contur/looptools) are
+      # scoped to the run that built them and are deleted at the end of a
+      # SUCCESSFUL run by the heptools_cache job. A failed run keeps them on
+      # purpose, so that re-running just the broken job does not rebuild the
+      # whole chain -- but nothing ever collected them afterwards, and they are
+      # not small: ~3.5GB per run across both images. Three consecutive failed
+      # runs on 2026-09-09 therefore pushed the repo past GitHub's 10GB cache
+      # quota, LRU eviction started, and the *next* run lost its own looptools
+      # sub-cache 27 minutes after saving it -- failing that run, stranding
+      # another 3.5GB, and so on. It also cost the production heptools-ubuntu24
+      # cache, which is why every ubuntu-24.04 job needing lhapdf went red.
+      #
+      # So sweep them here, at the start of the run, bounding the leak to one
+      # generation while keeping the re-run affordance: this run's own id is
+      # skipped (its caches do not exist yet anyway, but a re-run of this run
+      # would find them), and so is any run that is still going, so a warm_cache
+      # running concurrently on another branch cannot have the ground taken from
+      # under it.
+      - name: Collect intermediate caches left behind by earlier runs
+        run: |
+          set -u
+          for prefix in lhapdf boost pythia8 emela contur looptools; do
+            # never let a gh hiccup fail the whole warm run: this is a cleanup,
+            # not a precondition (hence the "|| true", which -o pipefail would
+            # otherwise turn into a step failure).
+            entries=$(gh cache list --repo "$GITHUB_REPOSITORY" \
+                          --key "$prefix-$CACHE_KEY-" --limit 100 \
+                          --json id,key --jq '.[]|"\(.id) \(.key)"' 2>/dev/null || true)
+            [ -n "$entries" ] || continue
+            while read -r id key; do
+              [ -n "$key" ] || continue
+              run_id=${key##*-}
+              case "$run_id" in
+                ''|*[!0-9]*)
+                  echo "keeping $key (no run id in the key)"; continue ;;
+                "$GITHUB_RUN_ID")
+                  echo "keeping $key (this run)"; continue ;;
+              esac
+              # An unknown run (deleted, or beyond the retention window) can
+              # only have stale caches, so treat a lookup failure as completed.
+              status=$(gh run view "$run_id" --repo "$GITHUB_REPOSITORY" \
+                                   --json status --jq .status 2>/dev/null || echo completed)
+              if [ "$status" != completed ]; then
+                echo "keeping $key (run $run_id is $status)"
+                continue
+              fi
+              echo "deleting $key (run $run_id completed)"
+              gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
+            done <<EOF
+          $entries
+          EOF
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Delete heptools related cache
         if: inputs.reset_heptools
         run: |
@@ -627,47 +682,62 @@ jobs:
       # the earlier attempt of this same run left behind - run_id is stable
       # across attempts). No restore-keys here, so a stale sub-cache from an
       # unrelated run can never be folded into the combined cache.
-      - name: Restore lhapdf (if available)
+      #
+      # fail-on-cache-miss, because the job gate above already establishes that
+      # the cache MUST be there: the sub-cache job reported success, and it
+      # saves unconditionally on success. A miss therefore means the entry was
+      # evicted between that job and this one -- the repo is over its 10GB cache
+      # quota -- and that has to be reported as what it is. Without it the
+      # restore quietly does nothing and the failure surfaces two steps later as
+      # "HEPTools cache incomplete: missing file .../CutTools/lib/libcts.a",
+      # which sends you looking at CutTools instead of at the quota.
+      - name: Restore lhapdf
         if: needs.lhapdf_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: lhapdf-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Restore boost (if available)
+      - name: Restore boost
         if: needs.boost_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: boost-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Restore pythia8 (if available)
+      - name: Restore pythia8
         if: needs.pythia8_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: pythia8-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Restore emela (if available)
+      - name: Restore emela
         if: needs.emela_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: emela-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Restore contur (if available)
+      - name: Restore contur
         if: needs.contur_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: contur-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
-      - name: Restore looptools (if available)
+      - name: Restore looptools
         if: needs.looptools_cache.result == 'success'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/HEPtools
           key: looptools-${{ env.CACHE_KEY }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       # Green sub-jobs are not proof that the tree is complete: a sub-cache may
       # predate the checks above, or a restore may have silently produced


### PR DESCRIPTION
## What happened

Every ubuntu-24.04 job that needs lhapdf has been red since the evening of 2026-09-09, on every branch:

```
Exception: lhapdf executable (/home/runner/.cache/HEPtools/bin/lhapdf-config)
           is not found on your system
```

`heptools-ubuntu24` had been **evicted**. The repo was sitting at **10.26 GB against GitHub's 10 GB per-repo cache limit**, and LRU took it — along with `delphes-ubuntu24`, `root_cache-ubuntu24` and `pip-numpy-ubuntu24`. Only the 22.04 variants survived, which is exactly the split we were seeing.

## Why the repo was over quota

The intermediate caches (`lhapdf`/`boost`/`pythia8`/`emela`/`contur`/`looptools`, ~3.5 GB per run across both images) are deleted at the end of a **successful** run by `heptools_cache`, and deliberately kept on a failed one so re-running the single broken job does not rebuild the whole chain. Nothing ever collected them afterwards, and `delete-cache` only sweeps them when `reset_heptools` is explicitly ticked.

So each failure stranded another 3.5 GB — and the loop closes on itself. Three consecutive failures on 2026-09-09 left this behind:

| key prefix | run 34401001946 | run 34402071954 | run 34402367805 |
|---|---|---|---|
| `emela-ubuntu{22,24}` | 1220 MB | 1219 MB | 1220 MB |
| `contur-ubuntu{22,24}` | 1115 MB | 1115 MB | 1115 MB |
| `boost-ubuntu{22,24}` | 745 MB | 745 MB | *evicted* |
| `lhapdf-ubuntu{22,24}` | 345 MB | 345 MB | *evicted* |

Over quota, eviction starts, and run 34402367805 lost **its own** `looptools` sub-cache 27 minutes after saving it:

```
20:56:15  Cache saved with key: looptools-ubuntu24-34402367805
21:23:33  Cache not found for input keys: looptools-ubuntu24-34402367805
```

which failed that run, which stranded another 3.5 GB.

## Why it was hard to see

The restore that missed was not `fail-on-cache-miss`, so it quietly did nothing and the job carried on to the content check, which reported:

```
HEPTools cache incomplete (lhapdf boost pythia8 emela contur looptools):
  missing file: /home/runner/.cache/HEPtools/CutTools/lib/libcts.a
```

CutTools is not even in the tool list being checked — it is part of the `looptools` bundle that never got restored. The message sends you to CutTools instead of to the quota.

## The change

1. **`delete-cache` sweeps intermediate caches left behind by earlier runs**, bounding the leak to one generation. The re-run affordance is kept: this run's own id is skipped (`run_id` is stable across attempts), and so is any run still in progress, so a `warm_cache` running concurrently on another branch cannot have the ground taken from under it. A run that cannot be looked up (deleted, or past retention) can only have stale caches, so it is treated as completed.
2. **`fail-on-cache-miss: true` on the six sub-cache restores in `heptools_cache`.** The job gate already establishes the entry must exist — the sub-cache job reported success, and it saves unconditionally on success — so a miss means eviction and should say so.

## Testing

The sweep's shell was run against a stubbed `gh` covering all four branches:

```
keeping  emela-ubuntu24-900 (this run)
keeping  emela-ubuntu24-901 (run 901 is in_progress)
deleting emela-ubuntu24-902 (run 902 completed)
deleting boost-ubuntu24-903 (run 903 completed)
exit=0                                   # under bash -e -o pipefail
```

`warm_cache.yml` parses clean, and both jobs keep their step order.

## Already done by hand

The 20 stranded entries (8.98 GB) were deleted to unblock CI — the repo went from 24 caches to 4, and is now at 4.43 GB. `heptools-ubuntu22` was left untouched. This PR is what keeps them from coming back.

## Still outstanding, unrelated to this PR

`heptools-ubuntu24` is **not** rebuilt yet. The warm run triggered after the cleanup ([34453237224](https://github.com/mg5amcnlo/mg5amcnlo/actions/runs/34453237224)) got lhapdf, boost, emela, looptools, root and delphes back for both images, then failed on `pythia8_cache` for a completely separate reason — a broken zlib download in HEPToolsInstaller_V168:

```
wget ... http://www.zlib.net//zlib-1.3.2.tar.gz     <- note the double slash
HTTP request sent, awaiting response... 200 OK
Length: 12040 (12K) [text/html]
gzip: stdin: not in gzip format
```

`HEPToolInstaller.py` builds that URL from `'www' : ['http://www.zlib.net/', ...]` and `'tarball': ['online','%(www)s/zlib-1.3.2.tar.gz']` — trailing slash plus leading slash. zlib.net answers a double-slash path with its homepage and a **200**, so wget exits 0, the mirror fallback never fires, and a 12 KB HTML page is unpacked as a tarball. The single-slash URL still serves the real tarball:

```
http://www.zlib.net/zlib-1.3.2.tar.gz    200  application/x-gzip  1502830
http://www.zlib.net//zlib-1.3.2.tar.gz   200  text/html             12040
```

The double slash has presumably always been there; what changed is zlib.net. The **same URL, double slash and all**, returned the real tarball in the last good warm run less than a day earlier:

```
2026-09-09 14:18:48  wget ... http://www.zlib.net//zlib-1.3.2.tar.gz
2026-09-09 14:18:49  'zlib-1.3.2.tar.gz' saved [1502830/1502830]     <- run 34362422159
2026-09-10 08:10:16  'zlib-1.3.2.tar.gz' saved [12040/12040]         <- run 34453237224
```

so the server stopped normalising `//` somewhere in between. Two fixes suggest themselves, both in `HEPToolInstaller.py` on `madgraph.phys.ucl.ac.be` rather than in this repo: drop the duplicated slash, and refuse a "download" that is not actually a gzip — a 200-OK HTML page currently sails through, which is also why the mirror fallback never fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
