### PR TITLE
CI: warm the caches automatically only on 3.x and test_ci

### DIFF
--- a/.github/workflows/warm_cache.yml
+++ b/.github/workflows/warm_cache.yml
@@ -6,6 +6,20 @@ permissions:
   contents: read
 on:
   push:
+    # Only these two branches warm the caches automatically. Every warm run
+    # rebuilds ~3.5GB of intermediate caches across both images against a 10GB
+    # per-repo quota, so letting a push to any feature branch that happens to
+    # touch one of the paths below start one is how the quota gets exhausted
+    # and the shared heptools caches get evicted. Use the workflow_dispatch
+    # button (below) to warm from anywhere else; that is a deliberate act.
+    #
+    # The schedule trigger needs no equivalent filter: GitHub only ever runs
+    # cron workflows on the default branch, which is 3.x.
+    branches:
+      - '3.x'
+      - 'test_ci'
+    # NB both filters must match: a push to 3.x/test_ci that touches none of
+    # these paths does not warm anything either.
     paths:
       - '.github/workflows/warm_cache.yml'
       - '.github/actions/restore_heptools/**'


### PR DESCRIPTION
`warm_cache`'s `push` trigger was filtered by path but not by branch, so **any** branch that happened to touch `warm_cache.yml` or one of the `restore_*` / `check_heptools` actions started a full warm run of its own.

That is expensive in a way that is not local to the branch doing it: every warm run rebuilds ~3.5 GB of intermediate caches across both images against a 10 GB per-repo quota, and two overlapping runs are enough to exhaust it and start evicting the *shared* heptools caches. That is what took out `heptools-ubuntu24` and turned every ubuntu-24.04 lhapdf job red on every branch (see #412).

Not hypothetical: merging #412 put a warm run on 3.8.0 while the one its own feature-branch push had started was still queued —

```
2026-09-10T08:33:53Z  queued  3.8.0                             <- the merge
2026-09-10T08:21:40Z  queued  claude/ci-bound-warm-cache-leak   <- the branch push
```

both about to build the same 3.5 GB twice, against 4.43 GB already in use.

## The change

Restrict the `push` trigger to `3.x` and `test_ci`. Warming from anywhere else stays available through the `workflow_dispatch` button, where it is a deliberate act rather than a side effect of editing a workflow file.

Both `push` filters must match, so a push to `3.x` that touches none of the listed paths still warms nothing — unchanged from today.

## The rest of the trigger surface

| trigger | runs on | needs a filter? |
|---|---|---|
| `push` | any branch → **`3.x`, `test_ci`** | this PR |
| `schedule` | default branch only, which is `3.x` | no — GitHub only ever runs cron on the default branch |
| `workflow_dispatch` | any ref, on request | no — manual, not automatic |

There is no `pull_request`, `workflow_call` or `workflow_run` trigger here, and no other workflow in `.github/workflows/` references `warm_cache`, so those three are the whole surface.

`test_ci` does not exist on the remote yet. Naming it costs nothing and the filter starts applying the day it is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Limit automatic cache warming to the 3.x and test_ci branches while preserving manual warming for other refs.

Bug Fixes:
- Restrict automatic cache-warming runs to pushes on the 3.x and test_ci branches, preventing feature-branch changes from consuming shared cache quota and evicting shared caches.

CI:
- Limit the warm-cache workflow's push trigger to the designated branches while retaining scheduled and manual execution behavior.