### PR TITLE
Drop the six dependency from the loop_MSSM test fixture

### DIFF
--- a/tests/input_files/loop_MSSM/object_library.py
+++ b/tests/input_files/loop_MSSM/object_library.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 import cmath
 import re
-import six
 
 class UFOError(Exception):
         """Exception raised if when inconsistencies are detected in the UFO model."""
@@ -135,7 +134,7 @@ class Particle(UFOBaseClass):
         if self.selfconjugate:
             raise Exception('%s has no anti particle.' % self.name) 
         outdic = {}
-        for k,v in six.iteritems(self.__dict__):
+        for k,v in self.__dict__.items():
             if k not in self.require_args_all:                
                 outdic[k] = -v
         if self.color in [1,8]:

--- a/tests/input_files/loop_MSSM/write_param_card.py
+++ b/tests/input_files/loop_MSSM/write_param_card.py
@@ -1,6 +1,5 @@
 
 from __future__ import absolute_import
-from six.moves import range
 __date__ = "02 Aug 2012"
 __author__ = 'olivier.mattelaer@uclouvain.be'
 


### PR DESCRIPTION
`tests/input_files/loop_MSSM` still carries python2 compatibility shims: `object_library.py` imports `six` and uses `six.iteritems`, `write_param_card.py` imports `six.moves.range`.

MG5aMC loads a UFO model with a sanitised `sys.path` that excludes user site-packages, so an interpreter that has `six` only there still fails:

```
models.UFOError: No module named 'six'
```

and the parallel MadLoop tests that use this model (`test_ML5MSSMQCD`) cannot run at all.

There is a second-order trap too. After that failure MG5aMC attempts its in-place python2 → python3 conversion, which leaves `models/loop_MSSM/__init__.py` as

```python
import function_library
import object_library

from __future__ import absolute_import
```

— a hard syntax error on the next run (`from __future__ imports must occur at the beginning of the file`). The failure then persists, with a different message, until the copied model under `models/` is deleted by hand. That is what made this look like two unrelated problems when I first hit it.

## The change

```diff
 import re
-import six
...
-        for k,v in six.iteritems(self.__dict__):
+        for k,v in self.__dict__.items():
...
 from __future__ import absolute_import
-from six.moves import range
```

This is the same change MadGraph7 already applied to its copy of the fixture, in `d8ec200fb` ("simple run of modernise") and `7e0a11ff2` ("remove remaining uses of the six module"). The two copies are byte-identical after this commit.

## Checks

Run under `python3 -s` so that user site-packages — the only place `six` exists on this machine — is hidden:

| fixture | `import loop_MSSM` |
| --- | --- |
| before | `ModuleNotFoundError: No module named 'six'` |
| after | imports cleanly, 98 particles |

`test_short_mssm_vs_stored_HCR_gg_gogo_QCD` passes on this branch (`Ran 1 test in 491s, OK`), with `models/loop_MSSM` copied fresh from the fixed fixture.

## Not in scope

`DM_pion`, `fourfermion_UFO`, `full_sm_UFO` and `loop_smgrav` still import `six` and would need the same treatment; this PR only covers `loop_MSSM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the six dependency from the loop_MSSM test fixture to restore reliable Python 3 test execution.

Bug Fixes:
- Remove the remaining Python 2 compatibility dependency on six from the loop_MSSM test fixture so it loads successfully in environments without six installed.

Enhancements:
- Modernize loop_MSSM fixture code to use native Python 3 iteration and range behavior.

Tests:
- Verify that the loop_MSSM fixture imports cleanly without user site-packages and that the relevant MadLoop MSSM test passes.