### PR TITLE
Fix two independent loop-wavefunction bugs in check_majorana_and_flip_flow (LP#2159043, arXiv:2108.11404 app. A)

### DIFF
--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1387,7 +1387,28 @@ class HelasWavefunction(base_objects.PhysicsObject):
                 # Use the copy in wavefunctions instead.
                 # Remove this copy from diagram_wavefunctions
                 new_wf_number = new_wf.get('number')
-                new_wf = wavefunctions[wavefunctions.index(new_wf)]
+                # HelasWavefunction.__eq__ ignores the pdg code, so for a loop
+                # wavefunction whose particle and antiparticle differ in nothing
+                # else -- a colour singlet, i.e. a lepton -- index() can return
+                # the wrong sign. Match the pdg code explicitly for every loop
+                # wavefunction. See appendix A of arXiv:2108.11404, which
+                # reported this for leptoquark pair production at NLO; the
+                # workaround given there guards only pdg < 0, but nothing makes
+                # the other sign safe, so the check is applied symmetrically.
+                if not new_wf.get('is_loop'):
+                    index_wf = wavefunctions.index(new_wf)
+                else:
+                    for i_wf, wf in enumerate(wavefunctions):
+                        if new_wf == wf and \
+                           wf.get('pdg_code') == new_wf.get('pdg_code'):
+                            index_wf = i_wf
+                            break
+                    else:
+                        # No pdg-matching candidate: same outcome as index()
+                        # finding nothing, i.e. keep the local copy. Caught by
+                        # the 'except ValueError' closing this try block.
+                        raise ValueError
+                new_wf = wavefunctions[index_wf]
                 diagram_wf_numbers = [w.get('number') for w in \
                                                           diagram_wavefunctions]
                 index = diagram_wf_numbers.index(new_wf_number)

--- a/madgraph/core/helas_objects.py
+++ b/madgraph/core/helas_objects.py
@@ -1415,9 +1415,14 @@ class HelasWavefunction(base_objects.PhysicsObject):
                     # have this replaced wavefunction in their mothers. This
                     # plays the role of the 'number_to_wavefunction' dictionary
                     # used for tree level.
+                    # Match on object identity rather than on the 'number'
+                    # attribute: numbers are reshuffled by the insertions above
+                    # (and by the renumbering just performed), so an unrelated
+                    # wavefunction can transiently carry new_wf_number and get
+                    # its mother silently overwritten.
                     for wf in diagram_wavefunctions:
                         for i,mother_wf in enumerate(wf.get('mothers')):
-                            if mother_wf.get('number')==new_wf_number:
+                            if mother_wf is self:
                                 wf.get('mothers')[i]=new_wf
 
             except ValueError:


### PR DESCRIPTION
Fixes [LP#2159043](https://bugs.launchpad.net/mg5amcnlo/+bug/2159043).

## The bug

`HelasWavefunction.check_majorana_and_flip_flow` ends with an `is_loop`-only sweep that repoints, inside the current diagram, every mother still referring to the wavefunction just superseded by a reused copy. It selected those mothers with `mother_wf.get('number') == new_wf_number`.

That key is not stable. The insertion branches earlier in the same function renumber every wavefunction after the insertion point by ±1 to keep `diagram_wavefunctions` contiguous, and the reuse branch immediately above pops the copy and decrements everything after it. By the time the sweep runs, the slot that held `new_wf_number+1` holds `new_wf_number` and belongs to an unrelated wavefunction, whose mother is then silently overwritten.

Matching on object identity is unambiguous and immune to the renumbering. The comment already says "the wf which is replaced", i.e. `self`.

## How it surfaces

The reporter's model has a colour-sextet scalar diquark with a fermion-number-violating `six3 -> t t` coupling. `p p > t t t~ t~ [QCD]` produces enough flip-and-renumber churn per loop diagram for a collision to land on a live wavefunction. Instrumenting the sweep catches it directly:

```
host_wf=2694  interaction=100 (g t t~)  mother slot i=1
  old mother  : number=2693  pdg=21   interaction=100
  replaced by : number=2656  pdg=-6   interaction=46  (t t six3~)
```

A `g t t~` vertex loses its gluon mother to a top line from the |dF|=2 vertex. Two vertices later `sort_by_pdg_codes` receives mothers `[-6, -6]` where the interaction says `[-6, 21]`:

```
ValueError : 21 is not in list
  madgraph/loop/loop_helas_objects.py  generate_helas_diagrams
  madgraph/core/helas_objects.py       sorted_mothers
  madgraph/core/helas_objects.py       sort_by_pdg_codes
```

The same collision has been firing since the sweep was added in 961564b6c (2014, for `g g > go go g [virt=QCD]`); in MSSM output it happens to hit wavefunctions nothing downstream reads, so it stayed latent.

Note the reporter's attachment also proposes generalising the L-cut Majorana gate in `madgraph/loop/loop_helas_objects.py`. That is deliberately **not** included: the crash is fixed without it, verified on a tree where that file is untouched.

## Reproducer

Faster than the `[QCD]` command in the report and crashes identically, skipping the FKS machinery:

```
set complex_mass_scheme
import model SextetDiquarks_six3_NLOFULL_5FS_cms_bsm_UFO
generate g g > t t t~ t~ QED<=0 QCD<=2 NP<=2 [virt=QCD]
output
```

On 3.8.0 (`1ce45e2ae`): `ValueError: list.index(x): x not in list`. With this commit: completes cleanly.

## Validation

Generation-level, on this branch and on MadGraph7 (where the change is identical): each process built twice through `LoopHelasProcess` and compared on a canonical HELAS fingerprint — per diagram, every wavefunction's number, PDG, interaction id, colour key, state, fermion flow and mother list, plus the amplitudes — in **both** `loop_optimized_output` modes.

42 configurations across `loop_sm` (6 processes), `LoopSMEWTest` (4), `loop_smgrav` (2), `loop_MSSM` (7) and the reporter's model: **41 byte-identical, 1 crash-to-clean.**

Two things are worth calling out:

- The sweep sits behind a fermion-flow flip on a loop line. SM, EW, the graviton model, squark loops and neutralino loops never produce one, so 32 of the 42 configurations record zero hits on either key — those are unaffected by construction, not merely untested.
- Where it is reachable, the change is large and still inert: `g g > go go g` flips 41 substitution decisions and `u u~ > go go g` flips 85, with no change to the generated matrix element in either mode.

Disabling the sweep entirely *does* change `g g > go go g`, so it is load-bearing; this keeps it load-bearing and makes it correct.

Suites on this branch:

| suite | result |
| --- | --- |
| `./tests/test_manager.py -p U loop` | 24/24 OK |
| `LoopSquaredOrder_IOTest` | 1/1 |
| `short_ML_SMQCD_default` / `_optimized` | 2/2 each |
| `long_ML_SMQCD_default` / `_optimized` | 2/2 each |
| `short_ML_SMQCD_LoopInduced` | 1/1 |
| `IOExportFKSTest` | 6/6 |
| `test_short_mssm_vs_stored_HCR_gg_gogo_QCD` | OK |
| `test_long_mssm_vs_stored_HCR_gg_gogog_QCD` | OK |

The last two are the ones that matter for a Majorana loop line, and they compare |M|² against the stored hard-coded references.

## Second commit: pdg code ignored when reusing a loop wavefunction

A second, independent defect in the same method, reported five years ago in **appendix A of [arXiv:2108.11404](https://arxiv.org/abs/2108.11404)** (scalar leptoquark pair production at NLO) and never fixed. The paper carries a patched copy of MG5aMC and notes the bug "has been acknowledged by the MadGraph5_aMC@NLO authors and will be fixed in future releases of the code".

`HelasWavefunction.__eq__` deliberately ignores the pdg code, so a particle and its antiparticle compare equal when nothing else separates them. A coloured fermion is saved by its colour representation; a colour singlet -- a lepton -- is not. So

```python
new_wf = wavefunctions[wavefunctions.index(new_wf)]
```

can hand back the wrong sign for a loop wavefunction on a lepton line, and `sort_by_pdg_codes` fails downstream with the same `ValueError` as the first commit. Same symptom, different cause: the two are easy to confuse.

Reproducer, with the paper's model (`LQnlo_5FNS_v5_UFO`) and its `is_perturbating` addition so lepton loops are not vetoed:

| LQ species | `g g` | `u u~` | `d d~` | `b b~` |
| --- | --- | --- | --- | --- |
| LQ1d, LQ1dd, LQ3d, LQ3dd | ok | ok | **crash** | **crash** |
| LQ3u | ok | **crash** | ok | ok |
| LQ2uu, LQ2u, LQ2pu, LQ2d | ok | ok | ok | ok |

All nine crashing configurations build with this commit.

**The two commits are independent** — measured 2x2 on the nine leptoquark configurations and the sextet reproducer:

| helas_objects.py | leptoquark | sextet |
| --- | --- | --- |
| pristine | 0/9 | crash |
| commit 1 only | 0/9 | builds |
| commit 2 only | 9/9 | crash |
| both | 9/9 | builds |

**Deviation from the published workaround:** appendix A guards only `pdg < 0`; nothing makes the other sign safe, so the check here applies to every loop wavefunction. Instrumenting both variants over the whole process list shows they select the same wavefunction everywhere — including all nine leptoquark configurations, whose output is byte-identical either way — so the wider guard costs nothing measurable.

**Blast radius**, same instrumentation as the first commit, 42 configurations, both `loop_optimized_output` modes:

| model | guarded branch entered | selection changed |
| --- | --- | --- |
| `loop_sm`, `LoopSMEWTest`, `loop_smgrav`, MSSM squarks | 0 | 0 |
| MSSM gluinos, `g g > n1 n1` | 13 – 948 | 0 |
| sextet diquark | 773 | 0 |

The reuse branch needs a fermion-flow flip, which no SM, EW or graviton-model loop process produces — zero entries there is unreachability, not a sample. Where it is entered heavily it is inert: most entries are cases where `index()` finds nothing at all and both paths fall through to the same `except ValueError`.

## Two unrelated snags hit while validating, worth separate attention

1. `tests/input_files/loop_MSSM` still imports `six` (`object_library.py:13`, `write_param_card.py:3`). Without `six` installed the model cannot be imported, and the in-place py2→py3 conversion then leaves `models/loop_MSSM/__init__.py` with `import function_library` above its `from __future__`, which is a syntax error on the next run. The numbers above were obtained with a py3-clean copy of the same fixture.

2. `test_manager` skips tests whose recorded runtime exceeds its limit and still prints `Ran 0 tests ... OK`. A green line with a zero test count is a bypass, not a pass; the long comparisons need `-t` to actually run.

## What this does not fix

`check_poles` still fails on the single IR pole for the reporter's four-top diquark process. `output` completing is not the same as the amplitude being right — that is a separate investigation, and LP#2159043 should not be closed on this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
